### PR TITLE
Bump up protobuf version from 3.20.5 to 4.21.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "pytest",
         "typer==0.9.0",
         "rich",
-        "protobuf<=3.20.5",
+        "protobuf>=4.21.6",
         "pandas",
         "pydantic",  # loosen pydantic requirements as we support multiple
         "sentry-sdk",


### PR DESCRIPTION
## Motivation

Current specified version of protobuf is `protobuf<=3.20.5` but it's too old to coexist with many LLM related library such as qdrant-client. So updating is needed.

## What I did

- bump up protobuf version from 3.20.5 to 4.21.6

## Why I specified `>=4.21.6`?

This version is minimum requirement for qdrant-client

https://github.com/qdrant/qdrant-client/blob/8875b45feac121d499e4939d395d5a9e1c39da51/poetry.lock#L731-L732

## Related issue

#321