### PR TITLE
Typo fix at ContextualPrecisionMetric

### DIFF
--- a/deepeval/metrics/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision.py
@@ -31,12 +31,11 @@ class ContextualPrecisionMetric(BaseMetric):
     def measure(self, test_case: LLMTestCase) -> float:
         if (
             test_case.input is None
-            or test_case.actual_output is None
             or test_case.retrieval_context is None
             or test_case.expected_output is None
         ):
             raise ValueError(
-                "Input, actual output, expected output, or retrieval context cannot be None"
+                "Input, expected output, or retrieval context cannot be None"
             )
 
         with metrics_progress_context(self.__name__):

--- a/docs/docs/metrics-contextual-precision.mdx
+++ b/docs/docs/metrics-contextual-precision.mdx
@@ -11,7 +11,7 @@ The contextual precision metric measures your RAG pipeline's retriever by evalua
 To use the `ContextualPrecisionMetric`, you'll have to provide the following arguments when creating an `LLMTestCase`:
 
 - `input`
-- `actual_output`
+- `expected_output`
 - `retrieval_context`
 
 ## Example
@@ -21,8 +21,8 @@ from deepeval import evaluate
 from deepeval.metrics import ContextualPrecisionMetric
 from deepeval.test_case import LLMTestCase
 
-# Replace this with the actual output from your LLM application
-actual_output = "We offer a 30-day full refund at no extra cost."
+# Replace this with the expected output from your RAG generator
+expected_output = "We offer a 30-day full refund at no extra cost."
 
 # Replace this with the actual retrieved context from your RAG pipeline
 retrieval_context = ["All customers are eligible for a 30 day full refund at no extra cost."]
@@ -34,7 +34,7 @@ metric = ContextualPrecisionMetric(
 )
 test_case = LLMTestCase(
     input="What if these shoes don't fit?",
-    actual_output=actual_output,
+    expected_output=expected_output,
     retrieval_context=retrieval_context
 )
 


### PR DESCRIPTION
Hi, there!

Fist of all, I found typo at document about `ContextualPrecisionMetric`.
I understood that `ContextualPrecisionMetric` use `expected_output` parameter not `actual_output`. But `actual_output` is written at document as below link.
[Contextual Precision Documentation]((https://docs.confident-ai.com/docs/metrics-contextual-precision))

So, I could fix this typo at document.
Also, I could fix `measure()` function because of unnecessary type checking.
