### PR TITLE
Fix logprob-based G-Eval

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -295,10 +295,12 @@ class GEval(BaseMetric):
                 # Filter out non-decimal token to prevent errors in later int(token) conversion
                 if not token_logprob["token"].isdecimal():
                     continue
-        
+
                 # Calculate the linear probability
                 linear_prob = math.exp(logprob)
-                token_linear_probability[int(token_logprob["token"])] = linear_prob
+                token_linear_probability[int(token_logprob["token"])] = (
+                    linear_prob
+                )
                 sum_linear_probability += linear_prob
 
             sum_of_weighted_scores = 0.0


### PR DESCRIPTION
Fix issues of logprob-based G-Eval:
1. The `return_raw_response` parameter is no longer needed now that we introduced `generate_raw_response`
2. Fix the score value (`int(token_logprob["token"])` instead of `int(logprob)`). Also add a decimal check before the conversion.
3. Move the `math.log(0.01)` up before the for loop to reduce unnecessary re-computation