### PR TITLE
Support custom GPTModel arguments

### DIFF
--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -6,6 +6,7 @@ from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.test_case import (
     LLMTestCase,
@@ -13,7 +14,7 @@ from deepeval.test_case import (
     ConversationalTestCase,
 )
 from deepeval.metrics import BaseMetric
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.answer_relevancy.template import AnswerRelevancyTemplate
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.telemetry import capture_metric_type
@@ -39,12 +40,7 @@ class AnswerRelevancyMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.async_mode = async_mode

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -9,12 +9,13 @@ from deepeval.test_case import (
 )
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.telemetry import capture_metric_type
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.utils import get_or_create_event_loop
 from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.metrics.bias.template import BiasTemplate
 
@@ -41,12 +42,7 @@ class BiasMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 0 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.async_mode = async_mode

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -6,6 +6,7 @@ from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.test_case import (
     LLMTestCase,
@@ -13,7 +14,7 @@ from deepeval.test_case import (
     ConversationalTestCase,
 )
 from deepeval.metrics import BaseMetric
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.contextual_precision.template import (
     ContextualPrecisionTemplate,
 )
@@ -45,12 +46,7 @@ class ContextualPrecisionMetric(BaseMetric):
     ):
         self.threshold = 1 if strict_mode else threshold
         self.include_reason = include_reason
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.async_mode = async_mode
         self.strict_mode = strict_mode

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -6,6 +6,7 @@ from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.test_case import (
     LLMTestCase,
@@ -13,7 +14,7 @@ from deepeval.test_case import (
     ConversationalTestCase,
 )
 from deepeval.metrics import BaseMetric
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.contextual_recall.template import ContextualRecallTemplate
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.telemetry import capture_metric_type
@@ -41,12 +42,7 @@ class ContextualRecallMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.async_mode = async_mode

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -7,6 +7,7 @@ from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.test_case import (
     LLMTestCase,
@@ -14,7 +15,7 @@ from deepeval.test_case import (
     ConversationalTestCase,
 )
 from deepeval.metrics import BaseMetric
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.contextual_relevancy.template import (
     ContextualRelevancyTemplate,
 )
@@ -43,12 +44,7 @@ class ContextualRelevancyMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.async_mode = async_mode

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -13,8 +13,9 @@ from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.faithfulness.template import FaithfulnessTemplate
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.telemetry import capture_metric_type
@@ -41,12 +42,7 @@ class FaithfulnessMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.async_mode = async_mode

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -16,8 +16,9 @@ from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.telemetry import capture_metric_type
 from deepeval.metrics.indicator import metric_progress_indicator
 
@@ -84,12 +85,7 @@ class GEval(BaseMetric):
             )
 
         self.criteria = criteria
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.evaluation_steps = evaluation_steps
         self.threshold = 1 if strict_mode else threshold

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -12,9 +12,10 @@ from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.metrics.hallucination.template import HallucinationTemplate
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.telemetry import capture_metric_type
 
@@ -40,12 +41,7 @@ class HallucinationMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 0 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.async_mode = async_mode

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -6,8 +6,9 @@ from deepeval.metrics import BaseConversationalMetric
 from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
+    initialize_model,
 )
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.knowledge_retention.template import (
     KnowledgeRetentionTemplate,
 )
@@ -34,12 +35,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.strict_mode = strict_mode

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -9,12 +9,13 @@ from deepeval.test_case import (
     ConversationalTestCase,
 )
 from deepeval.metrics import BaseMetric
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.utils import get_or_create_event_loop
 from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.metrics.summarization.template import SummarizationTemplate
 from deepeval.metrics.faithfulness.template import FaithfulnessTemplate
@@ -56,12 +57,7 @@ class SummarizationMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
 
         if assessment_questions is not None and len(assessment_questions) == 0:

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -9,12 +9,13 @@ from deepeval.test_case import (
 )
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.telemetry import capture_metric_type
-from deepeval.models import GPTModel, DeepEvalBaseLLM
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.utils import get_or_create_event_loop
 from deepeval.metrics.utils import (
     validate_conversational_test_case,
     trimAndLoadJson,
     check_llm_test_case_params,
+    initialize_model,
 )
 from deepeval.metrics.bias.template import BiasTemplate
 from deepeval.metrics.toxicity.template import ToxicityTemplate
@@ -41,12 +42,7 @@ class ToxicityMetric(BaseMetric):
         strict_mode: bool = False,
     ):
         self.threshold = 0 if strict_mode else threshold
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
         self.include_reason = include_reason
         self.async_mode = async_mode

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -14,7 +14,7 @@ def validate_conversational_test_case(
     test_case: ConversationalTestCase,
     metric: BaseMetric,
 ) -> LLMTestCase:
-    if len(test_case.messages) is 0:
+    if len(test_case.messages) == 0:
         error_str = "'messages' in conversational test case cannot be empty."
         metric.error = error_str
         raise ValueError(error_str)

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Optional, List, Union
+from typing import Any, Optional, List, Union, Tuple
+from deepeval.models import GPTModel, DeepEvalBaseLLM
 
 from deepeval.metrics import BaseMetric
 from deepeval.test_case import (
@@ -62,3 +63,19 @@ def trimAndLoadJson(
         raise ValueError(error_str)
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
+
+
+def initialize_model(
+    model: Optional[Union[str, DeepEvalBaseLLM]] = None,
+) -> Tuple[DeepEvalBaseLLM, bool]:
+    """
+    Returns a tuple of (initialized DeepEvalBaseLLM, using_native_model boolean)
+    """
+    # If model is a GPTModel, it should be deemed as using native model
+    if isinstance(model, GPTModel):
+        return model, True
+    # If model is a DeepEvalBaseLLM but not a GPTModel, we can not assume it is a native model
+    if isinstance(model, DeepEvalBaseLLM):
+        return model, False
+    # Otherwise (the model is a string or None), we initialize a GPTModel and us as a native model
+    return GPTModel(model=model), True

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -77,5 +77,5 @@ def initialize_model(
     # If model is a DeepEvalBaseLLM but not a GPTModel, we can not assume it is a native model
     if isinstance(model, DeepEvalBaseLLM):
         return model, False
-    # Otherwise (the model is a string or None), we initialize a GPTModel and us as a native model
+    # Otherwise (the model is a string or None), we initialize a GPTModel and use as a native model
     return GPTModel(model=model), True

--- a/deepeval/models/gpt_model.py
+++ b/deepeval/models/gpt_model.py
@@ -46,7 +46,10 @@ class GPTModel(DeepEvalBaseLLM):
             model_name = default_gpt_model
 
         self._openai_api_key = _openai_api_key
-        super().__init__(model_name, *args, **kwargs)
+        # args and kwargs will be passed to the underlying model, in load_model function
+        self.args = args
+        self.kwargs = kwargs
+        super().__init__(model_name)
 
     def load_model(self):
         if self.should_use_azure_openai():
@@ -77,10 +80,15 @@ class GPTModel(DeepEvalBaseLLM):
                 azure_endpoint=azure_endpoint,
                 openai_api_key=openai_api_key,
                 model_version=model_version,
+                *self.args,
+                **self.kwargs,
             )
 
         return ChatOpenAI(
-            model_name=self.model_name, openai_api_key=self._openai_api_key
+            model_name=self.model_name,
+            openai_api_key=self._openai_api_key,
+            *self.args,
+            **self.kwargs,
         )
 
     @retry(

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -11,12 +11,9 @@ import math
 
 from deepeval.synthesizer.template import EvolutionTemplate, SynthesizerTemplate
 from deepeval.synthesizer.context_generator import ContextGenerator
-from deepeval.models import (
-    GPTModel,
-    DeepEvalBaseLLM,
-)
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.progress_context import synthesizer_progress_context
-from deepeval.metrics.utils import trimAndLoadJson
+from deepeval.metrics.utils import trimAndLoadJson, initialize_model
 from deepeval.dataset.golden import Golden
 
 valid_file_types = ["csv", "json"]
@@ -33,12 +30,7 @@ class Synthesizer:
         # embedder: Optional[Union[str, DeepEvalBaseEmbeddingModel]] = None,
         multithreading: bool = True,
     ):
-        if isinstance(model, DeepEvalBaseLLM):
-            self.using_native_model = False
-            self.model = model
-        else:
-            self.using_native_model = True
-            self.model = GPTModel(model=model)
+        self.model, self.using_native_model = initialize_model(model)
 
         # self.embedder = embedder
         self.generator_model = self.model.get_model_name()


### PR DESCRIPTION
# Why 
In many cases during our evaluation, we want the evaluation results to be deterministic and reproducible, e.g., through passing `temperature=0` and a fixed `seed` to the model. This is not currently easily achievable using the vanilla `GPTModel` interface -- cutting out a custom model class could help unblock, but in that way 1) it's an overhead anyways, 2) also we'll lose all the benefits using a native model (cost reporting, logprob based g-eval, etc.).

# What
1. We actually already have `*args, **kwargs` placeholders in GPTModel's init function but they are unused currently. This PR just enables us to utilize them.
2. Also updating the native model checking logic, by honoring any GPTModel as a native model
3. Deduplicate the model initialization and native model checking logic by introducing a shared util function, for easier maintenance.
