### PR TITLE
sentence -> reason to work with templates

### DIFF
--- a/deepeval/metrics/contextual_relevancy/template.py
+++ b/deepeval/metrics/contextual_relevancy/template.py
@@ -38,7 +38,7 @@ Example Input: "When what was some of Einstein's achievements?"
 Example:
 {{
     "verdict": "no",
-    "sentence": "Although the context contains information about Einstein winning the Nobel Prize, it irrelevantly includes 'There was a cat' when it has nothing to do with Einstein's achievements."
+    "reason": "Although the context contains information about Einstein winning the Nobel Prize, it irrelevantly includes 'There was a cat' when it has nothing to do with Einstein's achievements."
 }}
 **
 


### PR DESCRIPTION
Simple change but precision and recall call for "reason" (and so does the actual chat template text for relevancy). The original example should work fine on its own but if you define a chat template to provide structed json to work for all 3 metrics, it breaks on relevancy due to example asking for "sentence" instead of "reason" thus confusing the model with conflicting instructions.