### PR TITLE
Remove "input" argument requirement for Faithfulness metric

### DIFF
--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -1,27 +1,27 @@
-from typing import List, Optional, Union
-from pydantic import BaseModel, Field
 import asyncio
+from typing import List, Optional, Union
 
-from deepeval.test_case import (
-    LLMTestCase,
-    LLMTestCaseParams,
-    ConversationalTestCase,
-)
+from pydantic import BaseModel, Field
+
 from deepeval.metrics import BaseMetric
-from deepeval.utils import get_or_create_event_loop
-from deepeval.metrics.utils import (
-    validate_conversational_test_case,
-    trimAndLoadJson,
-    check_llm_test_case_params,
-    initialize_model,
-)
-from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.faithfulness.template import FaithfulnessTemplate
 from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.utils import (
+    check_llm_test_case_params,
+    initialize_model,
+    trimAndLoadJson,
+    validate_conversational_test_case,
+)
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.telemetry import capture_metric_type
+from deepeval.test_case import (
+    ConversationalTestCase,
+    LLMTestCase,
+    LLMTestCaseParams,
+)
+from deepeval.utils import get_or_create_event_loop
 
 required_params: List[LLMTestCaseParams] = [
-    LLMTestCaseParams.INPUT,
     LLMTestCaseParams.ACTUAL_OUTPUT,
     LLMTestCaseParams.RETRIEVAL_CONTEXT,
 ]
@@ -48,9 +48,7 @@ class FaithfulnessMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
 
-    def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
-    ) -> float:
+    def measure(self, test_case: Union[LLMTestCase, ConversationalTestCase]) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
         check_llm_test_case_params(test_case, required_params, self)

--- a/docs/docs/metrics-faithfulness.mdx
+++ b/docs/docs/metrics-faithfulness.mdx
@@ -16,7 +16,6 @@ Although similar to the `HallucinationMetric`, the faithfulness metric in `deepe
 
 To use the `FaithfulnessMetric`, you'll have to provide the following arguments when creating an `LLMTestCase`:
 
-- `input`
 - `actual_output`
 - `retrieval_context`
 
@@ -39,7 +38,6 @@ metric = FaithfulnessMetric(
     include_reason=True
 )
 test_case = LLMTestCase(
-    input="What if these shoes don't fit?",
     actual_output=actual_output,
     retrieval_context=retrieval_context
 )


### PR DESCRIPTION
The definition of the Faithfulness metric does not depend on Input.  I have checked the implementation code and prompts; the prompts do not appear to use input either.  Removing Input allows this metric to be used in contexts where I just want to check the claims from an output against a context (e.g. compare claims in actual output against claims from retrieval context).