### PR TITLE
Add function to show pass rates across all TestResult's 

### DIFF
--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -506,7 +506,7 @@ def print_test_result(test_result: TestResult):
 
 
 
-def aggregate_metric_pass_rates(test_results: List[TestResult]):
+def aggregate_metric_pass_rates(test_results: List[TestResult]) -> dict:
     metric_counts = {}
     metric_successes = {}
 

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -9,7 +9,7 @@ from deepeval.utils import (
     should_ignore_errors,
     should_use_cache,
 )
-from deepeval.telemetry import capture_evaluation_count
+from deepeval.telemetry import capture_evaluation_run
 from deepeval.metrics import BaseMetric
 from deepeval.metrics.indicator import (
     measure_metrics_with_indicator,
@@ -130,7 +130,9 @@ def create_api_test_case(
         )
     elif isinstance(test_case, ConversationalTestCase):
         return ConversationalApiTestCase(
-            name=os.getenv(PYTEST_RUN_TEST_NAME, f"conversational_test_case_{index}"),
+            name=os.getenv(
+                PYTEST_RUN_TEST_NAME, f"conversational_test_case_{index}"
+            ),
             success=True,
             metricsMetadata=None,
             runDuration=0,
@@ -161,98 +163,105 @@ def execute_test_cases(
     test_run_manager.save_to_disk = save_to_disk
     test_run = test_run_manager.get_test_run()
     for index, test_case in enumerate(test_cases):
-        if isinstance(test_case, ConversationalTestCase):
-            last_message_index = len(test_case.messages) - 1
-        else:
-            last_message_index = -1
-
-        cached_test_case = None
-        if use_cache and isinstance(
-            test_case, LLMTestCase
-        ):  # for now, don't use cache when it is a conversation
-            cached_test_case = test_run_cache_manager.get_cached_test_case(
-                test_case, test_run.hyperparameters
-            )
-
-        ##### Metric Calculation #####
-        # this can be a converational api or llm api test case
-        api_test_case = create_api_test_case(test_case, index)
-        new_cached_test_case: CachedTestCase = CachedTestCase()
-        test_start_time = time.perf_counter()
-
-        for metric in metrics:
-            metric_metadata = None
-            # cached_tet_case will always be false for conversationals
-            if cached_test_case is not None:
-                cached_metric_data = Cache.get_metric_data(metric, cached_test_case)
-                if cached_metric_data:
-                    metric_metadata = cached_metric_data.metric_metadata
-
-            # metric_metadata will always be false for conversationals
-            if metric_metadata is None:
-                metric.async_mode = False  # Override metric async
-                try:
-                    # if conversational, manually extract the last one for now
-                    # In the future, might add support for evaluating any message in a convo
-                    if isinstance(test_case, ConversationalTestCase):
-                        tc = test_case.messages[last_message_index]
-                    else:
-                        tc = test_case
-                    metric.measure(tc)
-                except Exception as e:
-                    if ignore_errors:
-                        metric.error = str(e)  # Override metric error
-                        metric.success = False  # Override metric success
-                    else:
-                        raise
-                metric_metadata = create_metric_metadata(metric)
-
+        with capture_evaluation_run("test case"):
             if isinstance(test_case, ConversationalTestCase):
-                # the index can be dynamic in the future, just not now
-                api_test_case.update(metric_metadata, last_message_index)
+                last_message_index = len(test_case.messages) - 1
             else:
-                api_test_case.update(metric_metadata)
+                last_message_index = -1
 
-            if metric.error is None and isinstance(
+            cached_test_case = None
+            if use_cache and isinstance(
                 test_case, LLMTestCase
-            ):  # Only save to cache if metric didn't error and not conversational
-                cache_metric_metadata = create_metric_metadata(metric)
-                cache_metric_metadata.evaluation_cost = (
-                    0  # Create copy and save 0 for cost
-                )
-                updated_cached_metric_data = CachedMetricData(
-                    metric_metadata=cache_metric_metadata,
-                    metric_configuration=Cache.create_metric_configuration(metric),
-                )
-                new_cached_test_case.cached_metrics_data.append(
-                    updated_cached_metric_data
+            ):  # for now, don't use cache when it is a conversation
+                cached_test_case = test_run_cache_manager.get_cached_test_case(
+                    test_case, test_run.hyperparameters
                 )
 
-        test_end_time = time.perf_counter()
-        run_duration = test_end_time - test_start_time
-        api_test_case.run_duration = run_duration
+            ##### Metric Calculation #####
+            # this can be a converational api or llm api test case
+            api_test_case = create_api_test_case(test_case, index)
+            new_cached_test_case: CachedTestCase = CachedTestCase()
+            test_start_time = time.perf_counter()
 
-        ### Update Test Run ###
-        test_run_manager.update_test_run(api_test_case, test_case)
+            for metric in metrics:
+                metric_metadata = None
+                # cached_tet_case will always be false for conversationals
+                if cached_test_case is not None:
+                    cached_metric_data = Cache.get_metric_data(
+                        metric, cached_test_case
+                    )
+                    if cached_metric_data:
+                        metric_metadata = cached_metric_data.metric_metadata
 
-        ### Cache Test Run ###
-        if isinstance(test_case, LLMTestCase):  # only cache if not conversational
-            test_run_cache_manager.cache_test_case(
-                test_case,
-                new_cached_test_case,
-                test_run.hyperparameters,
+                # metric_metadata will always be false for conversationals
+                if metric_metadata is None:
+                    metric.async_mode = False  # Override metric async
+                    try:
+                        # if conversational, manually extract the last one for now
+                        # In the future, might add support for evaluating any message in a convo
+                        if isinstance(test_case, ConversationalTestCase):
+                            tc = test_case.messages[last_message_index]
+                        else:
+                            tc = test_case
+                        metric.measure(tc)
+                    except Exception as e:
+                        if ignore_errors:
+                            metric.error = str(e)  # Override metric error
+                            metric.success = False  # Override metric success
+                        else:
+                            raise
+                    metric_metadata = create_metric_metadata(metric)
+
+                if isinstance(test_case, ConversationalTestCase):
+                    # the index can be dynamic in the future, just not now
+                    api_test_case.update(metric_metadata, last_message_index)
+                else:
+                    api_test_case.update(metric_metadata)
+
+                if metric.error is None and isinstance(
+                    test_case, LLMTestCase
+                ):  # Only save to cache if metric didn't error and not conversational
+                    cache_metric_metadata = create_metric_metadata(metric)
+                    cache_metric_metadata.evaluation_cost = (
+                        0  # Create copy and save 0 for cost
+                    )
+                    updated_cached_metric_data = CachedMetricData(
+                        metric_metadata=cache_metric_metadata,
+                        metric_configuration=Cache.create_metric_configuration(
+                            metric
+                        ),
+                    )
+                    new_cached_test_case.cached_metrics_data.append(
+                        updated_cached_metric_data
+                    )
+
+            test_end_time = time.perf_counter()
+            run_duration = test_end_time - test_start_time
+            api_test_case.run_duration = run_duration
+
+            ### Update Test Run ###
+            test_run_manager.update_test_run(api_test_case, test_case)
+
+            ### Cache Test Run ###
+            if isinstance(
+                test_case, LLMTestCase
+            ):  # only cache if not conversational
+                test_run_cache_manager.cache_test_case(
+                    test_case,
+                    new_cached_test_case,
+                    test_run.hyperparameters,
+                )
+                test_run_cache_manager.cache_test_case(
+                    test_case,
+                    new_cached_test_case,
+                    test_run.hyperparameters,
+                    to_temp=True,
+                )
+
+            test_result = create_test_result(
+                api_test_case, drop_and_copy(metrics, ["model", "embeddings"])
             )
-            test_run_cache_manager.cache_test_case(
-                test_case,
-                new_cached_test_case,
-                test_run.hyperparameters,
-                to_temp=True,
-            )
-
-        test_result = create_test_result(
-            api_test_case, drop_and_copy(metrics, ["model", "embeddings"])
-        )
-        test_results.append(test_result)
+            test_results.append(test_result)
 
     return test_results
 
@@ -269,72 +278,79 @@ async def a_execute_test_cases(
     test_run_manager.save_to_disk = save_to_disk
     test_run = test_run_manager.get_test_run()
     for index, test_case in enumerate(test_cases):
-        cached_test_case = None
-        # only use cache when NOT conversational test case
-        if use_cache and isinstance(test_case, LLMTestCase):
-            cached_test_case = test_run_cache_manager.get_cached_test_case(
-                test_case,
-                test_run.hyperparameters,
+        with capture_evaluation_run("test case"):
+            cached_test_case = None
+            # only use cache when NOT conversational test case
+            if use_cache and isinstance(test_case, LLMTestCase):
+                cached_test_case = test_run_cache_manager.get_cached_test_case(
+                    test_case,
+                    test_run.hyperparameters,
+                )
+
+            ##### Metric Calculation #####
+            # api test case can be conversational
+            api_test_case = create_api_test_case(test_case, index)
+
+            new_cached_test_case: CachedTestCase = CachedTestCase()
+            test_start_time = time.perf_counter()
+            await measure_metrics_with_indicator(
+                metrics, test_case, cached_test_case, ignore_errors
             )
+            for metric in metrics:
+                metric_metadata = create_metric_metadata(metric)
 
-        ##### Metric Calculation #####
-        # api test case can be conversational
-        api_test_case = create_api_test_case(test_case, index)
+                if isinstance(test_case, ConversationalTestCase):
+                    # index hardcoded as the last message for now
+                    api_test_case.update(
+                        metric_metadata, len(test_case.messages) - 1
+                    )
+                else:
+                    api_test_case.update(metric_metadata)
 
-        new_cached_test_case: CachedTestCase = CachedTestCase()
-        test_start_time = time.perf_counter()
-        await measure_metrics_with_indicator(
-            metrics, test_case, cached_test_case, ignore_errors
-        )
-        for metric in metrics:
-            metric_metadata = create_metric_metadata(metric)
+                if metric.error is None and isinstance(
+                    test_case, LLMTestCase
+                ):  # Only save to cache if metric didn't error AND is not conversational
+                    cache_metric_metadata = create_metric_metadata(metric)
+                    cache_metric_metadata.evaluation_cost = (
+                        0  # Create new copy and save 0 for cost
+                    )
+                    updated_cached_metric_data = CachedMetricData(
+                        metric_metadata=cache_metric_metadata,
+                        metric_configuration=Cache.create_metric_configuration(
+                            metric
+                        ),
+                    )
+                    new_cached_test_case.cached_metrics_data.append(
+                        updated_cached_metric_data
+                    )
 
-            if isinstance(test_case, ConversationalTestCase):
-                # index hardcoded as the last message for now
-                api_test_case.update(metric_metadata, len(test_case.messages) - 1)
-            else:
-                api_test_case.update(metric_metadata)
+            test_end_time = time.perf_counter()
+            run_duration = test_end_time - test_start_time
+            api_test_case.run_duration = run_duration
 
-            if metric.error is None and isinstance(
+            ### Update Test Run ###
+            test_run_manager.update_test_run(api_test_case, test_case)
+
+            ### Cache Test Run ###
+            if isinstance(
                 test_case, LLMTestCase
-            ):  # Only save to cache if metric didn't error AND is not conversational
-                cache_metric_metadata = create_metric_metadata(metric)
-                cache_metric_metadata.evaluation_cost = (
-                    0  # Create new copy and save 0 for cost
+            ):  # only cache if not conversational
+                test_run_cache_manager.cache_test_case(
+                    test_case,
+                    new_cached_test_case,
+                    test_run.hyperparameters,
                 )
-                updated_cached_metric_data = CachedMetricData(
-                    metric_metadata=cache_metric_metadata,
-                    metric_configuration=Cache.create_metric_configuration(metric),
-                )
-                new_cached_test_case.cached_metrics_data.append(
-                    updated_cached_metric_data
+                test_run_cache_manager.cache_test_case(
+                    test_case,
+                    new_cached_test_case,
+                    test_run.hyperparameters,
+                    to_temp=True,
                 )
 
-        test_end_time = time.perf_counter()
-        run_duration = test_end_time - test_start_time
-        api_test_case.run_duration = run_duration
-
-        ### Update Test Run ###
-        test_run_manager.update_test_run(api_test_case, test_case)
-
-        ### Cache Test Run ###
-        if isinstance(test_case, LLMTestCase):  # only cache if not conversational
-            test_run_cache_manager.cache_test_case(
-                test_case,
-                new_cached_test_case,
-                test_run.hyperparameters,
+            test_result = create_test_result(
+                api_test_case, drop_and_copy(metrics, ["model", "embeddings"])
             )
-            test_run_cache_manager.cache_test_case(
-                test_case,
-                new_cached_test_case,
-                test_run.hyperparameters,
-                to_temp=True,
-            )
-
-        test_result = create_test_result(
-            api_test_case, drop_and_copy(metrics, ["model", "embeddings"])
-        )
-        test_results.append(test_result)
+            test_results.append(test_result)
 
     return test_results
 
@@ -344,6 +360,7 @@ def assert_test(
     metrics: List[BaseMetric],
     run_async: bool = True,
 ):
+
     # TODO: keep this for now, blocking conversational metrics like KR
     for metric in metrics:
         if not isinstance(metric, BaseMetric):
@@ -415,27 +432,28 @@ def evaluate(
     start_time = time.perf_counter()
     if print_results:
         print("Evaluating test cases...")
-    if run_async:
-        loop = get_or_create_event_loop()
-        test_results = loop.run_until_complete(
-            a_execute_test_cases(
+
+    with capture_evaluation_run("evaluate()"):
+        if run_async:
+            loop = get_or_create_event_loop()
+            test_results = loop.run_until_complete(
+                a_execute_test_cases(
+                    test_cases,
+                    metrics,
+                    ignore_errors=ignore_errors,
+                    use_cache=use_cache,
+                    save_to_disk=write_cache,
+                )
+            )
+        else:
+            test_results = execute_test_cases(
                 test_cases,
                 metrics,
                 ignore_errors=ignore_errors,
                 use_cache=use_cache,
                 save_to_disk=write_cache,
             )
-        )
-    else:
-        test_results = execute_test_cases(
-            test_cases,
-            metrics,
-            ignore_errors=ignore_errors,
-            use_cache=use_cache,
-            save_to_disk=write_cache,
-        )
 
-    capture_evaluation_count()
     end_time = time.perf_counter()
     run_duration = end_time - start_time
     if print_results:
@@ -487,6 +505,7 @@ def print_test_result(test_result: TestResult):
     print(f"  - retrieval context: {test_result.retrieval_context}")
 
 
+
 def aggregate_metric_pass_rates(test_results: List[TestResult]):
     metric_counts = {}
     metric_successes = {}
@@ -513,3 +532,4 @@ def aggregate_metric_pass_rates(test_results: List[TestResult]):
     print("\n" + "=" * 70 + "\n")
 
     return metric_pass_rates
+

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -505,7 +505,6 @@ def print_test_result(test_result: TestResult):
     print(f"  - retrieval context: {test_result.retrieval_context}")
 
 
-
 def aggregate_metric_pass_rates(test_results: List[TestResult]) -> dict:
     metric_counts = {}
     metric_successes = {}

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -10,17 +10,49 @@ from deepeval.evaluate import aggregate_metric_pass_rates, TestResult
 from deepeval.metrics import AnswerRelevancyMetric, BiasMetric
 
 
-class StubMetric(BaseMetric):
-    def __init__(self, _success: bool, _name: str):
+class FakeMetric1(BaseMetric):
+    def __init__(self, threshold: float = 0.5, _success: bool = True):
+        self.threshold = threshold
         self.success = _success
-        self.name = _name
+
+    def measure(self, test_case: LLMTestCase):
+        self.reason = "This metric looking good!"
+        return self.score
+
+    async def a_measure(self, test_case: LLMTestCase):
+        self.score = 0.5
+        self.reason = "This async metric looking good!"
+        return self.score
 
     def is_successful(self):
         return self.success
 
     @property
     def __name__(self):
-        return self.name
+        return "Fake"
+
+
+class FakeMetric2(BaseMetric):
+    def __init__(self, threshold: float = 0.5, _success: bool = True):
+        self.threshold = threshold
+        self.success = _success
+
+    def measure(self, test_case: LLMTestCase):
+        self.score = 0.5
+        self.reason = "This metric looking good!"
+        return self.score
+
+    async def a_measure(self, test_case: LLMTestCase):
+        self.score = 0.5
+        self.reason = "This async metric looking good!"
+        return self.score
+
+    def is_successful(self):
+        return self.success
+
+    @property
+    def __name__(self):
+        return "Fake"
 
 
 def test_create_dataset():
@@ -42,21 +74,35 @@ def test_create_dataset():
     dataset.add_test_cases_from_json_file(
         file_path,
         input_key_name="query",
-        actual_output_key_name="actual_output",
         expected_output_key_name="expected_output",
         context_key_name="context",
         retrieval_context_key_name="retrieval",
+        actual_output_key_name="actual_output",
     )
     assert len(dataset.test_cases) == 10, "Test Cases not loaded from JSON"
 
 
 def test_aggregate_metric_pass_rates():
+    test_case = LLMTestCase(
+        input="What is the primary difference between a comet and an asteroid?",
+        actual_output="Comets and asteroids are both celestial bodies found in our solar system but differ in composition and behavior. Comets, made up of ice, dust, and small rocky particles, develop glowing comas and tails when near the Sun. In contrast, asteroids are primarily rocky or metallic and are mostly found in the asteroid belt between Mars and Jupiter. Rabbits are found in the wild.",
+        expected_output="Comets and asteroids are both celestial bodies found in our solar system but differ in composition and behavior. Comets, made up of ice, dust, and small rocky particles, develop glowing comas and tails when near the Sun. In contrast, asteroids are primarily rocky or metallic and are mostly found in the asteroid belt between Mars and Jupiter. Rabbits are found in the wild.",
+    )
+    fake_metric_1_fail = FakeMetric1(_success=False)
+    fake_metric_2_fail = FakeMetric2()
+    fake_metric_1_fail.measure(test_case=test_case)
+    fake_metric_2_fail.measure(test_case=test_case)
+
+    fake_metric_1_pass = FakeMetric1()
+    fake_metric_2_pass = FakeMetric2()
+    fake_metric_1_pass.measure(test_case=test_case)
+    fake_metric_2_pass.measure(test_case=test_case)
     test_results = [
         TestResult(
-            success=True,
+            success=False,
             metrics=[
-                StubMetric(_success=True, _name="AnswerRelevancyMetric"),
-                StubMetric(_success=True, _name="BiasMetric"),
+                fake_metric_1_fail,
+                fake_metric_2_fail,
             ],
             input="some input",
             actual_output="some output",
@@ -67,8 +113,8 @@ def test_aggregate_metric_pass_rates():
         TestResult(
             success=True,
             metrics=[
-                StubMetric(_success=False, _name="AnswerRelevancyMetric"),
-                StubMetric(_success=True, _name="BiasMetric"),
+                fake_metric_1_pass,
+                fake_metric_2_pass,
             ],
             input="another input",
             actual_output="another output",
@@ -78,8 +124,6 @@ def test_aggregate_metric_pass_rates():
         ),
     ]
 
-    expected_result = {"AnswerRelevancyMetric": 0.5, "BiasMetric": 1.0}
+    expected_result = {"FakeMetric1": 0.5, "FakeMetric2": 1.0}
     result = aggregate_metric_pass_rates(test_results)
-    assert (
-        result == expected_result
-    ), "The aggregate metric pass rates do not match the expected values."
+    assert result == expected_result


### PR DESCRIPTION
# Background
When working on evaluations for LLM-powered applications we use evaluation metrics to give us an understanding of how well the LLM system performs on a particular tasks. For example, if we were using an LLM to peform text summarization we can leverage another stronger LLMs in order to evaluate summaries more effectively compared to traditional metrics such as ROUGE, MoverScore, BERTScore, etc. using new metrics such as G-Eval which have shown to have a high Spearman correlation with human judgements. 

# Problem Statement
One issue I have right now is that when I run evaluations using metrics such as G-Eval is that it and similar metrics produce metric scores on a singular input and not across an entire evaluation dataset. 

For example running a couple metrics across an evaluation dataset:
```python
from deepeval import evaluate
from deepeval import assert_test
from deepeval.metrics import AnswerRelevancyMetric, BiasMetric

answer_relevancy_metric = AnswerRelevancyMetric(threshold=0.5)
hallucination_metric = metric = BiasMetric(threshold=0.5)

results = evaluate(dataset, [answer_relevancy_metric, hallucination_metric])
```
Outputs the following:
```python
======================================================================

Metrics Summary

  - ✅ Answer Relevancy (score: 1, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 1.00 because the response perfectly addresses the question about operating hours without any irrelevant information. Great job!, error: None)
  - ✅ Bias (score: 0, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 0.00 because the output maintains neutrality and objectivity, as evidenced by the absence of any cited biased phrases or issues., error: None)

For test case:

  - input: What are your operating hours?
  - actual output: ...
  - expected output: None
  - context: ['Our company operates from 10 AM to 6 PM, Monday to Friday.', 'We are closed on weekends and public holidays.', 'Our customer service is available 24/7.']
  - retrieval context: None

======================================================================

Metrics Summary

  - ✅ Answer Relevancy (score: 1, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 1.00 because the response accurately addresses the question about free shipping without any irrelevant information. Great job on maintaining focus!, error: None)
  - ✅ Bias (score: 0, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 0.00 because the actual output perfectly demonstrates neutrality and objectivity, without any indication of bias., error: None)

For test case:

  - input: Do you offer free shipping?
  - actual output: ...
  - expected output: Yes, we offer free shipping on orders over $50.
  - context: None
  - retrieval context: None

======================================================================
```
Each run of the evaluation on the evaluation dataset using the metrics with changes to the model, prompt, etc. would require a singular value in order to determine whether the LLM-powered application is improving or not compared to a prior run. This is very much like how evaluation runs within traditional machine learning, where if you are working on a fraud detection model would expect a challenger model to perform better than a champion model on metrics such as F1 score. One thing I am leaving out here is the importance of slice-based evaluation such as performance of the fraud detection model on different user groups, perhaps this is up for a separate conversation. 

# Solution
Incorporate the concept of pass rates as an additional layer to be run on the test results from the evaluation. Using the newly added function `aggregate_metric_pass_rates()`, we can gather the following evaluation results:
```python
======================================================================

Aggregate Metric Pass Rates

AnswerRelevancyMetric: 100.00% pass rate
BiasMetric: 100.00% pass rate

======================================================================

{'AnswerRelevancyMetric': 1.0, 'BiasMetric': 1.0}
```
## Benefits
1. I as user am able to easily understand whether my iterations are improving on key evaluation metrics
2. `aggregate_metric_pass_rates()` returns a dict of the `metrics -> pass_rate_score` meaning we can store and compare different iterations programmatically. 
```python
dataset_run_1 = EvaluationDataset(test_cases=[...])
dataset_run_2 = EvaluationDataset(test_cases=[...])

evaluation_results_run_1 = evaluate(dataset_run_1, [answer_relevancy_metric])
aggregate_metric_pass_rates(evaluation_results_run_1)

evaluation_results_run_1 = evaluate(dataset_run_1, [answer_relevancy_metric])
aggregate_metric_pass_rates(evaluation_results_run_1)

assert evaluation_results_run_2.get('AnswerRelevancyMetric') > evaluation_results_run_1.get('AnswerRelevancyMetric'), "Run 2 does not perform better than Run 1"
```