### PR TITLE
 Add function to show pass rates across all TestResult's

### DIFF
--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -130,7 +130,9 @@ def create_api_test_case(
         )
     elif isinstance(test_case, ConversationalTestCase):
         return ConversationalApiTestCase(
-            name=os.getenv(PYTEST_RUN_TEST_NAME, f"conversational_test_case_{index}"),
+            name=os.getenv(
+                PYTEST_RUN_TEST_NAME, f"conversational_test_case_{index}"
+            ),
             success=True,
             metricsMetadata=None,
             runDuration=0,
@@ -185,7 +187,9 @@ def execute_test_cases(
                 metric_metadata = None
                 # cached_tet_case will always be false for conversationals
                 if cached_test_case is not None:
-                    cached_metric_data = Cache.get_metric_data(metric, cached_test_case)
+                    cached_metric_data = Cache.get_metric_data(
+                        metric, cached_test_case
+                    )
                     if cached_metric_data:
                         metric_metadata = cached_metric_data.metric_metadata
 
@@ -223,7 +227,9 @@ def execute_test_cases(
                     )
                     updated_cached_metric_data = CachedMetricData(
                         metric_metadata=cache_metric_metadata,
-                        metric_configuration=Cache.create_metric_configuration(metric),
+                        metric_configuration=Cache.create_metric_configuration(
+                            metric
+                        ),
                     )
                     new_cached_test_case.cached_metrics_data.append(
                         updated_cached_metric_data
@@ -237,7 +243,9 @@ def execute_test_cases(
             test_run_manager.update_test_run(api_test_case, test_case)
 
             ### Cache Test Run ###
-            if isinstance(test_case, LLMTestCase):  # only cache if not conversational
+            if isinstance(
+                test_case, LLMTestCase
+            ):  # only cache if not conversational
                 test_run_cache_manager.cache_test_case(
                     test_case,
                     new_cached_test_case,
@@ -293,12 +301,14 @@ async def a_execute_test_cases(
 
                 if isinstance(test_case, ConversationalTestCase):
                     # index hardcoded as the last message for now
-                    api_test_case.update(metric_metadata, len(test_case.messages) - 1)
+                    api_test_case.update(
+                        metric_metadata, len(test_case.messages) - 1
+                    )
                 else:
                     api_test_case.update(metric_metadata)
 
-                if (
-                    metric.error is None and isinstance(test_case, LLMTestCase)
+                if metric.error is None and isinstance(
+                    test_case, LLMTestCase
                 ):  # Only save to cache if metric didn't error AND is not conversational
                     cache_metric_metadata = create_metric_metadata(metric)
                     cache_metric_metadata.evaluation_cost = (
@@ -306,7 +316,9 @@ async def a_execute_test_cases(
                     )
                     updated_cached_metric_data = CachedMetricData(
                         metric_metadata=cache_metric_metadata,
-                        metric_configuration=Cache.create_metric_configuration(metric),
+                        metric_configuration=Cache.create_metric_configuration(
+                            metric
+                        ),
                     )
                     new_cached_test_case.cached_metrics_data.append(
                         updated_cached_metric_data
@@ -320,7 +332,9 @@ async def a_execute_test_cases(
             test_run_manager.update_test_run(api_test_case, test_case)
 
             ### Cache Test Run ###
-            if isinstance(test_case, LLMTestCase):  # only cache if not conversational
+            if isinstance(
+                test_case, LLMTestCase
+            ):  # only cache if not conversational
                 test_run_cache_manager.cache_test_case(
                     test_case,
                     new_cached_test_case,

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -130,9 +130,7 @@ def create_api_test_case(
         )
     elif isinstance(test_case, ConversationalTestCase):
         return ConversationalApiTestCase(
-            name=os.getenv(
-                PYTEST_RUN_TEST_NAME, f"conversational_test_case_{index}"
-            ),
+            name=os.getenv(PYTEST_RUN_TEST_NAME, f"conversational_test_case_{index}"),
             success=True,
             metricsMetadata=None,
             runDuration=0,
@@ -187,9 +185,7 @@ def execute_test_cases(
                 metric_metadata = None
                 # cached_tet_case will always be false for conversationals
                 if cached_test_case is not None:
-                    cached_metric_data = Cache.get_metric_data(
-                        metric, cached_test_case
-                    )
+                    cached_metric_data = Cache.get_metric_data(metric, cached_test_case)
                     if cached_metric_data:
                         metric_metadata = cached_metric_data.metric_metadata
 
@@ -227,9 +223,7 @@ def execute_test_cases(
                     )
                     updated_cached_metric_data = CachedMetricData(
                         metric_metadata=cache_metric_metadata,
-                        metric_configuration=Cache.create_metric_configuration(
-                            metric
-                        ),
+                        metric_configuration=Cache.create_metric_configuration(metric),
                     )
                     new_cached_test_case.cached_metrics_data.append(
                         updated_cached_metric_data
@@ -243,9 +237,7 @@ def execute_test_cases(
             test_run_manager.update_test_run(api_test_case, test_case)
 
             ### Cache Test Run ###
-            if isinstance(
-                test_case, LLMTestCase
-            ):  # only cache if not conversational
+            if isinstance(test_case, LLMTestCase):  # only cache if not conversational
                 test_run_cache_manager.cache_test_case(
                     test_case,
                     new_cached_test_case,
@@ -301,14 +293,12 @@ async def a_execute_test_cases(
 
                 if isinstance(test_case, ConversationalTestCase):
                     # index hardcoded as the last message for now
-                    api_test_case.update(
-                        metric_metadata, len(test_case.messages) - 1
-                    )
+                    api_test_case.update(metric_metadata, len(test_case.messages) - 1)
                 else:
                     api_test_case.update(metric_metadata)
 
-                if metric.error is None and isinstance(
-                    test_case, LLMTestCase
+                if (
+                    metric.error is None and isinstance(test_case, LLMTestCase)
                 ):  # Only save to cache if metric didn't error AND is not conversational
                     cache_metric_metadata = create_metric_metadata(metric)
                     cache_metric_metadata.evaluation_cost = (
@@ -316,9 +306,7 @@ async def a_execute_test_cases(
                     )
                     updated_cached_metric_data = CachedMetricData(
                         metric_metadata=cache_metric_metadata,
-                        metric_configuration=Cache.create_metric_configuration(
-                            metric
-                        ),
+                        metric_configuration=Cache.create_metric_configuration(metric),
                     )
                     new_cached_test_case.cached_metrics_data.append(
                         updated_cached_metric_data
@@ -332,9 +320,7 @@ async def a_execute_test_cases(
             test_run_manager.update_test_run(api_test_case, test_case)
 
             ### Cache Test Run ###
-            if isinstance(
-                test_case, LLMTestCase
-            ):  # only cache if not conversational
+            if isinstance(test_case, LLMTestCase):  # only cache if not conversational
                 test_run_cache_manager.cache_test_case(
                     test_case,
                     new_cached_test_case,
@@ -360,7 +346,6 @@ def assert_test(
     metrics: List[BaseMetric],
     run_async: bool = True,
 ):
-
     # TODO: keep this for now, blocking conversational metrics like KR
     for metric in metrics:
         if not isinstance(metric, BaseMetric):
@@ -503,3 +488,31 @@ def print_test_result(test_result: TestResult):
     print(f"  - expected output: {test_result.expected_output}")
     print(f"  - context: {test_result.context}")
     print(f"  - retrieval context: {test_result.retrieval_context}")
+
+
+def aggregate_metric_pass_rates(test_results: List[TestResult]) -> dict:
+    metric_counts = {}
+    metric_successes = {}
+
+    for result in test_results:
+        for metric in result.metrics:
+            metric_name = metric.__class__.__name__
+            if metric_name not in metric_counts:
+                metric_counts[metric_name] = 0
+                metric_successes[metric_name] = 0
+            metric_counts[metric_name] += 1
+            if metric.success:
+                metric_successes[metric_name] += 1
+
+    metric_pass_rates = {
+        metric: (metric_successes[metric] / metric_counts[metric])
+        for metric in metric_counts
+    }
+
+    print("\n" + "=" * 70 + "\n")
+    print("Aggregate Metric Pass Rates\n")
+    for metric, pass_rate in metric_pass_rates.items():
+        print(f"{metric}: {pass_rate:.2%} pass rate")
+    print("\n" + "=" * 70 + "\n")
+
+    return metric_pass_rates


### PR DESCRIPTION
# Background
  When working on evaluations for LLM-powered applications we use evaluation metrics to give us an understanding of how well the LLM system performs on a particular tasks. For example, if we were using an LLM to peform text summarization we can leverage another stronger LLMs in order to evaluate summaries more effectively compared to traditional metrics such as ROUGE, MoverScore, BERTScore, etc. using new metrics such as G-Eval which have shown to have a high Spearman correlation with human judgements. 
  
  # Problem Statement
  One issue I have right now is that when I run evaluations using metrics such as G-Eval is that it and similar metrics produce metric scores on a singular input and not across an entire evaluation dataset. 
  
  For example running a couple metrics across an evaluation dataset:
  ```python
  from deepeval import evaluate
  from deepeval import assert_test
  from deepeval.metrics import AnswerRelevancyMetric, BiasMetric
  
  answer_relevancy_metric = AnswerRelevancyMetric(threshold=0.5)
  hallucination_metric = metric = BiasMetric(threshold=0.5)
  
  results = evaluate(dataset, [answer_relevancy_metric, hallucination_metric])
  ```
  Outputs the following:
  ```python
  ======================================================================
  
  Metrics Summary
  
    - ✅ Answer Relevancy (score: 1, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 1.00 because the response perfectly addresses the question about operating hours without any irrelevant information. Great job!, error: None)
    - ✅ Bias (score: 0, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 0.00 because the output maintains neutrality and objectivity, as evidenced by the absence of any cited biased phrases or issues., error: None)
  
  For test case:
  
    - input: What are your operating hours?
    - actual output: ...
    - expected output: None
    - context: ['Our company operates from 10 AM to 6 PM, Monday to Friday.', 'We are closed on weekends and public holidays.', 'Our customer service is available 24/7.']
    - retrieval context: None
  
  ======================================================================
  
  Metrics Summary
  
    - ✅ Answer Relevancy (score: 1, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 1.00 because the response accurately addresses the question about free shipping without any irrelevant information. Great job on maintaining focus!, error: None)
    - ✅ Bias (score: 0, threshold: 0.5, strict: False, evaluation model: gpt-4-turbo, reason: The score is 0.00 because the actual output perfectly demonstrates neutrality and objectivity, without any indication of bias., error: None)
  
  For test case:
  
    - input: Do you offer free shipping?
    - actual output: ...
    - expected output: Yes, we offer free shipping on orders over $50.
    - context: None
    - retrieval context: None
  
  ======================================================================
  ```
  Each run of the evaluation on the evaluation dataset using the metrics with changes to the model, prompt, etc. would require a singular value in order to determine whether the LLM-powered application is improving or not compared to a prior run. This is very much like how evaluation runs within traditional machine learning, where if you are working on a fraud detection model would expect a challenger model to perform better than a champion model on metrics such as F1 score. One thing I am leaving out here is the importance of slice-based evaluation such as performance of the fraud detection model on different user groups, perhaps this is up for a separate conversation. 
  
  # Solution
  Incorporate the concept of pass rates as an additional layer to be run on the test results from the evaluation. Using the newly added function `aggregate_metric_pass_rates()`, we can gather the following evaluation results:
  ```python
  ======================================================================
  
  Aggregate Metric Pass Rates
  
  AnswerRelevancyMetric: 100.00% pass rate
  BiasMetric: 100.00% pass rate
  
  ======================================================================
  
  {'AnswerRelevancyMetric': 1.0, 'BiasMetric': 1.0}
  ```
  ## Benefits
  1. I as user am able to easily understand whether my iterations are improving on key evaluation metrics
  2. `aggregate_metric_pass_rates()` returns a dict of the `metrics -> pass_rate_score` meaning we can store and compare different iterations programmatically. 
  ```python
  dataset_run_1 = EvaluationDataset(test_cases=[...])
  dataset_run_2 = EvaluationDataset(test_cases=[...])
  
  evaluation_results_run_1 = evaluate(dataset_run_1, [answer_relevancy_metric])
  aggregate_metric_pass_rates(evaluation_results_run_1)
  
  evaluation_results_run_1 = evaluate(dataset_run_1, [answer_relevancy_metric])
  aggregate_metric_pass_rates(evaluation_results_run_1)
  
  assert evaluation_results_run_2.get('AnswerRelevancyMetric') > evaluation_results_run_1.get('AnswerRelevancyMetric'), "Run 2 does not perform better than Run 1"
  ```