### PR TITLE
docs: fix in custom metric

### DIFF
--- a/docs/docs/metrics-custom.mdx
+++ b/docs/docs/metrics-custom.mdx
@@ -31,7 +31,7 @@ class LatencyMetric(BaseMetric):
 
     def measure(self, test_case: LLMTestCase):
         # Set self.success and self.score in the "measure" method
-        self.success = test_case.latency <= self.threshold
+        self.success = test_case.additional_metadata["latency"] <= self.threshold
         if self.success:
             self.score = 1
         else:
@@ -42,6 +42,9 @@ class LatencyMetric(BaseMetric):
         self.reason = "Too slow!"
         return self.score
 
+    async def a_measure(self, test_case: LLMTestCase):
+        return self.measure(test_case)
+    
     def is_successful(self):
         return self.success
 
@@ -69,6 +72,6 @@ from deepeval.test_case import LLMTestCase
 
 # Note that we pass in latency since the measure method requires it for evaluation
 latency_metric = LatencyMetric(max_seconds=10.0)
-test_case = LLMTestCase(input="...", actual_output="...", latency=8.3)
+test_case = LLMTestCase(input="...", actual_output="...", additional_metadata={"latency": 8.5})
 evaluate([test_case], [latency_metric])
 ```


### PR DESCRIPTION
Slight changes on custom metric documentation 


* [`docs/docs/metrics-custom.mdx`](diffhunk://#diff-80ee84a78e451d1a681f52937c3dd2a7c241361de908c0ebb4088a3c43ede194L34-R34): In the `LatencyMetric` class, the `measure` method now uses `additional_metadata` for latency instead of directly accessing the `latency` attribute. There is a restriction otherwise on the LLMTestCase and the previous input in the class was causing an error.
* [`docs/docs/metrics-custom.mdx`](diffhunk://#diff-80ee84a78e451d1a681f52937c3dd2a7c241361de908c0ebb4088a3c43ede194R45-R47): An asynchronous `a_measure` method was added to the `LatencyMetric` class. This method needs to be defined for the code to execute. It can be replaced with an async function by the user.
* [`docs/docs/metrics-custom.mdx`](diffhunk://#diff-80ee84a78e451d1a681f52937c3dd2a7c241361de908c0ebb4088a3c43ede194L72-R75): The instantiation of `LLMTestCase` was updated to include latency in `additional_metadata`. 