### PR TITLE
Stateless Metrics

### DIFF
--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -283,6 +283,7 @@ async def a_execute_test_cases(
     test_run_cache_manager.disable_write_cache = save_to_disk == False
     test_run_manager.save_to_disk = save_to_disk
     test_run = test_run_manager.get_test_run()
+
     for index, test_case in enumerate(test_cases):
         with capture_evaluation_run("test case"):
             cached_test_case = None

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -405,7 +405,7 @@ def assert_test(
 
         failed_metrics_str = ", ".join(
             [
-                f"{metrics_metadata.__name__} (score: {metrics_metadata.score}, threshold: {metrics_metadata.threshold}, strict: {metrics_metadata.strict_mode}, error: {metrics_metadata.error})"
+                f"{metrics_metadata.metric} (score: {metrics_metadata.score}, threshold: {metrics_metadata.threshold}, strict: {metrics_metadata.strict_mode}, error: {metrics_metadata.error})"
                 for metrics_metadata in failed_metrics_metadata
             ]
         )

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -95,7 +95,7 @@ class AnswerRelevancyMetric(BaseMetric):
                 self.reason = self._generate_reason(test_case.input)
                 self.success = self.score >= self.threshold
                 if verbose:
-                    print(f"statements: {self.statements}\nverdicts: {self.verdicts}")                
+                    print(f"statements: {self.statements}\nverdicts: {self.verdicts}\n")                
                 return self.score
     
     async def _measure_async(
@@ -135,7 +135,7 @@ class AnswerRelevancyMetric(BaseMetric):
             self.reason = await self._a_generate_reason(test_case.input)
             self.success = self.score >= self.threshold
             if verbose:
-                print(f"statements: {self.statements}\nverdicts: {self.verdicts}\nscore: {self.score}, success: {self.success}")
+                print(f"statements: {self.statements}\nverdicts: {self.verdicts}\nscore: {self.score}, success: {self.success}\n")
             return self.score
 
     async def _a_generate_reason(self, input: str) -> str:

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -32,11 +32,7 @@ class AnswerRelvancyVerdict(BaseModel):
 
 class AnswerRelevancyMetric(BaseMetric):
 
-    _statements: ContextVar[Optional[List[str]]] = ContextVar('statements', default=None)
-    _verdicts: ContextVar[Optional[List[AnswerRelvancyVerdict]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
+    
 
     def __init__(
         self,
@@ -46,6 +42,9 @@ class AnswerRelevancyMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._statements: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_statements', default=None)
+        self._verdicts: ContextVar[Optional[List[AnswerRelvancyVerdict]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -66,27 +65,6 @@ class AnswerRelevancyMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List[AnswerRelvancyVerdict]]):
         self._verdicts.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -78,40 +78,22 @@ class AnswerRelevancyMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    statements, 
-                    verdicts, 
-                    score, 
-                    reason, 
-                    success
+                    self.statements, 
+                    self.verdicts, 
+                    self.score, 
+                    self.reason, 
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.statements = statements
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
-
             else:
-                statements: List[str] = self._generate_statements(
+                self.statements = self._generate_statements(
                     test_case.actual_output
                 )
-                self.statements = statements
-
-                verdicts: List[AnswerRelvancyVerdict] = (
-                    self._generate_verdicts(test_case.input)
-                )
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason(test_case.input)
-                self.reason = reason
-
-                success = self.score >= self.threshold
-                self.success = success
-                
+                self.verdicts = self._generate_verdicts(test_case.input)
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason(test_case.input)
+                self.success = self.score >= self.threshold                
                 return self.score
     
     async def _measure_async(
@@ -139,25 +121,15 @@ class AnswerRelevancyMetric(BaseMetric):
         with metric_progress_indicator(
             self, async_mode=True, _show_indicator=_show_indicator
         ):
-            statements: List[str] = await self._a_generate_statements(
+            self.statements = await self._a_generate_statements(
                 test_case.actual_output
             )
-            self.statements = statements
-
-            verdicts: List[AnswerRelvancyVerdict] = (
+            self.verdicts = (
                 await self._a_generate_verdicts(test_case.input)
             )
-            self.verdicts = verdicts
-
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason(test_case.input)
-            self.reason = reason
-
-            success = self.score >= self.threshold
-            self.success = success
-    
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason(test_case.input)
+            self.success = self.score >= self.threshold    
             return self.score
 
     async def _a_generate_reason(self, input: str) -> str:

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -1,3 +1,4 @@
+from contextvars import ContextVar
 from typing import Optional, List, Union
 from pydantic import BaseModel, Field
 
@@ -30,6 +31,13 @@ class AnswerRelvancyVerdict(BaseModel):
 
 
 class AnswerRelevancyMetric(BaseMetric):
+
+    _statements: ContextVar[List[str]] = ContextVar('statements', default=[])
+    _verdicts: ContextVar[List[AnswerRelvancyVerdict]] = ContextVar('verdicts', default=[])
+    _score: ContextVar[float] = ContextVar('score', default=0)
+    _reason: ContextVar[str] = ContextVar('reason', default="")
+    _success: ContextVar[bool] = ContextVar('success', default=False)
+
     def __init__(
         self,
         threshold: float = 0.5,
@@ -44,6 +52,22 @@ class AnswerRelevancyMetric(BaseMetric):
         self.include_reason = include_reason
         self.async_mode = async_mode
         self.strict_mode = strict_mode
+    
+    @property
+    def statements(self) -> List[str]:
+        return self._statements.get()
+    @property
+    def verdicts(self) -> List[AnswerRelvancyVerdict]:
+        return self._verdicts.get()
+    @property
+    def score(self) -> float:
+        return self._score.get()
+    @property
+    def reason(self) -> str:
+        return self._reason.get()
+    @property
+    def success(self) -> str:
+        return self._success.get()
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -56,20 +80,54 @@ class AnswerRelevancyMetric(BaseMetric):
         with metric_progress_indicator(self):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
-                    self.a_measure(test_case, _show_indicator=False)
+                (
+                    statements, 
+                    verdicts, 
+                    score, 
+                    reason, 
+                    success
+                ) = loop.run_until_complete(
+                    self._measure_async(test_case)
                 )
+                self._statements.set(statements)
+                self._verdicts.set(verdicts)
+                self._score.set(score)
+                self._reason.set(reason)
+                self._success.set(success)
+
             else:
-                self.statements: List[str] = self._generate_statements(
+                statements: List[str] = self._generate_statements(
                     test_case.actual_output
                 )
-                self.verdicts: List[AnswerRelvancyVerdict] = (
+                self._statements.set(statements)
+
+                verdicts: List[AnswerRelvancyVerdict] = (
                     self._generate_verdicts(test_case.input)
                 )
-                self.score = self._calculate_score()
-                self.reason = self._generate_reason(test_case.input)
-                self.success = self.score >= self.threshold
+                self._verdicts.set(verdicts)
+
+                score = self._calculate_score()
+                self._score.set(score)
+
+                reason = self._generate_reason(test_case.input)
+                self._reason.set(reason)
+
+                success = self.score >= self.threshold
+                self._success.set(success)
+                
                 return self.score
+    
+    async def _measure_async(
+            self,
+            test_case: Union[LLMTestCase, ConversationalTestCase]):
+        await self.a_measure(test_case, _show_indicator=False)
+        return (
+            self.statements, 
+            self.verdicts, 
+            self.score, 
+            self.reason, 
+            self.success
+            )
 
     async def a_measure(
         self,
@@ -84,15 +142,25 @@ class AnswerRelevancyMetric(BaseMetric):
         with metric_progress_indicator(
             self, async_mode=True, _show_indicator=_show_indicator
         ):
-            self.statements: List[str] = await self._a_generate_statements(
+            statements: List[str] = await self._a_generate_statements(
                 test_case.actual_output
             )
-            self.verdicts: List[AnswerRelvancyVerdict] = (
+            self._statements.set(statements)
+
+            verdicts: List[AnswerRelvancyVerdict] = (
                 await self._a_generate_verdicts(test_case.input)
             )
-            self.score = self._calculate_score()
-            self.reason = await self._a_generate_reason(test_case.input)
-            self.success = self.score >= self.threshold
+            self._verdicts.set(verdicts)
+
+            score = self._calculate_score()
+            self._score.set(score)
+
+            reason = await self._a_generate_reason(test_case.input)
+            self._reason.set(reason)
+
+            success = self.score >= self.threshold
+            self._success.set(success)
+    
             return self.score
 
     async def _a_generate_reason(self, input: str) -> str:
@@ -221,11 +289,29 @@ class AnswerRelevancyMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score >= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
 
     @property
     def __name__(self):
         return "Answer Relevancy"
+    
+
+##########################################################
+##########################################################
+##########################################################
+
+
+
+
+
+
+# import asyncio
+
+
+
+
+# if __name__ == "__main__":
+#     asyncio.run(test_g_eval())

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -56,18 +56,37 @@ class AnswerRelevancyMetric(BaseMetric):
     @property
     def statements(self) -> Optional[List[str]]:
         return self._statements.get()
+    @statements.setter
+    def statements(self, value: Optional[List[str]]):
+        self._statements.set(value)
+        
     @property
     def verdicts(self) -> Optional[List[AnswerRelvancyVerdict]]:
         return self._verdicts.get()
+    @verdicts.setter
+    def verdicts(self, value: Optional[List[AnswerRelvancyVerdict]]):
+        self._verdicts.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -89,31 +108,31 @@ class AnswerRelevancyMetric(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._statements.set(statements)
-                self._verdicts.set(verdicts)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.statements = statements
+                self.verdicts = verdicts
+                self.score = score
+                self.reason = reason
+                self.success = success
 
             else:
                 statements: List[str] = self._generate_statements(
                     test_case.actual_output
                 )
-                self._statements.set(statements)
+                self.statements = statements
 
                 verdicts: List[AnswerRelvancyVerdict] = (
                     self._generate_verdicts(test_case.input)
                 )
-                self._verdicts.set(verdicts)
+                self.verdicts = verdicts
 
                 score = self._calculate_score()
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason(test_case.input)
-                self._reason.set(reason)
+                self.reason = reason
 
                 success = self.score >= self.threshold
-                self._success.set(success)
+                self.success = success
                 
                 return self.score
     
@@ -145,21 +164,21 @@ class AnswerRelevancyMetric(BaseMetric):
             statements: List[str] = await self._a_generate_statements(
                 test_case.actual_output
             )
-            self._statements.set(statements)
+            self.statements = statements
 
             verdicts: List[AnswerRelvancyVerdict] = (
                 await self._a_generate_verdicts(test_case.input)
             )
-            self._verdicts.set(verdicts)
+            self.verdicts = verdicts
 
             score = self._calculate_score()
-            self._score.set(score)
+            self.score = score
 
             reason = await self._a_generate_reason(test_case.input)
-            self._reason.set(reason)
+            self.reason = reason
 
             success = self.score >= self.threshold
-            self._success.set(success)
+            self.success = success
     
             return self.score
 
@@ -289,9 +308,9 @@ class AnswerRelevancyMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self.success = self.score >= self.threshold
             except:
-                self._success.set(False)
+                self.success = False
         return self.success
 
     @property

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -32,8 +32,6 @@ class AnswerRelvancyVerdict(BaseModel):
 
 class AnswerRelevancyMetric(BaseMetric):
 
-    
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -67,7 +65,9 @@ class AnswerRelevancyMetric(BaseMetric):
         self._verdicts.set(value)
 
     def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
+        self, 
+        test_case: Union[LLMTestCase, ConversationalTestCase], 
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -84,7 +84,7 @@ class AnswerRelevancyMetric(BaseMetric):
                     self.reason, 
                     self.success
                 ) = loop.run_until_complete(
-                    self._measure_async(test_case)
+                    self._measure_async(test_case, verbose)
                 )
             else:
                 self.statements = self._generate_statements(
@@ -93,13 +93,16 @@ class AnswerRelevancyMetric(BaseMetric):
                 self.verdicts = self._generate_verdicts(test_case.input)
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason(test_case.input)
-                self.success = self.score >= self.threshold                
+                self.success = self.score >= self.threshold
+                if verbose:
+                    print(f"statements: {self.statements}\nverdicts: {self.verdicts}")                
                 return self.score
     
     async def _measure_async(
             self,
-            test_case: Union[LLMTestCase, ConversationalTestCase]):
-        await self.a_measure(test_case, _show_indicator=False)
+            test_case: Union[LLMTestCase, ConversationalTestCase],
+            verbose: bool):
+        await self.a_measure(test_case, _show_indicator=False, verbose=verbose)
         return (
             self.statements, 
             self.verdicts, 
@@ -112,6 +115,7 @@ class AnswerRelevancyMetric(BaseMetric):
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
         _show_indicator: bool = True,
+        verbose: bool = True
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -129,7 +133,9 @@ class AnswerRelevancyMetric(BaseMetric):
             )
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason(test_case.input)
-            self.success = self.score >= self.threshold    
+            self.success = self.score >= self.threshold
+            if verbose:
+                print(f"statements: {self.statements}\nverdicts: {self.verdicts}\nscore: {self.score}, success: {self.success}")
             return self.score
 
     async def _a_generate_reason(self, input: str) -> str:

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -32,11 +32,11 @@ class AnswerRelvancyVerdict(BaseModel):
 
 class AnswerRelevancyMetric(BaseMetric):
 
-    _statements: ContextVar[List[str]] = ContextVar('statements', default=[])
-    _verdicts: ContextVar[List[AnswerRelvancyVerdict]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _statements: ContextVar[Optional[List[str]]] = ContextVar('statements', default=None)
+    _verdicts: ContextVar[Optional[List[AnswerRelvancyVerdict]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -54,19 +54,19 @@ class AnswerRelevancyMetric(BaseMetric):
         self.strict_mode = strict_mode
     
     @property
-    def statements(self) -> List[str]:
+    def statements(self) -> Optional[List[str]]:
         return self._statements.get()
     @property
-    def verdicts(self) -> List[AnswerRelvancyVerdict]:
+    def verdicts(self) -> Optional[List[AnswerRelvancyVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
 
     def measure(
@@ -297,21 +297,3 @@ class AnswerRelevancyMetric(BaseMetric):
     @property
     def __name__(self):
         return "Answer Relevancy"
-    
-
-##########################################################
-##########################################################
-##########################################################
-
-
-
-
-
-
-# import asyncio
-
-
-
-
-# if __name__ == "__main__":
-#     asyncio.run(test_g_eval())

--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -1,25 +1,69 @@
 from abc import abstractmethod
-
-from deepeval.test_case import LLMTestCase, ConversationalTestCase
+from contextvars import ContextVar
 from typing import Optional, Dict
 
+from deepeval.test_case import LLMTestCase, ConversationalTestCase
 
 class BaseMetric:
-    score: Optional[float] = None
-    score_breakdown: Dict = None
-    reason: Optional[str] = None
-    success: Optional[bool] = None
+
     evaluation_model: Optional[str] = None
     strict_mode: bool = False
     async_mode: bool = True
     include_reason: bool = False
-    error: Optional[str] = None
     evaluation_cost: Optional[float] = None
+
+    def __init__(self):
+        self._score = ContextVar(f'{self.__class__.__name__}_score', default=None)
+        self._score_breakdown = ContextVar(f'{self.__class__.__name__}_score_breakdown', default=None)
+        self._reason = ContextVar(f'{self.__class__.__name__}_reason', default=None)
+        self._success = ContextVar(f'{self.__class__.__name__}_success', default=None)
+        self._error = ContextVar(f'{self.__class__.__name__}_error', default=None)
+
+    @property
+    def score(self) -> Optional[float]:
+        return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]) -> None:
+        self._score.set(value)
+
+    @property
+    def score_breakdown(self) -> Optional[Dict]:
+        return self._score_breakdown.get()
+    @score_breakdown.setter
+    def score_breakdown(self, value: Optional[Dict]) -> None:
+        self._score_breakdown.set(value)
+
+    @property
+    def reason(self) -> Optional[str]:
+        return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]) -> None:
+        self._reason.set(value)
+
+    @property
+    def success(self) -> Optional[bool]:
+        return self._success.get()
+    @success.setter
+    def success(self, value: Optional[bool]) -> None:
+        self._success.set(value)
+
+    @property
+    def error(self) -> Optional[str]:
+        return self._error.get()
+    @error.setter
+    def error(self, value: Optional[str]) -> None:
+        self._error.set(value)
+
+    @property
+    def error(self) -> Optional[str]:
+        return self._error.get()
+    @error.setter
+    def error(self, value: Optional[str]) -> None:
+        self._error.set(value)
 
     @property
     def threshold(self) -> float:
         return self._threshold
-
     @threshold.setter
     def threshold(self, value: float):
         self._threshold = value
@@ -44,19 +88,49 @@ class BaseMetric:
 
 
 class BaseConversationalMetric:
-    score: Optional[float] = None
-    score_breakdown: Dict = None
-    reason: Optional[str] = None
+
     evaluation_model: Optional[str] = None
-    error: Optional[str] = None
     # Not changeable for now
     strict_mode: bool = False
     async_mode: bool = False
 
+    def __init__(self):
+        self._score = ContextVar(f'{self.__class__.__name__}_score', default=None)
+        self._score_breakdown = ContextVar(f'{self.__class__.__name__}_score_breakdown', default=None)
+        self._reason = ContextVar(f'{self.__class__.__name__}_reason', default=None)
+        self._error = ContextVar(f'{self.__class__.__name__}_error', default=None)
+
+    @property
+    def score(self) -> Optional[float]:
+        return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]) -> None:
+        self._score.set(value)
+
+    @property
+    def score_breakdown(self) -> Optional[Dict]:
+        return self._score_breakdown.get()
+    @score_breakdown.setter
+    def score_breakdown(self, value: Optional[Dict]) -> None:
+        self._score_breakdown.set(value)
+
+    @property
+    def reason(self) -> Optional[str]:
+        return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]) -> None:
+        self._reason.set(value)
+
+    @property
+    def error(self) -> Optional[str]:
+        return self._error.get()
+    @error.setter
+    def error(self, value: Optional[str]) -> None:
+        self._error.set(value)
+
     @property
     def threshold(self) -> float:
         return self._threshold
-
     @threshold.setter
     def threshold(self, value: float):
         self._threshold = value

--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -13,11 +13,11 @@ class BaseMetric:
     evaluation_cost: Optional[float] = None
 
     def __init__(self):
-        self._score = ContextVar(f'{self.__class__.__name__}_score', default=None)
-        self._score_breakdown = ContextVar(f'{self.__class__.__name__}_score_breakdown', default=None)
-        self._reason = ContextVar(f'{self.__class__.__name__}_reason', default=None)
-        self._success = ContextVar(f'{self.__class__.__name__}_success', default=None)
-        self._error = ContextVar(f'{self.__class__.__name__}_error', default=None)
+        self._score: ContextVar[Optional[float]] = ContextVar(f'{self.__class__.__name__}_score', default=None)
+        self._score_breakdown: ContextVar[Optional[Dict]] = ContextVar(f'{self.__class__.__name__}_score_breakdown', default=None)
+        self._reason: ContextVar[Optional[str]] = ContextVar(f'{self.__class__.__name__}_reason', default=None)
+        self._success: ContextVar[Optional[bool]] = ContextVar(f'{self.__class__.__name__}_success', default=None)
+        self._error: ContextVar[Optional[str]] = ContextVar(f'{self.__class__.__name__}_error', default=None)
 
     @property
     def score(self) -> Optional[float]:

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -78,37 +78,22 @@ class BiasMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    opinions,
-                    verdicts,
-                    score,
-                    reason,
-                    success
+                    self.opinions,
+                    self.verdicts,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.opinions = opinions
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
             else:
-                opinions: List[str] = self._generate_opinions(
+                self.opinions = self._generate_opinions(
                     test_case.actual_output
                 )
-                self.opinions = opinions
-                
-                verdicts: List[BiasVerdict] = self._generate_verdicts()
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason()
-                self.reason = reason
-
-                success = self.score <= self.threshold
-                self.success = success
-
+                self.verdicts = self._generate_verdicts()
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason()
+                self.success = self.score <= self.threshold
                 return self.score
     
     async def _measure_async(
@@ -138,21 +123,11 @@ class BiasMetric(BaseMetric):
             async_mode=True,
             _show_indicator=_show_indicator,
         ):
-            opinions: List[str] = await self._a_generate_opinions(test_case.actual_output)
-            self.opinions = opinions
-
-            verdicts: List[BiasVerdict] = await self._a_generate_verdicts()
-            self.verdicts = verdicts
-            
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason()
-            self.reason = reason
-
-            success = self.score <= self.threshold
-            self.reason = reason
-
+            self.opinions = await self._a_generate_opinions(test_case.actual_output)
+            self.verdicts = await self._a_generate_verdicts()            
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason()
+            self.success = self.score <= self.threshold
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -268,7 +268,7 @@ class BiasMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self._success.set(self.score <= self.threshold)
             except:
                 self._success.set(False)
         return self.success

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -268,9 +268,9 @@ class BiasMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score <= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
 
     @property

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -97,7 +97,7 @@ class BiasMetric(BaseMetric):
                 self.reason = self._generate_reason()
                 self.success = self.score <= self.threshold
                 if verbose:
-                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")                                    
+                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}\n")                                    
                 return self.score
     
     async def _measure_async(
@@ -135,7 +135,7 @@ class BiasMetric(BaseMetric):
             self.reason = await self._a_generate_reason()
             self.success = self.score <= self.threshold
             if verbose:
-                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")                
+                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}\n")                
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -34,12 +34,6 @@ class BiasVerdict(BaseModel):
 
 class BiasMetric(BaseMetric):
 
-    _opinions: ContextVar[Optional[List[str]]] = ContextVar('opinions', default=None)
-    _verdicts: ContextVar[Optional[List[BiasVerdict]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -48,6 +42,9 @@ class BiasMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._opinions: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_opinions', default=None)
+        self._verdicts: ContextVar[Optional[List[BiasVerdict]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)
         self.threshold = 0 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -68,27 +65,6 @@ class BiasMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List[BiasVerdict]]):
         self._verdicts.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
     
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -34,11 +34,11 @@ class BiasVerdict(BaseModel):
 
 class BiasMetric(BaseMetric):
 
-    _opinions: ContextVar[List[str]] = ContextVar('opinions', default=[])
-    _verdicts: ContextVar[List[BiasVerdict]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _opinions: ContextVar[Optional[List[str]]] = ContextVar('opinions', default=None)
+    _verdicts: ContextVar[Optional[List[BiasVerdict]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -56,19 +56,19 @@ class BiasMetric(BaseMetric):
         self.strict_mode = strict_mode
 
     @property
-    def opinions(self) -> List[str]:
+    def opinions(self) -> Optional[List[str]]:
         return self._opinions.get()
     @property
-    def verdicts(self) -> List[BiasVerdict]:
+    def verdicts(self) -> Optional[List[BiasVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
     
     def measure(

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -67,7 +67,9 @@ class BiasMetric(BaseMetric):
         self._verdicts.set(value)
     
     def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
+        self, 
+        test_case: Union[LLMTestCase, ConversationalTestCase],
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -84,7 +86,7 @@ class BiasMetric(BaseMetric):
                     self.reason,
                     self.success
                 ) = loop.run_until_complete(
-                    self._measure_async(test_case)
+                    self._measure_async(test_case, verbose)
                 )
             else:
                 self.opinions = self._generate_opinions(
@@ -94,12 +96,15 @@ class BiasMetric(BaseMetric):
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason()
                 self.success = self.score <= self.threshold
+                if verbose:
+                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")                                    
                 return self.score
     
     async def _measure_async(
             self,
-            test_case: Union[LLMTestCase, ConversationalTestCase]):
-        await self.a_measure(test_case, _show_indicator=False)
+            test_case: Union[LLMTestCase, ConversationalTestCase],
+            verbose: bool):
+        await self.a_measure(test_case, _show_indicator=False, verbose=verbose)
         return (
             self.opinions,
             self.verdicts,
@@ -112,6 +117,7 @@ class BiasMetric(BaseMetric):
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
         _show_indicator: bool = True,
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -128,6 +134,8 @@ class BiasMetric(BaseMetric):
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason()
             self.success = self.score <= self.threshold
+            if verbose:
+                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")                
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -37,10 +37,10 @@ class ContextualPrecisionVerdict(BaseModel):
 
 class ContextualPrecisionMetric(BaseMetric):
 
-    _verdicts: ContextVar[List[ContextualPrecisionVerdict]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _verdicts: ContextVar[Optional[List[ContextualPrecisionVerdict]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -58,16 +58,16 @@ class ContextualPrecisionMetric(BaseMetric):
         self.strict_mode = strict_mode
 
     @property
-    def verdicts(self) -> List[ContextualPrecisionVerdict]:
+    def verdicts(self) -> Optional[List[ContextualPrecisionVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
     
     def measure(

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -94,7 +94,7 @@ class ContextualPrecisionMetric(BaseMetric):
                 self.reason = self._generate_reason(test_case.input)
                 self.success = self.score >= self.threshold
                 if verbose:
-                    print(f"verdicts: {self.verdicts}")                
+                    print(f"verdicts: {self.verdicts}\n")                
                 return self.score
             
     async def _measure_async(
@@ -136,7 +136,7 @@ class ContextualPrecisionMetric(BaseMetric):
             self.reason = await self._a_generate_reason(test_case.input)
             self.success = self.score >= self.threshold
             if verbose:
-                print(f"verdicts: {self.verdicts}")                                   
+                print(f"verdicts: {self.verdicts}\n")                                   
             return self.score
 
     async def _a_generate_reason(self, input: str):

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -269,11 +269,11 @@ class ContextualPrecisionMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score >= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
-
+    
     @property
     def __name__(self):
         return "Contextual Precision"

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -74,36 +74,24 @@ class ContextualPrecisionMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    verdicts,
-                    score,
-                    reason,
-                    success
+                    self.verdicts,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
             else:
-                verdicts: List[ContextualPrecisionVerdict] = (
+                self.verdicts = (
                     self._generate_verdicts(
                         test_case.input,
                         test_case.expected_output,
                         test_case.retrieval_context,
                     )
                 )
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason(test_case.input)
-                self.reason = reason
-
-                success = self.score >= self.threshold
-                self.success = success
-
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason(test_case.input)
+                self.success = self.score >= self.threshold
                 return self.score
             
     async def _measure_async(
@@ -132,24 +120,16 @@ class ContextualPrecisionMetric(BaseMetric):
             async_mode=True,
             _show_indicator=_show_indicator,
         ):
-            verdicts: List[ContextualPrecisionVerdict] = (
+            self.verdicts = (
                 await self._a_generate_verdicts(
                     test_case.input,
                     test_case.expected_output,
                     test_case.retrieval_context,
                 )
             )
-            self.verdicts = verdicts
-
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason(test_case.input)
-            self.reason = reason
-
-            success = self.score >= self.threshold
-            self.success = success
-            
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason(test_case.input)
+            self.success = self.score >= self.threshold            
             return self.score
 
     async def _a_generate_reason(self, input: str):

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -1,3 +1,4 @@
+from contextvars import ContextVar
 from typing import Optional, List, Union
 from pydantic import BaseModel
 
@@ -35,6 +36,12 @@ class ContextualPrecisionVerdict(BaseModel):
 
 
 class ContextualPrecisionMetric(BaseMetric):
+
+    _verdicts: ContextVar[List[ContextualPrecisionVerdict]] = ContextVar('verdicts', default=[])
+    _score: ContextVar[float] = ContextVar('score', default=0)
+    _reason: ContextVar[str] = ContextVar('reason', default="")
+    _success: ContextVar[bool] = ContextVar('success', default=False)
+
     def __init__(
         self,
         threshold: float = 0.5,
@@ -50,6 +57,19 @@ class ContextualPrecisionMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
 
+    @property
+    def verdicts(self) -> List[ContextualPrecisionVerdict]:
+        return self._verdicts.get()
+    @property
+    def score(self) -> float:
+        return self._score.get()
+    @property
+    def reason(self) -> str:
+        return self._reason.get()
+    @property
+    def success(self) -> str:
+        return self._success.get()
+    
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:
@@ -61,21 +81,49 @@ class ContextualPrecisionMetric(BaseMetric):
         with metric_progress_indicator(self):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
-                    self.a_measure(test_case, _show_indicator=False)
+                (
+                    verdicts,
+                    score,
+                    reason,
+                    success
+                ) = loop.run_until_complete(
+                    self._measure_async(test_case)
                 )
+                self._verdicts.set(verdicts)
+                self._score.set(score)
+                self._reason.set(reason)
+                self._success.set(success)
             else:
-                self.verdicts: List[ContextualPrecisionVerdict] = (
+                verdicts: List[ContextualPrecisionVerdict] = (
                     self._generate_verdicts(
                         test_case.input,
                         test_case.expected_output,
                         test_case.retrieval_context,
                     )
                 )
-                self.score = self._calculate_score()
-                self.reason = self._generate_reason(test_case.input)
-                self.success = self.score >= self.threshold
+                self._verdicts.set(verdicts)
+
+                score = self._calculate_score()
+                self._score.set(score)
+
+                reason = self._generate_reason(test_case.input)
+                self._reason.set(reason)
+                
+                success = self.score >= self.threshold
+                self._success.set(success)
+
                 return self.score
+            
+    async def _measure_async(
+            self,
+            test_case: Union[LLMTestCase, ConversationalTestCase]):
+        await self.a_measure(test_case, _show_indicator=False)
+        return (
+            self.verdicts,
+            self.score,
+            self.reason,
+            self.success
+            )
 
     async def a_measure(
         self,
@@ -92,16 +140,24 @@ class ContextualPrecisionMetric(BaseMetric):
             async_mode=True,
             _show_indicator=_show_indicator,
         ):
-            self.verdicts: List[ContextualPrecisionVerdict] = (
+            verdicts: List[ContextualPrecisionVerdict] = (
                 await self._a_generate_verdicts(
                     test_case.input,
                     test_case.expected_output,
                     test_case.retrieval_context,
                 )
             )
-            self.score = self._calculate_score()
-            self.reason = await self._a_generate_reason(test_case.input)
-            self.success = self.score >= self.threshold
+            self._verdicts.set(verdicts)
+
+            score = self._calculate_score()
+            self._score.set(score)
+
+            reason = await self._a_generate_reason(test_case.input)
+            self._reason.set(reason)
+
+            success = self.score >= self.threshold
+            self._success.set(success)
+            
             return self.score
 
     async def _a_generate_reason(self, input: str):

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -60,15 +60,30 @@ class ContextualPrecisionMetric(BaseMetric):
     @property
     def verdicts(self) -> Optional[List[ContextualPrecisionVerdict]]:
         return self._verdicts.get()
+    @verdicts.setter
+    def verdicts(self, value: Optional[List[ContextualPrecisionVerdict]]):
+        self._verdicts.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
     
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -89,10 +104,10 @@ class ContextualPrecisionMetric(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._verdicts.set(verdicts)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.verdicts = verdicts
+                self.score = score
+                self.reason = reason
+                self.success = success
             else:
                 verdicts: List[ContextualPrecisionVerdict] = (
                     self._generate_verdicts(
@@ -101,16 +116,16 @@ class ContextualPrecisionMetric(BaseMetric):
                         test_case.retrieval_context,
                     )
                 )
-                self._verdicts.set(verdicts)
+                self.verdicts = verdicts
 
                 score = self._calculate_score()
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason(test_case.input)
-                self._reason.set(reason)
-                
+                self.reason = reason
+
                 success = self.score >= self.threshold
-                self._success.set(success)
+                self.success = success
 
                 return self.score
             
@@ -147,16 +162,16 @@ class ContextualPrecisionMetric(BaseMetric):
                     test_case.retrieval_context,
                 )
             )
-            self._verdicts.set(verdicts)
+            self.verdicts = verdicts
 
             score = self._calculate_score()
-            self._score.set(score)
+            self.score = score
 
             reason = await self._a_generate_reason(test_case.input)
-            self._reason.set(reason)
+            self.reason = reason
 
             success = self.score >= self.threshold
-            self._success.set(success)
+            self.success = success
             
             return self.score
 
@@ -269,9 +284,9 @@ class ContextualPrecisionMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self.success = self.score >= self.threshold
             except:
-                self._success.set(False)
+                self.success = False
         return self.success
     
     @property

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -37,7 +37,6 @@ class ContextualPrecisionVerdict(BaseModel):
 
 class ContextualPrecisionMetric(BaseMetric):
 
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -63,7 +62,9 @@ class ContextualPrecisionMetric(BaseMetric):
         self._verdicts.set(value)
     
     def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
+        self, 
+        test_case: Union[LLMTestCase, ConversationalTestCase],
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -79,7 +80,7 @@ class ContextualPrecisionMetric(BaseMetric):
                     self.reason,
                     self.success
                 ) = loop.run_until_complete(
-                    self._measure_async(test_case)
+                    self._measure_async(test_case, verbose)
                 )
             else:
                 self.verdicts = (
@@ -92,12 +93,15 @@ class ContextualPrecisionMetric(BaseMetric):
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason(test_case.input)
                 self.success = self.score >= self.threshold
+                if verbose:
+                    print(f"verdicts: {self.verdicts}")                
                 return self.score
             
     async def _measure_async(
             self,
-            test_case: Union[LLMTestCase, ConversationalTestCase]):
-        await self.a_measure(test_case, _show_indicator=False)
+            test_case: Union[LLMTestCase, ConversationalTestCase],
+            verbose: bool):
+        await self.a_measure(test_case, _show_indicator=False, verbose=verbose)
         return (
             self.verdicts,
             self.score,
@@ -109,6 +113,7 @@ class ContextualPrecisionMetric(BaseMetric):
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
         _show_indicator: bool = True,
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -129,7 +134,9 @@ class ContextualPrecisionMetric(BaseMetric):
             )
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason(test_case.input)
-            self.success = self.score >= self.threshold            
+            self.success = self.score >= self.threshold
+            if verbose:
+                print(f"verdicts: {self.verdicts}")                                   
             return self.score
 
     async def _a_generate_reason(self, input: str):

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -37,10 +37,6 @@ class ContextualPrecisionVerdict(BaseModel):
 
 class ContextualPrecisionMetric(BaseMetric):
 
-    _verdicts: ContextVar[Optional[List[ContextualPrecisionVerdict]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -50,6 +46,8 @@ class ContextualPrecisionMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._verdicts: ContextVar[Optional[List[ContextualPrecisionVerdict]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)
         self.threshold = 1 if strict_mode else threshold
         self.include_reason = include_reason
         self.model, self.using_native_model = initialize_model(model)
@@ -63,27 +61,6 @@ class ContextualPrecisionMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List[ContextualPrecisionVerdict]]):
         self._verdicts.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
     
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -34,10 +34,10 @@ class ContextualRecallVerdict(BaseModel):
 
 class ContextualRecallMetric(BaseMetric):
 
-    _verdicts: ContextVar[List[ContextualRecallVerdict]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _verdicts: ContextVar[Optional[List[ContextualRecallVerdict]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -55,16 +55,16 @@ class ContextualRecallMetric(BaseMetric):
         self.strict_mode = strict_mode
     
     @property
-    def verdicts(self) -> List[ContextualRecallVerdict]:
+    def verdicts(self) -> Optional[List[ContextualRecallVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
     
     def measure(

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -57,16 +57,31 @@ class ContextualRecallMetric(BaseMetric):
     @property
     def verdicts(self) -> Optional[List[ContextualRecallVerdict]]:
         return self._verdicts.get()
+    @verdicts.setter
+    def verdicts(self, value: Optional[List[ContextualRecallVerdict]]):
+        self._verdicts.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
-    
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
+
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:
@@ -86,26 +101,26 @@ class ContextualRecallMetric(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._verdicts.set(verdicts)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.verdicts = verdicts
+                self.score = score
+                self.reason = reason
+                self.success = success
             else:
                 verdicts: List[ContextualRecallVerdict] = (
                     self._generate_verdicts(
                         test_case.expected_output, test_case.retrieval_context
                     )
                 )
-                self._verdicts.set(verdicts)
+                self.verdicts = verdicts
 
                 score = self._calculate_score()
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason(test_case.expected_output)
-                self._reason.set(reason)
+                self.reason = reason
 
                 success = self.score >= self.threshold
-                self._success.set(success)
+                self.success = success
 
                 return self.score
             
@@ -140,18 +155,18 @@ class ContextualRecallMetric(BaseMetric):
                     test_case.expected_output, test_case.retrieval_context
                 )
             )
-            self._verdicts.set(verdicts)
+            self.verdicts = verdicts
 
             score = self._calculate_score()
-            self._score.set(score)
+            self.score = score
 
             reason = await self._a_generate_reason(
                 test_case.expected_output
             )
-            self._reason.set(reason)
+            self.reason = reason
 
             success = self.score >= self.threshold
-            self._success.set(success)
+            self.success = success
 
             return self.score
 
@@ -259,9 +274,9 @@ class ContextualRecallMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self.success = self.score >= self.threshold
             except:
-                self._success.set(False)
+                self.success = False        
         return self.success
 
     @property

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -34,11 +34,6 @@ class ContextualRecallVerdict(BaseModel):
 
 class ContextualRecallMetric(BaseMetric):
 
-    _verdicts: ContextVar[Optional[List[ContextualRecallVerdict]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -47,6 +42,8 @@ class ContextualRecallMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._verdicts: ContextVar[Optional[List[ContextualRecallVerdict]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -60,27 +57,6 @@ class ContextualRecallMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List[ContextualRecallVerdict]]):
         self._verdicts.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -259,9 +259,9 @@ class ContextualRecallMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score >= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
 
     @property

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -59,7 +59,9 @@ class ContextualRecallMetric(BaseMetric):
         self._verdicts.set(value)
 
     def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
+        self, 
+        test_case: Union[LLMTestCase, ConversationalTestCase],
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -75,7 +77,7 @@ class ContextualRecallMetric(BaseMetric):
                     self.reason,
                     self.success
                 ) = loop.run_until_complete(
-                    self._measure_async(test_case)
+                    self._measure_async(test_case, verbose)
                 )
             else:
                 self.verdicts = (
@@ -86,12 +88,16 @@ class ContextualRecallMetric(BaseMetric):
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason(test_case.input)
                 self.success = self.score >= self.threshold
+                if verbose:
+                    print(f"verdicts: {self.verdicts}")                  
                 return self.score
             
     async def _measure_async(
             self,
-            test_case: Union[LLMTestCase, ConversationalTestCase]):
-        await self.a_measure(test_case, _show_indicator=False)
+            test_case: Union[LLMTestCase, ConversationalTestCase],
+            verbose: bool
+            ):
+        await self.a_measure(test_case, _show_indicator=False, verbose=verbose)
         return (
             self.verdicts,
             self.score,
@@ -103,6 +109,7 @@ class ContextualRecallMetric(BaseMetric):
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
         _show_indicator: bool = True,
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -121,7 +128,9 @@ class ContextualRecallMetric(BaseMetric):
             )
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason(test_case.input)
-            self.success = self.score >= self.threshold     
+            self.success = self.score >= self.threshold   
+            if verbose:
+                print(f"verdicts: {self.verdicts}")     
             return self.score
 
     async def _a_generate_reason(self, expected_output: str):

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -89,7 +89,7 @@ class ContextualRecallMetric(BaseMetric):
                 self.reason = self._generate_reason(test_case.input)
                 self.success = self.score >= self.threshold
                 if verbose:
-                    print(f"verdicts: {self.verdicts}")                  
+                    print(f"verdicts: {self.verdicts}\n")                  
                 return self.score
             
     async def _measure_async(
@@ -130,7 +130,7 @@ class ContextualRecallMetric(BaseMetric):
             self.reason = await self._a_generate_reason(test_case.input)
             self.success = self.score >= self.threshold   
             if verbose:
-                print(f"verdicts: {self.verdicts}")     
+                print(f"verdicts: {self.verdicts}\n")     
             return self.score
 
     async def _a_generate_reason(self, expected_output: str):

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -70,34 +70,22 @@ class ContextualRecallMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    verdicts,
-                    score,
-                    reason,
-                    success
+                    self.verdicts,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
             else:
-                verdicts: List[ContextualRecallVerdict] = (
+                self.verdicts = (
                     self._generate_verdicts(
                         test_case.expected_output, test_case.retrieval_context
                     )
                 )
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason(test_case.expected_output)
-                self.reason = reason
-
-                success = self.score >= self.threshold
-                self.success = success
-
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason(test_case.input)
+                self.success = self.score >= self.threshold
                 return self.score
             
     async def _measure_async(
@@ -126,24 +114,14 @@ class ContextualRecallMetric(BaseMetric):
             async_mode=True,
             _show_indicator=_show_indicator,
         ):
-            verdicts: List[ContextualRecallVerdict] = (
+            self.verdicts = (
                 await self._a_generate_verdicts(
                     test_case.expected_output, test_case.retrieval_context
                 )
             )
-            self.verdicts = verdicts
-
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason(
-                test_case.expected_output
-            )
-            self.reason = reason
-
-            success = self.score >= self.threshold
-            self.success = success
-
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason(test_case.input)
+            self.success = self.score >= self.threshold     
             return self.score
 
     async def _a_generate_reason(self, expected_output: str):

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -36,10 +36,10 @@ class ContextualRelevancyVerdict(BaseModel):
 
 class ContextualRelevancyMetric(BaseMetric):
 
-    _verdicts: ContextVar[List[ContextualRelevancyVerdict]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _verdicts: ContextVar[Optional[List[ContextualRelevancyVerdict]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -57,16 +57,16 @@ class ContextualRelevancyMetric(BaseMetric):
         self.strict_mode = strict_mode
 
     @property
-    def verdicts(self) -> List[ContextualRelevancyVerdict]:
+    def verdicts(self) -> Optional[List[ContextualRelevancyVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
     
     def measure(

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -36,11 +36,6 @@ class ContextualRelevancyVerdict(BaseModel):
 
 class ContextualRelevancyMetric(BaseMetric):
 
-    _verdicts: ContextVar[Optional[List[ContextualRelevancyVerdict]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -49,6 +44,8 @@ class ContextualRelevancyMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._verdicts: ContextVar[Optional[List[ContextualRelevancyVerdict]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)        
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -62,28 +59,7 @@ class ContextualRelevancyMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List[ContextualRelevancyVerdict]]):
         self._verdicts.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
-    
+        
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -72,35 +72,22 @@ class ContextualRelevancyMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    verdicts,
-                    score,
-                    reason,
-                    success
+                    self.verdicts,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
-                
             else:
-                verdicts: List[ContextualRelevancyVerdict] = (
+                self.verdicts = (
                     self._generate_verdicts(
                         test_case.input, test_case.retrieval_context
                     )
                 )
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason(test_case.input)
-                self.reason = reason
-
-                success = self.score >= self.threshold
-                self.success = success
-
+                self.score = self._calculate_score()
+                self.reason = self._a_generate_reason(test_case.input)
+                self.success = self.score >= self.threshold     
                 return self.score
     
     async def _measure_async(
@@ -129,22 +116,14 @@ class ContextualRelevancyMetric(BaseMetric):
             async_mode=True,
             _show_indicator=_show_indicator,
         ):
-            verdicts: List[ContextualRelevancyVerdict] = (
+            self.verdicts = (
                 await self._a_generate_verdicts(
                     test_case.input, test_case.retrieval_context
                 )
             )
-            self.verdicts = verdicts
-
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason(test_case.input)
-            self.reason = reason
-
-            success = self.score >= self.threshold
-            self.success = success
-
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason(test_case.input)
+            self.success = self.score >= self.threshold    
             return self.score
 
     async def _a_generate_reason(self, input: str):

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -59,15 +59,30 @@ class ContextualRelevancyMetric(BaseMetric):
     @property
     def verdicts(self) -> Optional[List[ContextualRelevancyVerdict]]:
         return self._verdicts.get()
+    @verdicts.setter
+    def verdicts(self, value: Optional[List[ContextualRelevancyVerdict]]):
+        self._verdicts.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
     
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -88,10 +103,10 @@ class ContextualRelevancyMetric(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._verdicts.set(verdicts)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.verdicts = verdicts
+                self.score = score
+                self.reason = reason
+                self.success = success
                 
             else:
                 verdicts: List[ContextualRelevancyVerdict] = (
@@ -99,16 +114,16 @@ class ContextualRelevancyMetric(BaseMetric):
                         test_case.input, test_case.retrieval_context
                     )
                 )
-                self._verdicts.set(verdicts)
+                self.verdicts = verdicts
 
                 score = self._calculate_score()
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason(test_case.input)
-                self._reason.set(reason)
+                self.reason = reason
 
                 success = self.score >= self.threshold
-                self._success.set(success)
+                self.success = success
 
                 return self.score
     
@@ -143,16 +158,16 @@ class ContextualRelevancyMetric(BaseMetric):
                     test_case.input, test_case.retrieval_context
                 )
             )
-            self._verdicts.set(verdicts)
+            self.verdicts = verdicts
 
             score = self._calculate_score()
-            self._score.set(score)
+            self.score = score
 
             reason = await self._a_generate_reason(test_case.input)
-            self._reason.set(reason)
+            self.reason = reason
 
             success = self.score >= self.threshold
-            self._success.set(success)
+            self.success = success
 
             return self.score
 
@@ -262,9 +277,9 @@ class ContextualRelevancyMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self.success = self.score >= self.threshold
             except:
-                self._success.set(False)
+                self.success = False
         return self.success
     
     @property

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -91,7 +91,7 @@ class ContextualRelevancyMetric(BaseMetric):
                 self.reason = self._generate_reason(test_case.input)
                 self.success = self.score >= self.threshold
                 if verbose:
-                    print(f"verdicts: {self.verdicts}")    
+                    print(f"verdicts: {self.verdicts}\n")    
                 return self.score
     
     async def _measure_async(
@@ -131,7 +131,7 @@ class ContextualRelevancyMetric(BaseMetric):
             self.reason = await self._a_generate_reason(test_case.input)
             self.success = self.score >= self.threshold
             if verbose:
-                print(f"verdicts: {self.verdicts}")    
+                print(f"verdicts: {self.verdicts}\n")    
             return self.score
 
     async def _a_generate_reason(self, input: str):

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -1,3 +1,4 @@
+from contextvars import ContextVar
 from typing import Optional, List, Union
 from pydantic import BaseModel, Field
 import asyncio
@@ -34,6 +35,12 @@ class ContextualRelevancyVerdict(BaseModel):
 
 
 class ContextualRelevancyMetric(BaseMetric):
+
+    _verdicts: ContextVar[List[ContextualRelevancyVerdict]] = ContextVar('verdicts', default=[])
+    _score: ContextVar[float] = ContextVar('score', default=0)
+    _reason: ContextVar[str] = ContextVar('reason', default="")
+    _success: ContextVar[bool] = ContextVar('success', default=False)
+
     def __init__(
         self,
         threshold: float = 0.5,
@@ -49,6 +56,19 @@ class ContextualRelevancyMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
 
+    @property
+    def verdicts(self) -> List[ContextualRelevancyVerdict]:
+        return self._verdicts.get()
+    @property
+    def score(self) -> float:
+        return self._score.get()
+    @property
+    def reason(self) -> str:
+        return self._reason.get()
+    @property
+    def success(self) -> str:
+        return self._success.get()
+    
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:
@@ -60,19 +80,48 @@ class ContextualRelevancyMetric(BaseMetric):
         with metric_progress_indicator(self):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
-                    self.a_measure(test_case, _show_indicator=False)
+                (
+                    verdicts,
+                    score,
+                    reason,
+                    success
+                ) = loop.run_until_complete(
+                    self._measure_async(test_case)
                 )
+                self._verdicts.set(verdicts)
+                self._score.set(score)
+                self._reason.set(reason)
+                self._success.set(success)
+                
             else:
-                self.verdicts: List[ContextualRelevancyVerdict] = (
+                verdicts: List[ContextualRelevancyVerdict] = (
                     self._generate_verdicts(
                         test_case.input, test_case.retrieval_context
                     )
                 )
-                self.score = self._calculate_score()
-                self.reason = self._generate_reason(test_case.input)
-                self.success = self.score >= self.threshold
+                self._verdicts.set(verdicts)
+
+                score = self._calculate_score()
+                self._score.set(score)
+
+                reason = self._generate_reason(test_case.input)
+                self._reason.set(reason)
+
+                success = self.score >= self.threshold
+                self._success.set(success)
+
                 return self.score
+    
+    async def _measure_async(
+            self,
+            test_case: Union[LLMTestCase, ConversationalTestCase]):
+        await self.a_measure(test_case, _show_indicator=False)
+        return (
+            self.verdicts,
+            self.score,
+            self.reason,
+            self.success
+            )
 
     async def a_measure(
         self,
@@ -89,14 +138,22 @@ class ContextualRelevancyMetric(BaseMetric):
             async_mode=True,
             _show_indicator=_show_indicator,
         ):
-            self.verdicts: List[ContextualRelevancyVerdict] = (
+            verdicts: List[ContextualRelevancyVerdict] = (
                 await self._a_generate_verdicts(
                     test_case.input, test_case.retrieval_context
                 )
             )
-            self.score = self._calculate_score()
-            self.reason = await self._a_generate_reason(test_case.input)
-            self.success = self.score >= self.threshold
+            self._verdicts.set(verdicts)
+
+            score = self._calculate_score()
+            self._score.set(score)
+
+            reason = await self._a_generate_reason(test_case.input)
+            self._reason.set(reason)
+
+            success = self.score >= self.threshold
+            self._success.set(success)
+
             return self.score
 
     async def _a_generate_reason(self, input: str):

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -262,11 +262,11 @@ class ContextualRelevancyMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score >= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
-
+    
     @property
     def __name__(self):
         return "Contextual Relevancy"

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -84,40 +84,22 @@ class FaithfulnessMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    truths,
-                    claims,
-                    verdicts,
-                    score,
-                    reason,
-                    success
+                    self.truths,
+                    self.claims,
+                    self.verdicts,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.truths = truths
-                self.claims = claims
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
             else:
-                truths = self._generate_truths(test_case.retrieval_context)
-                self.truths = truths
-
-                claims = self._generate_claims(test_case.actual_output)
-                self.claims = claims
-                
-                verdicts = self._generate_verdicts()
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason()
-                self.reason = reason
-
-                success = self.score >= self.threshold
-                self.success = success
-                
+                self.truths = self._generate_truths(test_case.retrieval_context)
+                self.claims = self._generate_claims(test_case.actual_output)                
+                self.verdicts = self._generate_verdicts()
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason()
+                self.success = self.score >= self.threshold                
                 return self.score
             
     async def _measure_async(
@@ -146,25 +128,14 @@ class FaithfulnessMetric(BaseMetric):
         with metric_progress_indicator(
             self, async_mode=True, _show_indicator=_show_indicator
         ):
-            truths, claims = await asyncio.gather(
+            self.truths, self.claims = await asyncio.gather(
                 self._a_generate_truths(test_case.retrieval_context),
                 self._a_generate_claims(test_case.actual_output),
             )
-            self.truths = truths
-            self.claims = claims
-
-            verdicts  = await self._a_generate_verdicts()
-            self.verdicts = verdicts
-
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason()
-            self.reason = reason
-
-            success = self.score >= self.threshold
-            self.success = success
-
+            self.verdicts  = await self._a_generate_verdicts()
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason()
+            self.success = self.score >= self.threshold
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -56,21 +56,44 @@ class FaithfulnessMetric(BaseMetric):
     @property
     def truths(self) -> Optional[List[str]]:
         return self._truths.get()
+    @truths.setter
+    def truths(self, value: Optional[List[str]]):
+        self._truths.set(value)
+
     @property
     def claims(self) -> Optional[List[str]]:
         return self._claims.get()
+    @claims.setter
+    def claims(self, value: Optional[List[str]]):
+        self._claims.set(value)
+
     @property
     def verdicts(self) -> Optional[List[FaithfulnessVerdict]]:
         return self._verdicts.get()
+    @verdicts.setter
+    def verdicts(self, value: Optional[List['FaithfulnessVerdict']]):
+        self._verdicts.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -93,30 +116,30 @@ class FaithfulnessMetric(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._truths.set(truths)
-                self._claims.set(claims)
-                self._verdicts.set(verdicts)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.truths = truths
+                self.claims = claims
+                self.verdicts = verdicts
+                self.score = score
+                self.reason = reason
+                self.success = success
             else:
                 truths = self._generate_truths(test_case.retrieval_context)
-                self._truths.set(truths)
+                self.truths = truths
 
                 claims = self._generate_claims(test_case.actual_output)
-                self._claims.set(claims)
+                self.claims = claims
                 
                 verdicts = self._generate_verdicts()
-                self._verdicts.set(verdicts)
+                self.verdicts = verdicts
 
                 score = self._calculate_score()
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason()
-                self._reason.set(reason)
+                self.reason = reason
 
                 success = self.score >= self.threshold
-                self._success.set(success)
+                self.success = success
                 
                 return self.score
             
@@ -150,20 +173,20 @@ class FaithfulnessMetric(BaseMetric):
                 self._a_generate_truths(test_case.retrieval_context),
                 self._a_generate_claims(test_case.actual_output),
             )
-            self._truths.set(truths)
-            self._claims.set(claims)
+            self.truths = truths
+            self.claims = claims
 
             verdicts  = await self._a_generate_verdicts()
-            self._verdicts.set(verdicts)
+            self.verdicts = verdicts
 
             score = self._calculate_score()
-            self._score.set(score)
+            self.score = score
 
             reason = await self._a_generate_reason()
-            self._reason.set(reason)
+            self.reason = reason
 
             success = self.score >= self.threshold
-            self._success.set(success)
+            self.success = success
 
             return self.score
 
@@ -309,9 +332,9 @@ class FaithfulnessMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self.success = self.score >= self.threshold
             except:
-                self._success.set(False)
+                self._success = False
         return self.success
 
     @property

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -31,12 +31,12 @@ class FaithfulnessVerdict(BaseModel):
     reason: str = Field(default=None)
 
 class FaithfulnessMetric(BaseMetric):
-    _truths: ContextVar[List[str]] = ContextVar('truths', default=[])
-    _claims: ContextVar[List[str]] = ContextVar('claims', default=[])
-    _verdicts: ContextVar[List[FaithfulnessVerdict]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _truths: ContextVar[Optional[List[str]]] = ContextVar('truths', default=None)
+    _claims: ContextVar[Optional[List[str]]] = ContextVar('claims', default=None)
+    _verdicts: ContextVar[Optional[List[FaithfulnessVerdict]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -54,22 +54,22 @@ class FaithfulnessMetric(BaseMetric):
         self.strict_mode = strict_mode
     
     @property
-    def truths(self) -> List[str]:
+    def truths(self) -> Optional[List[str]]:
         return self._truths.get()
     @property
-    def claims(self) -> List[str]:
+    def claims(self) -> Optional[List[str]]:
         return self._claims.get()
     @property
-    def verdicts(self) -> List[FaithfulnessVerdict]:
+    def verdicts(self) -> Optional[List[FaithfulnessVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
 
     def measure(

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -69,7 +69,7 @@ class FaithfulnessMetric(BaseMetric):
     def verdicts(self) -> Optional[List[FaithfulnessVerdict]]:
         return self._verdicts.get()
     @verdicts.setter
-    def verdicts(self, value: Optional[List['FaithfulnessVerdict']]):
+    def verdicts(self, value: Optional[List[FaithfulnessVerdict]]):
         self._verdicts.set(value)
 
     def measure(

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -73,7 +73,9 @@ class FaithfulnessMetric(BaseMetric):
         self._verdicts.set(value)
 
     def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
+        self, 
+        test_case: Union[LLMTestCase, ConversationalTestCase],
+        verbose: bool = True
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -91,7 +93,7 @@ class FaithfulnessMetric(BaseMetric):
                     self.reason,
                     self.success
                 ) = loop.run_until_complete(
-                    self._measure_async(test_case)
+                    self._measure_async(test_case, verbose)
                 )
             else:
                 self.truths = self._generate_truths(test_case.retrieval_context)
@@ -99,13 +101,16 @@ class FaithfulnessMetric(BaseMetric):
                 self.verdicts = self._generate_verdicts()
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason()
-                self.success = self.score >= self.threshold                
+                self.success = self.score >= self.threshold
+                if verbose:
+                    print(f"truths: {self.truths}\nclaims: {self.claims}\nverdicts: {self.verdicts}")                        
                 return self.score
             
     async def _measure_async(
             self,
-            test_case: Union[LLMTestCase, ConversationalTestCase]):
-        await self.a_measure(test_case, _show_indicator=False)
+            test_case: Union[LLMTestCase, ConversationalTestCase],
+            verbose: bool):
+        await self.a_measure(test_case, _show_indicator=False, verbose=verbose)
         return (
             self.truths,
             self.claims, 
@@ -119,6 +124,7 @@ class FaithfulnessMetric(BaseMetric):
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
         _show_indicator: bool = True,
+        verbose: bool = True,
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -136,6 +142,8 @@ class FaithfulnessMetric(BaseMetric):
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason()
             self.success = self.score >= self.threshold
+            if verbose:
+                    print(f"truths: {self.truths}\nclaims: {self.claims}\nverdicts: {self.verdicts}")          
             return self.score
 
     async def _a_generate_reason(self) -> str:
@@ -282,7 +290,7 @@ class FaithfulnessMetric(BaseMetric):
             try:
                 self.success = self.score >= self.threshold
             except:
-                self._success = False
+                self.success = False
         return self.success
 
     @property

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -37,6 +37,7 @@ class FaithfulnessMetric(BaseMetric):
     _verdicts: ContextVar[List[FaithfulnessVerdict]] = ContextVar('verdicts', default=[])
     _score: ContextVar[float] = ContextVar('score', default=0)
     _reason: ContextVar[str] = ContextVar('reason', default="")
+    _success: ContextVar[bool] = ContextVar('success', default=False)
 
     def __init__(
         self,
@@ -68,6 +69,9 @@ class FaithfulnessMetric(BaseMetric):
     @property
     def reason(self) -> str:
         return self._reason.get()
+    @property
+    def success(self) -> str:
+        return self._success.get()
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -113,7 +117,7 @@ class FaithfulnessMetric(BaseMetric):
             self._claims.set(claims)
 
             verdicts  = await self._a_generate_verdicts()
-            self.verdicts.set(verdicts)
+            self._verdicts.set(verdicts)
 
             score = self._calculate_score()
             self._score.set(score)
@@ -121,7 +125,9 @@ class FaithfulnessMetric(BaseMetric):
             reason = await self._a_generate_reason()
             self._reason.set(reason)
 
-            self.success = self.score >= self.threshold
+            success = self.score >= self.threshold
+            self._success.set(success)
+
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -103,7 +103,7 @@ class FaithfulnessMetric(BaseMetric):
                 self.reason = self._generate_reason()
                 self.success = self.score >= self.threshold
                 if verbose:
-                    print(f"truths: {self.truths}\nclaims: {self.claims}\nverdicts: {self.verdicts}")                        
+                    print(f"truths: {self.truths}\nclaims: {self.claims}\nverdicts: {self.verdicts}\n")                        
                 return self.score
             
     async def _measure_async(
@@ -143,7 +143,7 @@ class FaithfulnessMetric(BaseMetric):
             self.reason = await self._a_generate_reason()
             self.success = self.score >= self.threshold
             if verbose:
-                    print(f"truths: {self.truths}\nclaims: {self.claims}\nverdicts: {self.verdicts}")          
+                    print(f"truths: {self.truths}\nclaims: {self.claims}\nverdicts: {self.verdicts}\n")          
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -31,13 +31,7 @@ class FaithfulnessVerdict(BaseModel):
     reason: str = Field(default=None)
 
 class FaithfulnessMetric(BaseMetric):
-    _truths: ContextVar[Optional[List[str]]] = ContextVar('truths', default=None)
-    _claims: ContextVar[Optional[List[str]]] = ContextVar('claims', default=None)
-    _verdicts: ContextVar[Optional[List[FaithfulnessVerdict]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-
+    
     def __init__(
         self,
         threshold: float = 0.5,
@@ -46,6 +40,10 @@ class FaithfulnessMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._truths: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_truths', default=None)
+        self._claims: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_claims', default=None)
+        self._verdicts: ContextVar[Optional[List[FaithfulnessVerdict]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -73,27 +71,6 @@ class FaithfulnessMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List['FaithfulnessVerdict']]):
         self._verdicts.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -113,23 +113,17 @@ class GEval(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    evaluation_steps,
-                    score,
-                    reason,
-                    success
+                    self.evaluation_steps,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.evaluation_steps = evaluation_steps
-                self.score = score
-                self.reason = reason
-                self.success = success
             else:
-                evaluation_steps: List[str] = (
+                self.evaluation_steps = (
                     self._generate_evaluation_steps()
                 )
-                self.evaluation_steps = evaluation_steps
-
                 g_score, reason = self.evaluate(test_case)
                 self.reason = reason
                 self.score = float(g_score) / 10
@@ -138,10 +132,7 @@ class GEval(BaseMetric):
                     if self.strict_mode and self.score < self.threshold
                     else self.score
                 )
-
-                success = self.score >= self.threshold
-                self.success = success
-
+                self.success = self.score >= self.threshold
                 return self.score
             
     async def _measure_async(
@@ -170,11 +161,9 @@ class GEval(BaseMetric):
             async_mode=True,
             _show_indicator=_show_indicator,
         ):
-            evaluation_steps: List[str] = (
+            self.evaluation_steps = (
                 await self._a_generate_evaluation_steps()
             )
-            self.evaluation_steps = evaluation_steps
-
             g_score, reason = await self._a_evaluate(test_case)
             self.reason = reason
             self.score = float(g_score) / 10
@@ -183,10 +172,7 @@ class GEval(BaseMetric):
                 if self.strict_mode and self.score < self.threshold
                 else self.score
             )
-            
-            success = self.score >= self.threshold
-            self.success = success
-
+            self.success = self.score >= self.threshold
             return self.score
 
     async def _a_generate_evaluation_steps(self) -> List[str]:

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -54,10 +54,10 @@ class GEvalResponse(BaseModel):
 
 class GEval(BaseMetric):
 
-    _evaluation_steps: ContextVar[List[str]] = ContextVar('evaluation_steps', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _evaluation_steps: ContextVar[Optional[List[str]]] = ContextVar('evaluation_steps', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
     
     def __init__(
         self,
@@ -98,16 +98,16 @@ class GEval(BaseMetric):
         self.async_mode = async_mode
 
     @property
-    def evaluation_steps(self) -> List[str]:
+    def evaluation_steps(self) -> Optional[List[str]]:
         return self._evaluation_steps.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
     
     def measure(

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -102,7 +102,9 @@ class GEval(BaseMetric):
         self._evaluation_steps.set(value)
 
     def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
+        self, 
+        test_case: Union[LLMTestCase, ConversationalTestCase],
+        verbose: bool = True
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -118,7 +120,7 @@ class GEval(BaseMetric):
                     self.reason,
                     self.success
                 ) = loop.run_until_complete(
-                    self._measure_async(test_case)
+                    self._measure_async(test_case, verbose)
                 )
             else:
                 self.evaluation_steps = (
@@ -133,12 +135,15 @@ class GEval(BaseMetric):
                     else self.score
                 )
                 self.success = self.score >= self.threshold
+                if verbose:
+                    print(f"evaluation_steps: {self.evaluation_steps}")          
                 return self.score
             
     async def _measure_async(
             self,
-            test_case: Union[LLMTestCase, ConversationalTestCase]):
-        await self.a_measure(test_case, _show_indicator=False)
+            test_case: Union[LLMTestCase, ConversationalTestCase],
+            verbose: bool):
+        await self.a_measure(test_case, _show_indicator=False, verbose=verbose)
         return (
             self.evaluation_steps,
             self.score,
@@ -150,6 +155,7 @@ class GEval(BaseMetric):
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
         _show_indicator: bool = True,
+        verbose: bool = True
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -173,6 +179,8 @@ class GEval(BaseMetric):
                 else self.score
             )
             self.success = self.score >= self.threshold
+            if verbose:
+                print(f"evaluation_steps: {self.evaluation_steps}")        
             return self.score
 
     async def _a_generate_evaluation_steps(self) -> List[str]:

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -100,16 +100,31 @@ class GEval(BaseMetric):
     @property
     def evaluation_steps(self) -> Optional[List[str]]:
         return self._evaluation_steps.get()
+    @evaluation_steps.setter
+    def evaluation_steps(self, value: Optional[List[str]]):
+        self._evaluation_steps.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+    
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
-    
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
+
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:
@@ -129,27 +144,27 @@ class GEval(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._evaluation_steps.set(evaluation_steps)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.evaluation_steps = evaluation_steps
+                self.score = score
+                self.reason = reason
+                self.success = success
             else:
                 evaluation_steps: List[str] = (
                     self._generate_evaluation_steps()
                 )
-                self._evaluation_steps.set(evaluation_steps)
+                self.evaluation_steps = evaluation_steps
 
                 g_score, reason = self.evaluate(test_case)
-                self._reason.set(reason)
-                self._score.set(float(g_score) / 10)
-                self._score.set(
+                self.reason = reason
+                self.score = float(g_score) / 10
+                self.score = (
                     0
                     if self.strict_mode and self.score < self.threshold
                     else self.score
                 )
 
                 success = self.score >= self.threshold
-                self._success.set(success)
+                self.success = success
 
                 return self.score
             
@@ -182,19 +197,19 @@ class GEval(BaseMetric):
             evaluation_steps: List[str] = (
                 await self._a_generate_evaluation_steps()
             )
-            self._evaluation_steps.set(evaluation_steps)
+            self.evaluation_steps = evaluation_steps
 
             g_score, reason = await self._a_evaluate(test_case)
-            self._reason.set(reason)
-            self._score.set(float(g_score) / 10)
-            self._score.set(
+            self.reason = reason
+            self.score = float(g_score) / 10
+            self.score = (
                 0
                 if self.strict_mode and self.score < self.threshold
                 else self.score
             )
             
             success = self.score >= self.threshold
-            self._success.set(success)
+            self.success = success
 
             return self.score
 
@@ -422,9 +437,9 @@ class GEval(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self.success = self.score >= self.threshold
             except:
-                self._success.set(False)
+                self.success = False
         return self.success
 
     @property

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -422,9 +422,9 @@ class GEval(BaseMetric):
             self.success = False
         else:
             try:
-                self.score >= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
 
     @property

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -136,7 +136,7 @@ class GEval(BaseMetric):
                 )
                 self.success = self.score >= self.threshold
                 if verbose:
-                    print(f"evaluation_steps: {self.evaluation_steps}")          
+                    print(f"evaluation_steps: {self.evaluation_steps}\n")          
                 return self.score
             
     async def _measure_async(
@@ -180,7 +180,7 @@ class GEval(BaseMetric):
             )
             self.success = self.score >= self.threshold
             if verbose:
-                print(f"evaluation_steps: {self.evaluation_steps}")        
+                print(f"evaluation_steps: {self.evaluation_steps}\n")        
             return self.score
 
     async def _a_generate_evaluation_steps(self) -> List[str]:

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -53,12 +53,7 @@ class GEvalResponse(BaseModel):
 
 
 class GEval(BaseMetric):
-
-    _evaluation_steps: ContextVar[Optional[List[str]]] = ContextVar('evaluation_steps', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-    
+   
     def __init__(
         self,
         name: str,
@@ -70,6 +65,8 @@ class GEval(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._evaluation_steps: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_evaluation_steps', default=None)
         self.name = name
         self.evaluation_params = evaluation_params
 
@@ -103,27 +100,6 @@ class GEval(BaseMetric):
     @evaluation_steps.setter
     def evaluation_steps(self, value: Optional[List[str]]):
         self._evaluation_steps.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-    
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -1,3 +1,4 @@
+from contextvars import ContextVar
 from typing import Optional, Union, List
 from pydantic import BaseModel, Field
 
@@ -24,13 +25,18 @@ required_params: List[LLMTestCaseParams] = [
     LLMTestCaseParams.CONTEXT,
 ]
 
-
 class HallucinationVerdict(BaseModel):
     verdict: str
     reason: str = Field(default=None)
 
 
 class HallucinationMetric(BaseMetric):
+
+    _verdicts: ContextVar[List[HallucinationTemplate]] = ContextVar('verdicts', default=[])
+    _score: ContextVar[float] = ContextVar('score', default=0)
+    _reason: ContextVar[str] = ContextVar('reason', default="")
+    _success: ContextVar[bool] = ContextVar('success', default=False)
+
     def __init__(
         self,
         threshold: float = 0.5,
@@ -46,6 +52,19 @@ class HallucinationMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
 
+    @property
+    def verdicts(self) -> List[HallucinationVerdict]:
+        return self._verdicts.get()
+    @property
+    def score(self) -> float:
+        return self._score.get()
+    @property
+    def reason(self) -> str:
+        return self._reason.get()
+    @property
+    def success(self) -> str:
+        return self._success.get()
+
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:
@@ -57,19 +76,47 @@ class HallucinationMetric(BaseMetric):
         with metric_progress_indicator(self):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
-                    self.a_measure(test_case, _show_indicator=False)
+                (
+                    verdicts,
+                    score,
+                    reason,
+                    success
+                ) = loop.run_until_complete(
+                    self._measure_async(test_case)
                 )
+                self._verdicts.set(verdicts)
+                self._score.set(score)
+                self._reason.set(reason)
+                self._success.set(success)
             else:
-                self.verdicts: List[HallucinationVerdict] = (
+                verdicts: List[HallucinationVerdict] = (
                     self._generate_verdicts(
                         test_case.actual_output, test_case.context
                     )
                 )
-                self.score = self._calculate_score()
-                self.reason = self._generate_reason()
-                self.success = self.score <= self.threshold
+                self._verdicts.set(verdicts)
+
+                score = self._calculate_score()
+                self._score.set(score)
+
+                reason = self._generate_reason()
+                self._reason.set(reason)
+
+                success = self.score <= self.threshold
+                self._success.set(success)
+
                 return self.score
+    
+    async def _measure_async(
+            self,
+            test_case: Union[LLMTestCase, ConversationalTestCase]):
+        await self.a_measure(test_case, _show_indicator=False)
+        return (
+            self.verdicts,
+            self.score,
+            self.reason,
+            self.success
+            )
 
     async def a_measure(
         self,
@@ -84,14 +131,22 @@ class HallucinationMetric(BaseMetric):
         with metric_progress_indicator(
             self, async_mode=True, _show_indicator=_show_indicator
         ):
-            self.verdicts: List[HallucinationVerdict] = (
+            verdicts: List[HallucinationVerdict] = (
                 await self._a_generate_verdicts(
                     test_case.actual_output, test_case.context
                 )
             )
-            self.score = self._calculate_score()
-            self.reason = await self._a_generate_reason()
-            self.success = self.score <= self.threshold
+            self._verdicts.set(verdicts)
+
+            score = self._calculate_score()
+            self._score.set(score)
+
+            reason = await self._a_generate_reason()
+            self._reason.set(reason)
+
+            success = self.score <= self.threshold
+            self._success.set(success)
+
             return self.score
 
     async def _a_generate_reason(self):

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -32,10 +32,10 @@ class HallucinationVerdict(BaseModel):
 
 class HallucinationMetric(BaseMetric):
 
-    _verdicts: ContextVar[List[HallucinationTemplate]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _verdicts: ContextVar[Optional[List[HallucinationTemplate]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -53,16 +53,16 @@ class HallucinationMetric(BaseMetric):
         self.strict_mode = strict_mode
 
     @property
-    def verdicts(self) -> List[HallucinationVerdict]:
+    def verdicts(self) -> Optional[List[HallucinationVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
 
     def measure(

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -68,34 +68,22 @@ class HallucinationMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    verdicts,
-                    score,
-                    reason,
-                    success
+                    self.verdicts,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
             else:
-                verdicts: List[HallucinationVerdict] = (
+                self.verdicts = (
                     self._generate_verdicts(
                         test_case.actual_output, test_case.context
                     )
                 )
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason()
-                self.reason = reason
-
-                success = self.score <= self.threshold
-                self.success = success
-
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason()
+                self.success = self.score <= self.threshold
                 return self.score
     
     async def _measure_async(
@@ -122,22 +110,14 @@ class HallucinationMetric(BaseMetric):
         with metric_progress_indicator(
             self, async_mode=True, _show_indicator=_show_indicator
         ):
-            verdicts: List[HallucinationVerdict] = (
+            self.verdicts = (
                 await self._a_generate_verdicts(
                     test_case.actual_output, test_case.context
                 )
             )
-            self.verdicts = verdicts
-
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason()
-            self.reason = reason
-
-            success = self.score <= self.threshold
-            self.success = success
-
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason()
+            self.success = self.score <= self.threshold
             return self.score
 
     async def _a_generate_reason(self):

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -249,9 +249,9 @@ class HallucinationMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score <= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
 
     @property

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -32,11 +32,6 @@ class HallucinationVerdict(BaseModel):
 
 class HallucinationMetric(BaseMetric):
 
-    _verdicts: ContextVar[Optional[List[HallucinationTemplate]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -45,6 +40,8 @@ class HallucinationMetric(BaseMetric):
         async_mode: bool = False,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._verdicts: ContextVar[Optional[List[HallucinationTemplate]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)
         self.threshold = 0 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -58,27 +55,6 @@ class HallucinationMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List[HallucinationVerdict]]):
         self._score.set(value)
-    
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-    
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -85,7 +85,7 @@ class HallucinationMetric(BaseMetric):
                 self.reason = self._generate_reason()
                 self.success = self.score <= self.threshold
                 if verbose:
-                    print(f"verdicts: {self.verdicts}")  
+                    print(f"verdicts: {self.verdicts}\n")  
                 return self.score
     
     async def _measure_async(
@@ -121,7 +121,7 @@ class HallucinationMetric(BaseMetric):
             self.reason = await self._a_generate_reason()
             self.success = self.score <= self.threshold
             if verbose:
-                print(f"verdicts: {self.verdicts}") 
+                print(f"verdicts: {self.verdicts}\n") 
             return self.score
 
     async def _a_generate_reason(self):

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -249,7 +249,7 @@ class HallucinationMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self._success.set(self.score <= self.threshold)
             except:
                 self._success.set(False)
         return self.success

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -59,7 +59,7 @@ class HallucinationMetric(BaseMetric):
     def measure(
         self, 
         test_case: Union[LLMTestCase, ConversationalTestCase],
-        verbose: bool
+        verbose: bool = True
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -55,15 +55,30 @@ class HallucinationMetric(BaseMetric):
     @property
     def verdicts(self) -> Optional[List[HallucinationVerdict]]:
         return self._verdicts.get()
+    @verdicts.setter
+    def verdicts(self, value: Optional[List[HallucinationVerdict]]):
+        self._score.set(value)
+    
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+    
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -84,26 +99,26 @@ class HallucinationMetric(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._verdicts.set(verdicts)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.verdicts = verdicts
+                self.score = score
+                self.reason = reason
+                self.success = success
             else:
                 verdicts: List[HallucinationVerdict] = (
                     self._generate_verdicts(
                         test_case.actual_output, test_case.context
                     )
                 )
-                self._verdicts.set(verdicts)
+                self.verdicts = verdicts
 
                 score = self._calculate_score()
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason()
-                self._reason.set(reason)
+                self.reason = reason
 
                 success = self.score <= self.threshold
-                self._success.set(success)
+                self.success = success
 
                 return self.score
     
@@ -136,16 +151,16 @@ class HallucinationMetric(BaseMetric):
                     test_case.actual_output, test_case.context
                 )
             )
-            self._verdicts.set(verdicts)
+            self.verdicts = verdicts
 
             score = self._calculate_score()
-            self._score.set(score)
+            self.score = score
 
             reason = await self._a_generate_reason()
-            self._reason.set(reason)
+            self.reason = reason
 
             success = self.score <= self.threshold
-            self._success.set(success)
+            self.success = success
 
             return self.score
 
@@ -249,9 +264,9 @@ class HallucinationMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score <= self.threshold)
+                self.success = self.score <= self.threshold
             except:
-                self._success.set(False)
+                self.success = False
         return self.success
 
     @property

--- a/deepeval/metrics/indicator.py
+++ b/deepeval/metrics/indicator.py
@@ -41,58 +41,58 @@ progress = Progress(
 )
 
 # A lock to safely update task count
-lock = threading.Lock()
-active_tasks = 0
+# lock = threading.Lock()
+# active_tasks = 0
 
-def start_progress():
-    with lock:
-        global active_tasks
-        if active_tasks == 0:
-            progress.start()
-        active_tasks += 1
+# def start_progress():
+#     with lock:
+#         global active_tasks
+#         if active_tasks == 0:
+#             progress.start()
+#         active_tasks += 1
 
-def update_progress():
-    with lock:
-        global active_tasks
-        active_tasks -= 1
-        if active_tasks == 0:
-            progress.stop()
+# def update_progress():
+#     with lock:
+#         global active_tasks
+#         active_tasks -= 1
+#         if active_tasks == 0:
+#             progress.stop()
 
 @contextmanager
 def metric_progress_indicator(metric, async_mode=False, _show_indicator=True, total=9999):
     with capture_metric_type(metric.__name__):
         if _show_indicator and show_indicator():
-            if async_mode==False:
-                with Progress(
-                    SpinnerColumn(style="rgb(106,0,255)"),
-                    TextColumn("[progress.description]{task.description}"),
-                    console=console,  # Use the custom console
-                    transient=True,
-                ) as progress_sync:
-                    progress_sync.add_task(
-                        description=format_metric_description(metric, async_mode),
-                        total=total,
-                    )
-                    yield
-            else:
-                start_progress() 
-                start_time = time.perf_counter()
-                task_id = progress.add_task(
+            # if async_mode==False:
+            with Progress(
+                SpinnerColumn(style="rgb(106,0,255)"),
+                TextColumn("[progress.description]{task.description}"),
+                console=console,  # Use the custom console
+                transient=True,
+            ) as progress_sync:
+                progress_sync.add_task(
                     description=format_metric_description(metric, async_mode),
                     total=total,
                 )
-                try:
-                    yield task_id
-                finally:
-                    end_time = time.perf_counter()
-                    time_taken = format(end_time - start_time, ".2f")
-                    progress.update(task_id, completed=total)
-                    progress.update(
-                        task_id,
-                        description=f"{progress.tasks[task_id].description} [rgb(25,227,160)]Done! ({time_taken}s)",
-                    )
-                    progress.stop_task(task_id)
-                    update_progress()
+                yield
+            # else:
+            #     start_progress() 
+            #     start_time = time.perf_counter()
+            #     task_id = progress.add_task(
+            #         description=format_metric_description(metric, async_mode),
+            #         total=total,
+            #     )
+            #     try:
+            #         yield task_id
+            #     finally:
+            #         end_time = time.perf_counter()
+            #         time_taken = format(end_time - start_time, ".2f")
+            #         progress.update(task_id, completed=total)
+            #         progress.update(
+            #             task_id,
+            #             description=f"{progress.tasks[task_id].description} [rgb(25,227,160)]Done! ({time_taken}s)",
+            #         )
+            #         progress.stop_task(task_id)
+            #         update_progress()
         else:
             yield None
 

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -71,7 +71,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
             self.success = knowledge_retention_score >= self.threshold
             self.score = knowledge_retention_score
             if verbose:
-                print(f"knowledges: {self.knowledges}\nverdicts: {self.verdicts}")                        
+                print(f"knowledges: {self.knowledges}\nverdicts: {self.verdicts}\n")                        
             return self.score
 
     def _generate_reason(self, score: float) -> str:

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -60,10 +60,10 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
     def measure(self, test_case: ConversationalTestCase):
         validate_conversational_test_case(test_case, self)
         with metric_progress_indicator(self):
-            self.knowledges: List[Knowledge] = self._generate_knowledges(
+            self.knowledges = self._generate_knowledges(
                 test_case
             )
-            self.verdicts: List[KnowledgeRetentionVerdict] = (
+            self.verdicts = (
                 self._generate_verdicts(test_case)
             )
             knowledge_retention_score = self._calculate_score()

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -57,7 +57,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
     def verdicts(self, value: Optional[List[KnowledgeRetentionVerdict]]):
         self._verdicts.set(value)
 
-    def measure(self, test_case: ConversationalTestCase):
+    def measure(self, test_case: ConversationalTestCase, verbose: bool = True):
         validate_conversational_test_case(test_case, self)
         with metric_progress_indicator(self):
             self.knowledges = self._generate_knowledges(
@@ -70,6 +70,8 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
             self.reason = self._generate_reason(knowledge_retention_score)
             self.success = knowledge_retention_score >= self.threshold
             self.score = knowledge_retention_score
+            if verbose:
+                print(f"knowledges: {self.knowledges}\nverdicts: {self.verdicts}")                        
             return self.score
 
     def _generate_reason(self, score: float) -> str:

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -68,7 +68,6 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
             )
             knowledge_retention_score = self._calculate_score()
             self.reason = self._generate_reason(knowledge_retention_score)
-
             self.success = knowledge_retention_score >= self.threshold
             self.score = knowledge_retention_score
             return self.score

--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -24,6 +24,7 @@ class RAGASContextualPrecisionMetric(BaseMetric):
         model: Optional[Union[str, BaseChatModel]] = "gpt-3.5-turbo",
         _track: bool = True,
     ):
+        super.__init__()
         self.threshold = threshold
         self.model = model
         self._track = _track

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -47,16 +47,16 @@ class ScoreType(Enum):
 
 class SummarizationMetric(BaseMetric):
 
-    _truths: ContextVar[List[str]] = ContextVar('truths', default=[])
-    _claims: ContextVar[List[str]] = ContextVar('claims', default=[])
-    _coverage_verdicts: ContextVar[List[SummarizationCoverageVerdict]] = ContextVar('coverage_verdicts', default=[])
-    _alignment_verdicts: ContextVar[List[SummarizationAlignmentVerdict]] = ContextVar('alignment_verdicts', default=[])
-    _coverage_score: ContextVar[float] = ContextVar('coverage_score', default=[])
-    _alignment_score: ContextVar[float] = ContextVar('alignment_score', default=[])
-    _score_breakdown: ContextVar[Dict] = ContextVar('score_breakdown', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _truths: ContextVar[Optional[List[str]]] = ContextVar('truths', default=None)
+    _claims: ContextVar[Optional[List[str]]] = ContextVar('claims', default=None)
+    _coverage_verdicts: ContextVar[Optional[List[SummarizationCoverageVerdict]]] = ContextVar('coverage_verdicts', default=None)
+    _alignment_verdicts: ContextVar[Optional[List[SummarizationAlignmentVerdict]]] = ContextVar('alignment_verdicts', default=None)
+    _coverage_score: ContextVar[Optional[float]] = ContextVar('coverage_score', default=None)
+    _alignment_score: ContextVar[Optional[float]] = ContextVar('alignment_score', default=None)
+    _score_breakdown: ContextVar[Optional[Dict]] = ContextVar('score_breakdown', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -83,31 +83,31 @@ class SummarizationMetric(BaseMetric):
         self.strict_mode = strict_mode
 
     @property
-    def truths(self) -> List[str]:
+    def truths(self) -> Optional[List[str]]:
         return self._truths.get()
     @property
-    def claims(self) -> List[str]:
+    def claims(self) -> Optional[List[str]]:
         return self._claims.get()
     @property
-    def coverage_verdicts(self) -> List[SummarizationCoverageVerdict]:
+    def coverage_verdicts(self) -> Optional[List[SummarizationCoverageVerdict]]:
         return self._coverage_verdicts.get()
     @property
-    def alignment_verdicts(self) -> List[SummarizationAlignmentVerdict]:
+    def alignment_verdicts(self) -> Optional[List[SummarizationAlignmentVerdict]]:
         return self._alignment_verdicts.get()
     @property
-    def coverage_score(self) -> float:
+    def coverage_score(self) -> Optional[float]:
         return self._coverage_score.get()
     @property
-    def alignment_score(self) -> float:
+    def alignment_score(self) -> Optional[float]:
         return self._alignment_score.get()
     @property
-    def score_breakdown(self) -> Dict:
+    def score_breakdown(self) -> Optional[Dict]:
         return self._score_breakdown.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
     def success(self) -> str:

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -47,17 +47,6 @@ class ScoreType(Enum):
 
 class SummarizationMetric(BaseMetric):
 
-    _truths: ContextVar[Optional[List[str]]] = ContextVar('truths', default=None)
-    _claims: ContextVar[Optional[List[str]]] = ContextVar('claims', default=None)
-    _coverage_verdicts: ContextVar[Optional[List[SummarizationCoverageVerdict]]] = ContextVar('coverage_verdicts', default=None)
-    _alignment_verdicts: ContextVar[Optional[List[SummarizationAlignmentVerdict]]] = ContextVar('alignment_verdicts', default=None)
-    _coverage_score: ContextVar[Optional[float]] = ContextVar('coverage_score', default=None)
-    _alignment_score: ContextVar[Optional[float]] = ContextVar('alignment_score', default=None)
-    _score_breakdown: ContextVar[Optional[Dict]] = ContextVar('score_breakdown', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -68,6 +57,13 @@ class SummarizationMetric(BaseMetric):
         async_mode=True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._truths: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_truths', default=None)
+        self._claims: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_claims', default=None)
+        self._coverage_verdicts: ContextVar[Optional[List[SummarizationCoverageVerdict]]] = ContextVar(f'{self.__class__.__name__}_coverage_verdicts', default=None)
+        self._alignment_verdicts: ContextVar[Optional[List[SummarizationAlignmentVerdict]]] = ContextVar(f'{self.__class__.__name__}_alignment_verdicts', default=None)
+        self._coverage_score: ContextVar[Optional[float]] = ContextVar(f'{self.__class__.__name__}_coverage_score', default=None)
+        self._alignment_score: ContextVar[Optional[float]] = ContextVar(f'{self.__class__.__name__}_alignment_score', default=None)
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -123,34 +119,6 @@ class SummarizationMetric(BaseMetric):
     @alignment_score.setter
     def alignment_score(self, value: Optional[float]):
         self._alignment_score.set(value)
-
-    @property
-    def score_breakdown(self) -> Optional[Dict]:
-        return self._score_breakdown.get()
-    @score_breakdown.setter
-    def score_breakdown(self, value: Optional[Dict]):
-        self._score_breakdown.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> bool:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -547,9 +547,9 @@ class SummarizationMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score >= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
 
     @property

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -168,8 +168,7 @@ class SummarizationMetric(BaseMetric):
                 self.reason = self._generate_reason()
                 self.success = self.score >= self.threshold   
                 if verbose:
-                    print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: 
-                          {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}")          
+                    print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}")          
                 return self.score
             
     async def _measure_async(
@@ -228,8 +227,7 @@ class SummarizationMetric(BaseMetric):
             self.reason = await self._a_generate_reason()
             self.success = self.score >= self.threshold
             if verbose:
-                print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: 
-                      {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}")         
+                print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}")         
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -168,7 +168,7 @@ class SummarizationMetric(BaseMetric):
                 self.reason = self._generate_reason()
                 self.success = self.score >= self.threshold   
                 if verbose:
-                    print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}")          
+                    print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}\n")          
                 return self.score
             
     async def _measure_async(
@@ -227,7 +227,7 @@ class SummarizationMetric(BaseMetric):
             self.reason = await self._a_generate_reason()
             self.success = self.score >= self.threshold
             if verbose:
-                print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}")         
+                print(f"truths: {self.truths}\nclaims: {self.claims}\ncoverage_verdicts: {self.coverage_verdicts}\nalignment_verdicts: {self.alignment_verdicts}\n")         
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -85,33 +85,72 @@ class SummarizationMetric(BaseMetric):
     @property
     def truths(self) -> Optional[List[str]]:
         return self._truths.get()
+    @truths.setter
+    def truths(self, value: Optional[List[str]]):
+        self._truths.set(value)
+
     @property
     def claims(self) -> Optional[List[str]]:
         return self._claims.get()
+    @claims.setter
+    def claims(self, value: Optional[List[str]]):
+        self._claims.set(value)
+
     @property
     def coverage_verdicts(self) -> Optional[List[SummarizationCoverageVerdict]]:
         return self._coverage_verdicts.get()
+    @coverage_verdicts.setter
+    def coverage_verdicts(self, value: Optional[List[SummarizationCoverageVerdict]]):
+        self._coverage_verdicts.set(value)
+
     @property
     def alignment_verdicts(self) -> Optional[List[SummarizationAlignmentVerdict]]:
         return self._alignment_verdicts.get()
+    @alignment_verdicts.setter
+    def alignment_verdicts(self, value: Optional[List[SummarizationAlignmentVerdict]]):
+        self._alignment_verdicts.set(value)
+
     @property
     def coverage_score(self) -> Optional[float]:
         return self._coverage_score.get()
+    @coverage_score.setter
+    def coverage_score(self, value: Optional[float]):
+        self._coverage_score.set(value)
+
     @property
     def alignment_score(self) -> Optional[float]:
         return self._alignment_score.get()
+    @alignment_score.setter
+    def alignment_score(self, value: Optional[float]):
+        self._alignment_score.set(value)
+
     @property
     def score_breakdown(self) -> Optional[Dict]:
         return self._score_breakdown.get()
+    @score_breakdown.setter
+    def score_breakdown(self, value: Optional[Dict]):
+        self._score_breakdown.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> str:
+    def success(self) -> bool:
         return self._success.get()
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
 
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
@@ -138,56 +177,56 @@ class SummarizationMetric(BaseMetric):
                     ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._truths.set(truths)
-                self._claims.set(claims)
-                self._coverage_verdicts.set(coverage_verdicts)
-                self._alignment_verdicts.set(alignment_verdicts)
-                self._coverage_score.set(coverage_score)
-                self._alignment_score.set(alignment_score)
-                self._score_breakdown.set(score_breakdown)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.truths = truths
+                self.claims = claims
+                self.coverage_verdicts = coverage_verdicts
+                self.alignment_verdicts = alignment_verdicts
+                self.coverage_score = coverage_score
+                self.alignment_score = alignment_score
+                self.score_breakdown = score_breakdown
+                self.score = score
+                self.reason = reason
+                self.success = success
 
             else:
                 truths: List[str] = self._generate_claims(test_case.input)
-                self._truths.set(truths)
+                self.truths = truths
                 
                 claims: List[str] = self._generate_claims(
                     test_case.actual_output
                 )
-                self._claims.set(claims)
+                self.claims = claims
 
                 coverage_verdicts: List[SummarizationCoverageVerdict] = (
                     self._generate_coverage_verdicts(test_case)
                 )
-                self._coverage_verdicts.set(coverage_verdicts)
+                self.coverage_verdicts = coverage_verdicts
 
                 alignment_verdicts: List[SummarizationAlignmentVerdict] = (
                     self._generate_alignment_verdicts()
                 )
-                self._alignment_verdicts.set(alignment_verdicts)
+                self.alignment_verdicts = alignment_verdicts
 
                 alignment_score = self._calculate_score(ScoreType.ALIGNMENT)
-                self._alignment_score.set(alignment_score)
+                self.alignment_score = alignment_score
 
                 coverage_score = self._calculate_score(ScoreType.COVERAGE)
-                self._coverage_score.set(coverage_score)
+                self.coverage_score = coverage_score
 
                 score_breakdown = {
                     ScoreType.ALIGNMENT.value: alignment_score,
                     ScoreType.COVERAGE.value: coverage_score,
                 }
-                self._score_breakdown.set(score_breakdown)
+                self.score_breakdown = score_breakdown
 
                 score = min(alignment_score, coverage_score)
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason()
-                self._reason.set(reason)
+                self.reason = reason
 
                 success = self.score >= self.threshold
-                self._success.set(success)
+                self.success = success
             
                 return self.score
             
@@ -547,9 +586,9 @@ class SummarizationMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self.success = self.score >= self.threshold
             except:
-                self._success.set(False)
+                self.success = False
         return self.success
 
     @property

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -34,12 +34,6 @@ class ToxicityVerdict(BaseModel):
 
 class ToxicityMetric(BaseMetric):
 
-    _opinions: ContextVar[Optional[List[str]]] = ContextVar('opinions', default=None)
-    _verdicts: ContextVar[Optional[List[ToxicityVerdict]]] = ContextVar('verdicts', default=None)
-    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
-    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
-    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
-
     def __init__(
         self,
         threshold: float = 0.5,
@@ -48,6 +42,9 @@ class ToxicityMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
     ):
+        super().__init__()
+        self._opinions: ContextVar[Optional[List[str]]] = ContextVar(f'{self.__class__.__name__}_opinions', default=None)
+        self._verdicts: ContextVar[Optional[List[ToxicityVerdict]]] = ContextVar(f'{self.__class__.__name__}_verdicts', default=None)
         self.threshold = 0 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
@@ -68,28 +65,7 @@ class ToxicityMetric(BaseMetric):
     @verdicts.setter
     def verdicts(self, value: Optional[List['ToxicityVerdict']]):
         self._verdicts.set(value)
-
-    @property
-    def score(self) -> Optional[float]:
-        return self._score.get()
-    @score.setter
-    def score(self, value: Optional[float]):
-        self._score.set(value)
-
-    @property
-    def reason(self) -> Optional[str]:
-        return self._reason.get()
-    @reason.setter
-    def reason(self, value: Optional[str]):
-        self._reason.set(value)
-
-    @property
-    def success(self) -> Optional[bool]:
-        return self._success.get()
-    @success.setter
-    def success(self, value: Optional[bool]):
-        self._success.set(value)
-
+        
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -97,7 +97,7 @@ class ToxicityMetric(BaseMetric):
                 self.reason = self._generate_reason()
                 self.success = self.score <= self.threshold
                 if verbose:
-                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")  
+                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}\n")  
                 return self.score
             
     async def _measure_async(
@@ -138,7 +138,7 @@ class ToxicityMetric(BaseMetric):
             self.reason = await self._a_generate_reason()
             self.success = self.score <= self.threshold
             if verbose: 
-                print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")                  
+                print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}\n")                  
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -270,11 +270,10 @@ class ToxicityMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self.success = self.score <= self.threshold
+                self._success.set(self.score >= self.threshold)
             except:
-                self.success = False
+                self._success.set(False)
         return self.success
-
     @property
     def __name__(self):
         return "Toxicity"

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -58,19 +58,38 @@ class ToxicityMetric(BaseMetric):
     @property
     def opinions(self) -> Optional[List[str]]:
         return self._opinions.get()
+    @opinions.setter
+    def opinions(self, value: Optional[List[str]]):
+        self._opinions.set(value)
+
     @property
     def verdicts(self) -> Optional[List[ToxicityVerdict]]:
         return self._verdicts.get()
+    @verdicts.setter
+    def verdicts(self, value: Optional[List['ToxicityVerdict']]):
+        self._verdicts.set(value)
+
     @property
     def score(self) -> Optional[float]:
         return self._score.get()
+    @score.setter
+    def score(self, value: Optional[float]):
+        self._score.set(value)
+
     @property
     def reason(self) -> Optional[str]:
         return self._reason.get()
+    @reason.setter
+    def reason(self, value: Optional[str]):
+        self._reason.set(value)
+
     @property
-    def success(self) -> Optional[str]:
+    def success(self) -> Optional[bool]:
         return self._success.get()
-    
+    @success.setter
+    def success(self, value: Optional[bool]):
+        self._success.set(value)
+
     def measure(
         self, test_case: Union[LLMTestCase, ConversationalTestCase]
     ) -> float:
@@ -91,28 +110,28 @@ class ToxicityMetric(BaseMetric):
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self._opinions.set(opinions)
-                self._verdicts.set(verdicts)
-                self._score.set(score)
-                self._reason.set(reason)
-                self._success.set(success)
+                self.opinions = opinions
+                self.verdicts = verdicts
+                self.score = score
+                self.reason = reason
+                self.success = success
             else:
                 opinions: List[str] = self._generate_opinions(
                     test_case.actual_output
                 )
-                self._opinions.set(opinions)
+                self.opinions = opinions
 
                 verdicts: List[ToxicityVerdict] = self._generate_verdicts()
-                self._verdicts.set(verdicts)
+                self.verdicts = verdicts
 
                 score = self._calculate_score()
-                self._score.set(score)
+                self.score = score
 
                 reason = self._generate_reason()
-                self._reason.set(reason)
+                self.reason = reason
 
                 success = self.score <= self.threshold
-                self._success.set(success)
+                self.success = success
 
                 return self.score
             
@@ -144,21 +163,21 @@ class ToxicityMetric(BaseMetric):
             opinions: List[str] = await self._a_generate_opinions(
                 test_case.actual_output
             )
-            self._opinions.set(opinions)
+            self.opinions = opinions
 
             verdicts: List[ToxicityVerdict] = (
                 await self._a_generate_verdicts()
             )
-            self._verdicts.set(verdicts)
+            self.verdicts = verdicts
 
             score = self._calculate_score()
-            self._score.set(score)
+            self.score = score
 
             reason = await self._a_generate_reason()
-            self._reason.set(reason)
+            self.reason = reason
 
             success = self.score <= self.threshold
-            self._success.set(success)
+            self.success = success
 
             return self.score
 
@@ -270,9 +289,9 @@ class ToxicityMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score <= self.threshold)
+                self.success = self.score <= self.threshold
             except:
-                self._success.set(False)
+                self.success = False
         return self.success
     @property
     def __name__(self):

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -270,7 +270,7 @@ class ToxicityMetric(BaseMetric):
             self.success = False
         else:
             try:
-                self._success.set(self.score >= self.threshold)
+                self._success.set(self.score <= self.threshold)
             except:
                 self._success.set(False)
         return self.success

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -34,11 +34,11 @@ class ToxicityVerdict(BaseModel):
 
 class ToxicityMetric(BaseMetric):
 
-    _opinions: ContextVar[List[str]] = ContextVar('opinions', default=[])
-    _verdicts: ContextVar[List[ToxicityVerdict]] = ContextVar('verdicts', default=[])
-    _score: ContextVar[float] = ContextVar('score', default=0)
-    _reason: ContextVar[str] = ContextVar('reason', default="")
-    _success: ContextVar[bool] = ContextVar('success', default=False)
+    _opinions: ContextVar[Optional[List[str]]] = ContextVar('opinions', default=None)
+    _verdicts: ContextVar[Optional[List[ToxicityVerdict]]] = ContextVar('verdicts', default=None)
+    _score: ContextVar[Optional[float]] = ContextVar('score', default=None)
+    _reason: ContextVar[Optional[str]] = ContextVar('reason', default=None)
+    _success: ContextVar[Optional[bool]] = ContextVar('success', default=None)
 
     def __init__(
         self,
@@ -56,19 +56,19 @@ class ToxicityMetric(BaseMetric):
         self.strict_mode = strict_mode
 
     @property
-    def opinions(self) -> List[str]:
+    def opinions(self) -> Optional[List[str]]:
         return self._opinions.get()
     @property
-    def verdicts(self) -> List[ToxicityVerdict]:
+    def verdicts(self) -> Optional[List[ToxicityVerdict]]:
         return self._verdicts.get()
     @property
-    def score(self) -> float:
+    def score(self) -> Optional[float]:
         return self._score.get()
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         return self._reason.get()
     @property
-    def success(self) -> str:
+    def success(self) -> Optional[str]:
         return self._success.get()
     
     def measure(

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -78,37 +78,22 @@ class ToxicityMetric(BaseMetric):
             if self.async_mode:
                 loop = get_or_create_event_loop()
                 (
-                    opinions,
-                    verdicts,
-                    score,
-                    reason,
-                    success
+                    self.opinions,
+                    self.verdicts,
+                    self.score,
+                    self.reason,
+                    self.success
                 ) = loop.run_until_complete(
                     self._measure_async(test_case)
                 )
-                self.opinions = opinions
-                self.verdicts = verdicts
-                self.score = score
-                self.reason = reason
-                self.success = success
             else:
-                opinions: List[str] = self._generate_opinions(
+                self.opinions = self._generate_opinions(
                     test_case.actual_output
                 )
-                self.opinions = opinions
-
-                verdicts: List[ToxicityVerdict] = self._generate_verdicts()
-                self.verdicts = verdicts
-
-                score = self._calculate_score()
-                self.score = score
-
-                reason = self._generate_reason()
-                self.reason = reason
-
-                success = self.score <= self.threshold
-                self.success = success
-
+                self.verdicts: List[ToxicityVerdict] = self._generate_verdicts()
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason()
+                self.success = self.score <= self.threshold
                 return self.score
             
     async def _measure_async(
@@ -136,25 +121,15 @@ class ToxicityMetric(BaseMetric):
         with metric_progress_indicator(
             self, async_mode=True, _show_indicator=_show_indicator
         ):
-            opinions: List[str] = await self._a_generate_opinions(
+            self.opinions = await self._a_generate_opinions(
                 test_case.actual_output
             )
-            self.opinions = opinions
-
-            verdicts: List[ToxicityVerdict] = (
+            self.verdicts = (
                 await self._a_generate_verdicts()
             )
-            self.verdicts = verdicts
-
-            score = self._calculate_score()
-            self.score = score
-
-            reason = await self._a_generate_reason()
-            self.reason = reason
-
-            success = self.score <= self.threshold
-            self.success = success
-
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason()
+            self.success = self.score <= self.threshold
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -67,7 +67,9 @@ class ToxicityMetric(BaseMetric):
         self._verdicts.set(value)
         
     def measure(
-        self, test_case: Union[LLMTestCase, ConversationalTestCase]
+        self, 
+        test_case: Union[LLMTestCase, ConversationalTestCase],
+        verbose: bool = True
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -84,7 +86,7 @@ class ToxicityMetric(BaseMetric):
                     self.reason,
                     self.success
                 ) = loop.run_until_complete(
-                    self._measure_async(test_case)
+                    self._measure_async(test_case, verbose)
                 )
             else:
                 self.opinions = self._generate_opinions(
@@ -94,12 +96,16 @@ class ToxicityMetric(BaseMetric):
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason()
                 self.success = self.score <= self.threshold
+                if verbose:
+                    print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")  
                 return self.score
             
     async def _measure_async(
             self,
-            test_case: Union[LLMTestCase, ConversationalTestCase]):
-        await self.a_measure(test_case, _show_indicator=False)
+            test_case: Union[LLMTestCase, ConversationalTestCase],
+            verbose: bool
+            ):
+        await self.a_measure(test_case, _show_indicator=False, verbose=verbose)
         return (
             self.opinions,
             self.verdicts,
@@ -112,6 +118,7 @@ class ToxicityMetric(BaseMetric):
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
         _show_indicator: bool = True,
+        verbose: bool = True
     ) -> float:
         if isinstance(test_case, ConversationalTestCase):
             test_case = validate_conversational_test_case(test_case, self)
@@ -130,6 +137,8 @@ class ToxicityMetric(BaseMetric):
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason()
             self.success = self.score <= self.threshold
+            if verbose: 
+                print(f"opinions: {self.opinions}\nverdicts: {self.verdicts}")                  
             return self.score
 
     async def _a_generate_reason(self) -> str:

--- a/deepeval/test_run/cache.py
+++ b/deepeval/test_run/cache.py
@@ -156,7 +156,7 @@ class TestRunCacheManager:
         if to_temp:
             try:
                 with portalocker.Lock(
-                    self.temp_cache_file_name, mode="w", timeout=5
+                    self.temp_cache_file_name, mode="w"
                 ) as file:
                     self.temp_cached_test_run = self.temp_cached_test_run.save(
                         file
@@ -169,7 +169,7 @@ class TestRunCacheManager:
         else:
             try:
                 with portalocker.Lock(
-                    self.cache_file_name, mode="w", timeout=5
+                    self.cache_file_name, mode="w"
                 ) as file:
                     self.cached_test_run = self.cached_test_run.save(file)
             except Exception as e:
@@ -204,7 +204,6 @@ class TestRunCacheManager:
                 with portalocker.Lock(
                     self.temp_cache_file_name,
                     mode="r",
-                    timeout=5,
                     flags=portalocker.LOCK_SH | portalocker.LOCK_NB,
                 ) as file:
                     content = file.read().strip()
@@ -231,7 +230,6 @@ class TestRunCacheManager:
                 with portalocker.Lock(
                     self.cache_file_name,
                     mode="r",
-                    timeout=5,
                     flags=portalocker.LOCK_SH | portalocker.LOCK_NB,
                 ) as file:
                     content = file.read().strip()
@@ -262,7 +260,7 @@ class TestRunCacheManager:
         self.get_cached_test_run(from_temp=True)
         try:
             with portalocker.Lock(
-                self.cache_file_name, mode="w", timeout=5
+                self.cache_file_name, mode="w"
             ) as file:
                 self.temp_cached_test_run = self.temp_cached_test_run.save(file)
         except Exception as e:

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -288,7 +288,6 @@ class TestRunManager:
                 with portalocker.Lock(
                     self.temp_file_name,
                     mode="r",
-                    timeout=5,
                     flags=portalocker.LOCK_SH | portalocker.LOCK_NB,
                 ) as file:
                     self.test_run = self.test_run.load(file)
@@ -305,7 +304,7 @@ class TestRunManager:
         if self.save_to_disk:
             try:
                 with portalocker.Lock(
-                    self.temp_file_name, mode="w", timeout=5
+                    self.temp_file_name, mode="w"
                 ) as file:
                     self.test_run = self.test_run.save(file)
             except portalocker.exceptions.LockException:
@@ -324,7 +323,6 @@ class TestRunManager:
                 with portalocker.Lock(
                     self.temp_file_name,
                     mode="r+",
-                    timeout=5,
                     flags=portalocker.LOCK_EX,
                 ) as file:
                     file.seek(0)

--- a/llama_test/test_llama_index_chatbot.py
+++ b/llama_test/test_llama_index_chatbot.py
@@ -9,6 +9,7 @@ import asyncio
 
 from deepeval.tracing import Tracer, TraceType
 from deepeval.integrations.llama_index import LlamaIndexCallbackHandler
+import deepeval.tracing
 
 ###########################################################
 # set up integration

--- a/tests/test_everything_stateless.py
+++ b/tests/test_everything_stateless.py
@@ -208,7 +208,7 @@ def test_sync():
         else:  # Odd index
             tasks.append(single_sync_call(metric1, test_case))
 
-test_sync()
+#test_sync()
 
 # ##########################################################
 # # measure in async mode
@@ -228,24 +228,24 @@ def test_sync_in_async():
     strict_mode = False
     metrics = [
         AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=async_mode),
-        # FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # BiasMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # ToxicityMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # HallucinationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # SummarizationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
-        # GEval(
-        #     name="Coherence",
-        #     criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
-        #     evaluation_params=[
-        #         LLMTestCaseParams.INPUT,
-        #         LLMTestCaseParams.ACTUAL_OUTPUT,
-        #         LLMTestCaseParams.RETRIEVAL_CONTEXT,
-        #     ],
-        #     async_mode=True  # Assuming it allows synchronous operations
-        # )
+        FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        BiasMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        ToxicityMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        HallucinationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        SummarizationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        GEval(
+            name="Coherence",
+            criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+                LLMTestCaseParams.RETRIEVAL_CONTEXT,
+            ],
+            async_mode=True  # Assuming it allows synchronous operations
+        )
     ]
 
     tasks = []
@@ -259,7 +259,7 @@ test_sync_in_async()
 # # evaluate
 # ##########################################################
 
-async_mode = False
+async_mode = True
 strict_mode = False
 metric1 = AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=async_mode)
 metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)

--- a/tests/test_everything_stateless.py
+++ b/tests/test_everything_stateless.py
@@ -156,14 +156,14 @@ async def test_async():
     tasks = []
     for i, test_case in enumerate(test_cases):
         if i % 2 == 0:  # Even index
-            tasks.append(single_async_call(metric1, test_case))
+            tasks.append(single_async_call(metric3, test_case))
         else:  # Odd index
-            tasks.append(single_async_call(metric2, test_case))
+            tasks.append(single_async_call(metric4, test_case))
 
     # Execute all tasks asynchronously
     await asyncio.gather(*tasks)
 
-#asyncio.run(test_async())
+asyncio.run(test_async())
 
 # ##########################################################
 # # measure in sync mode

--- a/tests/test_everything_stateless.py
+++ b/tests/test_everything_stateless.py
@@ -125,7 +125,7 @@ test_cases = [
 async def single_async_call(
         metric: BaseMetric,
         test_case: LLMTestCase):
-    await metric.a_measure(test_case)
+    await metric.a_measure(test_case, verbose=True)
     print("metric: " + metric.__name__)
     print("score: " + str(metric.score))
     print("reason: " + metric.reason)
@@ -156,14 +156,14 @@ async def test_async():
     tasks = []
     for i, test_case in enumerate(test_cases):
         if i % 2 == 0:  # Even index
-            tasks.append(single_async_call(metric3, test_case))
+            tasks.append(single_async_call(metric1, test_case))
         else:  # Odd index
-            tasks.append(single_async_call(metric4, test_case))
+            tasks.append(single_async_call(metric1, test_case))
 
     # Execute all tasks asynchronously
     await asyncio.gather(*tasks)
 
-asyncio.run(test_async())
+#asyncio.run(test_async())
 
 # ##########################################################
 # # measure in sync mode
@@ -206,9 +206,9 @@ def test_sync():
         if i % 2 == 0:  # Even index
             tasks.append(single_sync_call(metric1, test_case))
         else:  # Odd index
-            tasks.append(single_sync_call(metric2, test_case))
+            tasks.append(single_sync_call(metric1, test_case))
 
-#test_sync()
+test_sync()
 
 # ##########################################################
 # # measure in async mode
@@ -224,27 +224,28 @@ def single_sync_in_async_call(
 
 def test_sync_in_async():
     # metrics
+    async_mode = False
     strict_mode = False
     metrics = [
-        AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=True),
-        FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode),
-        ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode),
-        ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode),
-        ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode),
-        BiasMetric(threshold=0.5, strict_mode=strict_mode),
-        ToxicityMetric(threshold=0.5, strict_mode=strict_mode),
-        HallucinationMetric(threshold=0.5, strict_mode=strict_mode),
-        SummarizationMetric(threshold=0.5, strict_mode=strict_mode),
-        GEval(
-            name="Coherence",
-            criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
-            evaluation_params=[
-                LLMTestCaseParams.INPUT,
-                LLMTestCaseParams.ACTUAL_OUTPUT,
-                LLMTestCaseParams.RETRIEVAL_CONTEXT,
-            ],
-            async_mode=False  # Assuming it allows synchronous operations
-        )
+        AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=async_mode),
+        # FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # BiasMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # ToxicityMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # HallucinationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # SummarizationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode),
+        # GEval(
+        #     name="Coherence",
+        #     criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+        #     evaluation_params=[
+        #         LLMTestCaseParams.INPUT,
+        #         LLMTestCaseParams.ACTUAL_OUTPUT,
+        #         LLMTestCaseParams.RETRIEVAL_CONTEXT,
+        #     ],
+        #     async_mode=True  # Assuming it allows synchronous operations
+        # )
     ]
 
     tasks = []
@@ -252,21 +253,22 @@ def test_sync_in_async():
     for metric in metrics:
         tasks.append(single_sync_in_async_call(metric, test_case_1))
 
-#test_sync_in_async()
+test_sync_in_async()
 
 # ##########################################################
 # # evaluate
 # ##########################################################
 
+async_mode = False
 strict_mode = False
-metric1 = AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=False)
-metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
-metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
-metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
-metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
-metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
-metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
-metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric1 = AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=async_mode)
+metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)
+metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)
+metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)
+metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)
+metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)
+metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)
+metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=async_mode)
 metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
 metric10 = GEval(
     name="Coherence",
@@ -282,121 +284,121 @@ metric10 = GEval(
 dataset = EvaluationDataset(test_cases=test_cases)
 #dataset.evaluate([metric1, metric2])
 #evaluate(dataset, [metric1, metric2])
-#evaluate(dataset, [metric1, metric2], run_async=False, show_indicator=True)
+#evaluate(dataset, [metric10, metric2], run_async=False, show_indicator=True)
 
-##########################################################
-# deep eval test run
-##########################################################
-strict_mode = False
+# ##########################################################
+# # deep eval test run
+# ##########################################################
+# strict_mode = False
 
-#@pytest.mark.skip(reason="openai is expensive")
-def test_everything():
-    metric1 = AnswerRelevancyMetric(
-        threshold=0.1,
-        strict_mode=strict_mode,
-        async_mode=False,
-        model="gpt-4-0125-preview",
-    )
-    metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode)
-    metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode)
-    metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode)
-    metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode)
-    metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode)
-    metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode)
-    metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode)
-    metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode)
-    metric10 = GEval(
-        name="Coherence",
-        criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
-        evaluation_params=[
-            LLMTestCaseParams.INPUT,
-            LLMTestCaseParams.ACTUAL_OUTPUT,
-            LLMTestCaseParams.RETRIEVAL_CONTEXT,
-        ],
-        strict_mode=strict_mode,
-        model="gpt-4-0125-preview",
-    )
+# #@pytest.mark.skip(reason="openai is expensive")
+# def test_everything():
+#     metric1 = AnswerRelevancyMetric(
+#         threshold=0.1,
+#         strict_mode=strict_mode,
+#         async_mode=False,
+#         model="gpt-4-0125-preview",
+#     )
+#     metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric10 = GEval(
+#         name="Coherence",
+#         criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+#         evaluation_params=[
+#             LLMTestCaseParams.INPUT,
+#             LLMTestCaseParams.ACTUAL_OUTPUT,
+#             LLMTestCaseParams.RETRIEVAL_CONTEXT,
+#         ],
+#         strict_mode=strict_mode,
+#         model="gpt-4-0125-preview",
+#     )
 
-    test_case = LLMTestCase(
-        input="What is this",
-        actual_output="this is a latte",
-        expected_output="this is a mocha",
-        retrieval_context=["I love coffee"],
-        context=["I love coffee"],
-    )
-    c_test_case = ConversationalTestCase(messages=[test_case, test_case])
-    assert_test(
-        c_test_case,
-        [
-            metric1,
-            # metric2,
-            # metric3,
-            # metric4,
-            # metric5,
-            # metric6,
-            # metric7,
-            # metric8,
-            # metric9,
-            metric10,
-        ],
-        # run_async=False,
-    )
-
-
-@pytest.mark.skip(reason="openadi is expensive")
-def test_everything_2():
-    metric1 = AnswerRelevancyMetric(threshold=0.5, strict_mode=strict_mode)
-    metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode)
-    metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode)
-    metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode)
-    metric5 = ContextualRelevancyMetric(threshold=0.1, strict_mode=strict_mode)
-    metric6 = BiasMetric(threshold=0.2, strict_mode=strict_mode)
-    metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode)
-    metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode)
-    metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode, n=2)
-    metric10 = (
-        GEval(
-            name="Coherence",
-            criteria="Coherence - determine if the actual output is coherent with the input.",
-            evaluation_params=[
-                LLMTestCaseParams.INPUT,
-                LLMTestCaseParams.ACTUAL_OUTPUT,
-            ],
-            strict_mode=True,
-        ),
-    )
-    metric11 = RagasMetric(
-        threshold=0.5, model="gpt-3.5-turbo", embeddings=OpenAIEmbeddings()
-    )
-
-    test_case = LLMTestCase(
-        input="What is this again?",
-        actual_output="this is a latte",
-        expected_output="this is a mocha",
-        retrieval_context=["I love coffee"],
-        context=["I love coffee"],
-    )
-    assert_test(
-        test_case,
-        [
-            metric1,
-            metric2,
-            metric3,
-            metric4,
-            # metric5,
-            metric6,
-            # metric7,
-            # metric8,
-            # metric9,
-            # metric10,
-            # metric11,
-        ],
-        run_async=False,
-    )
+#     test_case = LLMTestCase(
+#         input="What is this",
+#         actual_output="this is a latte",
+#         expected_output="this is a mocha",
+#         retrieval_context=["I love coffee"],
+#         context=["I love coffee"],
+#     )
+#     c_test_case = ConversationalTestCase(messages=[test_case, test_case])
+#     assert_test(
+#         c_test_case,
+#         [
+#             metric1,
+#             # metric2,
+#             # metric3,
+#             # metric4,
+#             # metric5,
+#             # metric6,
+#             # metric7,
+#             # metric8,
+#             # metric9,
+#             metric10,
+#         ],
+#         # run_async=False,
+#     )
 
 
-@deepeval.log_hyperparameters(
-    model="gpt-4", prompt_template="another template!"
-)
-def hyperparameters():
-    return {"chunk_size": 600, "temperature": 1}
+# @pytest.mark.skip(reason="openadi is expensive")
+# def test_everything_2():
+#     metric1 = AnswerRelevancyMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric5 = ContextualRelevancyMetric(threshold=0.1, strict_mode=strict_mode)
+#     metric6 = BiasMetric(threshold=0.2, strict_mode=strict_mode)
+#     metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode)
+#     metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode, n=2)
+#     metric10 = (
+#         GEval(
+#             name="Coherence",
+#             criteria="Coherence - determine if the actual output is coherent with the input.",
+#             evaluation_params=[
+#                 LLMTestCaseParams.INPUT,
+#                 LLMTestCaseParams.ACTUAL_OUTPUT,
+#             ],
+#             strict_mode=True,
+#         ),
+#     )
+#     metric11 = RagasMetric(
+#         threshold=0.5, model="gpt-3.5-turbo", embeddings=OpenAIEmbeddings()
+#     )
+
+#     test_case = LLMTestCase(
+#         input="What is this again?",
+#         actual_output="this is a latte",
+#         expected_output="this is a mocha",
+#         retrieval_context=["I love coffee"],
+#         context=["I love coffee"],
+#     )
+#     assert_test(
+#         test_case,
+#         [
+#             metric1,
+#             metric2,
+#             metric3,
+#             metric4,
+#             # metric5,
+#             metric6,
+#             # metric7,
+#             # metric8,
+#             # metric9,
+#             # metric10,
+#             # metric11,
+#         ],
+#         run_async=False,
+#     )
+
+
+# @deepeval.log_hyperparameters(
+#     model="gpt-4", prompt_template="another template!"
+# )
+# def hyperparameters():
+#     return {"chunk_size": 600, "temperature": 1}

--- a/tests/test_everything_stateless.py
+++ b/tests/test_everything_stateless.py
@@ -253,7 +253,7 @@ def test_sync_in_async():
     for metric in metrics:
         tasks.append(single_sync_in_async_call(metric, test_case_1))
 
-test_sync_in_async()
+#test_sync_in_async()
 
 # ##########################################################
 # # evaluate
@@ -282,7 +282,7 @@ metric10 = GEval(
 )
     
 dataset = EvaluationDataset(test_cases=test_cases)
-#dataset.evaluate([metric1, metric2])
+dataset.evaluate([metric1, metric2])
 #evaluate(dataset, [metric1, metric2])
 #evaluate(dataset, [metric10, metric2], run_async=False, show_indicator=True)
 

--- a/tests/test_everything_stateless.py
+++ b/tests/test_everything_stateless.py
@@ -1,0 +1,402 @@
+import pytest
+from langchain_openai import OpenAIEmbeddings
+import asyncio
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+import deepeval
+from deepeval.test_case import (
+    LLMTestCase,
+    LLMTestCaseParams,
+    ConversationalTestCase,
+)
+from deepeval.metrics import (
+    AnswerRelevancyMetric,
+    FaithfulnessMetric,
+    ContextualRecallMetric,
+    ContextualRelevancyMetric,
+    ContextualPrecisionMetric,
+    HallucinationMetric,
+    BiasMetric,
+    ToxicityMetric,
+    GEval,
+    SummarizationMetric,
+    BaseMetric
+)
+from deepeval.dataset import EvaluationDataset
+from deepeval.metrics.ragas import RagasMetric
+from deepeval import assert_test, evaluate
+
+#########################################################
+# test cases
+##########################################################
+
+test_case_1 = LLMTestCase(
+        input="What is this again?",
+        actual_output="This is a latte.",
+        expected_output="This is a mocha.",
+        retrieval_context=["I love coffee."],
+        context=["I love coffee."],
+    )
+
+test_case_2 = LLMTestCase(
+        input="What is this again?",
+        actual_output="This is a latte.",
+        expected_output="This is a latte.",
+        retrieval_context=["I love coffee."],
+        context=["I love coffee."],
+    )
+
+test_case_3 = LLMTestCase(
+        input="Do you have cold brew?",
+        actual_output="Cold brew has numerous health benefits.",
+        expected_output="No, we only have latte and americano",
+        retrieval_context=["I love coffee."],
+        context=["Our drinks include latte and americano"],
+    )
+
+test_case_4 = LLMTestCase(
+        input="Can I get an americano with almond milk?",
+        actual_output="We don't have almond milk.",
+        expected_output="Yes, we can make an americano with almond milk.",
+        retrieval_context=["We have soy and oat milk."],
+        context=["We offer various milk options, including almond milk."]
+    )
+
+test_case_5 = LLMTestCase(
+        input="Is the espresso strong?",
+        actual_output="Our espresso is mild.",
+        expected_output="Yes, our espresso is quite strong.",
+        retrieval_context=["Some customers find our coffee mild."],
+        context=["Our espresso is known for its strong flavor."]
+    )
+
+test_case_6 = LLMTestCase(
+        input="What desserts do you have?",
+        actual_output="We have cakes and cookies.",
+        expected_output="We have cakes, cookies, and brownies.",
+        retrieval_context=["Our cafe offers cookies and brownies."],
+        context=["Our dessert options include cakes, cookies, and brownies."]
+    )
+
+test_case_7 = LLMTestCase(
+        input="Do you serve breakfast all day?",
+        actual_output="Breakfast is only served until 11 AM.",
+        expected_output="Yes, we serve breakfast all day.",
+        retrieval_context=["Breakfast times are usually until noon."],
+        context=["Breakfast is available all day at our cafe."]
+    )
+
+test_case_8 = LLMTestCase(
+        input="Do you have any vegan options?",
+        actual_output="We have vegan salads.",
+        expected_output="We offer vegan salads and smoothies.",
+        retrieval_context=["We recently started offering vegan dishes."],
+        context=["We have vegan salads and smoothies on our menu."]
+    )
+
+test_case_9 = LLMTestCase(
+        input="Is there parking nearby?",
+        actual_output="There is no parking available.",
+        expected_output="Yes, there is a parking lot right behind the cafe.",
+        retrieval_context=["Street parking can be hard to find."],
+        context=["Parking is available behind the cafe."]
+    )
+
+test_cases = [
+    test_case_1,
+    test_case_2,
+    test_case_3,
+    # test_case_4,
+    # test_case_5,
+    # test_case_6,
+    # test_case_7,
+    # test_case_8,
+    # test_case_9
+]
+
+##########################################################
+# a_measure 
+##########################################################
+
+async def single_async_call(
+        metric: BaseMetric,
+        test_case: LLMTestCase):
+    await metric.a_measure(test_case)
+    print("metric: " + metric.__name__)
+    print("score: " + str(metric.score))
+    print("reason: " + metric.reason)
+
+async def test_async():
+    # metrics
+    strict_mode = False
+    metric1 = AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode)
+    metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode)
+    metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode)
+    metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode)
+    metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode)
+    metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode)
+    metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode)
+    metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode)
+    metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode)
+    metric10 = GEval(
+        name="Coherence",
+        criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.RETRIEVAL_CONTEXT,
+        ],
+    )
+
+    # Prepare the list of metrics based on even and odd indexed test cases
+    tasks = []
+    for i, test_case in enumerate(test_cases):
+        if i % 2 == 0:  # Even index
+            tasks.append(single_async_call(metric1, test_case))
+        else:  # Odd index
+            tasks.append(single_async_call(metric2, test_case))
+
+    # Execute all tasks asynchronously
+    await asyncio.gather(*tasks)
+
+#asyncio.run(test_async())
+
+# ##########################################################
+# # measure in sync mode
+# ##########################################################
+
+def single_sync_call(
+        metric: BaseMetric,
+        test_case: LLMTestCase):
+    metric.measure(test_case)
+    print("metric: " + metric.__name__)
+    print("score: " + str(metric.score))
+    print("reason: " + metric.reason)
+
+def test_sync():
+    # metrics
+    strict_mode = False
+    metric1 = AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=False)
+    metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+    metric10 = GEval(
+        name="Coherence",
+        criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.RETRIEVAL_CONTEXT,
+        ],
+        async_mode=False
+    )
+
+    # Prepare the list of metrics based on even and odd indexed test cases
+    tasks = []
+    for i, test_case in enumerate(test_cases):
+        if i % 2 == 0:  # Even index
+            tasks.append(single_sync_call(metric1, test_case))
+        else:  # Odd index
+            tasks.append(single_sync_call(metric2, test_case))
+
+#test_sync()
+
+# ##########################################################
+# # measure in async mode
+# ##########################################################
+
+def single_sync_in_async_call(
+        metric: BaseMetric,
+        test_case: LLMTestCase):
+    metric.measure(test_case)
+    print("metric: " + metric.__name__)
+    print("score: " + str(metric.score))
+    print("reason: " + metric.reason)
+
+def test_sync_in_async():
+    # metrics
+    strict_mode = False
+    metrics = [
+        AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=True),
+        FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode),
+        ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode),
+        ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode),
+        ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode),
+        BiasMetric(threshold=0.5, strict_mode=strict_mode),
+        ToxicityMetric(threshold=0.5, strict_mode=strict_mode),
+        HallucinationMetric(threshold=0.5, strict_mode=strict_mode),
+        SummarizationMetric(threshold=0.5, strict_mode=strict_mode),
+        GEval(
+            name="Coherence",
+            criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+                LLMTestCaseParams.RETRIEVAL_CONTEXT,
+            ],
+            async_mode=False  # Assuming it allows synchronous operations
+        )
+    ]
+
+    tasks = []
+    # Test every metric on every test case
+    for metric in metrics:
+        tasks.append(single_sync_in_async_call(metric, test_case_1))
+
+#test_sync_in_async()
+
+# ##########################################################
+# # evaluate
+# ##########################################################
+
+strict_mode = False
+metric1 = AnswerRelevancyMetric(threshold=0.1, strict_mode=strict_mode, async_mode=False)
+metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode, async_mode=False)
+metric10 = GEval(
+    name="Coherence",
+    criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+    evaluation_params=[
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+        LLMTestCaseParams.RETRIEVAL_CONTEXT,
+    ],
+    async_mode=False
+)
+    
+dataset = EvaluationDataset(test_cases=test_cases)
+#dataset.evaluate([metric1, metric2])
+#evaluate(dataset, [metric1, metric2])
+#evaluate(dataset, [metric1, metric2], run_async=False, show_indicator=True)
+
+##########################################################
+# deep eval test run
+##########################################################
+strict_mode = False
+
+#@pytest.mark.skip(reason="openai is expensive")
+def test_everything():
+    metric1 = AnswerRelevancyMetric(
+        threshold=0.1,
+        strict_mode=strict_mode,
+        async_mode=False,
+        model="gpt-4-0125-preview",
+    )
+    metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode)
+    metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode)
+    metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode)
+    metric5 = ContextualRelevancyMetric(threshold=0.5, strict_mode=strict_mode)
+    metric6 = BiasMetric(threshold=0.5, strict_mode=strict_mode)
+    metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode)
+    metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode)
+    metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode)
+    metric10 = GEval(
+        name="Coherence",
+        criteria="Coherence - determine if the actual output is coherent with the input, and does not contradict anything in the retrieval context.",
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.RETRIEVAL_CONTEXT,
+        ],
+        strict_mode=strict_mode,
+        model="gpt-4-0125-preview",
+    )
+
+    test_case = LLMTestCase(
+        input="What is this",
+        actual_output="this is a latte",
+        expected_output="this is a mocha",
+        retrieval_context=["I love coffee"],
+        context=["I love coffee"],
+    )
+    c_test_case = ConversationalTestCase(messages=[test_case, test_case])
+    assert_test(
+        c_test_case,
+        [
+            metric1,
+            # metric2,
+            # metric3,
+            # metric4,
+            # metric5,
+            # metric6,
+            # metric7,
+            # metric8,
+            # metric9,
+            metric10,
+        ],
+        # run_async=False,
+    )
+
+
+@pytest.mark.skip(reason="openadi is expensive")
+def test_everything_2():
+    metric1 = AnswerRelevancyMetric(threshold=0.5, strict_mode=strict_mode)
+    metric2 = FaithfulnessMetric(threshold=0.5, strict_mode=strict_mode)
+    metric3 = ContextualPrecisionMetric(threshold=0.5, strict_mode=strict_mode)
+    metric4 = ContextualRecallMetric(threshold=0.5, strict_mode=strict_mode)
+    metric5 = ContextualRelevancyMetric(threshold=0.1, strict_mode=strict_mode)
+    metric6 = BiasMetric(threshold=0.2, strict_mode=strict_mode)
+    metric7 = ToxicityMetric(threshold=0.5, strict_mode=strict_mode)
+    metric8 = HallucinationMetric(threshold=0.5, strict_mode=strict_mode)
+    metric9 = SummarizationMetric(threshold=0.5, strict_mode=strict_mode, n=2)
+    metric10 = (
+        GEval(
+            name="Coherence",
+            criteria="Coherence - determine if the actual output is coherent with the input.",
+            evaluation_params=[
+                LLMTestCaseParams.INPUT,
+                LLMTestCaseParams.ACTUAL_OUTPUT,
+            ],
+            strict_mode=True,
+        ),
+    )
+    metric11 = RagasMetric(
+        threshold=0.5, model="gpt-3.5-turbo", embeddings=OpenAIEmbeddings()
+    )
+
+    test_case = LLMTestCase(
+        input="What is this again?",
+        actual_output="this is a latte",
+        expected_output="this is a mocha",
+        retrieval_context=["I love coffee"],
+        context=["I love coffee"],
+    )
+    assert_test(
+        test_case,
+        [
+            metric1,
+            metric2,
+            metric3,
+            metric4,
+            # metric5,
+            metric6,
+            # metric7,
+            # metric8,
+            # metric9,
+            # metric10,
+            # metric11,
+        ],
+        run_async=False,
+    )
+
+
+@deepeval.log_hyperparameters(
+    model="gpt-4", prompt_template="another template!"
+)
+def hyperparameters():
+    return {"chunk_size": 600, "temperature": 1}


### PR DESCRIPTION
### Stateless Support for Metrics

Stateless support was implemented for all metrics except RAGAS and knowledge retention. This involves adding context variables and changing the measure and a_measure accordingly. The measure method is more complex, because there is also support for async_mode, which involved implementing an additional function to overcome the loss of information due to using context variables in coroutines. In addition, the indicator was adapted to support a_measure.