### PR TITLE
Improve loading of json if end of json is not found for metrics

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -54,6 +54,10 @@ def trimAndLoadJson(
     end = input_string.rfind("}") + 1
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
 
+    if start != -1 and end == 0:
+        input_string = input_string + "}"
+        end = len(input_string)
+
     try:
         return json.loads(jsonStr)
     except json.JSONDecodeError:


### PR DESCRIPTION
Some LLMs struggle to generate a complete and correct JSON (e.g. mistral-7b-instruct). Also see issue #743.
However, often, only the closing bracket of the JSON is missing. This can be fixed easily by adding the bracket at the end of the input string.