### PR TITLE
Add custom embedder in synthesizer and context generator

### DIFF
--- a/deepeval/synthesizer/context_generator.py
+++ b/deepeval/synthesizer/context_generator.py
@@ -18,7 +18,7 @@ class ContextGenerator:
         chunk_size: int = 1024,
         chunk_overlap: int = 0,
         multithreading: bool = False,
-        embedder: DeepEvalBaseEmbeddingModel = None, 
+        embedder: DeepEvalBaseEmbeddingModel = None,
     ):
 
         if embedder is None:

--- a/deepeval/synthesizer/context_generator.py
+++ b/deepeval/synthesizer/context_generator.py
@@ -18,9 +18,13 @@ class ContextGenerator:
         chunk_size: int = 1024,
         chunk_overlap: int = 0,
         multithreading: bool = False,
+        embedder: DeepEvalBaseEmbeddingModel = None, 
     ):
 
-        self.embedder: DeepEvalBaseEmbeddingModel = OpenAIEmbeddingModel()
+        if embedder is None:
+            self.embedder: DeepEvalBaseEmbeddingModel = OpenAIEmbeddingModel()
+        else:
+            self.embedder = embedder
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
 

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -15,6 +15,7 @@ from deepeval.models import DeepEvalBaseLLM
 from deepeval.progress_context import synthesizer_progress_context
 from deepeval.metrics.utils import trimAndLoadJson, initialize_model
 from deepeval.dataset.golden import Golden
+from deepeval.models.base_model import DeepEvalBaseEmbeddingModel
 
 valid_file_types = ["csv", "json"]
 
@@ -27,7 +28,7 @@ class Synthesizer:
     def __init__(
         self,
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
-        # embedder: Optional[Union[str, DeepEvalBaseEmbeddingModel]] = None,
+        embedder: Optional[Union[str, DeepEvalBaseEmbeddingModel]] = None,
         multithreading: bool = True,
     ):
         self.model, self.using_native_model = initialize_model(model)
@@ -35,7 +36,7 @@ class Synthesizer:
         self.multithreading = multithreading
         self.synthetic_goldens: List[Golden] = []
         self.context_generator = None
-        # self.embedder = embedder
+        self.embedder = embedder
 
     def evolve(
         self,
@@ -261,6 +262,7 @@ class Synthesizer:
                     chunk_size,
                     chunk_overlap,
                     multithreading=self.multithreading,
+                    embedder=self.embedder,
                 )
 
             max_goldens_per_context = 2


### PR DESCRIPTION
It is not possible to use a custom embedder to create synthetic data. Adding an optional param for the synthesizer and the context creator fixes this.