### PR TITLE
Improve loading of json if end of json is not found for metrics

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -52,7 +52,7 @@ def trimAndLoadJson(
 ) -> Any:
     start = input_string.find("{")
     end = input_string.rfind("}") + 1
-    
+
     if end == 0 and start != -1:
         input_string = input_string + "}"
         end = len(input_string)

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -52,6 +52,11 @@ def trimAndLoadJson(
 ) -> Any:
     start = input_string.find("{")
     end = input_string.rfind("}") + 1
+    
+    if end == 0 and start != -1:
+        input_string = input_string + "}"
+        end = len(input_string)
+
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
 
     try:


### PR DESCRIPTION
Some LLMs struggle to generate valid jsons (e.g. mistral-7b-instruct). See also #743.
However, often, the problem is only that the closing bracket is missing. Adding the bracket helps using custom LLMs.