### PR TITLE
Add dataset as optional argument in DeepEvalBaseBenchmark and across benchmarks

### DIFF
--- a/deepeval/benchmarks/base_benchmark.py
+++ b/deepeval/benchmarks/base_benchmark.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import List, TypeVar, Generic, List
+from typing import List, TypeVar, Generic, List, Optional
+from datasets import Dataset
 
 from deepeval.dataset import Golden
 
@@ -8,8 +9,9 @@ T = TypeVar("T")
 
 
 class DeepEvalBaseBenchmark(ABC, Generic[T]):
-    def __init__(self):
+    def __init__(self, dataset: Optional[Dataset] = None):
         self.tasks: List[T] = []
+        self.dataset = dataset
 
     @abstractmethod
     def load_benchmark_dataset(self) -> List[Golden]:

--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -18,9 +18,10 @@ class BigBenchHard(DeepEvalBaseBenchmark):
         tasks: List[BigBenchHardTask] = None,
         n_shots: int = 3,
         enable_cot: bool = True,
+        **kwargs
     ):
         assert n_shots <= 3, "BBH only supports n_shots <= 3"
-        super().__init__()
+        super().__init__(**kwargs)
         self.tasks: List[BigBenchHardTask] = (
             list(BigBenchHardTask) if tasks is None else tasks
         )
@@ -162,8 +163,12 @@ class BigBenchHard(DeepEvalBaseBenchmark):
         return res
 
     def load_benchmark_dataset(self, task: BigBenchHardTask) -> List[Golden]:
-        # load from hugging face
-        dataset = load_dataset("lukaemon/bbh", task.value)
+        if self.dataset:
+            dataset = self.dataset
+        else:
+            # load from hugging face
+            dataset = load_dataset("lukaemon/bbh", task.value)
+
         goldens: List[Golden] = []
         for data in dataset["test"]:
             golden = Golden(input=data["input"], expectedOutput=data["target"])

--- a/deepeval/benchmarks/drop/drop.py
+++ b/deepeval/benchmarks/drop/drop.py
@@ -15,12 +15,11 @@ DELIMITER = ","
 
 
 class DROP(DeepEvalBaseBenchmark):
-    def __init__(self, tasks: List[DROPTask] = None, n_shots: int = 5):
+    def __init__(self, tasks: List[DROPTask] = None, n_shots: int = 5, **kwargs):
         assert n_shots <= 5, "DROP only supports n_shots <= 5"
-        super().__init__()
+        super().__init__(**kwargs)
         self.tasks: List[DROPTask] = list(DROPTask) if tasks is None else tasks
         self.scorer = Scorer()
-        self.dataset: Dataset = None
         self.shots_dataset: List[Dict] = None
         self.n_shots: int = n_shots
         self.predictions: Optional[pd.DataFrame] = None

--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -12,12 +12,11 @@ from deepeval.scorer import Scorer
 
 class GSM8K(DeepEvalBaseBenchmark):
     def __init__(
-        self, n_shots: int = 3, enable_cot: bool = True, n_problems: int = 1319
+        self, n_shots: int = 3, enable_cot: bool = True, n_problems: int = 1319, **kwargs
     ):
         assert n_shots <= 15, "GSM8K only supports n_shots <= 15"
-        super().__init__()
+        super().__init__(**kwargs)
         self.scorer = Scorer()
-        self.dataset: Dataset = None
         self.shots_dataset: List[Dict] = None
 
         self.n_shots: int = n_shots

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -13,14 +13,13 @@ from deepeval.scorer import Scorer
 
 
 class HellaSwag(DeepEvalBaseBenchmark):
-    def __init__(self, tasks: List[HellaSwagTask] = None, n_shots: int = 10):
+    def __init__(self, tasks: List[HellaSwagTask] = None, n_shots: int = 10, **kwargs):
         assert n_shots <= 15, "HellaSwag only supports n_shots <= 15."
-        super().__init__()
+        super().__init__(**kwargs)
         self.tasks: List[HellaSwagTask] = (
             list(HellaSwagTask) if tasks is None else tasks
         )
         self.scorer = Scorer()
-        self.dataset: Dataset = None
         self.shots_dataset: List[Dict] = None
         self.n_shots = n_shots
         self.predictions: Optional[pd.DataFrame] = None

--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -11,14 +11,13 @@ from deepeval.scorer import Scorer
 
 
 class HumanEval(DeepEvalBaseBenchmark):
-    def __init__(self, tasks: List[HumanEvalTask] = None, n: int = 200):
+    def __init__(self, tasks: List[HumanEvalTask] = None, n: int = 200, **kwargs):
 
-        super().__init__()
+        super().__init__(**kwargs)
         self.tasks: List[HumanEvalTask] = (
             list(HumanEvalTask) if tasks is None else tasks
         )
         self.scorer = Scorer()
-        self.dataset: Dataset = None
 
         self.temperature = 0.8
         self.n = n

--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -13,12 +13,11 @@ from deepeval.scorer import Scorer
 
 
 class MMLU(DeepEvalBaseBenchmark):
-    def __init__(self, tasks: List[MMLUTask] = None, n_shots: int = 5):
+    def __init__(self, tasks: List[MMLUTask] = None, n_shots: int = 5, **kwargs):
         assert n_shots <= 5, "MMLU only supports n_shots <= 5"
-        super().__init__()
+        super().__init__(**kwargs)
         self.tasks: List[MMLUTask] = list(MMLUTask) if tasks is None else tasks
         self.scorer = Scorer()
-        self.dataset: Dataset = None
         self.shots_dataset: List[Dict] = None
         self.n_shots: int = n_shots
         self.predictions: Optional[pd.DataFrame] = None

--- a/deepeval/benchmarks/truthful_qa/truthful_qa.py
+++ b/deepeval/benchmarks/truthful_qa/truthful_qa.py
@@ -18,14 +18,15 @@ class TruthfulQA(DeepEvalBaseBenchmark):
         self,
         tasks: List[TruthfulQATask] = None,
         mode: TruthfulQAMode = TruthfulQAMode.MC1,
+        **kwargs
     ):
-        super().__init__()
+        super().__init__(**kwargs)
         self.tasks: List[TruthfulQATask] = (
             list(TruthfulQATask) if tasks is None else tasks
         )
         self.mode: TruthfulQAMode = mode
         self.scorer = Scorer()
-        self.mc_dataset: Dataset = None
+        self.mc_dataset: Dataset = self.dataset
 
         self.predictions: Optional[pd.DataFrame] = None
         self.task_scores: Optional[pd.DataFrame] = None


### PR DESCRIPTION
The benchmark module entirely depends on having access to HuggingFace. Equally, it is not possible to run the benchmarks on your own custom datasets.

Have added an optional parameter to provide with a dataset loaded from local so it can be used across all benchmarks.