### PR TITLE
Fix superclass initialization across all classes in ragas.py

### DIFF
--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -24,7 +24,7 @@ class RAGASContextualPrecisionMetric(BaseMetric):
         model: Optional[Union[str, BaseChatModel]] = "gpt-3.5-turbo",
         _track: bool = True,
     ):
-        super.__init__()
+        super().__init__()
         self.threshold = threshold
         self.model = model
         self._track = _track
@@ -92,7 +92,7 @@ class RAGASContextualRelevancyMetric(BaseMetric):
         model: Optional[Union[str, BaseChatModel]] = "gpt-3.5-turbo",
         _track: bool = True,
     ):
-        super.__init__()
+        super().__init__()
         self.threshold = threshold
         self.model = model
         self._track = _track
@@ -161,7 +161,7 @@ class RAGASAnswerRelevancyMetric(BaseMetric):
         embeddings: Optional[Embeddings] = None,
         _track: bool = True,
     ):
-        super.__init__()
+        super().__init__()
         self.threshold = threshold
         self.model = model
         self._track = _track
@@ -228,7 +228,7 @@ class RAGASFaithfulnessMetric(BaseMetric):
         model: Optional[Union[str, BaseChatModel]] = "gpt-3.5-turbo",
         _track: bool = True,
     ):
-        super.__init__()
+        super().__init__()
         self.threshold = threshold
         self.model = model
         self._track = _track
@@ -290,7 +290,7 @@ class RAGASContextualRecallMetric(BaseMetric):
         model: Optional[Union[str, BaseChatModel]] = "gpt-3.5-turbo",
         _track: bool = True,
     ):
-        super.__init__()
+        super().__init__()
         self.threshold = threshold
         self.model = model
         self._track = _track
@@ -352,7 +352,7 @@ class RagasMetric(BaseMetric):
         model: Optional[Union[str, BaseChatModel]] = "gpt-3.5-turbo",
         embeddings: Optional[Embeddings] = None,
     ):
-        super.__init__()
+        super().__init__()
         self.threshold = threshold
         self.model = model
         if isinstance(model, str):


### PR DESCRIPTION
Previously, superclass initialization in multiple classes within ragas.py incorrectly used `super.__init__()`, resulting in a `TypeError`. This syntax has been corrected to `super().__init__()` to ensure proper execution of the superclass (BaseMetric)'s initialization before initializing class-specific attributes.

This change resolves the `TypeError: descriptor '__init__' of 'super' object needs an argument` encountered during initialization. It aligns with standard Python syntax for invoking superclass constructors, improving code readability and maintainability.