### PR TITLE
Fix weighted_summed_score in GEval metrics.

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -364,9 +364,11 @@ class GEval(BaseMetric):
 
                 # Calculate the linear probability
                 linear_prob = math.exp(logprob)
-                token_linear_probability[int(token_logprob["token"])] = (
-                    linear_prob
-                )
+                token_score = int(token_logprob["token"])
+                if token_linear_probability.get(token_score):
+                    token_linear_probability[token_score] += linear_prob
+                else:
+                    token_linear_probability[token_score] = linear_prob
                 sum_linear_probability += linear_prob
 
             sum_of_weighted_scores = 0.0


### PR DESCRIPTION
A simple fix on issue #853 .

Original behavior:

> For example, ('8', '0.01') and ('8', '0.001') are both in the score_logprobs,
> After traversing ('8', '0.01'), token_linear_probability['8'] = 0.01, and sum_linear_probability=0.01
> When coming to ('8', '0.001'), token_linear_probability['8'] = 0.001, and sum_linear_probability=0.011.

This will leads to the normalization error in the No.378 line.

Current behavior:
> After traversing ('8', '0.01'), token_linear_probability['8'] = 0.01, and sum_linear_probability=0.01
> When coming to ('8', '0.001'), **token_linear_probability['8'] = 0.011**, and sum_linear_probability=0.011.
