### PR TITLE
Fix pyright compatibility issues with Field defaults in Golden pydantic models

### DIFF
--- a/deepeval/dataset/golden.py
+++ b/deepeval/dataset/golden.py
@@ -5,27 +5,29 @@ from typing import Optional, Dict, List
 class Golden(BaseModel):
     input: str
     actual_output: Optional[str] = Field(
-        None, serialization_alias="actualOutput"
+        default=None, serialization_alias="actualOutput"
     )
     expected_output: Optional[str] = Field(
-        None, serialization_alias="expectedOutput"
+        default=None, serialization_alias="expectedOutput"
     )
-    context: Optional[List[str]] = Field(None)
+    context: Optional[List[str]] = Field(default=None)
     retrieval_context: Optional[List[str]] = Field(
-        None, serialization_alias="retrievalContext"
+        default=None, serialization_alias="retrievalContext"
     )
     additional_metadata: Optional[Dict] = Field(
-        None, serialization_alias="additionalMetadata"
+        default=None, serialization_alias="additionalMetadata"
     )
-    comments: Optional[str] = Field(None)
-    source_file: Optional[str] = Field(None, serialization_alias="sourceFile")
+    comments: Optional[str] = Field(default=None)
+    source_file: Optional[str] = Field(
+        default=None, serialization_alias="sourceFile"
+    )
 
 
 class ConversationalGolden(BaseModel):
     additional_metadata: Optional[Dict] = Field(
-        None, serialization_alias="additionalMetadata"
+        default=None, serialization_alias="additionalMetadata"
     )
-    comments: Optional[str] = Field(None)
+    comments: Optional[str] = Field(default=None)
     messages: List[Golden] = Field(
         default_factory=lambda: [],
         serialization_alias="goldens",


### PR DESCRIPTION
# Summary
This PR addresses a compatibility issue when using Pyright static type checking with the `Field` instantiation from the Pydantic library in `Golden` model definitions. By explicitly specifying the `default` keyword in the `Field` instantiation, we ensure Pyright doesn't throw errors for users who employ Pyright alongside Golden models.

# Issue Encountered
When attempting to instantiate a `Golden` object with minimal arguments in a project using Pyright, the type checker raised errors about missing arguments that should be optional. Here's the code snippet and the error message encountered:

```python
from deepeval.dataset import Golden

Golden(input="my input")
```

This resulted in the following Pyright error:
```bash
pyright deepeval_x_pyright.py

/home/seku/dev/deepeval/deepeval_x_pyright.py
  /home/seku/dev/deepeval/deepeval_x_pyright.py:4:1 - error: Arguments missing for parameters "actual_output", "expected_output", "context", "retrieval_context", "additional_metadata", "comments", "source_file" (reportCallIssue)
1 error, 0 warnings, 0 information
```

# Solution
To resolve this, `default=None` was explicitly added to the `Field` ([as suggested](https://github.com/pydantic/pydantic/issues/3617) in the Pydantic's repository) specifications for optional fields in the `Golden` Pydantic models. This modification clears the Pyright errors and makes the field defaults explicit, adhering to the updated practices recommended for Pydantic.

# Expected Benefits
*Compatibility*: Ensures Goldens' compatibility with Pyright, facilitating development without static type-checking interruptions.
*Usability*: Assures that all developers using the Golden model with Pyright experience no interruptions or false positives from type checking.
*Clarity and Maintenance*: Improves the maintainability and clarity of the code by explicitly defining optional parameters as such.