### PR TITLE
Patch for issue 882 "deepeval --login" fails

### DIFF
--- a/deepeval/cli/main.py
+++ b/deepeval/cli/main.py
@@ -8,11 +8,12 @@ import webbrowser
 app = typer.Typer(name="deepeval")
 app.add_typer(test_app, name="test")
 
+
 @app.command()
 def login(
     api_key: str = typer.Option(
-        "", 
-        help="API key to get from https://app.confident-ai.com. Required if you want to log events to the server."
+        "",
+        help="API key to get from https://app.confident-ai.com. Required if you want to log events to the server.",
     ),
     confident_api_key: Optional[str] = typer.Option(
         None,

--- a/deepeval/cli/main.py
+++ b/deepeval/cli/main.py
@@ -1,25 +1,19 @@
 import typer
-from typing_extensions import Annotated
-
+from typing import Optional
 from rich import print
 from deepeval.key_handler import KEY_FILE_HANDLER, KeyValues
 from deepeval.cli.test import app as test_app
-from typing import Optional
 import webbrowser
 
 app = typer.Typer(name="deepeval")
-
 app.add_typer(test_app, name="test")
-
 
 @app.command()
 def login(
-    api_key: Annotated[
-        str,
-        typer.Option(
-            help="API key to get from https://app.confident-ai.com. Required if you want to log events to the server."
-        ),
-    ] = "",
+    api_key: str = typer.Option(
+        "", 
+        help="API key to get from https://app.confident-ai.com. Required if you want to log events to the server."
+    ),
     confident_api_key: Optional[str] = typer.Option(
         None,
         "--confident-api-key",


### PR DESCRIPTION
https://github.com/confident-ai/deepeval/issues/882

This is a misuse of the Annotations class according to GPT-4o, and i can't disagree since this patch fixes the issue in my non-working environment (docker/ubuntu), and doesn't regress in my working environment (mac m3).  It also passes `deepeval/cli/test.py`.  I did not run other tests.