### PR TITLE
add pip install requirement to documentation for rouge_score

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -20,6 +20,8 @@ class Scorer:
         Rouge (Recall-Oriented Understudy for Gisting Evaluation) is a metric used for evaluating the quality of generated text,
         especially in tasks like text summarization.
 
+        To utilize the rouge_score scoring method, be sure to `pip install rouge-score` before calling this method.
+
         Args:
             target (str): The actual label or target text.
             prediction (str): The generated text from the model or LLM.


### PR DESCRIPTION
I got caught starting a new project using `rouge_score`. The method assumes the user has installed the `rouge-score` package. If it is not included in the list of dependencies for this project, I think it should at least be included in the description of the method.