### PR TITLE
remove the weird prompt before generations

### DIFF
--- a/deepeval/benchmarks/mmlu/template.py
+++ b/deepeval/benchmarks/mmlu/template.py
@@ -16,9 +16,6 @@ class MMLUTemplate:
         for i in range(n_shots):
             prompt += MMLUTemplate.format_question(train_set[i])
         prompt += input
-
-        # define ouptut confinement
-        prompt += "Output 'A', 'B', 'C', or 'D'. Full answer not needed."
         return prompt
 
     @staticmethod


### PR DESCRIPTION

Here is an example:
```
<s> The following are multiple choice questions (with answers) about high school computer science.

Which of the following is an example of the use of a device on the Internet of Things (IoT) ?
A. A car alerts a driver that it is about to hit an object.
B. A hiker uses a G P S watch to keep track of her position.
C. A refrigerator orders milk from an online delivery service when the milk in the refrigerator is almost gone.
D. A runner uses a watch with optical sensors to monitor his heart rate.
Answer: C

Many Web browsers allow users to open anonymous windows. During a browsing session in an anonymous window, the browser does not record a browsing history or a list of downloaded files. When the anonymous window is exited, cookies created during the session are deleted. Which of the following statements about browsing sessions in an anonymous window is true?
A. The activities of a user browsing in an anonymous window will not be visible to people who monitor the user's network, such as the system administrator.
B. Items placed in a Web store's shopping cart for future purchase during the anonymous browsing session will not be saved on the user's computer.
C. A user will not be able to log in to e-mail or social media accounts during the anonymous browsing session.
D. A user browsing in an anonymous window will be protected from viruses launched from any web sites visited or files downloaded.
Answer: B

What is the output of "abc"[::-1] in Python 3?
A. Error
B. abc
C. cba
D. c
Answer: C

Let x = 1. What is x << 3 in Python 3?
A. 1
B. 3
C. 8
D. 16
Answer:Output 'A', 'B', 'C', or 'D'. Full answer not needed.
```

The output prompt `Output 'A', 'B', 'C', or 'D'. Full answer not needed.` is redundent. LLM should start answer with `Answer:`.