### PR TITLE
Minor typing improvements

### DIFF
--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 import os
-from typing import List, Optional, Union, Dict
+from typing import List, Optional, Union, Dict, Sequence
 import time
 from dataclasses import dataclass
 
@@ -539,7 +539,7 @@ def assert_test(
 
 
 def evaluate(
-    test_cases: List[Union[LLMTestCase, ConversationalTestCase]],
+    test_cases: Sequence[Union[LLMTestCase, ConversationalTestCase]],
     metrics: List[BaseMetric],
     hyperparameters: Optional[Dict[str, Union[str, int, float]]] = None,
     run_async: bool = True,

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -128,7 +128,7 @@ class Scorer:
         predictions: Union[str, List[str]],
         model: Optional[str] = "microsoft/deberta-large-mnli",
         lang: Optional[str] = "en",
-    ) -> float:
+    ) -> dict[str, np.ndarray]:
         """
         Calculate BERTScore for one or more reference sentences compared to one or more prediction sentences using a specified BERT model.
 


### PR DESCRIPTION
This is a small pull request related to some types that are causing my IDE to show some red lines:

1: `deepeval.evaluate`:

```
Argument of type "list[LLMTestCase]" cannot be assigned to parameter "test_cases" of type "List[LLMTestCase | ConversationalTestCase]" in function "evaluate"
  "list[LLMTestCase]" is incompatible with "List[LLMTestCase | ConversationalTestCase]"
    Type parameter "_T@list" is invariant, but "LLMTestCase" is not the same as "LLMTestCase | ConversationalTestCase"
    Consider switching from "list" to "Sequence" which is covariant
```

2: `deepeval.scorer.scorer.bert_score`: it returns dict of numpy arrays