### PR TITLE
Bugfix (utils): Assign error string before raising

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -114,7 +114,8 @@ def check_llm_test_case_params(
     metric: BaseMetric,
 ):
     if isinstance(test_case, LLMTestCase) is False:
-        metric.error = f"Unable to evaluate test cases that are not of type 'LLMTestCase' using the non-conversational '{metric.__name__}' metric."
+        error_str = f"Unable to evaluate test cases that are not of type 'LLMTestCase' using the non-conversational '{metric.__name__}' metric."
+        metric.error = error_str
         raise ValueError(error_str)
 
     missing_params = []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+"""Test module for utils."""
+
+import pytest
+
+from deepeval.metrics import BaseMetric, utils
+from deepeval.test_case import LLMTestCaseParams
+
+
+def test_check_llm_test_case_params_raies_ValueError_for_wrong_type():
+    with pytest.raises(ValueError):
+        utils.check_llm_test_case_params(
+            test_case="test_case",
+            test_case_params=[LLMTestCaseParams.ACTUAL_OUTPUT],
+            metric=BaseMetric(),
+        )


### PR DESCRIPTION
Before, the check_llm_test_case_params function would raise an UnboundLocalError instead of the probably intended and better manageable ValueError.