### PR TITLE
Give an explicit number to prevent JSON errors.

### DIFF
--- a/deepeval/metrics/hallucination/template.py
+++ b/deepeval/metrics/hallucination/template.py
@@ -24,7 +24,7 @@ Example:
     ]  
 }}
 
-You should NOT incorporate any prior knowledge you have and take each context at face value. Since you are going to generate a verdict for each context, the number of 'verdicts' SHOULD BE EXACTLY EQUAL TO {len(contexts)}.
+You should NOT incorporate any prior knowledge you have and take each context at face value. Since you are going to generate a verdict for each context, the number of 'verdicts' SHOULD BE STRICTLY EQUAL TO {len(contexts)}.
 You should FORGIVE cases where the actual output is lacking in detail, you should ONLY provide a 'no' answer if IT IS A CONTRADICTION.
 **
 

--- a/deepeval/metrics/hallucination/template.py
+++ b/deepeval/metrics/hallucination/template.py
@@ -24,7 +24,7 @@ Example:
     ]  
 }}
 
-You should NOT incorporate any prior knowledge you have and take each context at face value. Since you are going to generate a verdict for each context, the number of 'verdicts' SHOULD BE STRICTLY EQUAL to that of contexts.
+You should NOT incorporate any prior knowledge you have and take each context at face value. Since you are going to generate a verdict for each context, the number of 'verdicts' SHOULD BE EXACTLY EQUAL TO {len(contexts)}.
 You should FORGIVE cases where the actual output is lacking in detail, you should ONLY provide a 'no' answer if IT IS A CONTRADICTION.
 **
 


### PR DESCRIPTION
I'm getting errors each time I run this for some test cases because the JSON output was just an infinite list of verdicts that was eventually cut off. Maybe because in my case I only have a single context.

Specifying the actual number seems to give more reliable results.