### PR TITLE
Missing retrieval_context variable in sample code

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -58,7 +58,8 @@ def test_answer_relevancy():
     test_case = LLMTestCase(
         input="What if these shoes don't fit?",
         # Replace this with the actual output of your LLM application
-        actual_output="We offer a 30-day full refund at no extra cost."
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
     )
     assert_test(test_case, [answer_relevancy_metric])
 ```


### PR DESCRIPTION
retrieval_context is used in the "Let's breakdown what happened" section but it missing from the sample code.

I restored the original context of the variable from a previous edit of the file. I assume it was lost somehow during a more recent update to the documentation.