### PR TITLE
fix(docs): typo in MMLU import statement

### DIFF
--- a/docs/docs/benchmarks-introduction.mdx
+++ b/docs/docs/benchmarks-introduction.mdx
@@ -111,7 +111,7 @@ Notice you can also **optionally** define a `batch_generate()` method if your LL
 Next, define a MMLU benchmark using the `MMLU` class:
 
 ```python
-from deepeval.benchmarks.mmlu import MMLU
+from deepeval.benchmarks import MMLU
 ...
 
 benchmark = MMLU()


### PR DESCRIPTION
I noticed a small typo in the docs when trying to use the MMLU benchmark. Thanks for developing a great tool for evaluations!