### PR TITLE
Fix copied_turns in ConversationalTestCase

### DIFF
--- a/deepeval/test_case/conversational_test_case.py
+++ b/deepeval/test_case/conversational_test_case.py
@@ -23,6 +23,6 @@ class ConversationalTestCase:
         for turn in self.turns:
             if not isinstance(turn, LLMTestCase):
                 raise TypeError("'turns' must be a list of `LLMTestCases`")
-        copied_turns.append(deepcopy(turn))
+            copied_turns.append(deepcopy(turn))
 
         self.turns = copied_turns


### PR DESCRIPTION
There is a bug at the time of using `ConversationalTestCase` with more than one turn. Currently only the last turn is added to `copied_turns` list.

Moving this line inside the for loop (adding each turn to `copied_turns`) solves the bug.