### PR TITLE
Adding variable-length arguments and keyword arguments support for `load_benchmark_dataset`

### DIFF
--- a/deepeval/benchmarks/base_benchmark.py
+++ b/deepeval/benchmarks/base_benchmark.py
@@ -14,6 +14,6 @@ class DeepEvalBaseBenchmark(ABC, Generic[T]):
         self.dataset = dataset
 
     @abstractmethod
-    def load_benchmark_dataset(self) -> List[Golden]:
+    def load_benchmark_dataset(self, *args, **kwargs) -> List[Golden]:
         """Load the benchmark dataset and initialize tasks."""
         raise NotImplementedError


### PR DESCRIPTION
Resolves #1053 

Adding variable-length arguments and keyword arguments support for `load_benchmark_dataset`.
This helps ensure adherence to proper types when implementing this abstract method.