### PR TITLE
fix(deepeval/metrics): catch attribute error on metric async evaluation

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import re
 from typing import Any, Dict, Optional, List, Union, Tuple
 from deepeval.errors import MissingTestCaseParamsError
 from deepeval.models import (
@@ -235,6 +236,8 @@ def trimAndLoadJson(
         end = len(input_string)
 
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
+    # Remove trailing comma if one is present
+    jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
 
     try:
         return json.loads(jsonStr)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,3 +13,15 @@ def test_check_llm_test_case_params_raies_ValueError_for_wrong_type():
             test_case_params=[LLMTestCaseParams.ACTUAL_OUTPUT],
             metric=BaseMetric(),
         )
+
+
+def test_trimAndLoadJson_correctly_parses_with_trailing_comma():
+    test_data = [
+        '{\n    "verdict": "yes",\n}',
+        '{\n    "verdict": "yes",\n}',
+    ]
+    verdicts = [utils.trimAndLoadJson(v) for v in test_data]
+
+    assert len(verdicts) == 2
+    for v in verdicts:
+        assert v.get("verdict") == "yes"


### PR DESCRIPTION
### Background

I found this library when I was working on [an example from this repo](https://github.com/NirDiamant/RAG_Techniques/blob/main/all_rag_techniques_runnable_scripts/simple_rag.py) where it uses an [evaluate method](https://github.com/NirDiamant/RAG_Techniques/blob/main/evaluation/evalute_rag.py#L124-L127) using a few different metrics, specifically:
* **GEval**
* **Faithfulness**
* **ContextualRelevancy**

After trying to hook it up via [using a custom LLM](https://docs.confident-ai.com/docs/metrics-introduction#azure-openai-example) (using Ollama / Llama3.1) I was running into a few issues where the metrics were returning as strings and causing an `AttributeError` during runtime, which just needed to be added to the `except` error block in most cases.

I also had an issue where when the response would be returned the `trimAndLoadJson` utility function would error out due to a trailing comma.

Let me know what I can do to change the PR / if you would like the try/except blocks to also look for attribute errors as well. I'm sure the same issue could happen on the `generate` / non-async workflow as well when providing a custom model. I also could be mistaken on how to construct the custom model etc.

### Example Usage

Here was my example LLM class for context:
```python
class Ollama_3_1(DeepEvalBaseLLM):
    def __init__(self):
        self.model = Ollama(
            temperature=0,
            model="llama3.1",
            base_url=OLLAMA_SERVER,
        )

    def load_model(self):
        return self.model

    def generate(self, prompt: str) -> str:
        return self.model.invoke(prompt)

    async def a_generate(
        self,
        prompt: str,
        *a,
        **kw,
    ) -> str:
        return await self.model.ainvoke(prompt)

    def get_model_name(self):
        return "Ollama3.1"

OLLAMA_EVALUATOR = Ollama_3_1()

CORRECTNESS_METRIC = GEval(
    name="Correctness",
    model=OLLAMA_EVALUATOR,
    evaluation_params=[
        LLMTestCaseParams.EXPECTED_OUTPUT,
        LLMTestCaseParams.ACTUAL_OUTPUT,
    ],
    evaluation_steps=[
        "Determine whether the actual output is factually correct based on the expected output."
    ],
)
FAITHFULNESS_METRIC = FaithfulnessMetric(
    threshold=0.7,
    model=OLLAMA_EVALUATOR,
    include_reason=False,
)
RELEVANCE_METRIC = ContextualRelevancyMetric(
    threshold=1,
    model=OLLAMA_EVALUATOR,
    include_reason=True,
)
```