### PR TITLE
Pass back test_run info with evaluate

### DIFF
--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -72,8 +72,8 @@ class TestResult:
 
 @dataclass
 class EvaluateResult:
-    test_results = List[TestResult]
-    test_run = Optional[TestRunHttpResponse]
+    test_results: List[TestResult]
+    test_run: Optional[TestRunHttpResponse]
 
 
 def create_metric_data(metric: BaseMetric) -> MetricData:

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -74,7 +74,7 @@ class TestResult:
 @dataclass
 class EvaluateResult:
     test_results = List[TestResult]
-    test_run = TestRunHttpResponse
+    test_run = Optional[TestRunHttpResponse]
 
 
 

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -72,7 +72,7 @@ class TestResult:
     retrieval_context: Optional[List[str]] = None
 
 @dataclass
-class ExecuteResult:
+class EvaluateResult:
     test_results = List[TestResult]
     test_run = TestRunHttpResponse
 
@@ -1009,7 +1009,7 @@ def evaluate(
     verbose_mode: Optional[bool] = None,
     throttle_value: int = 0,
     max_concurrent: int = 100,
-) ->  ExecuteResult:
+) ->  EvaluateResult:
     check_valid_test_cases_type(test_cases)
 
     if hyperparameters is not None:
@@ -1073,7 +1073,7 @@ def evaluate(
     test_run.hyperparameters = hyperparameters
     global_test_run_manager.save_test_run()
     test_run_response = global_test_run_manager.wrap_up_test_run(run_duration, display_table=False)
-    return ExecuteResult(test_results=test_results, test_run=test_run_response)
+    return EvaluateResult(test_results=test_results, test_run=test_run_response)
 
 
 def print_test_result(test_result: TestResult):

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -1,7 +1,7 @@
 import asyncio
 from copy import deepcopy
 import os
-from typing import Callable, List, Optional, Union, Dict
+from typing import Callable, List, Optional, Union, Dict, Tuple
 import time
 from dataclasses import dataclass
 from rich.console import Console
@@ -999,7 +999,7 @@ def evaluate(
     verbose_mode: Optional[bool] = None,
     throttle_value: int = 0,
     max_concurrent: int = 100,
-):
+) ->  Tuple[list[TestResult], str]:
     check_valid_test_cases_type(test_cases)
 
     if hyperparameters is not None:
@@ -1062,8 +1062,8 @@ def evaluate(
     test_run = global_test_run_manager.get_test_run()
     test_run.hyperparameters = hyperparameters
     global_test_run_manager.save_test_run()
-    global_test_run_manager.wrap_up_test_run(run_duration, display_table=False)
-    return test_results
+    link = global_test_run_manager.wrap_up_test_run(run_duration, display_table=False)
+    return test_results, link
 
 
 def print_test_result(test_result: TestResult):

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -4,6 +4,10 @@ import os
 from typing import Callable, List, Optional, Union, Dict, Tuple
 import time
 from dataclasses import dataclass
+
+from openai import BaseModel
+
+from deepeval.test_run.api import TestRunHttpResponse
 from rich.console import Console
 from tqdm.asyncio import tqdm_asyncio
 from tqdm import tqdm
@@ -66,6 +70,12 @@ class TestResult:
     expected_output: Optional[str] = None
     context: Optional[List[str]] = None
     retrieval_context: Optional[List[str]] = None
+
+@dataclass
+class ExecuteResult:
+    test_results = List[TestResult]
+    test_run = TestRunHttpResponse
+
 
 
 def create_metric_data(metric: BaseMetric) -> MetricData:
@@ -999,7 +1009,7 @@ def evaluate(
     verbose_mode: Optional[bool] = None,
     throttle_value: int = 0,
     max_concurrent: int = 100,
-) ->  Tuple[list[TestResult], str]:
+) ->  ExecuteResult:
     check_valid_test_cases_type(test_cases)
 
     if hyperparameters is not None:
@@ -1062,8 +1072,8 @@ def evaluate(
     test_run = global_test_run_manager.get_test_run()
     test_run.hyperparameters = hyperparameters
     global_test_run_manager.save_test_run()
-    link = global_test_run_manager.wrap_up_test_run(run_duration, display_table=False)
-    return test_results, link
+    test_run_response = global_test_run_manager.wrap_up_test_run(run_duration, display_table=False)
+    return ExecuteResult(test_results=test_results, test_run=test_run_response)
 
 
 def print_test_result(test_result: TestResult):

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -5,8 +5,6 @@ from typing import Callable, List, Optional, Union, Dict
 import time
 from dataclasses import dataclass
 
-from openai import BaseModel
-
 from deepeval.test_run.api import TestRunHttpResponse
 from rich.console import Console
 from tqdm.asyncio import tqdm_asyncio
@@ -71,11 +69,11 @@ class TestResult:
     context: Optional[List[str]] = None
     retrieval_context: Optional[List[str]] = None
 
+
 @dataclass
 class EvaluateResult:
     test_results = List[TestResult]
     test_run = Optional[TestRunHttpResponse]
-
 
 
 def create_metric_data(metric: BaseMetric) -> MetricData:
@@ -1009,7 +1007,7 @@ def evaluate(
     verbose_mode: Optional[bool] = None,
     throttle_value: int = 0,
     max_concurrent: int = 100,
-) ->  EvaluateResult:
+) -> EvaluateResult:
     check_valid_test_cases_type(test_cases)
 
     if hyperparameters is not None:
@@ -1072,7 +1070,9 @@ def evaluate(
     test_run = global_test_run_manager.get_test_run()
     test_run.hyperparameters = hyperparameters
     global_test_run_manager.save_test_run()
-    test_run_response = global_test_run_manager.wrap_up_test_run(run_duration, display_table=False)
+    test_run_response = global_test_run_manager.wrap_up_test_run(
+        run_duration, display_table=False
+    )
     return EvaluateResult(test_results=test_results, test_run=test_run_response)
 
 

--- a/deepeval/evaluate.py
+++ b/deepeval/evaluate.py
@@ -1,7 +1,7 @@
 import asyncio
 from copy import deepcopy
 import os
-from typing import Callable, List, Optional, Union, Dict, Tuple
+from typing import Callable, List, Optional, Union, Dict
 import time
 from dataclasses import dataclass
 

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -710,7 +710,9 @@ class TestRunManager:
                 print(f"Results saved in {local_folder} as {new_test_filename}")
             os.remove(new_test_filename)
 
-    def wrap_up_test_run(self, runDuration: float, display_table: bool = True) -> Optional[TestRunHttpResponse]:
+    def wrap_up_test_run(
+        self, runDuration: float, display_table: bool = True
+    ) -> Optional[TestRunHttpResponse]:
         test_run = self.get_test_run()
         if test_run is None:
             print("Test Run is empty, please try again.")

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -571,7 +571,7 @@ class TestRunManager:
             f"Total estimated evaluation tokens cost: {test_run.evaluation_cost} USD"
         )
 
-    def post_test_run(self, test_run: TestRun) -> Optional[str]:
+    def post_test_run(self, test_run: TestRun) -> Optional[TestRunHttpResponse]:
         console = Console()
 
         if is_confident() and self.disable_request is False:
@@ -682,7 +682,7 @@ class TestRunManager:
 
             if is_in_ci_env() == False:
                 webbrowser.open(link)
-            return link
+            return response
 
         else:
             console.print(
@@ -710,7 +710,7 @@ class TestRunManager:
                 print(f"Results saved in {local_folder} as {new_test_filename}")
             os.remove(new_test_filename)
 
-    def wrap_up_test_run(self, runDuration: float, display_table: bool = True) -> Optional[str]:
+    def wrap_up_test_run(self, runDuration: float, display_table: bool = True) -> Optional[TestRunHttpResponse]:
         test_run = self.get_test_run()
         if test_run is None:
             print("Test Run is empty, please try again.")

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -571,7 +571,7 @@ class TestRunManager:
             f"Total estimated evaluation tokens cost: {test_run.evaluation_cost} USD"
         )
 
-    def post_test_run(self, test_run: TestRun):
+    def post_test_run(self, test_run: TestRun) -> Optional[str]:
         console = Console()
 
         if is_confident() and self.disable_request is False:
@@ -682,6 +682,7 @@ class TestRunManager:
 
             if is_in_ci_env() == False:
                 webbrowser.open(link)
+            return link
 
         else:
             console.print(
@@ -709,7 +710,7 @@ class TestRunManager:
                 print(f"Results saved in {local_folder} as {new_test_filename}")
             os.remove(new_test_filename)
 
-    def wrap_up_test_run(self, runDuration: float, display_table: bool = True):
+    def wrap_up_test_run(self, runDuration: float, display_table: bool = True) -> Optional[str]:
         test_run = self.get_test_run()
         if test_run is None:
             print("Test Run is empty, please try again.")
@@ -754,7 +755,7 @@ class TestRunManager:
             or len(test_run.conversational_test_cases) > 0
         ):
             test_run.guard_mllm_test_cases()
-            self.post_test_run(test_run)
+            return self.post_test_run(test_run)
 
 
 global_test_run_manager = TestRunManager()


### PR DESCRIPTION
I'm automating a flow with DeepEval but need to publish a Slack message with the test run link. This passes back the test_run info when I used the evaluate function.

But this changes the interface of the evaluate function.