### PR TITLE
Introducing DeepEval Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@
     <a href="https://github.com/confident-ai/deepeval/blob/master/LICENSE.md">
         <img alt="License" src="https://img.shields.io/github/license/confident-ai/deepeval.svg?color=yellow">
     </a>
+     <a href="https://img.shields.io/badge/Gurubase-Ask%20DeepEval%20Guru-006BFF">
+        <img alt="DeepEval Guru" src="https://gurubase.io/g/deepeval">
+    </a>
 </p>
 
 **DeepEval** is a simple-to-use, open-source LLM evaluation framework, for evaluating large-language model systems. It is similar to Pytest but specialized for unit testing LLM outputs. DeepEval incorporates the latest research to evaluate LLM outputs based on metrics such as G-Eval, hallucination, answer relevancy, RAGAS, etc., which uses LLMs and various other NLP models that runs **locally on your machine** for evaluation.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [DeepEval Guru](https://gurubase.io/g/deepeval) to Gurubase. DeepEval Guru uses the data from this repo and data from the [docs](https://docs.confident-ai.com/docs/getting-started) to answer questions by leveraging the LLM.

In this PR, I showcased the "DeepEval Guru", which highlights that DeepEval now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable DeepEval Guru in Gurubase, just let me know that's totally fine.