### PR TITLE
GEval docs: `strict` -> `strict_mode`

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -132,7 +132,7 @@ correctness_metric = GEval(
     name="Correctness",
     criteria="Correctness - determine if the actual output is correct according to the expected output.",
     evaluation_params=[LLMTestCaseParams.ACTUAL_OUTPUT, LLMTestCaseParams.EXPECTED_OUTPUT],
-    strict=True
+    strict_mode=True
 )
 
 correctness_metric.measure(test_case)


### PR DESCRIPTION
The docs as written lead to:

```
TypeError: GEval.__init__() got an unexpected keyword argument 'strict'
```