### PR TITLE
Fix link in getting-started.mdx

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -81,7 +81,7 @@ deepeval test run test_example.py
 :::info
 You'll need to set your `OPENAI_API_KEY` as an enviornment variable before running the `AnswerRelevancyMetric`, since the `AnswerRelevancyMetric` is an LLM-evaluated metric.
 
-To use **ANY** custom LLM of your choice, [check out this part of the docs](evaluation-introduction#using-a-custom-llm).
+To use **ANY** custom LLM of your choice, [check out this part of the docs](guides-using-custom-llms).
 :::
 
 You can also save test results locally for each test run. Simply set the `DEEPEVAL_RESULTS_FOLDER` environment variable to your relative path of choice:


### PR DESCRIPTION
- This link doesn't seem to work: https://docs.confident-ai.com/docs/evaluation-introduction#using-a-custom-llm
- I assume the correct link is: https://docs.confident-ai.com/docs/guides-using-custom-llms