### PR TITLE
Avoid asking for OPENAI_API_KEY when creating an empty EvaluationDataset

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Dict
+from typing import List, Optional, Union
 from dataclasses import dataclass, field
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -25,7 +25,6 @@ from deepeval.dataset.api import (
 from deepeval.dataset.golden import Golden, ConversationalGolden
 from deepeval.test_case import LLMTestCase, ConversationalTestCase, MLLMTestCase
 from deepeval.utils import convert_keys_to_snake_case, is_confident
-from deepeval.synthesizer.types import *
 
 valid_file_types = ["csv", "json"]
 


### PR DESCRIPTION
Just removed line 28:

```python
from deepeval.synthesizer.types import *
```
from `deepval/dataset/dataset.py`

This should solve the following issue https://github.com/confident-ai/deepeval/issues/1140