### PR TITLE
Redteam Jailbreak Linear / Tree Fix

### DIFF
--- a/deepeval/red_teaming/attack_enhancements/jailbreaking_linear/jailbreaking_linear.py
+++ b/deepeval/red_teaming/attack_enhancements/jailbreaking_linear/jailbreaking_linear.py
@@ -67,7 +67,7 @@ class JailbreakingLinear(AttackEnhancement):
                 attack, current_attack
             )
             res: OnTopic = self._generate_schema(is_on_topic_prompt, OnTopic)
-           
+
             on_topic = res.on_topic
             pbar.update(1)
 
@@ -86,8 +86,7 @@ class JailbreakingLinear(AttackEnhancement):
                 attack, current_attack, target_response
             )
             res: Rating = self._generate_schema(judge_prompt, Rating)
-            
-            # Changed from original
+
             score = res.rating
             pbar.update(1)
 
@@ -166,7 +165,7 @@ class JailbreakingLinear(AttackEnhancement):
             # 4th step: Generate a response from the target LLM using the enhanced attack
             target_response = await self.target_model.a_generate(current_attack)
             penalized_phrases = ["in the face of impending doom"]
-            
+
             contains_penalized_phrase = any(
                 phrase.lower() in target_response.lower()
                 for phrase in penalized_phrases

--- a/deepeval/red_teaming/attack_enhancements/jailbreaking_linear/jailbreaking_linear.py
+++ b/deepeval/red_teaming/attack_enhancements/jailbreaking_linear/jailbreaking_linear.py
@@ -67,11 +67,13 @@ class JailbreakingLinear(AttackEnhancement):
                 attack, current_attack
             )
             res: OnTopic = self._generate_schema(is_on_topic_prompt, OnTopic)
-            on_topic = res.response
+           
+            on_topic = res.on_topic
             pbar.update(1)
 
             # 4th step: Generate a response from the target LLM using the enhanced attack
             target_response = self.target_model.generate(current_attack)
+
             penalized_phrases = ["in the face of impending doom"]
             contains_penalized_phrase = any(
                 phrase.lower() in target_response.lower()
@@ -84,7 +86,9 @@ class JailbreakingLinear(AttackEnhancement):
                 attack, current_attack, target_response
             )
             res: Rating = self._generate_schema(judge_prompt, Rating)
-            score = res.number
+            
+            # Changed from original
+            score = res.rating
             pbar.update(1)
 
             # Apply penalty if the phrase is present
@@ -156,12 +160,13 @@ class JailbreakingLinear(AttackEnhancement):
             res: OnTopic = await self._a_generate_schema(
                 is_on_topic_prompt, OnTopic
             )
-            on_topic = res.response
+            on_topic = res.on_topic
             pbar.update(1)
 
             # 4th step: Generate a response from the target LLM using the enhanced attack
             target_response = await self.target_model.a_generate(current_attack)
             penalized_phrases = ["in the face of impending doom"]
+            
             contains_penalized_phrase = any(
                 phrase.lower() in target_response.lower()
                 for phrase in penalized_phrases
@@ -173,7 +178,7 @@ class JailbreakingLinear(AttackEnhancement):
                 attack, current_attack, target_response
             )
             res: Rating = await self._a_generate_schema(judge_prompt, Rating)
-            score = res.number
+            score = res.rating
             pbar.update(1)
 
             # Apply penalty if the phrase is present

--- a/deepeval/red_teaming/attack_enhancements/jailbreaking_linear/schema.py
+++ b/deepeval/red_teaming/attack_enhancements/jailbreaking_linear/schema.py
@@ -8,11 +8,11 @@ class ImprovementPrompt(BaseModel):
 
 
 class OnTopic(BaseModel):
-    response: bool
+    on_topic: bool
 
 
 class Rating(BaseModel):
-    number: int
+    rating: int
 
 
 class NonRefusal(BaseModel):

--- a/deepeval/red_teaming/attack_enhancements/jailbreaking_tree/jailbreaking_tree.py
+++ b/deepeval/red_teaming/attack_enhancements/jailbreaking_tree/jailbreaking_tree.py
@@ -141,7 +141,7 @@ class JailbreakingTree(AttackEnhancement):
                 initial_attack, enhanced_attack, target_response
             )
             res: Rating = self._generate_schema(judge_prompt, Rating)
-            score = res.number
+            score = res.rating
 
             # Prune if the score is too low
             if score <= PRUNE_THRESHOLD:
@@ -275,7 +275,7 @@ class JailbreakingTree(AttackEnhancement):
             initial_attack, enhanced_attack, target_response
         )
         res: Rating = await self._a_generate_schema(judge_prompt, Rating)
-        score = res.number
+        score = res.rating
 
         # Prune if the score is too low
         if score <= PRUNE_THRESHOLD:

--- a/deepeval/red_teaming/attack_enhancements/jailbreaking_tree/schema.py
+++ b/deepeval/red_teaming/attack_enhancements/jailbreaking_tree/schema.py
@@ -8,11 +8,11 @@ class ImprovementPrompt(BaseModel):
 
 
 class OnTopic(BaseModel):
-    response: bool
+    on_topic: bool
 
 
 class Rating(BaseModel):
-    number: int
+    rating: int
 
 
 class NonRefusal(BaseModel):


### PR DESCRIPTION
It seems that the there is mismatch between what the on_topic prompt and ratings prompt output and what the schemas expect, causing these two methods to not work correctly.

Changed jailbreak linear / jailbreak tree to use the expected fields outputted from the LLM calls. 
