### PR TITLE
Replace context with retrieval_context in LLMTestCaseParams for HallucinationMetric

### DIFF
--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -21,7 +21,7 @@ from deepeval.metrics.hallucination.schema import *
 required_params: List[LLMTestCaseParams] = [
     LLMTestCaseParams.INPUT,
     LLMTestCaseParams.ACTUAL_OUTPUT,
-    LLMTestCaseParams.CONTEXT,
+    LLMTestCaseParams.RETRIEVAL_CONTEXT,
 ]
 
 
@@ -62,7 +62,7 @@ class HallucinationMetric(BaseMetric):
             else:
                 self.verdicts: List[HallucinationVerdict] = (
                     self._generate_verdicts(
-                        test_case.actual_output, test_case.context
+                        test_case.actual_output, test_case.retrieval_context
                     )
                 )
                 self.score = self._calculate_score()
@@ -93,7 +93,7 @@ class HallucinationMetric(BaseMetric):
         ):
             self.verdicts: List[HallucinationVerdict] = (
                 await self._a_generate_verdicts(
-                    test_case.actual_output, test_case.context
+                    test_case.actual_output, test_case.retrieval_context
                 )
             )
             self.score = self._calculate_score()

--- a/examples/tracing/test_chatbot.py
+++ b/examples/tracing/test_chatbot.py
@@ -76,7 +76,7 @@ chatbot = Chatbot()
 
 
 def test_hallucination():
-    context = [
+    retrieval_context = [
         "Be a natural-born citizen of the United States.",
         "Be at least 35 years old.",
         "Have been a resident of the United States for 14 years.",
@@ -87,6 +87,6 @@ def test_hallucination():
     test_case = LLMTestCase(
         input=input,
         actual_output=chatbot.query(user_input=input),
-        context=context,
+        retrieval_context=retrieval_context,
     )
     assert_test(test_case, [metric])

--- a/tests/test_hallucination.py
+++ b/tests/test_hallucination.py
@@ -40,7 +40,10 @@ def test_hallucination_metric_3():
     test_case = LLMTestCase(
         input="placeholder",
         actual_output="Python is a programming language.",
-        retrieval_context=["Python is a snake.", "Pythons like to lurk in the forests."],
+        retrieval_context=[
+            "Python is a snake.",
+            "Pythons like to lurk in the forests.",
+        ],
         cost=0.1,
         latency=13.0,
     )

--- a/tests/test_hallucination.py
+++ b/tests/test_hallucination.py
@@ -12,7 +12,7 @@ def test_hallucination_metric():
     test_case = LLMTestCase(
         input="placeholder",
         actual_output="A blond drinking water in public.",
-        context=[
+        retrieval_context=[
             "A man with blond-hair, and a brown shirt drinking out of a public water fountain."
         ],
         cost=0.4,
@@ -27,7 +27,7 @@ def test_hallucination_metric_2():
     test_case = LLMTestCase(
         input="placeholder",
         actual_output="Python is a programming language.",
-        context=["Python is NOT a programming language."],
+        retrieval_context=["Python is NOT a programming language."],
         cost=1,
         latency=0.2,
     )
@@ -40,7 +40,7 @@ def test_hallucination_metric_3():
     test_case = LLMTestCase(
         input="placeholder",
         actual_output="Python is a programming language.",
-        context=["Python is a snake.", "Pythons like to lurk in the forests."],
+        retrieval_context=["Python is a snake.", "Pythons like to lurk in the forests."],
         cost=0.1,
         latency=13.0,
     )


### PR DESCRIPTION
Replace `context` with `retrieval_context` in `LLMTestCaseParams` for `HallucinationMetric` to align with other classes and implement a loop over evaluators using the same `TestCase`.

Previously, this class was the only one not to borrow this nomenclature, which blocked the possibility of producing loops on the same `TestCase`. Now, codes like the following are possible

```python
requests = [
    request
] if isinstance(request, EvaluationRequest) else request

for req in tqdm(requests):
    test_case = LLMTestCase(
        input=req.question,
        actual_output=req.output,
        expected_output=req.expected_output or None,
        retrieval_context=req.contexts if req.contexts else None,
    )
    for metric in tqdm(self.metrics):
        instance = self.metrics_config.get_metric_instance(
            metric, self.client
        )

        instance.measure(test_case)

        self.evaluations.append(
            EvaluationResult(
                request=req,
                evaluator_type=metric,
                overall_score=instance.score,
                feedback=instance.reason,
            )
        )
```

Let me know if you have any questions.

Louis Brulé Naudet