### PR TITLE
Fixed g-eval doc.

### DIFF
--- a/docs/docs/metrics-llm-evals.mdx
+++ b/docs/docs/metrics-llm-evals.mdx
@@ -36,7 +36,7 @@ correctness_metric = GEval(
         "You should also heavily penalize omission of detail",
         "Vague language, or contradicting OPINIONS, are OK"
     ],
-    evaluation_params=[LLMTestCaseParams.INPUT, LLMTestCaseParams.ACTUAL_OUTPUT],
+    evaluation_params=[LLMTestCaseParams.INPUT, LLMTestCaseParams.ACTUAL_OUTPUT, LLMTestCaseParams.EXPECTED_OUTPUT],
 )
 ```
 


### PR DESCRIPTION
I was following the G-Eval guide for `Correctness` metric and could not get the evaluation to work correctly as it kept ignoring the `expected_output` in my LLMTestCase, despite the criteria or evaluation_steps explicitly stating to evaluate against the expected output (following exactly the example code). I realised that `LLMTestCaseParams.EXPECTED_OUTPUT` should be in the `evaluation_params` list, and after adding that, it worked correctly.