### PR TITLE
Fix issue #1171

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -778,7 +778,7 @@ class EvaluationDataset:
         full_file_path = os.path.join(directory, new_filename)
 
         if file_type == "json":
-            with open(full_file_path, "w") as file:
+            with open(full_file_path, "w", encoding="utf-8") as file:
                 json_data = [
                     {
                         "input": golden.input,
@@ -789,10 +789,10 @@ class EvaluationDataset:
                     }
                     for golden in self.goldens
                 ]
-                json.dump(json_data, file, indent=4)
+                json.dump(json_data, file, indent=4, ensure_ascii=False)
 
         elif file_type == "csv":
-            with open(full_file_path, "w", newline="") as file:
+            with open(full_file_path, "w", newline="", encoding="utf-8") as file:
                 writer = csv.writer(file)
                 writer.writerow(
                     [


### PR DESCRIPTION
This is the PR to fix Issue #1171 

Only changes in save_as() method are needed as the two open("r") versions now have the required encoding argument (with "utf-8" as the default string).

I've not added encoding_type string argument like has been done for the two open("r") versions in this file.
Can be added if you wish, but then ensure_ascii maybe should be too.
Plus if we add encoding_type (and ensure_ascii) here then we probably should do the same in synthesizer save_as method too.
Will let you decide how much is needed.

At this point all I've done is **exactly mirror the code** that exists in synthesizer.save_as().