### PR TITLE
Fixes #1207

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 docs/.docusaurus
 node_modules
 .deepeval

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "opentelemetry-sdk>=1.24.0,<2.0.0",
         "opentelemetry-exporter-otlp-proto-grpc>=1.24.0,<2.0.0",
         "grpcio==1.60.1",
+        "nest-asyncio",
     ],
     extras_require={
         "dev": ["black"],


### PR DESCRIPTION
I encountered a `ModuleNotFoundError: No module named 'nest_asyncio'` error after installing the `deepeval` library. It seems that `nest_asyncio`, which is required by the library, is not automatically installed as a dependency.

see #1207