### PR TITLE
Add doc count to the ContextualPrecision template (Fixes #1205)

### DIFF
--- a/deepeval/metrics/contextual_precision/template.py
+++ b/deepeval/metrics/contextual_precision/template.py
@@ -1,6 +1,9 @@
 class ContextualPrecisionTemplate:
     @staticmethod
-    def generate_verdicts(input, expected_output, retrieval_context):
+    def generate_verdicts(input, expected_output, retrieval_context: str | list):
+        document_count_str = ""
+        if isinstance(retrieval_context, list):
+            document_count_str = f" ({len(retrieval_context)} document{'s' if len(retrieval_context) > 1 else ''})"
         return f"""Given the input, expected output, and retrieval context, please generate a list of JSON objects to determine whether each node in the retrieval context was remotely useful in arriving at the expected output.
 
 **
@@ -35,7 +38,7 @@ Input:
 Expected output:
 {expected_output}
 
-Retrieval Context:
+Retrieval Context{document_count_str}:
 {retrieval_context}
 
 JSON:


### PR DESCRIPTION
# Resolve Endless Generation Issue (ContextualPrecision Verdicts)

As described in issue #1205, for longer lists of complex contexts, (less capable) LLMs could loose track of the document count and therefore enter an endless generation loop. This can often be resolved by simply passing the explicit document count as part of the prompt.