### PR TITLE
fix: MMLUTemplate.format_subject should be a static method

### DIFF
--- a/deepeval/benchmarks/mmlu/template.py
+++ b/deepeval/benchmarks/mmlu/template.py
@@ -30,6 +30,7 @@ class MMLUTemplate:
             prompt += " {}\n\n".format(data["target"])
         return prompt
 
+    @staticmethod
     def format_subject(subject: str):
         l = subject.split("_")
         s = ""


### PR DESCRIPTION
This appears to be a minor oversight and can be resolved by simply adding the `@staticmethod` decorator.