### PR TITLE
Grammar fix in RAG eval guide

### DIFF
--- a/docs/docs/guides-rag-evaluation.mdx
+++ b/docs/docs/guides-rag-evaluation.mdx
@@ -58,7 +58,7 @@ We'll explore what other hyperparameters to consider in the generation step of a
 
 The generation step, which follows the retrieval step, typically involves:
 
-1. **Constructing a prompt** based on the initial input the previous vector-fetched retrieval context.
+1. **Constructing a prompt** based on the initial input and the previous vector-fetched retrieval context.
 2. **Providing this prompt to your LLM.** This yields the final augmented output.
 
 The generation step is typically more straightforward thanks to standardized LLMs. Similarly, here are some questions RAG evaluation can answer in the generation step:


### PR DESCRIPTION
This PR simply fixes a grammatical error in the RAG Evaluation Guide in docs