### PR TITLE
Changed Error type

### DIFF
--- a/deepeval/synthesizer/chunking/doc_chunker.py
+++ b/deepeval/synthesizer/chunking/doc_chunker.py
@@ -60,7 +60,7 @@ class DocumentChunker:
         )
         try:
             collection = client.get_collection(name=collection_name)
-        except ValueError:
+        except chromadb.errors.InvalidCollectionException:
             # Collection doesn't exist, so create it and then add documents
             collection = client.create_collection(name=collection_name)
 


### PR DESCRIPTION
### Summary
I couldnt create a synthetic data because the code in the except section of `a_chunk_doc` function wasnt being executed. The reason was the type of error used in try - except section was `ValueError`, and the error chromaDB was putting out was `chromadb.errors.InvalidCollectionException`. Therefore the rest of the code wasnt executed.

### Changes
Changed `ValueError` to `chromadb.errors.InvalidCollectionException`

### Additional Notes
This is my first time im contributing a open-source project. lmk if theres anything I could do better