### PR TITLE
top_logprobs configurable

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -59,6 +59,7 @@ class GEval(BaseMetric):
         evaluation_steps: Optional[List[str]] = None,
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
         threshold: float = 0.5,
+        top_logprobs: int = 20,
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
@@ -88,6 +89,7 @@ class GEval(BaseMetric):
         self.evaluation_model = self.model.get_model_name()
         self.evaluation_steps = evaluation_steps
         self.threshold = 1 if strict_mode else threshold
+        self.top_logprobs = top_logprobs
         self.strict_mode = strict_mode
         self.async_mode = async_mode
         self.verbose_mode = verbose_mode
@@ -239,7 +241,7 @@ class GEval(BaseMetric):
             # Don't have to check for using native model
             # since generate raw response only exist for deepeval's native model
             res, cost = await self.model.a_generate_raw_response(
-                prompt, logprobs=True, top_logprobs=20
+                prompt, logprobs=True, top_logprobs=self.top_logprobs
             )
             self.evaluation_cost += cost
             data = trimAndLoadJson(res.content, self)
@@ -293,7 +295,7 @@ class GEval(BaseMetric):
 
         try:
             res, cost = self.model.generate_raw_response(
-                prompt, logprobs=True, top_logprobs=20
+                prompt, logprobs=True, top_logprobs=self.top_logprobs
             )
             self.evaluation_cost += cost
             data = trimAndLoadJson(res.content, self)


### PR DESCRIPTION
Related to https://github.com/confident-ai/deepeval/issues/843

|Azure deployments have a version.
not all version of gpt-4 and gpt-4 on azure support logprobs and top_logprobs at all
when they do, the top_logprobs setting can only go to 5 instead of 20 on OpenAI service

for Azure OpenAI gtp-40 version 2024-11-20, I am seeing the behavior that azure is taking commands to 20 and then internally changing it to 5 (based on the test results), so this might not be necessary, but there are other Azure versions out there I can't test against and this might be useful to others who can't upgrade.

tested against your pytest with LLM skipped
tested against OpenAI service ... no problems
tested against Azure gtp-40 version 2024-11-20 ... no problems