### PR TITLE
Set default value of evaluation_cost to 0 in BaseMetric class

### DIFF
--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -16,7 +16,7 @@ class BaseMetric:
     verbose_mode: bool = True
     include_reason: bool = False
     error: Optional[str] = None
-    evaluation_cost: Optional[float] = None
+    evaluation_cost: Optional[float] = 0
     verbose_logs: Optional[str] = None
     skipped = False
 


### PR DESCRIPTION
Addresses #1262 The evaluate() method of GEval derived from BaseMetric was raising a TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int/float' when called directly (without a prior call to measure()). This was due to the evaluation_cost attribute being initialized to None in the BaseMetric class.

```self.evaluation_cost += cost``` This throws an error as evaluation_cost is None by default in BaseMetric class and cost is a float.

This PR initializes evaluation_cost to 0 in the BaseMetric attributes, preventing the TypeError and allowing evaluate() to be called directly without issues.