### PR TITLE
fix task reloading of MMLU

### DIFF
--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -232,13 +232,10 @@ class MMLU(DeepEvalBaseBenchmark):
 
     def load_benchmark_dataset(self, task: MMLUTask) -> List[Golden]:
 
-        if self.dataset:
-            dataset = self.dataset
-        else:
-            dataset = load_dataset(
-                "lukaemon/mmlu", task.value, trust_remote_code=True
-            )
-            self.dataset = dataset
+        dataset = load_dataset(
+            "lukaemon/mmlu", task.value, trust_remote_code=True
+        )
+        self.dataset = dataset
 
         # If dataset has not been previously loaded, construct
         # dataset of examples and save as instance var (to save time)


### PR DESCRIPTION
In the case of providing a new task, `MMLU.load_benchmark_dataset` will still only use the task that was loaded the first time. This will result in the same task being evaluated repeatedly.