### PR TITLE
fix batched evaluate() behavior 

### DIFF
--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -114,7 +114,13 @@ class BigBenchHard(DeepEvalBaseBenchmark):
                                 task_correct_predictions += 1
                                 overall_correct_predictions += 1
                             predictions_row.append(
-                                (task.value, golden.input, prediction, score)
+                                (
+                                    task.value,
+                                    golden.input,
+                                    prediction,
+                                    golden.expected_output,
+                                    score,
+                                )
                             )
                 else:
                     # Calculate task accuracy

--- a/deepeval/benchmarks/drop/drop.py
+++ b/deepeval/benchmarks/drop/drop.py
@@ -83,7 +83,13 @@ class DROP(DeepEvalBaseBenchmark):
                                 task_correct_predictions += 1
                                 overall_correct_predictions += 1
                             predictions_row.append(
-                                (task.value, golden.input, prediction, score)
+                                (
+                                    task.value,
+                                    golden.input,
+                                    prediction,
+                                    golden.expected_output,
+                                    score,
+                                )
                             )
                 else:
                     for idx, golden in enumerate(

--- a/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
+++ b/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
@@ -60,6 +60,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
                             task.value,
                             golden.input,
                             prediction,
+                            golden.expected_output,
                             score,
                         )
                     )
@@ -86,6 +87,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
                     "Task",
                     "Input",
                     "Prediction",
+                    "Expected Output",
                     "Correct",
                 ],
             )

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -83,7 +83,7 @@ class HellaSwag(DeepEvalBaseBenchmark):
                                 task_correct_predictions += 1
                                 overall_correct_predictions += 1
                             predictions_row.append(
-                                (task.value, golden.input, prediction, score)
+                                (task.value, golden.input, prediction, golden.expected_output, score)
                             )
                 else:
                     for idx, golden in enumerate(

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -83,7 +83,13 @@ class HellaSwag(DeepEvalBaseBenchmark):
                                 task_correct_predictions += 1
                                 overall_correct_predictions += 1
                             predictions_row.append(
-                                (task.value, golden.input, prediction, golden.expected_output, score)
+                                (
+                                    task.value,
+                                    golden.input,
+                                    prediction,
+                                    golden.expected_output,
+                                    score,
+                                )
                             )
                 else:
                     for idx, golden in enumerate(

--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -54,7 +54,13 @@ class HumanEval(DeepEvalBaseBenchmark):
                     task_correct = 1
                     overall_correct_predictions += 1
                 predictions_row.append(
-                    (task.value, golden.input, prediction, score)
+                    (
+                        task.value,
+                        golden.input,
+                        prediction,
+                        golden.expected_output,
+                        score,
+                    )
                 )
                 if self.verbose_mode:
                     self.print_verbose_logs(
@@ -75,7 +81,14 @@ class HumanEval(DeepEvalBaseBenchmark):
             # Columns: 'Task', 'Input', 'Prediction', 'Score'
             self.predictions = pd.DataFrame(
                 predictions_row,
-                columns=["Task", "Input", "Prediction", "Correct"],
+                columns=[
+                    "Task",
+                    "Input",
+                    "Prediction",
+                    "Correct",
+                    "Expected Output",
+                    "Score",
+                ],
             )
             self.task_scores = pd.DataFrame(
                 scores_row, columns=["Task", "Score"]

--- a/deepeval/benchmarks/logi_qa/logi_qa.py
+++ b/deepeval/benchmarks/logi_qa/logi_qa.py
@@ -86,7 +86,13 @@ class LogiQA(DeepEvalBaseBenchmark):
                                 task_correct_predictions += 1
                                 overall_correct_predictions += 1
                             predictions_row.append(
-                                (task.value, golden.input, prediction, score)
+                                (
+                                    task.value,
+                                    golden.input,
+                                    prediction,
+                                    golden.expected_output,
+                                    score,
+                                )
                             )
                 else:
                     for idx, golden in enumerate(

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -83,7 +83,13 @@ class MathQA(DeepEvalBaseBenchmark):
                                 task_correct_predictions += 1
                                 overall_correct_predictions += 1
                             predictions_row.append(
-                                (task.value, golden.input, prediction, score)
+                                (
+                                    task.value,
+                                    golden.input,
+                                    prediction,
+                                    golden.expected_output,
+                                    score,
+                                )
                             )
                 else:
                     for idx, golden in enumerate(

--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -82,7 +82,13 @@ class MMLU(DeepEvalBaseBenchmark):
                                 task_correct_predictions += 1
                                 overall_correct_predictions += 1
                             predictions_row.append(
-                                (task.value, golden.input, prediction, score)
+                                (
+                                    task.value,
+                                    golden.input,
+                                    prediction,
+                                    golden.expected_output,
+                                    score,
+                                )
                             )
                 else:
                     for idx, golden in enumerate(


### PR DESCRIPTION
In the batched .evaluate() case, the metrics gathered do not match the columns of the pd.DataFrame created 