### PR TITLE
Exclude tests folder during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author="Confident AI",
     author_email="jeffreyip@confident-ai.com",
     description="The Open-Source LLM Evaluation Framework.",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
After installed deepeval, I found that the tests folder also be installed under site-packages folder. Which cause the conflict if the original project already has a tests folder, so in this PR, I exclude the tests folder.