### PR TITLE
Azure function returns tuple

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -230,9 +230,16 @@ def check_mllm_test_case_params(
 
 
 def trimAndLoadJson(
-    input_string: str,
+    input_string: Any,
     metric: Optional[BaseMetric] = None,
 ) -> Any:
+    if isinstance(input_string, str):
+        input_string = input_string
+    elif isinstance(input_string, tuple):
+        if isinstance(input_string[0], str):
+            input_string = input_string[0]
+        elif isinstance(input_string[1], str):
+            input_string = input_string[1]
     start = input_string.find("{")
     end = input_string.rfind("}") + 1
 


### PR DESCRIPTION
1. Initialize model:
model = AzureChatOpenAI(
        openai_api_version="",
        azure_deployment="",
        azure_endpoint="",
        openai_api_key="",
        model="",
        validate_base_url=False,
    )
2. Create Instance of the DeepEvalBaseLLM
deepEvalModel  = GPTModelAzure(model=model)

3. Create metric
metric = AnswerRelevancyMetric(model=deepEvalModel, include_reason=True)
4. Measure
await metric.a_measure(test_case)

In this case the response returns not a string but tuple (score  and Json string) , so trimAndLoadJson() method fails on find() metod because of tuple. 

This fix check the instance of the input_string.

