### PR TITLE
revise the logic of deciding whether should_use_batch

### DIFF
--- a/deepeval/benchmarks/utils.py
+++ b/deepeval/benchmarks/utils.py
@@ -7,11 +7,7 @@ def should_use_batch(model: DeepEvalBaseLLM, batch_size: Optional[int] = None):
     if batch_size is None:
         return False
 
-    try:
-        model.batch_generate([""])
-    except Exception as AttributeError:
+    if not hasattr(model, 'batch_generate'):
         return False
-    except:
-        raise
 
     return True


### PR DESCRIPTION
The original logic of `should_use_batch` is problematic: it might never truly decide to use_batch for some benchmarks (if not all). Specifically:

```python
    try:
        model.batch_generate([""])
    except Exception as AttributeError:
        return False
```
will always return `False`. For example, [MMLU](https://github.com/confident-ai/deepeval/blob/main/deepeval/benchmarks/mmlu/mmlu.py#L211C1-L213C14) requires the tested model to have a `batch_generate(self, prompts, schemas)` method signature
```python
            responses: List[MultipleChoiceSchema] = model.batch_generate(
                prompts=prompts, schemas=[MultipleChoiceSchema for i in prompts]
            )
```
If the user did not set dedfault values for the `schemas` argument, the code `model.batch_generate([""])` will raise `TypeError: XXX.batch_generate() missing 1 required positional argument: 'schemas'`. Worse still, this exception will not be raised as it is caught by the next line 
```python
except Exception as AttributeError:
```
meaning to catch all types of exceptions, and give it a name `AttributeError`. I believe this is a bug written by someone not familiar with Python.

I guess the intention of that piece of code is to check whether the user implements the `batch_generate` method for the tested model. Hence, I propose to revise to to 

```python
    if not hasattr(model, 'batch_generate'):
        return False
```

As long as the tested model has that method, we should decide to `use_batch`. The code should not care about other things, like whether the`batch_generate` method is implemented properly. 