### PR TITLE
chore: Fix typo in telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ docs/.docusaurus
 node_modules
 .deepeval
 .deepeval-cache.json
-.deepeval_telemtry.txt
+.deepeval_telemetry.txt
 .vector_db
 */cache
 

--- a/deepeval/__init__.py
+++ b/deepeval/__init__.py
@@ -2,7 +2,7 @@ import os
 import warnings
 import re
 
-# Optionally add telemtry
+# Optionally add telemetry
 from ._version import __version__
 
 from deepeval.event import track

--- a/deepeval/telemetry.py
+++ b/deepeval/telemetry.py
@@ -20,7 +20,7 @@ class Feature(Enum):
     UNKNOWN = "unknown"
 
 
-TELEMETRY_DATA_FILE = ".deepeval_telemtry.txt"
+TELEMETRY_DATA_FILE = ".deepeval_telemetry.txt"
 
 #########################################################
 ### Telemetry Config ####################################

--- a/docs/docs/data-privacy.mdx
+++ b/docs/docs/data-privacy.mdx
@@ -12,7 +12,7 @@ If at any point you think you might have acceidentally sent us sensitive data, *
 
 ## Your Privacy Using DeepEval
 
-By default, `deepeval` uses `Sentry` to track only very basic telemetry data (number of evaluations run and which metric is used). Personally identifiable information is explicitly excluded. We also provide the option of opting out of the telemtry data collection through an environment variable:
+By default, `deepeval` uses `Sentry` to track only very basic telemetry data (number of evaluations run and which metric is used). Personally identifiable information is explicitly excluded. We also provide the option of opting out of the telemetry data collection through an environment variable:
 
 ```console
 export DEEPEVAL_TELEMETRY_OPT_OUT="YES"


### PR DESCRIPTION
Hi there, 
I noticed a typo in the generated telemetry files:
![image](https://github.com/user-attachments/assets/f23e2d8e-f1cf-47ae-bd7c-6f1e34ea8f91)

Digging into the repo, I found the root cause - a handful of typos in the telemetry code :detective: 

Thanks for the useful framework <3
