### PR TITLE
fix: typos in metrics templates

### DIFF
--- a/deepeval/metrics/contextual_precision/template.py
+++ b/deepeval/metrics/contextual_precision/template.py
@@ -48,7 +48,7 @@ JSON:
     @staticmethod
     def generate_reason(input, verdicts, score):
         # given the input and retrieval context for this input, where the verdict is whether ... and the node is the ..., give a reason for the score
-        return f"""Given the input, retrieval contexts, and contextual precision score, provide a CONCISE summarize for the score. Explain why it is not higher, but also why it is at its current score.
+        return f"""Given the input, retrieval contexts, and contextual precision score, provide a CONCISE summary for the score. Explain why it is not higher, but also why it is at its current score.
 The retrieval contexts is a list of JSON with three keys: `verdict`, `reason` (reason for the verdict) and `node`. `verdict` will be either 'yes' or 'no', which represents whether the corresponding 'node' in the retrieval context is relevant to the input. 
 Contextual precision represents if the relevant nodes are ranked higher than irrelevant nodes. Also note that retrieval contexts is given IN THE ORDER OF THEIR RANKINGS.
 
@@ -60,11 +60,11 @@ Example JSON:
 }}
 
 
-DO NOT mention 'verdict' in your reason, but instead phrase it as irrelevant nodes. The term 'verdict' are just here for you to understand the broader scope of things.
+DO NOT mention 'verdict' in your reason, but instead phrase it as irrelevant nodes. The term 'verdict' is just here for you to understand the broader scope of things.
 Also DO NOT mention there are `reason` fields in the retrieval contexts you are presented with, instead just use the information in the `reason` field.
 In your reason, you MUST USE the `reason`, QUOTES in the 'reason', and the node RANK (starting from 1, eg. first node) to explain why the 'no' verdicts should be ranked lower than the 'yes' verdicts.
-When addressing nodes, make it explicit that it is nodes in retrieval context.
-If the score is 1, keep it short and say something positive with an upbeat tone (but don't overdo it otherwise it gets annoying).
+When addressing nodes, make it explicit that they are nodes in retrieval contexts.
+If the score is 1, keep it short and say something positive with an upbeat tone (but don't overdo it, otherwise it gets annoying).
 **
 
 Contextual Precision Score:

--- a/deepeval/metrics/contextual_recall/template.py
+++ b/deepeval/metrics/contextual_recall/template.py
@@ -4,10 +4,10 @@ class ContextualRecallTemplate:
         expected_output, supportive_reasons, unsupportive_reasons, score
     ):
         return f"""
-Given the original expected output, a list of supportive reasons, and a list of unsupportive reasons (which is deduced directly from the 'expected output'), and a contextual recall score (closer to 1 the better), summarize a CONCISE reason for the score.
+Given the original expected output, a list of supportive reasons, and a list of unsupportive reasons (which are deduced directly from the 'expected output'), and a contextual recall score (closer to 1 the better), summarize a CONCISE reason for the score.
 A supportive reason is the reason why a certain sentence in the original expected output can be attributed to the node in the retrieval context.
 An unsupportive reason is the reason why a certain sentence in the original expected output cannot be attributed to anything in the retrieval context.
-In your reason, you should related supportive/unsupportive reasons to the sentence number in expected output, and info regarding the node number in retrieval context to support your final reason. The first mention of "node(s)" should specify "node(s) in retrieval context)".
+In your reason, you should relate supportive/unsupportive reasons to the sentence number in expected output, and include info regarding the node number in retrieval context to support your final reason. The first mention of "node(s)" should specify "node(s) in retrieval context".
 
 **
 IMPORTANT: Please make sure to only return in JSON format, with the 'reason' key providing the reason.
@@ -17,7 +17,7 @@ Example JSON:
 }}
 
 DO NOT mention 'supportive reasons' and 'unsupportive reasons' in your reason, these terms are just here for you to understand the broader scope of things.
-If the score is 1, keep it short and say something positive with an upbeat encouraging tone (but don't overdo it otherwise it gets annoying).
+If the score is 1, keep it short and say something positive with an upbeat encouraging tone (but don't overdo it, otherwise it gets annoying).
 **
 
 Contextual Recall Score:
@@ -56,7 +56,7 @@ IMPORTANT: Please make sure to only return in JSON format, with the 'verdicts' k
     ]  
 }}
 
-Since you are going to generate a verdict for each sentence, the number of 'verdicts' SHOULD BE STRICTLY EQUAL to the number of sentences in of `expected output`.
+Since you are going to generate a verdict for each sentence, the number of 'verdicts' SHOULD BE STRICTLY EQUAL to the number of sentences in `expected output`.
 **
 
 Expected Output:


### PR DESCRIPTION
Hi! First of I stumbled upon your cool projects while researching on how to do LLM eval with LLM prompt engineering, great project here!

This pr fixes a few typos/small wording issues that I noticed. The files I looked into are `deepeval/metrics/contextual_precision/template.py` and `deepeval/metrics/contextual_recall/template.py`.

Please let me know if I went off-road, and I'll be happy to correct my proposed changes :smiley: 