### PR TITLE
Use valid JSON booleans in DAG template

### DIFF
--- a/deepeval/metrics/dag/templates.py
+++ b/deepeval/metrics/dag/templates.py
@@ -48,9 +48,9 @@ class BinaryJudgementTemplate:
 {text}
 
 **
-IMPORTANT: Please make sure to only return a json with two keys: `verdict` (True or False), and
+IMPORTANT: Please make sure to only return a json with two keys: `verdict` (true or false), and
 {{
-    "verdict": True,
+    "verdict": true,
     "reason": "..."
 }}
 **


### PR DESCRIPTION
This capitalized True was confusing my model, causing it to sometimes send invalid JSON.
Changing this fixed the problem.