### PR TITLE
Fixing ValidationErrors when using a custom LLM for evaluation

### DIFF
--- a/deepeval/metrics/role_adherence/schema.py
+++ b/deepeval/metrics/role_adherence/schema.py
@@ -1,11 +1,11 @@
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class OutOfCharacterResponseVerdict(BaseModel):
     index: int
     reason: str
-    actual_output: Optional[str]
+    actual_output: Optional[str] = Field(default=None)
 
 
 class OutOfCharacterResponseVerdicts(BaseModel):


### PR DESCRIPTION
Copying the pattern from https://github.com/confident-ai/deepeval/pull/963

This is needed after https://github.com/confident-ai/deepeval/commit/e8d1e2d26565b1d0124f600867b888acdb8324d1 was merged since that changed the schema to use verdicts