### PR TITLE
Fix delete_test_case_instance_ids in test_run.py

### DIFF
--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -193,7 +193,8 @@ class TestRun(BaseModel):
                 del turn.conversational_instance_id
 
         for test_case in self.test_cases:
-            del test_case.conversational_instance_id
+            if hasattr(test_case, 'conversational_instance_id'):
+                del test_case.conversational_instance_id
 
     def construct_metrics_scores(self) -> int:
         # Use a dict to aggregate scores, passes, and fails for each metric.


### PR DESCRIPTION
### Problem

Running multiple non-conversational metrics in concurrent evaluate calls in the same process yields the following error.

```Traceback (most recent call last):
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/starlette/routing.py", line 73, in app
    response = await f(request)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/./src/evaluation_processor/fast_api.py", line 178, in eval
    evaluation_result = evaluate(
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/deepeval/evaluate.py", line 1090, in evaluate
    confident_link = global_test_run_manager.wrap_up_test_run(
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/deepeval/test_run/test_run.py", line 800, in wrap_up_test_run
    test_run.delete_test_case_instance_ids()
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/deepeval/test_run/test_run.py", line 197, in delete_test_case_instance_ids
    del test_case.conversational_instance_id
  File "/Users/cancelself/src/unblocked/infrastructure/cdk/core/assets/image/machine-learning/evaluation-model-image/.venv/lib/python3.10/site-packages/pydantic/main.py", line 959, in __delattr__
    object.__delattr__(self, item)
```

### Solution 
Check to see if `conversational_instance_id` is present on the test case before delete.