### PR TITLE
Fix azure embedding command

### DIFF
--- a/docs/guides/guides-using-custom-embedding-models.mdx
+++ b/docs/guides/guides-using-custom-embedding-models.mdx
@@ -23,7 +23,7 @@ deepeval set-azure-openai --openai-endpoint=<endpoint> \
 Then, run this to set the Azure OpenAI embedder:
 
 ```console
-deepeval set-azure-openai-embedding --embedding_deployment-name=<embedding_deployment_name>
+deepeval set-azure-openai-embedding --embedding-deployment-name=<embedding_deployment_name>
 ```
 
 :::tip Did You Know?


### PR DESCRIPTION
Fix azure embedding command.
Error:
No such option: --embedding_deployment-name Did you mean --embedding-deployment-name?  