### PR TITLE
Fix variable name in confident-ai-llm-monitoring.mdx

### DIFF
--- a/docs/confident-ai/confident-ai-llm-monitoring.mdx
+++ b/docs/confident-ai/confident-ai-llm-monitoring.mdx
@@ -98,7 +98,7 @@ async def async_without_stream(user_message: str):
 
     # Run monitor() asynchronously in the background
     asyncio.create_task(
-        deepeval.a_monitor(input=user_message, output=output, model=model, event_name="RAG chatbot")
+        deepeval.a_monitor(input=user_message, response=output, model=model, event_name="RAG chatbot")
     )
     return output
 

--- a/docs/confident-ai/confident-ai-llm-monitoring.mdx
+++ b/docs/confident-ai/confident-ai-llm-monitoring.mdx
@@ -98,7 +98,7 @@ async def async_without_stream(user_message: str):
 
     # Run monitor() asynchronously in the background
     asyncio.create_task(
-        deepeval.a_monitor(input=user_message, output=full_output, model=model, event_name="RAG chatbot")
+        deepeval.a_monitor(input=user_message, output=output, model=model, event_name="RAG chatbot")
     )
     return output
 


### PR DESCRIPTION
The variable `full_output` doesn't exist for the asynchronous monitoring example without streamlit.

This PR replaces it with `output`