### PR TITLE
Retry on more than rate limit exceptions

### DIFF
--- a/deepeval/models/providers/gpt_model.py
+++ b/deepeval/models/providers/gpt_model.py
@@ -112,6 +112,8 @@ model_pricing = {
 
 default_gpt_model = "gpt-4o"
 
+retryable_exceptions = (openai.RateLimitError, openai.APIConnectionError, openai.APITimeoutError)
+
 
 class GPTModel(DeepEvalBaseLLM):
     def __init__(
@@ -145,7 +147,7 @@ class GPTModel(DeepEvalBaseLLM):
 
     @retry(
         wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
-        retry=retry_if_exception_type(openai.RateLimitError),
+        retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
     def generate(
@@ -193,7 +195,7 @@ class GPTModel(DeepEvalBaseLLM):
 
     @retry(
         wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
-        retry=retry_if_exception_type(openai.RateLimitError),
+        retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
     async def a_generate(
@@ -245,7 +247,7 @@ class GPTModel(DeepEvalBaseLLM):
 
     @retry(
         wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
-        retry=retry_if_exception_type(openai.RateLimitError),
+        retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
     def generate_raw_response(
@@ -258,7 +260,7 @@ class GPTModel(DeepEvalBaseLLM):
 
     @retry(
         wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
-        retry=retry_if_exception_type(openai.RateLimitError),
+        retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
     async def a_generate_raw_response(
@@ -271,7 +273,7 @@ class GPTModel(DeepEvalBaseLLM):
 
     @retry(
         wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
-        retry=retry_if_exception_type(openai.RateLimitError),
+        retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
     def generate_samples(
@@ -452,7 +454,7 @@ class MultimodalGPTModel(DeepEvalBaseMLLM):
 
     @retry(
         wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
-        retry=retry_if_exception_type(openai.RateLimitError),
+        retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
     def generate(
@@ -474,7 +476,7 @@ class MultimodalGPTModel(DeepEvalBaseMLLM):
 
     @retry(
         wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
-        retry=retry_if_exception_type(openai.RateLimitError),
+        retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
     async def a_generate(

--- a/deepeval/models/providers/gpt_model.py
+++ b/deepeval/models/providers/gpt_model.py
@@ -112,7 +112,11 @@ model_pricing = {
 
 default_gpt_model = "gpt-4o"
 
-retryable_exceptions = (openai.RateLimitError, openai.APIConnectionError, openai.APITimeoutError)
+retryable_exceptions = (
+    openai.RateLimitError,
+    openai.APIConnectionError,
+    openai.APITimeoutError,
+)
 
 
 class GPTModel(DeepEvalBaseLLM):

--- a/deepeval/models/providers/gpt_model.py
+++ b/deepeval/models/providers/gpt_model.py
@@ -8,7 +8,12 @@ import base64
 import json
 import re
 
-from tenacity import retry, retry_if_exception_type, wait_exponential_jitter
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    wait_exponential_jitter,
+    RetryCallState,
+)
 from langchain_community.callbacks import get_openai_callback
 from langchain_core.messages import AIMessage
 from langchain.schema import HumanMessage
@@ -18,9 +23,10 @@ from deepeval.models import DeepEvalBaseLLM, DeepEvalBaseMLLM
 from deepeval.test_case import MLLMImage
 
 
-def log_retry_error(retry_state):
+def log_retry_error(retry_state: RetryCallState):
+    exception = retry_state.outcome.exception()
     logging.error(
-        f"OpenAI rate limit exceeded. Retrying: {retry_state.attempt_number} time(s)..."
+        f"OpenAI Error: {exception} Retrying: {retry_state.attempt_number} time(s)..."
     )
 
 
@@ -116,6 +122,7 @@ retryable_exceptions = (
     openai.RateLimitError,
     openai.APIConnectionError,
     openai.APITimeoutError,
+    openai.LengthFinishReasonError,
 )
 
 


### PR DESCRIPTION
I kept having my large test runs die due to connection issues. This adds a couple more types of exceptions to trigger the retries.


> Evaluating 797 test case(s) in parallel: |██████████████████████████████████████████████████████████████████████████████████████████████▌                                                                                    | 53% (421/797) [Time Taken: 08:40,  1.24s/test case]
ERROR:root:OpenAI Error: Connection error. Retrying: 1 time(s)...
ERROR:root:OpenAI Error: Connection error. Retrying: 1 time(s)...
Evaluating 797 test case(s) in parallel: |█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▉                                     | 79% (632/797) [Time Taken: 14:03,  1.44s/test case]