### PR TITLE
Allow GPT 4.5

### DIFF
--- a/deepeval/models/providers/gpt_model.py
+++ b/deepeval/models/providers/gpt_model.py
@@ -49,6 +49,7 @@ valid_gpt_models = [
     "o1-mini-2024-09-12",
     "o3-mini",
     "o3-mini-2025-01-31",
+    "gpt-4.5-preview-2025-02-27",
 ]
 
 unsupported_log_probs_gpt_models = [
@@ -60,6 +61,7 @@ unsupported_log_probs_gpt_models = [
     "o1-mini-2024-09-12",
     "o3-mini",
     "o3-mini-2025-01-31",
+    "gpt-4.5-preview-2025-02-27",
 ]
 
 structured_outputs_models = [
@@ -74,6 +76,7 @@ structured_outputs_models = [
     "o1-2024-12-17",
     "o3-mini",
     "o3-mini-2025-01-31",
+    "gpt-4.5-preview-2025-02-27",
 ]
 
 json_mode_models = [
@@ -108,6 +111,7 @@ model_pricing = {
     "o1-2024-12-17": {"input": 15.00 / 1e6, "output": 60.00 / 1e6},
     "o3-mini": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
     "o3-mini-2025-01-31": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
+    "gpt-4.5-preview-2025-02-27": {"input": 75.00 / 1e6, "output": 150.00 / 1e6},
 }
 
 default_gpt_model = "gpt-4o"

--- a/deepeval/models/providers/gpt_model.py
+++ b/deepeval/models/providers/gpt_model.py
@@ -111,7 +111,10 @@ model_pricing = {
     "o1-2024-12-17": {"input": 15.00 / 1e6, "output": 60.00 / 1e6},
     "o3-mini": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
     "o3-mini-2025-01-31": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
-    "gpt-4.5-preview-2025-02-27": {"input": 75.00 / 1e6, "output": 150.00 / 1e6},
+    "gpt-4.5-preview-2025-02-27": {
+        "input": 75.00 / 1e6,
+        "output": 150.00 / 1e6,
+    },
 }
 
 default_gpt_model = "gpt-4o"


### PR DESCRIPTION
I'm getting much better results with it, but I understand it's still in Preview. It's just easier if I can select it in the default GPTModel instead of wrapping my own.