### PR TITLE
Makes synthesizer work with Azure Open Ai

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -915,7 +915,7 @@ class Synthesizer:
         else:
             try:
                 res = model.generate(prompt, schema=schema)
-                return res
+                return res[0]
             except TypeError:
                 res = model.generate(prompt)
                 data = trimAndLoadJson(res, self)
@@ -963,7 +963,7 @@ class Synthesizer:
             else:
                 res, cost = self.model.generate(prompt)
                 self.synthesis_cost += cost
-                return res.response
+                return res
         else:
             try:
                 res: Response = self.model.generate(prompt, schema=Response)
@@ -981,7 +981,7 @@ class Synthesizer:
             else:
                 res, cost = await self.model.a_generate(prompt)
                 self.synthesis_cost += cost
-                return res.response
+                return res
         else:
             try:
                 res: Response = await self.model.a_generate(

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -13,7 +13,7 @@ import tqdm
 import csv
 import os
 
-from deepeval.models import GPTModel
+from deepeval.models import GPTModel, AzureOpenAIModel
 from deepeval.utils import get_or_create_event_loop, is_confident
 from deepeval.synthesizer.chunking.context_generator import ContextGenerator
 from deepeval.metrics.utils import (

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -915,7 +915,7 @@ class Synthesizer:
         else:
             try:
                 res = model.generate(prompt, schema=schema)
-                if isinstance(model, AzureOpenAIModel)
+                if isinstance(model, AzureOpenAIModel):
                     response, cost = res
                     if self.synthesis_cost is not None:
                         self.synthesis_cost += cost

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -915,7 +915,12 @@ class Synthesizer:
         else:
             try:
                 res = model.generate(prompt, schema=schema)
-                return res[0]
+                if isinstance(model, AzureOpenAIModel)
+                    response, cost = res
+                    if self.synthesis_cost is not None:
+                        self.synthesis_cost += cost
+                    return response
+                return res
             except TypeError:
                 res = model.generate(prompt)
                 data = trimAndLoadJson(res, self)


### PR DESCRIPTION
Hello guys, 

This more than a Pull Request is a space of discussion, since I want to be sure the changes don't just make it work for me but break for the other cases.

- The first fix is that `self.model.generate(prompt)` without `schema=Response` returns `str` and not `{ response:... }`
- The second one, and this perhaps more controversial.

that `res` is the following because the return of AzureOpenAi is a tuple of `Tuple[res, cost]`
``` python
(SyntheticDataList(data=[SyntheticData(input='.....')]), 0.0001128)
```

Therefore on line 727 it breaks. Since `AttributeError: 'tuple' object has no attribute 'data'`
```python
    synthetic_data_items = res.data
```

I'm not using any custom model, just Azure Open AI set in the config.
I don't understand why it's classified as `not_gpt_model`, but even if that's right then we need a special case for handling the output.

Is there anything im missing?