### PR TITLE
Fix: ollama base_url setting

### DIFF
--- a/deepeval/models/providers/ollama_model.py
+++ b/deepeval/models/providers/ollama_model.py
@@ -12,7 +12,7 @@ class OllamaModel(DeepEvalBaseLLM):
     ):
         model_name = KEY_FILE_HANDLER.fetch_data(KeyValues.LOCAL_MODEL_NAME)
         self.base_url = KEY_FILE_HANDLER.fetch_data(
-            KeyValues.LOCAL_EMBEDDING_BASE_URL
+            KeyValues.LOCAL_MODEL_BASE_URL
         )
         super().__init__(model_name)
 


### PR DESCRIPTION
When running `deepeval set-ollama <model-name> --base-url=<host>` it saves the base url as `LOCAL_MODEL_BASE_URL` in your `.deepeval` config. It appears that the ollama model handler in Deepeval was mistakenly looking at `LOCAL_EMBEDDING_BASE_URL` instead so it would still attempt to call the default localhost base url.