### PR TITLE
Fix async return logic in measure method

### DIFF
--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -81,7 +81,7 @@ class AnswerRelevancyMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -77,7 +77,7 @@ class BiasMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -85,7 +85,7 @@ class ContextualPrecisionMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -82,7 +82,7 @@ class ContextualRecallMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -82,7 +82,7 @@ class ContextualRelevancyMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/conversation_completeness/conversation_completeness.py
+++ b/deepeval/metrics/conversation_completeness/conversation_completeness.py
@@ -83,7 +83,7 @@ class ConversationCompletenessMetric(BaseConversationalMetric):
                         f"Score: {self.score}\nReason: {self.reason}",
                     ],
                 )
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/conversation_relevancy/conversation_relevancy.py
+++ b/deepeval/metrics/conversation_relevancy/conversation_relevancy.py
@@ -89,7 +89,7 @@ class ConversationRelevancyMetric(BaseConversationalMetric):
                         f"Score: {self.score}\nReason: {self.reason}",
                     ],
                 )
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
+++ b/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
@@ -106,7 +106,7 @@ class ConversationalGEval(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/dag/dag.py
+++ b/deepeval/metrics/dag/dag.py
@@ -75,7 +75,7 @@ class DAGMetric(BaseMetric):
                         f"Score: {self.score}\nReason: {self.reason}",
                     ],
                 )
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -90,7 +90,7 @@ class FaithfulnessMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -147,7 +147,7 @@ class GEval(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -80,7 +80,7 @@ class HallucinationMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/json_correctness/json_correctness.py
+++ b/deepeval/metrics/json_correctness/json_correctness.py
@@ -84,7 +84,7 @@ class JsonCorrectnessMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -80,7 +80,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
                         f"Score: {self.score}\nReason: {self.reason}",
                     ],
                 )
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/prompt_alignment/prompt_alignment.py
+++ b/deepeval/metrics/prompt_alignment/prompt_alignment.py
@@ -82,7 +82,7 @@ class PromptAlignmentMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/role_adherence/role_adherence.py
+++ b/deepeval/metrics/role_adherence/role_adherence.py
@@ -81,7 +81,7 @@ class RoleAdherenceMetric(BaseConversationalMetric):
                         f"Score: {self.score}\nReason: {self.reason}",
                     ],
                 )
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -108,7 +108,7 @@ class SummarizationMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/task_completion/task_completion.py
+++ b/deepeval/metrics/task_completion/task_completion.py
@@ -79,7 +79,7 @@ class TaskCompletionMetric(BaseMetric):
                         f"Score: {self.score}\nReason: {self.reason}",
                     ],
                 )
-                return self.score
+            return self.score
 
     async def a_measure(
         self,

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -79,7 +79,7 @@ class ToxicityMetric(BaseMetric):
                     ],
                 )
 
-                return self.score
+            return self.score
 
     async def a_measure(
         self,


### PR DESCRIPTION
**Bug Description**  
Async execution path in Metrcs `measure` method fails to return the score due to misplaced return statement while using `async_mode=True`.

**To Reproduce**  
1. Create test case using `LLMTestCase` class:
```py
case = LLMTestCase(
        input=query,
        actual_output=actual_output,
        expected_output=expected_output,
        context=[expected_output],
        retrieval_context=retrieval_context,
)
```
2. Create Metric, for example `ContextualPrecisionMetric` and use `async_mode=True`:
```py
metric = ContextualPrecisionMetric(
            threshold=threshold,
            model=model,
            async_mode=True,
)
```
3. Run metric calculation:
```py
result = metric.measure(case)
```
4. Observe result. Its value will be 'none', since incorrect placement of return statement in 'measure'


**Expected behavior**  
Both async and sync execution paths should return non `none` value -  `self.score`.