### PR TITLE
Add ability for synthesizer to work with ollama

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -12,7 +12,7 @@ import tqdm
 import csv
 import os
 
-from deepeval.models import GPTModel, AzureOpenAIModel
+from deepeval.models import GPTModel, AzureOpenAIModel, OllamaModel
 from deepeval.utils import get_or_create_event_loop, is_confident
 from deepeval.synthesizer.chunking.context_generator import ContextGenerator
 from deepeval.metrics.utils import (
@@ -901,7 +901,7 @@ class Synthesizer:
         schema: BaseModel,
         model: DeepEvalBaseLLM,
     ) -> BaseModel:
-        if isinstance(model, GPTModel):
+        if isinstance(model, GPTModel) or isinstance(model, OllamaModel):
             res, cost = model.generate(prompt)
             if self.synthesis_cost is not None:
                 self.synthesis_cost += cost
@@ -935,7 +935,7 @@ class Synthesizer:
         schema: BaseModel,
         model: DeepEvalBaseLLM,
     ) -> BaseModel:
-        if isinstance(model, GPTModel):
+        if isinstance(model, GPTModel) or isinstance(model, OllamaModel):
             res, cost = await model.a_generate(prompt)
             if self.synthesis_cost is not None:
                 self.synthesis_cost += cost


### PR DESCRIPTION
The synthesizer code `generate_schema` methods (async and non) both expect a model to generate a string response unless `isinstance(model, GPTModel)`, which generate a `tuple [string,cost]`.  But Ollama models also generate the same tuple, so currently they'll fail with `AttributeError: 'tuple' object has no attribute 'data'`.   I describe the error more [in this PR comment](https://github.com/confident-ai/deepeval/pull/1459#issuecomment-2744045709).

This error was partially addressed for the synchronous Azure OpenAI case in https://github.com/confident-ai/deepeval/pull/1459.  This adds Ollama support for both cases.  I do think the code could be cleaned up to not have so many nested ifs, but this fix was simple and straightforward and I tested it works locally.