### PR TITLE
Examples/faithfulness template protocol

### DIFF
--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -45,7 +45,7 @@ class FaithfulnessMetric(BaseMetric):
         strict_mode: bool = False,
         verbose_mode: bool = False,
         truths_extraction_limit: Optional[int] = None,
-        evaluation_template: Type[FaithfulnessTemplate] = FaithfulnessTemplate,
+        evaluation_template: Type[FaithfulnessTemplateProtocol] = FaithfulnessTemplate,
     ):
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -15,7 +15,10 @@ from deepeval.metrics.utils import (
     initialize_model,
 )
 from deepeval.models import DeepEvalBaseLLM
-from deepeval.metrics.faithfulness.template import FaithfulnessTemplate
+from deepeval.metrics.faithfulness.template import (
+    FaithfulnessTemplateProtocol,
+    FaithfulnessTemplate
+)
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.faithfulness.schema import (
     FaithfulnessVerdict,

--- a/deepeval/metrics/faithfulness/template.py
+++ b/deepeval/metrics/faithfulness/template.py
@@ -28,7 +28,7 @@ class FaithfulnessTemplate:
 These truths, MUST BE COHERENT, and CANNOT be taken out of context.
     
 Example:
-Example Text: q
+Example Text: 
 "Albert Einstein, the genius often associated with wild hair and mind-bending theories, famously won the Nobel Prize in Physics—though not for his groundbreaking work on relativity, as many assume. Instead, in 1968, he was honored for his discovery of the photoelectric effect, a phenomenon that laid the foundation for quantum mechanics."
 
 Example JSON: 

--- a/deepeval/metrics/faithfulness/template.py
+++ b/deepeval/metrics/faithfulness/template.py
@@ -18,6 +18,7 @@ class FaithfulnessTemplateProtocol(Protocol):
 
     @staticmethod
     def generate_reason(score: float, contradictions: List[str]) -> str:
+        ...
 
 
 class FaithfulnessTemplate:

--- a/deepeval/metrics/faithfulness/template.py
+++ b/deepeval/metrics/faithfulness/template.py
@@ -16,7 +16,6 @@ class FaithfulnessTemplateProtocol(Protocol):
     ) -> str:
         ...
 
-
     @staticmethod
     def generate_reason(score: float, contradictions: List[str]) -> str:
 

--- a/deepeval/metrics/faithfulness/template.py
+++ b/deepeval/metrics/faithfulness/template.py
@@ -1,9 +1,31 @@
-from typing import Optional, List
+from typing import Optional, List, Protocol
+
+
+from typing import Protocol, Optional
+
+class FaithfulnessTemplateProtocol(Protocol):
+    @staticmethod
+    def generate_claims(actual_output: str) -> str:
+        ...
+
+    @staticmethod
+    def generate_verdicts(claims: List[str], retrieval_context: str) -> str:
+        ...
+
+    @staticmethod
+    def generate_truths(
+        retrieval_context: str, extraction_limit: Optional[int] = None
+    ) -> str:
+        ...
+
+
+    @staticmethod
+    def generate_reason(score: float, contradictions: List[str]) -> str:
 
 
 class FaithfulnessTemplate:
     @staticmethod
-    def generate_claims(actual_output: str):
+    def generate_claims(actual_output: str) -> str:
         return f"""Based on the given text, please extract a comprehensive list of FACTUAL, undisputed truths, that can inferred from the provided text.
 These truths, MUST BE COHERENT, and CANNOT be taken out of context.
     
@@ -35,7 +57,7 @@ JSON:
     @staticmethod
     def generate_truths(
         retrieval_context: str, extraction_limit: Optional[int] = None
-    ):
+    ) -> str:
         if extraction_limit is None:
             limit = " FACTUAL, undisputed truths"
         elif extraction_limit == 1:
@@ -69,7 +91,7 @@ JSON:
 """
 
     @staticmethod
-    def generate_verdicts(claims: List[str], retrieval_context: str):
+    def generate_verdicts(claims: List[str], retrieval_context: str) -> str:
         return f"""Based on the given claims, which is a list of strings, generate a list of JSON objects to indicate whether EACH claim contradicts any facts in the retrieval context. The JSON will have 2 fields: 'verdict' and 'reason'.
 The 'verdict' key should STRICTLY be either 'yes', 'no', or 'idk', which states whether the given claim agrees with the context. 
 Provide a 'reason' ONLY if the answer is 'no'. 
@@ -121,7 +143,7 @@ JSON:
 """
 
     @staticmethod
-    def generate_reason(score: float, contradictions: List[str]):
+    def generate_reason(score: float, contradictions: List[str]) -> str:
         return f"""Below is a list of Contradictions. It is a list of strings explaining why the 'actual output' does not align with the information presented in the 'retrieval context'. Contradictions happen in the 'actual output', NOT the 'retrieval context'.
 Given the faithfulness score, which is a 0-1 score indicating how faithful the `actual output` is to the retrieval context (higher the better), CONCISELY summarize the contradictions to justify the score. 
 

--- a/deepeval/metrics/faithfulness/template.py
+++ b/deepeval/metrics/faithfulness/template.py
@@ -7,13 +7,13 @@ class FaithfulnessTemplateProtocol(Protocol):
         ...
 
     @staticmethod
-    def generate_verdicts(claims: List[str], retrieval_context: str) -> str:
-        ...
-
-    @staticmethod
     def generate_truths(
         retrieval_context: str, extraction_limit: Optional[int] = None
     ) -> str:
+        ...
+
+    @staticmethod
+    def generate_verdicts(claims: List[str], retrieval_context: str) -> str:
         ...
 
     @staticmethod

--- a/deepeval/metrics/faithfulness/template.py
+++ b/deepeval/metrics/faithfulness/template.py
@@ -1,8 +1,6 @@
 from typing import Optional, List, Protocol
 
 
-from typing import Protocol, Optional
-
 class FaithfulnessTemplateProtocol(Protocol):
     @staticmethod
     def generate_claims(actual_output: str) -> str:
@@ -30,7 +28,7 @@ class FaithfulnessTemplate:
 These truths, MUST BE COHERENT, and CANNOT be taken out of context.
     
 Example:
-Example Text: 
+Example Text: q
 "Albert Einstein, the genius often associated with wild hair and mind-bending theories, famously won the Nobel Prize in Physics—though not for his groundbreaking work on relativity, as many assume. Instead, in 1968, he was honored for his discovery of the photoelectric effect, a phenomenon that laid the foundation for quantum mechanics."
 
 Example JSON: 

--- a/examples/metrics_evaluation/templates.py
+++ b/examples/metrics_evaluation/templates.py
@@ -1,0 +1,146 @@
+from typing import List, Optional
+
+
+class MovieKGFaithfulnessTemplate:
+    @staticmethod
+    def generate_claims(actual_output: str) -> str:
+        return f"""Based on the given response, extract factual claims made about movies, actors, and directors. These should be concrete statements involving relationships such as 'acted in', 'directed', or 'released in'.
+
+IMPORTANT:
+- Only include claims that are explicitly stated in the actual output.
+- Do NOT add any prior knowledge.
+- Return ONLY JSON with key 'claims' and a list of strings.
+
+Example:
+Actual Output: ```
+In the 1995 movie \"Heat\", Robert De Niro not only starred as a criminal mastermind but also directed the film alongside Al Pacino, who played the lead detective.
+```
+
+Example JSON:
+{{
+  "claims": [
+    "Robert De Niro starred in the movie 'Heat' (1995).",
+    "Robert De Niro directed the movie 'Heat' (1995).",
+    "Al Pacino played the lead detective in 'Heat' (1995)."
+  ]
+}}
+
+Text:
+{actual_output}
+
+JSON:
+"""
+
+    @staticmethod
+    def generate_truths(retrieval_context: str, extraction_limit: Optional[int] = None) -> str:
+        if extraction_limit is None:
+            limit = " FACTUAL, undisputed truths"
+        elif extraction_limit == 1:
+            limit = " the single most important FACTUAL, undisputed truth"
+        else:
+            limit = f" the {extraction_limit} most important FACTUAL, undisputed truths per document"
+
+        return f"""Based on the given text, please generate a comprehensive list of{limit}, that can be inferred from the provided text.
+These truths MUST BE COHERENT. They must NOT be taken out of context.
+
+Example:
+Example Text: 
+[
+    "Movie: Unforgiven",
+    "Year: 1992",
+    "Director: Clint Eastwood",
+    "Actors: Clint Eastwood, Gene Hackman"
+]
+
+Example JSON:
+{{
+    "truths": [
+        "There is a movie titled 'Unforgiven'.",
+        "'Unforgiven' was released in 1992.",
+        "Clint Eastwood directed 'Unforgiven'.",
+        "Clint Eastwood acted in 'Unforgiven'.",
+        "Gene Hackman acted in 'Unforgiven'."
+    ]
+}}
+===== END OF EXAMPLE ======
+**
+IMPORTANT: Please make sure to only return in JSON format, with the \"truths\" key as a list of strings. No words or explanation is needed.
+Only include truths that are factual, BUT IT DOESN'T MATTER IF THEY ARE FACTUALLY CORRECT.
+**
+
+Text:
+{retrieval_context}
+
+JSON:
+"""
+
+    @staticmethod
+    def generate_verdicts(claims: List[str], retrieval_context: str) -> str:
+        return f"""Based on the given claims, which is a list of strings, generate a list of JSON objects to indicate whether EACH claim contradicts any facts in the retrieval context. The JSON will have 2 fields: 'verdict' and 'reason'.
+The 'verdict' key should STRICTLY be either 'yes', 'no', or 'idk', which states whether the given claim agrees with the context. 
+Provide a 'reason' ONLY if the answer is 'no'. 
+The provided claim is drawn from the actual output. Try to provide a correction in the reason using the facts in the retrieval context.
+
+**
+IMPORTANT: Please make sure to only return in JSON format, with the 'verdicts' key as a list of JSON objects.
+Example retrieval context: "'Unforgiven' was directed by Clint Eastwood. Gene Hackman played Little Bill Daggett. Morgan Freeman also appeared in the film."
+Example claims: ["Clint Eastwood directed 'Unforgiven'.", "Tom Hanks starred in 'Unforgiven'.", "Gene Hackman played a sheriff in 'Unforgiven'."]
+
+Example:
+{{
+    "verdicts": [
+        {{
+            "verdict": "yes"
+        }},
+        {{
+            "verdict": "no",
+            "reason": "The actual output claims Tom Hanks starred in 'Unforgiven', but the retrieval context does not mention Tom Hanks at all."
+        }},
+        {{
+            "verdict": "idk"
+        }}
+    ]  
+}}
+===== END OF EXAMPLE ======
+
+The length of 'verdicts' SHOULD BE STRICTLY EQUAL to that of claims.
+You DON'T have to provide a reason if the answer is 'yes' or 'idk'.
+ONLY provide a 'no' answer if the retrieval context DIRECTLY CONTRADICTS the claims. YOU SHOULD NEVER USE YOUR PRIOR KNOWLEDGE IN YOUR JUDGEMENT.
+Claims made using vague, suggestive, speculative language such as 'may have', 'possibility due to', does NOT count as a contradiction.
+Claims that are not backed up due to a lack of information/is not mentioned in the retrieval contexts MUST be answered 'idk', otherwise I WILL DIE.
+**
+
+Retrieval Contexts:
+{retrieval_context}
+
+Claims:
+{claims}
+
+JSON:
+"""
+
+    @staticmethod
+    def generate_reason(score: float, contradictions: List[str]) -> str:
+        return f"""Below is a list of Contradictions. It is a list of strings explaining why the 'actual output' does not align with the information presented in the 'retrieval context'. Contradictions happen in the 'actual output', NOT the 'retrieval context'.
+Given the faithfulness score, which is a 0-1 score indicating how faithful the `actual output` is to the retrieval context (higher the better), CONCISELY summarize the contradictions to justify the score. 
+
+** 
+IMPORTANT: Please make sure to only return in JSON format, with the 'reason' key providing the reason.
+Example JSON:
+{{
+    "reason": "The score is <faithfulness_score> because <your_reason>."
+}}
+
+If there are no contradictions, just say something positive with an upbeat encouraging tone (but don't overdo it otherwise it gets annoying).
+Your reason MUST use information in `contradiction` in your reason.
+Be sure in your reason, as if you know what the actual output is from the contradictions.
+**
+
+Faithfulness Score:
+{score}
+
+Contradictions:
+{contradictions}
+
+JSON:
+"""

--- a/examples/metrics_evaluation/templates.py
+++ b/examples/metrics_evaluation/templates.py
@@ -6,24 +6,28 @@ class MovieKGFaithfulnessTemplate:
     def generate_claims(actual_output: str) -> str:
         return f"""Based on the given response, extract factual claims made about movies, actors, and directors. These should be concrete statements involving relationships such as 'acted in', 'directed', or 'released in'.
 
-IMPORTANT:
-- Only include claims that are explicitly stated in the actual output.
-- Do NOT add any prior knowledge.
-- Return ONLY JSON with key 'claims' and a list of strings.
-
 Example:
 Actual Output: ```
-In the 1995 movie \"Heat\", Robert De Niro not only starred as a criminal mastermind but also directed the film alongside Al Pacino, who played the lead detective.
+In the 1992 movie \"Unforgiven\", Clint Eastwood portrayed a retired gunslinger named William Munny. The film was directed by Eastwood and also starred Gene Hackman as Little Bill Daggett.
 ```
 
 Example JSON:
 {{
   "claims": [
-    "Robert De Niro starred in the movie 'Heat' (1995).",
-    "Robert De Niro directed the movie 'Heat' (1995).",
-    "Al Pacino played the lead detective in 'Heat' (1995)."
+    "There is a movie titled 'Unforgiven'.",
+    "'Unforgiven' was released in 1992.",
+    "Clint Eastwood portrayed William Munny in the movie 'Unforgiven'.",
+    "Clint Eastwood directed the movie 'Unforgiven'.",
+    "Gene Hackman played Little Bill Daggett in 'Unforgiven'."
   ]
 }}
+===== END OF EXAMPLE ======
+
+**
+IMPORTANT: Please make sure to only return in JSON format, with the "claims" key as a list of strings. No words or explanation is needed.
+Only include claims that are factual, BUT IT DOESN'T MATTER IF THEY ARE FACTUALLY CORRECT. The claims you extract should include the full context it was presented in, NOT cherry picked facts.
+You should NOT include any prior knowledge, and take the text at face value when extracting claims.
+**
 
 Text:
 {actual_output}
@@ -49,18 +53,18 @@ Example Text:
     "Movie: Unforgiven",
     "Year: 1992",
     "Director: Clint Eastwood",
-    "Actors: Clint Eastwood, Gene Hackman"
+    "Actors: Clint Eastwood as William Munny, Gene Hackman as Little Bill Daggett"
 ]
 
-Example JSON:
+Example JSON: 
 {{
     "truths": [
         "There is a movie titled 'Unforgiven'.",
         "'Unforgiven' was released in 1992.",
         "Clint Eastwood directed 'Unforgiven'.",
-        "Clint Eastwood acted in 'Unforgiven'.",
-        "Gene Hackman acted in 'Unforgiven'."
-    ]
+        "Clint Eastwood portrayed William Munny in 'Unforgiven'.",
+        "Gene Hackman played Little Bill Daggett in 'Unforgiven'."
+    ]  
 }}
 ===== END OF EXAMPLE ======
 **

--- a/examples/metrics_evaluation/test_faithfulness_evaluation.py
+++ b/examples/metrics_evaluation/test_faithfulness_evaluation.py
@@ -1,0 +1,37 @@
+# Example: Using MovieKGFaithfulnessTemplate with DeepEval
+# pip install deepeval openai datasets
+
+from deepeval.test_case import LLMTestCase
+from deepeval import evaluate
+from deepeval.metrics import FaithfulnessMetric
+from examples.metrics_evaluation.templates import MovieKGFaithfulnessTemplate  
+
+# Mock: Your model's output and the reference context (e.g., from Neo4j movie graph)
+question = "Did Clint Eastwood direct and act in the movie 'Unforgiven'?"
+actual_output = "Yes, Clint Eastwood was both the director and lead actor in the 1992 film 'Unforgiven'."
+retrieval_context = [
+    "Movie: Unforgiven",
+    "Year: 1992",
+    "Director: Clint Eastwood",
+    "Actors: Clint Eastwood, Gene Hackman"
+]
+
+metric = FaithfulnessMetric(
+    threshold=0.9,
+    model="gpt-3.5-turbo",
+    include_reason=True,
+    evaluation_template=MovieKGFaithfulnessTemplate
+)
+
+# Create a test case for evaluation
+test_case = LLMTestCase(
+    input=question,
+    actual_output=actual_output,
+    retrieval_context=retrieval_context
+)
+
+# To run metric as a standalone
+# metric.measure(test_case)
+# print(metric.score, metric.reason)
+
+evaluate(test_cases=[test_case], metrics=[metric])


### PR DESCRIPTION
This example explains "Why switch to Protocol from ABC for Prompt Templates classes"

Prompt templates in metrics like FaithfulnessMetric are just collections of @staticmethods — stateless and functional by nature. This makes them a perfect fit for typing.Protocol.

With Protocol, users don’t need to inherit or register anything.
As long as a class defines the required method names with matching signatures, it just works.

✅ Key benefits:
* No need to understand or manage base classes

* Just match method names like `generate_claims`, and plug in your template

* Much easier for users to write and maintain custom prompt logic

* Fully compatible with editors, external type checkers(MyPy)

Tested locally with GPT-3.5 — works end-to-end with deepeval test run.
If accepted, I can help migrate other metrics to this pattern.