### PR TITLE
Make OllamaEmbeddingModel consistent with OllamaModel

### DIFF
--- a/deepeval/cli/main.py
+++ b/deepeval/cli/main.py
@@ -236,7 +236,7 @@ def set_ollama_embeddings_env(
         ..., help="Name of the Ollama embedding model"
     ),
     base_url: str = typer.Option(
-        "http://localhost:11434/v1/",
+        "http://localhost:11434",
         "-b",
         "--base-url",
         help="Base URL for the Ollama embedding model API",

--- a/deepeval/models/embedding_models/ollama_embedding_model.py
+++ b/deepeval/models/embedding_models/ollama_embedding_model.py
@@ -32,7 +32,7 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
             model=self.model_name,
             input=text,
         )
-        return response['embeddings']
+        return response['embeddings'][0]
 
     def embed_texts(self, texts: List[str]) -> List[List[float]]:
         embedding_model = self.load_model()
@@ -48,7 +48,7 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
             model=self.model_name,
             input=text,
         )
-        return response['embeddings']
+        return response['embeddings'][0]
 
     async def a_embed_texts(self, texts: List[str]) -> List[List[float]]:
         embedding_model = self.load_model(async_mode=True)

--- a/deepeval/models/embedding_models/ollama_embedding_model.py
+++ b/deepeval/models/embedding_models/ollama_embedding_model.py
@@ -32,7 +32,7 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
             model=self.model_name,
             input=text,
         )
-        return response['embeddings'][0]
+        return response["embeddings"][0]
 
     def embed_texts(self, texts: List[str]) -> List[List[float]]:
         embedding_model = self.load_model()
@@ -40,7 +40,7 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
             model=self.model_name,
             input=texts,
         )
-        return response['embeddings']
+        return response["embeddings"]
 
     async def a_embed_text(self, text: str) -> List[float]:
         embedding_model = self.load_model(async_mode=True)
@@ -48,7 +48,7 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
             model=self.model_name,
             input=text,
         )
-        return response['embeddings'][0]
+        return response["embeddings"][0]
 
     async def a_embed_texts(self, texts: List[str]) -> List[List[float]]:
         embedding_model = self.load_model(async_mode=True)
@@ -56,7 +56,7 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
             model=self.model_name,
             input=texts,
         )
-        return response['embeddings']
+        return response["embeddings"]
 
     def get_model_name(self):
         return self.model_name

--- a/deepeval/models/embedding_models/ollama_embedding_model.py
+++ b/deepeval/models/embedding_models/ollama_embedding_model.py
@@ -1,4 +1,4 @@
-from openai import OpenAI
+from ollama import Client, AsyncClient
 from typing import List
 
 from deepeval.key_handler import KeyValues, KEY_FILE_HANDLER
@@ -20,40 +20,43 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
         self.kwargs = kwargs
         super().__init__(model_name)
 
-    def load_model(self):
-        return OpenAI(base_url=self.base_url, api_key=self.api_key)
+    def load_model(self, async_mode: bool = False):
+        if not async_mode:
+            return Client(host=self.base_url)
+        else:
+            return AsyncClient(host=self.base_url)
 
     def embed_text(self, text: str) -> List[float]:
         embedding_model = self.load_model()
-        response = embedding_model.embeddings.create(
+        response = embedding_model.embed(
             model=self.model_name,
-            input=[text],
+            input=text,
         )
-        return response.data[0].embedding
+        return response['embeddings']
 
     def embed_texts(self, texts: List[str]) -> List[List[float]]:
         embedding_model = self.load_model()
-        response = embedding_model.embeddings.create(
+        response = embedding_model.embed(
             model=self.model_name,
             input=texts,
         )
-        return [data.embedding for data in response.data]
+        return response['embeddings']
 
     async def a_embed_text(self, text: str) -> List[float]:
-        embedding_model = self.load_model()
-        response = embedding_model.embeddings.create(
+        embedding_model = self.load_model(async_mode=True)
+        response = await embedding_model.embed(
             model=self.model_name,
-            input=[text],
+            input=text,
         )
-        return response.data[0].embedding
+        return response['embeddings']
 
     async def a_embed_texts(self, texts: List[str]) -> List[List[float]]:
-        embedding_model = self.load_model()
-        response = embedding_model.embeddings.create(
+        embedding_model = self.load_model(async_mode=True)
+        response = await embedding_model.embed(
             model=self.model_name,
             input=texts,
         )
-        return [data.embedding for data in response.data]
+        return response['embeddings']
 
     def get_model_name(self):
         return self.model_name


### PR DESCRIPTION
This is in reference to #1473, where I am attempting to ensure that `OllamaEmbeddingModel` is consistent with `OllamaModel` in that they both use the same underlying `ollama` module.

This addresses having to set a different base_url's between the two when using the same ollama host. OpenAI seems to need `<ollama_host>/v1` so its calls to `/embeddings` lands on `/v1/embeddings` where the OpenAI compatible endpoint actually is https://github.com/ollama/ollama/blob/main/docs/openai.md#openai-python-library. Since OllamaModel uses `ollama` it expects the base_url to not include `/v1` and it adds it automatically.

Using the same module let's us use the same `base_url` and makes this a bit less confusing.

It's fine if you'd rather handle this some other way, I figured I would at least open this as a result of my own debugging.