### PR TITLE
fixed issue where the tool correctness metric was failing due to an unhashable type error

### DIFF
--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -42,11 +42,12 @@ class ToolCall(BaseModel):
         input_params = (
             self.input_parameters if self.input_parameters is not None else {}
         )
-        output_hashable = (
-            frozenset(self.output.items())
-            if isinstance(self.output, dict)
-            else self.output
-        )
+        output_hashable = self.output
+        if isinstance(self.output, dict):
+            output_hashable = frozenset(self.output.items())
+        elif isinstance(self.output, list):
+            output_hashable = frozenset(self.output)
+
         return hash(
             (self.name, frozenset(input_params.items()), output_hashable)
         )


### PR DESCRIPTION
> [!CAUTION]
>  Getting this error when ToolCall passed output is list and when ToolCorrectness Metric is Invoked without order.

With the below example, the error can be reproduced

```python

from deepeval.test_case import LLMTestCase, ToolCall
from deepeval.metrics import ToolCorrectnessMetric
from deepeval import evaluate


tools = [
        ToolCall(
            name="Itinerary Generator",
            description="Creates travel plans based on destination and duration.",
            input_parameters={"destination": "Paris", "days": 3},
            output=[
                "Day 1: Eiffel Tower, Le Jules Verne.",
                "Day 2: Louvre Museum, Angelina Paris.",
                "Day 3: Montmartre, wine bar.",
            ],
        ),
        ToolCall(
            name="Restaurant Finder",
            description="Finds top restaurants in a city.",
            input_parameters={"city": "Paris"},
            output=["Le Jules Verne", "Angelina Paris", "local wine bars"],
        ),
    ]

test_case = LLMTestCase(
    input="Plan a 3-day itinerary for Paris with cultural landmarks and local cuisine.",
    actual_output=(
        "Day 1: Eiffel Tower, dinner at Le Jules Verne. "
        "Day 2: Louvre Museum, lunch at Angelina Paris. "
        "Day 3: Montmartre, evening at a wine bar."
    ),
    tools_called=tools,
    expected_tools=[ToolCall(name="Restaurant Finder"), ToolCall(name="Itinerary Generator")],
)
```


```error


Traceback (most recent call last):
  File "/Users/p1/Desktop/Github Projects/deepeval-tests.py", line 119, in <module>
    tool_correct_metric.measure(test_case, _show_indicator = True)
  File "/Users/p1/.virtualenvs/myenv/lib/python3.11/site-packages/deepeval/metrics/tool_correctness/tool_correctness.py", line 57, in measure
    self.score = self._calculate_score()
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/p1/.virtualenvs/myenv/lib/python3.11/site-packages/deepeval/metrics/tool_correctness/tool_correctness.py", line 146, in _calculate_score
    score = self._calculate_non_exact_match_score()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/p1/.virtualenvs/myenv/lib/python3.11/site-packages/deepeval/metrics/tool_correctness/tool_correctness.py", line 174, in _calculate_non_exact_match_score
    if called_tool in matched_called_tools:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/p1/.virtualenvs/myenv/lib/python3.11/site-packages/deepeval/test_case/llm_test_case.py", line 50, in __hash__
    return hash(
           ^^^^^
TypeError: unhashable type: 'list'

```
