### PR TITLE
fix: Correction of type hints

### DIFF
--- a/deepeval/synthesizer/config.py
+++ b/deepeval/synthesizer/config.py
@@ -49,8 +49,8 @@ class ContextConstructionConfig:
     max_context_length: int = 3
     chunk_size: int = 1024
     chunk_overlap: int = 0
-    context_quality_threshold: int = 0.5
-    context_similarity_threshold: int = 0.0
+    context_quality_threshold: float = 0.5
+    context_similarity_threshold: float = 0.0
     max_retries: int = 3
 
     def __post_init__(self):


### PR DESCRIPTION
The **context_quality_threshold** and **context_similarity_threshold** fields were originally typed as integers, but their default values were floats.