### PR TITLE
allow score param to support both string and float in the MetricData …

### DIFF
--- a/deepeval/test_run/api.py
+++ b/deepeval/test_run/api.py
@@ -8,7 +8,7 @@ class MetricData(BaseModel):
     name: str
     threshold: float
     success: bool
-    score: Optional[float] = None
+    score: Optional[Union[float, str]] = None
     reason: Optional[str] = None
     strict_mode: Optional[bool] = Field(False, alias="strictMode")
     evaluation_model: Optional[str] = Field(None, alias="evaluationModel")


### PR DESCRIPTION
- Changed score param in the `MetricData` class from `float` to `Union[float, str]`
- This helps in cases where a meaningful string like "not-acceptable", "fairly acceptable" or "acceptable" is more appropriate than a float
- Closes #1497 (link to the issue)