### PR TITLE
Fix type of `synthetic_input_quality_threshold` in `FiltrationConfig`

### DIFF
--- a/deepeval/synthesizer/config.py
+++ b/deepeval/synthesizer/config.py
@@ -9,7 +9,7 @@ from deepeval.synthesizer.types import Evolution
 
 @dataclass
 class FiltrationConfig:
-    synthetic_input_quality_threshold: int = 0.5
+    synthetic_input_quality_threshold: float = 0.5
     max_quality_retries: int = 3
     critic_model: Optional[Union[str, DeepEvalBaseLLM]] = None
 


### PR DESCRIPTION
The type of `synthetic_input_quality_threshold` was typed as an `int` when it should be a `float`