### PR TITLE
Remove async from `get_model_name` of `DeepEvalBaseEmbeddingModel`

### DIFF
--- a/deepeval/models/base_model.py
+++ b/deepeval/models/base_model.py
@@ -152,5 +152,5 @@ class DeepEvalBaseEmbeddingModel(ABC):
         pass
 
     @abstractmethod
-    async def get_model_name(self, *args, **kwargs) -> str:
+    def get_model_name(self, *args, **kwargs) -> str:
         pass


### PR DESCRIPTION
As defined, the model name prints as a coroutine object when generating goldens with a custom embedding model. I didn't see a reason for this to be an `async` function in the code