### PR TITLE
Update metrics-bias.mdx

### DIFF
--- a/docs/docs/metrics-bias.mdx
+++ b/docs/docs/metrics-bias.mdx
@@ -28,7 +28,7 @@ The `input` and `actual_output` are required to create an `LLMTestCase` (and hen
 ## Example
 
 ```python
-from deepeva import evaluate
+from deepeval import evaluate
 from deepeval.test_case import LLMTestCase
 from deepeval.metrics import BiasMetric
 


### PR DESCRIPTION
fix typo Example
"from deepeva" to "from depeval"