### PR TITLE
[feature] Support OpenAI client attribute extraction by patching client

### DIFF
--- a/deepeval/tracing/api.py
+++ b/deepeval/tracing/api.py
@@ -83,6 +83,8 @@ class BaseApiSpan(BaseModel):
     cost_per_output_token: Optional[float] = Field(
         None, alias="costPerOutputToken"
     )
+    tool_calls: Optional[List[Dict]] = None
+    tools: Optional[List[Dict]] = None
 
     ## evals
     span_test_case: Optional[SpanTestCase] = Field(None, alias="spanTestCase")

--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -517,9 +517,6 @@ class TraceManager:
         )
 
     def _convert_span_to_api_span(self, span: BaseSpan) -> BaseApiSpan:
-        print("---------span-----------------------")
-        print(span)
-        print("---------span-----------------------")
         # Determine span type
         if isinstance(span, AgentSpan):
             span_type = SpanApiType.AGENT

--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -78,9 +78,13 @@ class AgentAttributes(BaseModel):
 class LlmAttributes(BaseModel):
     # input
     input: Union[str, List[Dict[str, str]]]
+    # TODO: create an abstraction wrapper for tools
+    tools: Optional[List[Dict]] = None
+    
     # output
     output: str
     prompt: Optional[Prompt] = None
+    # TODO: create an abstraction wrapper for output tools
     tool_calls: Optional[List[Dict]] = None
 
     # Optional variables
@@ -513,6 +517,9 @@ class TraceManager:
         )
 
     def _convert_span_to_api_span(self, span: BaseSpan) -> BaseApiSpan:
+        print("---------span-----------------------")
+        print(span)
+        print("---------span-----------------------")
         # Determine span type
         if isinstance(span, AgentSpan):
             span_type = SpanApiType.AGENT

--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -544,6 +544,8 @@ class TraceManager:
             if span.attributes:
                 input_data = span.attributes.input
                 output_data = span.attributes.output
+                tools = span.attributes.tools
+                tool_calls = span.attributes.tool_calls
         else:
             # For BaseSpan, Agent, or Tool types, use the standard logic
             input_data = span.input
@@ -596,6 +598,8 @@ class TraceManager:
             metrics=(
                 span.metrics if is_metric_strings else None
             ),  # only need metric name if online evals
+            tools=tools,
+            tool_calls=tool_calls 
         )
 
         # Add type-specific attributes

--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Literal, Optional, Set, Union
 from pydantic import BaseModel, Field
 from rich.console import Console
 
-
 from deepeval.confident.api import Api, Endpoints, HttpMethods
 from deepeval.metrics import BaseMetric
 from deepeval.prompt import Prompt
@@ -78,10 +77,11 @@ class AgentAttributes(BaseModel):
 
 class LlmAttributes(BaseModel):
     # input
-    input: str
+    input: Union[str, List[Dict[str, str]]]
     # output
     output: str
     prompt: Optional[Prompt] = None
+    tool_calls: Optional[List[Dict]] = None
 
     # Optional variables
     input_token_count: Optional[int] = Field(

--- a/test_openai_client_trace.py
+++ b/test_openai_client_trace.py
@@ -30,7 +30,7 @@ deepeval.login_with_confident_api_key("<your-deepeval-api-key>")
 client = OpenAI(api_key="<your-openai-api-key>")
 
 
-@observe(type="llm", llm_provider="openai", client=client)
+@observe(model="gpt-4o-mini", type="llm", llm_provider="openai", client=client)
 def generate_response(input: str) -> str:
     response = client.chat.completions.create(
         model="gpt-4o-mini",  # or your preferred model

--- a/test_openai_client_trace.py
+++ b/test_openai_client_trace.py
@@ -1,0 +1,62 @@
+import time
+
+from openai import OpenAI
+
+import deepeval
+from deepeval.tracing import observe
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current temperature for provided coordinates in celsius.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "latitude": {"type": "number"},
+                    "longitude": {"type": "number"},
+                },
+                "required": ["latitude", "longitude"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+deepeval.login_with_confident_api_key("<your-deepeval-api-key>")
+# Initialize OpenAI client
+client = OpenAI(api_key="<your-openai-api-key>")
+
+
+@observe(type="llm", llm_provider="openai", client=client)
+def generate_response(input: str) -> str:
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",  # or your preferred model
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": input},
+        ],
+        temperature=0.7,
+        # tools=tools,
+        # tool_choice="auto"
+    )
+
+    # response = client.beta.chat.completions.parse(
+    #     model="gpt-4o-mini",
+    #     messages=[
+    #         {"role": "system", "content": "You are a helpful assistant."},
+    #         {"role": "user", "content": input}
+    #     ],
+    # )
+    return response
+
+
+try:
+    response = generate_response("What is the weather in Tokyo?")
+    print(response)
+except Exception as e:
+    raise e
+
+time.sleep(5)


### PR DESCRIPTION
Please have a look at this PR before merging:  https://github.com/confident-ai/deepeval/pull/1551

This enables tracing `LlmAttributes` for `OpenAI` client by patching it in `Observer`.

Example: 
```python
client = OpenAI(api_key="<your-openai-api-key>")

@observe(model="gpt-4o-mini", type="llm", llm_provider="openai", client=client)
def generate_response(input: str) -> str:
    response = client.chat.completions.create(
        model="gpt-4o-mini", 
        messages=[
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": input},
        ],
        temperature=0.7,
        tools=tools,
        tool_choice="auto"
    )
    return response
```

Note: Sample test in `test_open_client_trace.py`. 