### PR TITLE
Introduce get_actual_model_name() model helper

### DIFF
--- a/deepeval/models/base_model.py
+++ b/deepeval/models/base_model.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any, Optional, List
+from deepeval.models.utils import get_actual_model_name
 
 
 class DeepEvalBaseModel(ABC):
@@ -32,6 +33,7 @@ class DeepEvalBaseModel(ABC):
 class DeepEvalBaseLLM(ABC):
     def __init__(self, model_name: Optional[str] = None, *args, **kwargs):
         self.model_name = model_name
+        self.actual_model_name = get_actual_model_name(model_name)
         self.model = self.load_model(*args, **kwargs)
 
     @abstractmethod
@@ -77,6 +79,7 @@ class DeepEvalBaseLLM(ABC):
 class DeepEvalBaseMLLM(ABC):
     def __init__(self, model_name: Optional[str] = None, *args, **kwargs):
         self.model_name = model_name
+        self.actual_model_name = get_actual_model_name(model_name)
 
     @abstractmethod
     def generate(self, *args, **kwargs) -> str:
@@ -104,6 +107,8 @@ class DeepEvalBaseMLLM(ABC):
 class DeepEvalBaseEmbeddingModel(ABC):
     def __init__(self, model_name: Optional[str] = None, *args, **kwargs):
         self.model_name = model_name
+        self.actual_model_name = get_actual_model_name(model_name)
+
         self.model = self.load_model(*args, **kwargs)
 
     @abstractmethod

--- a/deepeval/models/embedding_models/azure_embedding_model.py
+++ b/deepeval/models/embedding_models/azure_embedding_model.py
@@ -63,10 +63,9 @@ class AzureOpenAIEmbeddingModel(DeepEvalBaseEmbeddingModel):
                 azure_endpoint=self.azure_endpoint,
                 azure_deployment=self.azure_embedding_deployment,
             )
-        else:
-            return AsyncAzureOpenAI(
-                api_key=self.azure_openai_api_key,
-                api_version=self.openai_api_version,
-                azure_endpoint=self.azure_endpoint,
-                azure_deployment=self.azure_embedding_deployment,
-            )
+        return AsyncAzureOpenAI(
+            api_key=self.azure_openai_api_key,
+            api_version=self.openai_api_version,
+            azure_endpoint=self.azure_endpoint,
+            azure_deployment=self.azure_embedding_deployment,
+        )

--- a/deepeval/models/embedding_models/ollama_embedding_model.py
+++ b/deepeval/models/embedding_models/ollama_embedding_model.py
@@ -23,8 +23,8 @@ class OllamaEmbeddingModel(DeepEvalBaseEmbeddingModel):
     def load_model(self, async_mode: bool = False):
         if not async_mode:
             return Client(host=self.base_url)
-        else:
-            return AsyncClient(host=self.base_url)
+
+        return AsyncClient(host=self.base_url)
 
     def embed_text(self, text: str) -> List[float]:
         embedding_model = self.load_model()

--- a/deepeval/models/embedding_models/openai_embedding_model.py
+++ b/deepeval/models/embedding_models/openai_embedding_model.py
@@ -60,7 +60,7 @@ class OpenAIEmbeddingModel(DeepEvalBaseEmbeddingModel):
         return self.model_name
 
     def load_model(self, async_mode: bool):
-        if async_mode == False:
+        if not async_mode:
             return OpenAI(api_key=self._openai_api_key)
-        else:
-            return AsyncOpenAI(api_key=self._openai_api_key)
+
+        return AsyncOpenAI(api_key=self._openai_api_key)

--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -91,7 +91,7 @@ class AnthropicModel(DeepEvalBaseLLM):
     ###############################################
 
     def calculate_cost(self, input_tokens: int, output_tokens: int) -> float:
-        pricing = model_pricing.get(self.model_name, model_pricing)
+        pricing = model_pricing.get(self.actual_model_name, model_pricing)
         input_cost = input_tokens * pricing["input"]
         output_cost = output_tokens * pricing["output"]
         return input_cost + output_cost

--- a/deepeval/models/llms/azure_model.py
+++ b/deepeval/models/llms/azure_model.py
@@ -76,7 +76,7 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
     ) -> Tuple[Union[str, Dict], float]:
         client = self.load_model(async_mode=False)
         if schema:
-            if self.model_name in structured_outputs_models:
+            if self.actual_model_name in structured_outputs_models:
                 completion = client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -93,7 +93,7 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
                     completion.usage.completion_tokens,
                 )
                 return structured_output, cost
-            if self.model_name in json_mode_models:
+            if self.actual_model_name in json_mode_models:
                 completion = client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -139,7 +139,7 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
     ) -> Tuple[Union[str, BaseModel], float]:
         client = self.load_model(async_mode=True)
         if schema:
-            if self.model_name in structured_outputs_models:
+            if self.actual_model_name in structured_outputs_models:
                 completion = await client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -156,7 +156,7 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
                     completion.usage.completion_tokens,
                 )
                 return structured_output, cost
-            if self.model_name in json_mode_models:
+            if self.actual_model_name in json_mode_models:
                 completion = await client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -253,7 +253,9 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
     ###############################################
 
     def calculate_cost(self, input_tokens: int, output_tokens: int) -> float:
-        pricing = model_pricing.get(self.model_name, model_pricing["gpt-4o"])
+        pricing = model_pricing.get(
+            self.actual_model_name, model_pricing["gpt-4o"]
+        )
         input_cost = input_tokens * pricing["input"]
         output_cost = output_tokens * pricing["output"]
         return input_cost + output_cost
@@ -266,17 +268,16 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
         return f"Azure OpenAI ({self.model_name})"
 
     def load_model(self, async_mode: bool = False):
-        if async_mode == False:
+        if not async_mode:
             return AzureOpenAI(
                 api_key=self.azure_openai_api_key,
                 api_version=self.openai_api_version,
                 azure_endpoint=self.azure_endpoint,
                 azure_deployment=self.deployment_name,
             )
-        else:
-            return AsyncAzureOpenAI(
-                api_key=self.azure_openai_api_key,
-                api_version=self.openai_api_version,
-                azure_endpoint=self.azure_endpoint,
-                azure_deployment=self.deployment_name,
-            )
+        return AsyncAzureOpenAI(
+            api_key=self.azure_openai_api_key,
+            api_version=self.openai_api_version,
+            azure_endpoint=self.azure_endpoint,
+            azure_deployment=self.deploynment_name,
+        )

--- a/deepeval/models/utils.py
+++ b/deepeval/models/utils.py
@@ -1,0 +1,25 @@
+def get_actual_model_name(model_name: str) -> str:
+    """Extract base model name from provider-prefixed format.
+
+    This function is useful for extracting the actual model name from a
+    provider-prefixed format which is used by some proxies like LiteLLM.
+    LiteLLM is designed to work with many different LLM providers (OpenAI, Anthropic,
+    Cohere, etc.). To tell it which provider's API to call, you prepend the provider
+    name to the model ID, in the form "<provider>/<model>". So openai/gpt-4.1-mini
+    literally means "OpenAI's GPT-4.1 Mini via the OpenAI chat completions endpoint."
+
+    Args:
+        model_name: Original model identifier, potentially in
+            "<provider>/<model>" format
+
+    Returns:
+        The model name without provider prefix
+
+    Examples:
+        get_actual_model_name("openai/gpt-4o") -> "gpt-4o"
+        get_actual_model_name("gpt-4o") -> "gpt-4o"
+    """
+    if "/" in model_name:
+        _, model_name = model_name.split("/", 1)
+        return model_name
+    return model_name

--- a/tests/test_models_utils.py
+++ b/tests/test_models_utils.py
@@ -1,0 +1,72 @@
+# from deepeval.models.utils import get_actual_model_name
+
+import pytest
+from deepeval.models.utils import get_actual_model_name
+
+
+class TestGetActualModelName:
+    """Test suite for the get_actual_model_name function."""
+
+    @pytest.mark.parametrize(
+        "input_model_name,expected_output",
+        [
+            # Standard provider/model format
+            ("openai/gpt-4o", "gpt-4o"),
+            ("anthropic/claude-3-opus", "claude-3-opus"),
+            ("cohere/command", "command"),
+            # No provider prefix
+            ("gpt-4o", "gpt-4o"),
+            ("claude-3-sonnet", "claude-3-sonnet"),
+            # Edge cases
+            ("", ""),  # Empty string
+            ("/", ""),  # Just a slash
+            ("openai/", ""),  # Provider with no model
+            (
+                "//model",
+                "/model",
+            ),  # Multiple slashes at start - splits only on first slash
+            (
+                "provider/model/version",
+                "model/version",
+            ),  # Multiple slashes in name
+            (
+                "provider/model-name/with/slashes",
+                "model-name/with/slashes",
+            ),  # Multiple slashes
+            # Mixed case and special characters
+            ("OpenAI/GPT-4o", "GPT-4o"),
+            ("custom-provider/model-123_test", "model-123_test"),
+            # Numerical and versioned names
+            ("openai/gpt-3.5-turbo", "gpt-3.5-turbo"),
+            ("anthropic/claude-2.1", "claude-2.1"),
+        ],
+    )
+    def test_get_actual_model_name(self, input_model_name, expected_output):
+        """
+        Test that get_actual_model_name correctly extracts the model name
+        from various input formats.
+
+        Args:
+            input_model_name: The model name to process
+            expected_output: The expected result after processing
+        """
+        assert get_actual_model_name(input_model_name) == expected_output
+
+    def test_get_actual_model_name_type_preservation(self):
+        """Test that the function preserves the string type and doesn't modify the input."""
+        result = get_actual_model_name("provider/model")
+        assert isinstance(result, str)
+
+        result = get_actual_model_name("")
+        assert isinstance(result, str)
+
+    def test_get_actual_model_name_identity(self):
+        """Test that the function returns equal values for inputs without providers."""
+        test_cases = ["gpt-4", "claude-3", "command-r", "model-with-dashes"]
+        for model_name in test_cases:
+            assert get_actual_model_name(model_name) == model_name
+
+    def test_get_actual_model_name_none_value(self):
+        """Test that the function raises TypeError when None is passed."""
+        with pytest.raises(TypeError):
+            get_actual_model_name(None)


### PR DESCRIPTION
### Introduce get_actual_model_name() model helper

This function is useful for extracting the actual model name from a provider-prefixed format which is used by some proxies like LiteLLM.

LiteLLM is designed to work with many different LLM providers (OpenAI, Anthropic, Cohere, etc.). To tell it which provider's API to call, you prepend the provider name to the model ID, in the form `<provider>/<model>`.

So `openai/gpt-4.1-mini` literally means "_OpenAI's GPT-4.1 Mini via the OpenAI chat completions endpoint._"

### Code cleanup

I switched from

```python
if variable == False:
```

to 

```python
if not variable:
```

because it's more Pythonic and concise - following PEP 8's guidance to avoid needless `==` comparisons - leverages Python’s built-in truthiness (so it catches None, empty sequences, 0, etc.), and sidesteps any odd behavior if someone overrides `__eq__`.

---

Also, I dropped the extra `else` because once you `return` you've already exited the function - so using a guard clause makes the code cleaner, reduces nesting, and feels more Pythonic.