### PR TITLE
Summarization metric: fix bug with updating assessment questions

### DIFF
--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -34,7 +34,6 @@ class SummarizationMetric(BaseMetric):
         threshold: float = 0.5,
         n: int = 5,
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
-        assessment_questions: Optional[List[str]] = None,
         include_reason: bool = True,
         async_mode=True,
         strict_mode: bool = False,
@@ -44,11 +43,6 @@ class SummarizationMetric(BaseMetric):
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()
-
-        if assessment_questions is not None and len(assessment_questions) == 0:
-            self.assessment_questions = None
-        else:
-            self.assessment_questions = assessment_questions
 
         self.include_reason = include_reason
         self.n = n
@@ -63,8 +57,14 @@ class SummarizationMetric(BaseMetric):
     def measure(
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
+        assessment_questions: Optional[List[str]] = None,
         _show_indicator: bool = True,
     ) -> float:
+        if assessment_questions is not None and len(assessment_questions) == 0:
+            self.assessment_questions = None
+        else:
+            self.assessment_questions = assessment_questions
+            
         if isinstance(test_case, ConversationalTestCase):
             test_case = test_case.turns[-1]
         check_llm_test_case_params(test_case, self._required_params, self)

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -113,8 +113,14 @@ class SummarizationMetric(BaseMetric):
     async def a_measure(
         self,
         test_case: Union[LLMTestCase, ConversationalTestCase],
+        assessment_questions: Optional[List[str]] = None,
         _show_indicator: bool = True,
     ) -> float:
+        if assessment_questions is not None and len(assessment_questions) == 0:
+            self.assessment_questions = None
+        else:
+            self.assessment_questions = assessment_questions
+            
         if isinstance(test_case, ConversationalTestCase):
             test_case = test_case.turns[-1]
         check_llm_test_case_params(test_case, self._required_params, self)


### PR DESCRIPTION
**Description of actions:**
1. The `SummarizationMetric` has been initialized, the value is `self.assessment_questions = None`.
2. I am creating a for loop with several original texts and summaries to them.
3. On the first pair of text and summary, `self.assessment_questions` is redefined because the check for `None` is triggered:
 ```
def _generate_coverage_verdicts(
    self, test_case: LLMTestCase
) -> List[SummarizationCoverageVerdict]:
    if self.assessment_questions is None:
        self.assessment_questions = self._generate_assessment_questions(
            test_case.input
        )
```
5. On the second pair text and summary, `self.assessment_questions` is NOT redefined because `self.assessment_questions != None` after step 3. So the current code does not allow you to generate new questions for a new pair of text and resume, but uses questions for the first pair, which does not allow you to calculate the metric correctly.

**The solution:**
Let's move `assessment_questions` to `def measure`, because:
1. This will generate new questions for each new pair without having to reinitialize the metric. 
2. `assessment_questions` can hardly be the same for every pair of texts and summaries.