### PR TITLE
Update synthesizer-generate-from-scratch.mdx

### DIFF
--- a/docs/docs/synthesizer-generate-from-scratch.mdx
+++ b/docs/docs/synthesizer-generate-from-scratch.mdx
@@ -46,7 +46,7 @@ from deepeval.synthesizer.config import StylingConfig
 styling_config = StylingConfig(
   input_format="Questions in English that asks for data in database.",
   expected_output_format="SQL query based on the given input",
-  task="Answering text-to-SQL-related queries by querying a database and returning the results to users"
+  task="Answering text-to-SQL-related queries by querying a database and returning the results to users",
   scenario="Non-technical users trying to query a database using plain English.",
 )
 


### PR DESCRIPTION
Fix syntax error in example of synthesizer-generate-from-scratch.mdx by adding missed comma