### PR TITLE
Pass extra/unknown arguments from deepeval test run to pytest

### DIFF
--- a/deepeval/cli/test.py
+++ b/deepeval/cli/test.py
@@ -41,8 +41,10 @@ def check_if_valid_file(test_file_or_directory: str):
         )
 
 
-@app.command()
+# Allow extra args and ignore unknown options allow extra args to be passed to pytest
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 def run(
+    ctx: typer.Context,
     test_file_or_directory: str,
     color: str = "yes",
     durations: int = 10,
@@ -156,6 +158,10 @@ def run(
 
     # Add the deepeval plugin file to pytest arguments
     pytest_args.extend(["-p", "plugins"])
+    # Append the extra arguments collected by allow_extra_args=True
+    # Pytest will raise its own error if the arguments are invalid (error:
+    if ctx.args:
+        pytest_args.extend(ctx.args)
 
     start_time = time.perf_counter()
     with capture_evaluation_run("deepeval test run"):


### PR DESCRIPTION
This allows 3rd party pytest plugins, custom/in-house plugins, and various add_option or hook parameters that might be passed on the command line to reach pytest without throwing an error.

I'm using this locally to great effect in order to add a "glob" that can decide what "examples" to run/not run the evaluations for. This would also immediately add support for any pytest plugin that is not currently support (but users have installed) and even their own custom hooks.

I am happy to make/assist in making any other changes at your instruction.
- I believe a version increment is in order (the change is extremely minor but the CLI has a "wider" interface, so I could see this being a micro/minor increment, let me know)
- Any help I can give with documenting this change?
- Should this change "subsume" the existing pytest "manually mapped" options

Small thought:
I also noticed in investigating this that you have a pytest plugin that is registered when using deepeval test run. I wonder if instead of requiring users run deepeval test run, you could expand the responsibilities of that plugin to include the "pretty table summary" and communication with confident ai? This would make deepeval more easily integrable with the rest of the pytest ecosystem.