### PR TITLE
Fix used Ollama model name in `OllamaModel.a_generate()` method

### DIFF
--- a/deepeval/models/llms/ollama_model.py
+++ b/deepeval/models/llms/ollama_model.py
@@ -54,9 +54,8 @@ class OllamaModel(DeepEvalBaseLLM):
         self, prompt: str, schema: Optional[BaseModel] = None
     ) -> Tuple[str, float]:
         chat_model = self.load_model(async_mode=True)
-        model_name = KEY_FILE_HANDLER.fetch_data(KeyValues.LOCAL_MODEL_NAME)
         response: ChatResponse = await chat_model.chat(
-            model=model_name,
+            model=self.model_name,
             messages=[{"role": "user", "content": prompt}],
             format=schema.model_json_schema() if schema else None,
             options={"temperature": self.temperature},


### PR DESCRIPTION
I've fixed the used Ollama model name in the `OllamaModel.a_generate()` method to use the one determined in the class constructor. This change makes the used model consistent with the [`OllamaModel.generate()`](https://github.com/confident-ai/deepeval/blob/89217e6e49c21f355ddd7c103a5adb9ee5442754/deepeval/models/llms/ollama_model.py#L39) method call.