### PR TITLE
TaskNodeOutput fix: Make all types in the `output` union valid for openai response formats

### DIFF
--- a/deepeval/metrics/dag/schema.py
+++ b/deepeval/metrics/dag/schema.py
@@ -7,7 +7,7 @@ class Reason(BaseModel):
 
 
 class TaskNodeOutput(BaseModel):
-    output: Union[str, list, Dict]
+    output: Union[str, list[str], dict[str, str]]
 
 
 class BinaryJudgementVerdict(BaseModel):


### PR DESCRIPTION
str is valid but list[Any] and dict[Any] are NOT valid response formats for OpenAI. Unfortunately, the OpenAI API obscures this error in two ways:

- If the model does not use (or maybe even "contemplate"?) the "illegal" types (list[Any], dict[Any]), no error will be thrown and the output will be a string
- If the model does attempt to use the illegal types, you will get an unhelpful OpenAI bad request error about the response format, it is extremely confusing because the same response format (TaskNodeOutput) succeeded in seemingly identical calls

This change fully specifies the list and dict outputs so that they will be valid response formats (constrained member types).