### PR TITLE
add saving of expected_output

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -848,6 +848,7 @@ class EvaluationDataset:
         goldens = [
             Golden(
                 input=golden.input,
+                expected_output=golden.expected_output,
                 actual_output=golden.actual_output,
                 retrieval_context=golden.retrieval_context,
                 context=golden.context,


### PR DESCRIPTION
Currently, the `expected_output` of the dataset's goldens are not being saved to the local directory. This update introduces a minor fix to add this functionality to the `save_as` method.