### PR TITLE
Fix tool ToolCorrectnessMetric InputParameters comparison

### DIFF
--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -254,6 +254,8 @@ class ToolCorrectnessMetric(BaseMetric):
 
     # For matching input parameters
     def _compare_dicts(self, dict1: Dict, dict2: Dict):
+        if dict1 == dict2:
+            return 1.0
         if self.should_exact_match:
             return 1.0 if dict1 == dict2 else 0.0
         match_score = 0


### PR DESCRIPTION
Fix a bug in ToolCorrectnessMetric when evaluating with ToolCallParams.INPUT_PARAMETERS failing when intput parameters and expected input parameters are {}