### PR TITLE
Geval rubric scale

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -96,7 +96,12 @@ class GEval(BaseMetric):
                     test_case, _additional_context=_additional_context
                 )
                 self.reason = reason
-                self.score = float(g_score) / 10
+                # Normalizing to rubric min/max range -> 0/1
+                if self.rubric:
+                    self.score = float(g_score) - self.rubric[0].score_range[0]
+                    self.score /= (self.rubric[-1].score_range[1] - self.rubric[0].score_range[0])
+                else:
+                    self.score = float(g_score) / 10
                 self.score = (
                     0
                     if self.strict_mode and self.score < self.threshold
@@ -140,8 +145,15 @@ class GEval(BaseMetric):
                 test_case, _additional_context=_additional_context
             )
             self.reason = reason
+
+            # Normalizing to rubric min/max range -> 0/1
+            if self.rubric:
+                g_score = float(g_score) - self.rubric[0].score_range[0]
+                g_score /= (self.rubric[-1].score_range[1] - self.rubric[0].score_range[0])
+            else:
+                g_score = float(g_score) / 10
             self.score = (
-                float(g_score) / 10 if not self.strict_mode else int(g_score)
+                g_score if not self.strict_mode else int(g_score)
             )
             self.success = self.score >= self.threshold
             self.verbose_logs = construct_verbose_logs(

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -98,6 +98,7 @@ class GEval(BaseMetric):
                 self.reason = reason
                 # Normalizing to rubric min/max range -> 0/1
                 if self.rubric:
+                    print("Normalizing score based on rubric")
                     self.score = float(g_score) - self.rubric[0].score_range[0]
                     self.score /= (self.rubric[-1].score_range[1] - self.rubric[0].score_range[0])
                 else:
@@ -148,6 +149,7 @@ class GEval(BaseMetric):
 
             # Normalizing to rubric min/max range -> 0/1
             if self.rubric:
+                print("Normalizing score based on rubric")
                 g_score = float(g_score) - self.rubric[0].score_range[0]
                 g_score /= (self.rubric[-1].score_range[1] - self.rubric[0].score_range[0])
             else:

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -98,7 +98,6 @@ class GEval(BaseMetric):
                 self.reason = reason
                 # Normalizing to rubric min/max range -> 0/1
                 if self.rubric:
-                    print("Normalizing score based on rubric")
                     self.score = float(g_score) - self.rubric[0].score_range[0]
                     self.score /= (self.rubric[-1].score_range[1] - self.rubric[0].score_range[0])
                 else:
@@ -149,7 +148,6 @@ class GEval(BaseMetric):
 
             # Normalizing to rubric min/max range -> 0/1
             if self.rubric:
-                print("Normalizing score based on rubric")
                 g_score = float(g_score) - self.rubric[0].score_range[0]
                 g_score /= (self.rubric[-1].score_range[1] - self.rubric[0].score_range[0])
             else:

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -888,11 +888,12 @@ class TestRunManager:
 
             return link
         else:
-            console.print(
-                "\n[rgb(5,245,141)]✓[/rgb(5,245,141)] Tests finished 🎉! Run [bold]'deepeval login'[/bold] to save and analyze evaluation results on Confident AI.\n",
-                LOGIN_PROMPT,
-                "\n",
-            )
+            pass
+            # console.print(
+            #     "\n[rgb(5,245,141)]✓[/rgb(5,245,141)] Tests finished 🎉! Run [bold]'deepeval login'[/bold] to save and analyze evaluation results on Confident AI.\n",
+            #     LOGIN_PROMPT,
+            #     "\n",
+            # )
 
     def save_test_run_locally(self):
         local_folder = os.getenv("DEEPEVAL_RESULTS_FOLDER")


### PR DESCRIPTION
Allowing for Rubric other than 0-10 when using GEval. `g_score` is min/max normalized based on the rubric min/max values. This allows for custom scales (e.g. 1-5) allowing the user to align their scale with an existing survey, or to reduce the dynamic range (e.g. 1-3) if needed.

The default range still defaults to 0-10.