### PR TITLE
add reason to thrown failed metrics string in assert_test

### DIFF
--- a/deepeval/evaluate/evaluate.py
+++ b/deepeval/evaluate/evaluate.py
@@ -162,7 +162,7 @@ def assert_test(
 
         failed_metrics_str = ", ".join(
             [
-                f"{metrics_data.name} (score: {metrics_data.score}, threshold: {metrics_data.threshold}, strict: {metrics_data.strict_mode}, error: {metrics_data.error})"
+                f"{metrics_data.name} (score: {metrics_data.score}, threshold: {metrics_data.threshold}, strict: {metrics_data.strict_mode}, error: {metrics_data.error}, reason: {metrics_data.reason})"
                 for metrics_data in failed_metrics_data
             ]
         )


### PR DESCRIPTION
It is very useful to also show the reason as part of the string that is thrown for `AssertionError`.

This is needed so we can see the reason when logging the exception, when abstracting the tests, when running with pytest, etc.