### PR TITLE
Fix/gsm8k tuple response attribute error

### DIFF
--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -123,7 +123,6 @@ class GSM8K(DeepEvalBaseBenchmark):
     def _extract_prediction_from_response(self, res) -> str:
         """
         Extract prediction from model response, handling various response types.
-        This fixes the AttributeError: 'tuple' object has no attribute 'answer' issue.
         """
         # Case 1: Response has .answer attribute (NumberSchema case)
         if hasattr(res, 'answer'):


### PR DESCRIPTION
##  Fix: Handle tuple responses in GSM8K model output to avoid AttributeError

### 📍 Summary

This PR resolves [(https://github.com/confident-ai/deepeval/issues/1612)](https://github.com/confident-ai/deepeval/issues/1612) by adding robust handling for non-standard model responses (e.g., tuples) that previously caused an `AttributeError` in the `GSM8K` benchmark.

### 🐞 Problem

The original implementation assumed that model outputs would always return an object with an `.answer` attribute (e.g., `NumberSchema`). However, in some cases, the model returns a tuple, causing the following error:

```
AttributeError: 'tuple' object has no attribute 'answer'
```

This occurred specifically at:

```python
prediction = str(res.answer)
```

and earlier:

```python
prediction, score = self.predict(model, golden).values()
```

### ✅ Solution

This PR includes a targeted fix that preserves backward compatibility:

* **Replaced unsafe `.values()` unpacking** with direct dictionary key access for safer and clearer code.
* **Introduced a helper method** `_extract_prediction_from_response()` to robustly extract the prediction from various formats:

  * `NumberSchema` objects
  * Tuples
  * Raw strings, dictionaries, or objects with `.text` or `.content` attributes
* **Improved exception handling** by catching both `AttributeError` and `TypeError` in case of unexpected structures.

### 🧼 Code Changes

#### In `gsm8k.py`:

* Replaced:

  ```python
  prediction, score = self.predict(model, golden).values()
  ```

  With:

  ```python
  result = self.predict(model, golden)
  prediction = result["prediction"]
  score = result["score"]
  ```

* Modified:

  ```python
  prediction = str(res.answer)
  ```

  To:

  ```python
  prediction = self._extract_prediction_from_response(res)
  ```

* Added a new method `_extract_prediction_from_response()` for robust prediction extraction.

### 🛡️ Impact

* ✅ Fixes the reported crash in GSM8K benchmark (#1612)
* ✅ Makes prediction extraction robust to unexpected model return formats
* ✅ Preserves existing functionality and backward compatibility

---

### 🧾 Related

* Issue: #1612
* Related discussion: #1535

---
