### PR TITLE
Fix FileNotFoundError in telemetry.py - missing dot in filename

### DIFF
--- a/deepeval/telemetry.py
+++ b/deepeval/telemetry.py
@@ -44,7 +44,7 @@ if os.path.exists(TELEMETRY_DATA_FILE):
 if os.path.exists(".deepeval-cache.json"):
     os.rename(".deepeval-cache.json", f"{HIDDEN_DIR}/.deepeval-cache.json")
 
-if os.path.exists("temp_test_run_data.json"):
+if os.path.exists(".temp_test_run_data.json"):
     os.rename(
         ".temp_test_run_data.json", f"{HIDDEN_DIR}/.temp_test_run_data.json"
     )


### PR DESCRIPTION
I got this error after updating from version 2.6.5 to 2.9.7

```  bash
FileNotFoundError: [Errno 2] No such file or directory: '.temp_test_run_data.json' -> '.deepeval/.temp_test_run_data.json' 
``` 

The code checks for "temp_test_run_data.json" (without dot) but tries to rename ".temp_test_run_data.json" (with dot).

Possibly (?) fixes #488, #671


