### PR TITLE
Use the async a_embed_text in _a_get_n_random_contexts_per_source_file.

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -450,13 +450,12 @@ class ContextGenerator:
 
             # Query for similar chunks
             similar_chunks = collection.query(
-                self.embedder.embed_text(random_chunk), n_results=context_size
+                await self.embedder.a_embed_text(random_chunk), n_results=context_size
             )
 
             # Disregard repeated chunks and chunks that don't pass the similarity threshold
             similar_chunk_texts = similar_chunks["documents"][num_query_docs]
             for j, similar_chunk_text in enumerate(similar_chunk_texts):
-
                 # Calculate chunk similarity score
                 similar_chunk_similarity_score = (
                     1 - similar_chunks["distances"][num_query_docs][j]


### PR DESCRIPTION
**Context and Purpose**
When running golden generation in async mode using `a_generate_goldens_from_docs` the context generator is still calling the sync version of `DeepEvalBaseEmbeddingModel.embed_text`. The sync version of `embed_text` performs a blocking call to the embedding model and will block the entire thread in which the event loop is being executed. This breaks parallelization and hurts performance significantly. 

Depending on how the `DeepEvalBaseEmbeddingModel` is implemented, it also risks crashing the entire application. For example if the implementation of the sync methods looks like in the screenshot below, it crashes with this error message: `RuntimeError: asyncio.run() cannot be called from a running event loop`.

![image](https://github.com/user-attachments/assets/89c8002c-3809-4517-9ba9-1bb1b6e69e07)

This PR fixes the error by calling the async method `a_embed_text` instead. 
