### PR TITLE
Fix: Support read only file systems

### DIFF
--- a/deepeval/telemetry.py
+++ b/deepeval/telemetry.py
@@ -27,30 +27,7 @@ TELEMETRY_DATA_FILE = ".deepeval_telemetry.txt"
 TELEMETRY_PATH = os.path.join(HIDDEN_DIR, TELEMETRY_DATA_FILE)
 
 #########################################################
-### Move Folders ########################################
-#########################################################
-
-if os.path.exists(KEY_FILE) and not os.path.isdir(HIDDEN_DIR):
-    temp_deepeval_file_name = ".deepeval_temp"
-    os.rename(KEY_FILE, temp_deepeval_file_name)
-    os.makedirs(HIDDEN_DIR, exist_ok=True)
-    os.rename(temp_deepeval_file_name, os.path.join(HIDDEN_DIR, KEY_FILE))
-
-os.makedirs(HIDDEN_DIR, exist_ok=True)
-
-if os.path.exists(TELEMETRY_DATA_FILE):
-    os.rename(TELEMETRY_DATA_FILE, TELEMETRY_PATH)
-
-if os.path.exists(".deepeval-cache.json"):
-    os.rename(".deepeval-cache.json", f"{HIDDEN_DIR}/.deepeval-cache.json")
-
-if os.path.exists(".temp_test_run_data.json"):
-    os.rename(
-        ".temp_test_run_data.json", f"{HIDDEN_DIR}/.temp_test_run_data.json"
-    )
-
-#########################################################
-### Telemetry Config ####################################
+### Telemetry HELPERS ###################################
 #########################################################
 
 
@@ -75,6 +52,32 @@ def get_anonymous_public_ip():
         pass
     return None
 
+#########################################################
+### Move Folders ########################################
+#########################################################
+if not telemetry_opt_out():
+    if os.path.exists(KEY_FILE) and not os.path.isdir(HIDDEN_DIR):
+        temp_deepeval_file_name = ".deepeval_temp"
+        os.rename(KEY_FILE, temp_deepeval_file_name)
+        os.makedirs(HIDDEN_DIR, exist_ok=True)
+        os.rename(temp_deepeval_file_name, os.path.join(HIDDEN_DIR, KEY_FILE))
+
+    os.makedirs(HIDDEN_DIR, exist_ok=True)
+
+    if os.path.exists(TELEMETRY_DATA_FILE):
+        os.rename(TELEMETRY_DATA_FILE, TELEMETRY_PATH)
+
+    if os.path.exists(".deepeval-cache.json"):
+        os.rename(".deepeval-cache.json", f"{HIDDEN_DIR}/.deepeval-cache.json")
+
+    if os.path.exists(".temp_test_run_data.json"):
+        os.rename(
+            ".temp_test_run_data.json", f"{HIDDEN_DIR}/.temp_test_run_data.json"
+        )
+
+#########################################################
+### Telemetry Config ####################################
+#########################################################
 
 anonymous_public_ip = None
 


### PR DESCRIPTION
When we import telemetry.py, we do some file system preparation. Some folks run their evaluation code in environments that don't allow write access to the file system like Lambda's or their Google Cloud or Azure equivalents. This causes evaluations to fail when DeepEval is imported. DeepEval provides an environmental variable to opt out of telemetry. It would be great if this flag was checked, before fiddling with the file system.

This PR wraps the file system in a check for the environmental variable, "DEEPEVAL_TELEMETRY_OPT_OUT".

We tested this branch in our AWS Lambdas and locally and it seemed to work in our use cases. 

closes #1577 