### PR TITLE
Implement don't re-write to a file if it's read only (addresses https://github.com/confident-ai/deepeval/issues/1707) 

### DIFF
--- a/deepeval/__init__.py
+++ b/deepeval/__init__.py
@@ -69,9 +69,5 @@ def update_warning_opt_in():
     return os.getenv("DEEPEVAL_UPDATE_WARNING_OPT_IN") == "YES"
 
 
-def is_read_only_env():
-    return os.getenv("DEEPEVAL_FILE_SYSTEM") == "READ_ONLY"
-
-
 if update_warning_opt_in():
     check_for_update()

--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -10,6 +10,7 @@ import datetime
 import time
 import ast
 
+from deepeval.utils import is_read_only_env
 from deepeval.metrics import BaseMetric
 from deepeval.confident.api import Api, Endpoints, HttpMethods
 from deepeval.dataset.utils import (
@@ -839,6 +840,9 @@ class EvaluationDataset:
         file_name: Optional[str] = None,
         include_test_cases: bool = False,
     ) -> str:
+        if is_read_only_env():
+            print("Warning: Skipping write due to DEEPEVAL_FILE_SYSTEM=READ_ONLY")
+            return ""
         if file_type not in valid_file_types:
             raise ValueError(
                 f"Invalid file type. Available file types to save as: {', '.join(type for type in valid_file_types)}"

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -21,6 +21,7 @@ import os
 from contextlib import nullcontext
 
 from deepeval.utils import get_or_create_event_loop, is_confident
+from deepeval.utils import is_read_only_env
 from deepeval.synthesizer.chunking.context_generator import ContextGenerator
 from deepeval.metrics.utils import (
     is_native_model,
@@ -1459,6 +1460,9 @@ class Synthesizer:
             ValueError: If file_type is invalid, no synthetic goldens exist,
             or file_name contains periods.
         """
+        if is_read_only_env():
+            print("Warning: Skipping write due to DEEPEVAL_FILE_SYSTEM=READ_ONLY")
+            return ""
         if str(file_type).lower() not in valid_file_types:
             raise ValueError(
                 "Invalid file type. Available file types to save as: , ".join(

--- a/deepeval/utils.py
+++ b/deepeval/utils.py
@@ -525,3 +525,7 @@ my_theme = Theme(
     }
 )
 custom_console = Console(theme=my_theme)
+
+
+def is_read_only_env():
+    return os.getenv("DEEPEVAL_FILE_SYSTEM") == "READ_ONLY"

--- a/tests/data/dataset.csv
+++ b/tests/data/dataset.csv
@@ -1,0 +1,6 @@
+query,expected_output,actual_output,context,retrieval
+1,Hello world!,Actual output for 1,,
+2,,Actual output for 2,"A powerful language model.;Context for 2;Additional info",
+3,CSV Example,Actual output for 3,"Working with CSV data.;Context for 3;Additional info",
+4,Python Programming,Actual output for 4,,"A powerful language model.;Context for 2;Additional info"
+5,Data Science,Actual output for 5,"Analyzing data.;Context for 5;Additional info", 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -80,3 +80,26 @@ def test_create_dataset():
         actual_output_key_name="actual_output",
     )
     assert len(dataset.test_cases) == 10, "Test Cases not loaded from JSON"
+
+
+def test_read_only_save_dataset(tmp_path, monkeypatch, capsys):
+    # Set the read-only environment variable
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+
+    # Create a dummy dataset
+    goldens = [
+        Golden(input="input1", actual_output="actual1", expected_output="expected1")
+    ]
+    dataset = EvaluationDataset(goldens=goldens)
+
+    # Attempt to save the dataset
+    file_name = "test_dataset"
+    file_path = tmp_path / f"{file_name}.json"
+    dataset.save_as("json", str(tmp_path), file_name=file_name)
+
+    # Check that the file was not created
+    assert not file_path.exists()
+
+    # Check that the warning was printed
+    captured = capsys.readouterr()
+    assert "Warning: Skipping write due to DEEPEVAL_FILE_SYSTEM=READ_ONLY" in captured.out

--- a/tests/test_read_only.py
+++ b/tests/test_read_only.py
@@ -1,0 +1,29 @@
+import pytest
+from deepeval import evaluate
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics import AnswerRelevancyMetric
+from deepeval.evaluate import DisplayConfig
+
+
+def test_read_only_evaluation(monkeypatch, capsys, tmp_path):
+    # Set the read-only environment variable
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+
+    # Create a dummy test case and metric
+    test_case = LLMTestCase(input="input", actual_output="actual")
+    metric = AnswerRelevancyMetric()
+
+    # Create a display config to control output
+    display_config = DisplayConfig(
+        print_results=False, file_output_dir=str(tmp_path)
+    )
+
+    # Attempt to evaluate and write the results
+    evaluate([test_case], [metric], display_config=display_config)
+
+    # Check that no files were created in the directory
+    assert not any(tmp_path.iterdir())
+
+    # Check that the warning was printed
+    captured = capsys.readouterr()
+    assert "Warning: Skipping write due to DEEPEVAL_FILE_SYSTEM=READ_ONLY" in captured.out 

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -476,6 +476,29 @@ def test_synthesis_costs(synthesizer: Synthesizer):
         assert "synthesis_cost" in dir(synthesizer)
 
 
+def test_read_only_save_synthesizer(monkeypatch, capsys, tmp_path):
+    # Set the read-only environment variable
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+
+    # Create a synthesizer with a dummy golden
+    synthesizer = Synthesizer()
+    synthesizer.synthetic_goldens = [
+        Golden(input="input", actual_output="actual")
+    ]
+
+    # Attempt to save the goldens
+    file_name = "test_synthesizer"
+    file_path = tmp_path / f"{file_name}.json"
+    synthesizer.save_as("json", str(tmp_path), file_name=file_name)
+
+    # Check that the file was not created
+    assert not file_path.exists()
+
+    # Check that the warning was printed
+    captured = capsys.readouterr()
+    assert "Warning: Skipping write due to DEEPEVAL_FILE_SYSTEM=READ_ONLY" in captured.out
+
+
 #########################################################
 ### Test Everything #####################################
 #########################################################


### PR DESCRIPTION
1. Moved the is_read_only_env() method from __init__.py to utils.py to avoid a circular dependency while importing 
2. Added is_read_only_env() check in front of critical code paths where we write to a file 
3. added some tests