### PR TITLE
Synthetic generation failing when context = 1

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -443,7 +443,9 @@ class ContextGenerator:
         )
 
         if context_size <= 1:
-            return random_chunks, scores
+            # Wrap each chunk in a list to maintain List[List[str]] structure
+            contexts = [[chunk] for chunk in random_chunks]
+            return contexts, scores
 
         # Find similar chunks for each context
         for random_chunk in random_chunks:
@@ -545,7 +547,9 @@ class ContextGenerator:
         )
 
         if context_size <= 1:
-            return random_chunks, scores
+            # Wrap each chunk in a list to maintain List[List[str]] structure
+            contexts = [[chunk] for chunk in random_chunks]
+            return contexts, scores
 
         # Find similar chunks for each context
         for random_chunk in random_chunks:


### PR DESCRIPTION
Hi guys, I found an issue generating golden samples due to wrong return types

## Problem Description

The `ContextGenerator` was inconsistently returning contexts as either `List[str]` or `List[List[str]]` depending on the number of chunks in a document. When a document had only one chunk, the `context_size` would be set to 1, triggering an early return that returned chunks directly as `List[str]` instead of wrapping them in lists.

This caused a type mismatch error in the `Golden` constructor, which expects the `context` field to be `Optional[List[str]]` but was receiving a string instead of a list.

### Error Details

```
Input should be a valid list [type=list_type, input_value='{\n  "id": "4edd33cb7a16...igital-lending"\n  }\n}', input_type=str]
```

The error occurred in `synthesizer.py` line 691 when creating a `Golden` object:

```python
golden = Golden(
    input=evolved_input,
    context=context,  # context was List[str] instead of List[List[str]]
    # ...
)
```

### Root Cause

In `context_generator.py`, the `_a_get_n_random_contexts_per_source_file` method had this logic:

```python
if context_size <= 1:
    return random_chunks, scores  # Returns List[str] instead of List[List[str]]
```

When `context_size <= 1` (which happens when `max_context_size = min(max_context_size, collection.count())` and the collection only has 1 chunk), it would return chunks directly without wrapping them in lists.

## Solution

Modified the `_a_get_n_random_contexts_per_source_file` method to always return `List[List[str]]` by wrapping single chunks in lists when `context_size <= 1`.
