### PR TITLE
Reason models renamed to force tool_calls response

### DIFF
--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -140,13 +140,13 @@ class AnswerRelevancyMetric(BaseMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=AnswerRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(
-                    prompt=prompt, schema=Reason
+                res: AnswerRelevancyScoreReason = await self.model.a_generate(
+                    prompt=prompt, schema=AnswerRelevancyScoreReason
                 )
                 return res.reason
             except TypeError:
@@ -170,12 +170,12 @@ class AnswerRelevancyMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=AnswerRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt=prompt, schema=Reason)
+                res: AnswerRelevancyScoreReason = self.model.generate(prompt=prompt, schema=AnswerRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/answer_relevancy/schema.py
+++ b/deepeval/metrics/answer_relevancy/schema.py
@@ -15,5 +15,5 @@ class Verdicts(BaseModel):
     verdicts: List[AnswerRelevancyVerdict]
 
 
-class Reason(BaseModel):
+class AnswerRelevancyScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -134,12 +134,12 @@ class BiasMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=BiasScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: BiasScoreReason = await self.model.a_generate(prompt, schema=BiasScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -161,12 +161,12 @@ class BiasMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=BiasScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: BiasScoreReason = self.model.generate(prompt, schema=BiasScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/bias/schema.py
+++ b/deepeval/metrics/bias/schema.py
@@ -16,5 +16,5 @@ class Verdicts(BaseModel):
     verdicts: List[BiasVerdict]
 
 
-class Reason(BaseModel):
+class BiasScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -144,12 +144,12 @@ class ContextualPrecisionMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=ContextualPrecisionScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: ContextualPrecisionScoreReason = await self.model.a_generate(prompt, schema=ContextualPrecisionScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -171,12 +171,12 @@ class ContextualPrecisionMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=ContextualPrecisionScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: ContextualPrecisionScoreReason = self.model.generate(prompt, schema=ContextualPrecisionScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/contextual_precision/schema.py
+++ b/deepeval/metrics/contextual_precision/schema.py
@@ -11,5 +11,5 @@ class Verdicts(BaseModel):
     verdicts: List[ContextualPrecisionVerdict]
 
 
-class Reason(BaseModel):
+class ContextualPrecisionScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -146,12 +146,12 @@ class ContextualRecallMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=ContextualRecallScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: ContextualRecallScoreReason = await self.model.a_generate(prompt, schema=ContextualRecallScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -178,12 +178,12 @@ class ContextualRecallMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=ContextualRecallScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: ContextualRecallScoreReason = self.model.generate(prompt, schema=ContextualRecallScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/contextual_recall/schema.py
+++ b/deepeval/metrics/contextual_recall/schema.py
@@ -11,5 +11,5 @@ class Verdicts(BaseModel):
     verdicts: List[ContextualRecallVerdict]
 
 
-class Reason(BaseModel):
+class ContextualRecallScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -147,12 +147,12 @@ class ContextualRelevancyMetric(BaseMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=ContextualRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: ContextualRelevancyScoreReason = await self.model.a_generate(prompt, schema=ContextualRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -179,12 +179,12 @@ class ContextualRelevancyMetric(BaseMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=ContextualRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: ContextualRelevancyScoreReason = self.model.generate(prompt, schema=ContextualRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/contextual_relevancy/schema.py
+++ b/deepeval/metrics/contextual_relevancy/schema.py
@@ -12,5 +12,5 @@ class ContextualRelevancyVerdicts(BaseModel):
     verdicts: List[ContextualRelevancyVerdict]
 
 
-class Reason(BaseModel):
+class ContextualRelevancyScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/conversation_completeness/conversation_completeness.py
+++ b/deepeval/metrics/conversation_completeness/conversation_completeness.py
@@ -137,12 +137,12 @@ class ConversationCompletenessMetric(BaseConversationalMetric):
             intentions=self.user_intentions,
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=ConversationCompletenessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: ConversationCompletenessScoreReason = await self.model.a_generate(prompt, schema=ConversationCompletenessScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -164,12 +164,12 @@ class ConversationCompletenessMetric(BaseConversationalMetric):
             intentions=self.user_intentions,
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=ConversationCompletenessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: ConversationCompletenessScoreReason = self.model.generate(prompt, schema=ConversationCompletenessScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/conversation_completeness/schema.py
+++ b/deepeval/metrics/conversation_completeness/schema.py
@@ -11,5 +11,5 @@ class ConversationCompletenessVerdict(BaseModel):
     reason: Optional[str] = Field(default=None)
 
 
-class Reason(BaseModel):
+class ConversationCompletenessScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/conversation_relevancy/conversation_relevancy.py
+++ b/deepeval/metrics/conversation_relevancy/conversation_relevancy.py
@@ -140,12 +140,12 @@ class ConversationRelevancyMetric(BaseConversationalMetric):
             score=self.score, irrelevancies=irrelevancies
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=ConversationRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: ConversationRelevancyScoreReason = await self.model.a_generate(prompt, schema=ConversationRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -164,12 +164,12 @@ class ConversationRelevancyMetric(BaseConversationalMetric):
             score=self.score, irrelevancies=irrelevancies
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=ConversationRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: ConversationRelevancyScoreReason = self.model.generate(prompt, schema=ConversationRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/conversation_relevancy/schema.py
+++ b/deepeval/metrics/conversation_relevancy/schema.py
@@ -8,5 +8,5 @@ class ConversationRelevancyVerdict(BaseModel):
     reason: Optional[str] = Field(default=None)
 
 
-class Reason(BaseModel):
+class ConversationRelevancyScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/dag/nodes.py
+++ b/deepeval/metrics/dag/nodes.py
@@ -4,7 +4,7 @@ from pydantic import create_model
 import asyncio
 
 from deepeval.metrics.dag.schema import (
-    Reason,
+    MetricScoreReason,
     BinaryJudgementVerdict,
     NonBinaryJudgementVerdict,
     TaskNodeOutput,
@@ -215,15 +215,15 @@ class VerdictNode(BaseNode):
             name=metric.__name__,
         )
         if metric.using_native_model:
-            res, cost = metric.model.generate(prompt, schema=Reason)
+            res, cost = metric.model.generate(prompt, schema=MetricScoreReason)
             metric.evaluation_cost += cost
         else:
             try:
-                res: Reason = metric.model.generate(prompt, schema=Reason)
+                res: MetricScoreReason = metric.model.generate(prompt, schema=MetricScoreReason)
             except TypeError:
                 res = metric.model.generate(prompt)
                 data = trimAndLoadJson(res, self)
-                res = Reason(**data)
+                res = MetricScoreReason(**data)
 
         return res.reason
 
@@ -234,17 +234,17 @@ class VerdictNode(BaseNode):
             name=metric.__name__,
         )
         if metric.using_native_model:
-            res, cost = await metric.model.a_generate(prompt, schema=Reason)
+            res, cost = await metric.model.a_generate(prompt, schema=MetricScoreReason)
             metric.evaluation_cost += cost
         else:
             try:
-                res: Reason = await metric.model.a_generate(
-                    prompt, schema=Reason
+                res: MetricScoreReason = await metric.model.a_generate(
+                    prompt, schema=MetricScoreReason
                 )
             except TypeError:
                 res = await metric.model.a_generate(prompt)
                 data = trimAndLoadJson(res, self)
-                res = Reason(**data)
+                res = MetricScoreReason(**data)
 
         return res.reason
 

--- a/deepeval/metrics/dag/schema.py
+++ b/deepeval/metrics/dag/schema.py
@@ -2,7 +2,7 @@ from typing import Literal, Dict, Union
 from pydantic import BaseModel
 
 
-class Reason(BaseModel):
+class MetricScoreReason(BaseModel):
     reason: str
 
 

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -20,7 +20,7 @@ from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.faithfulness.schema import (
     FaithfulnessVerdict,
     Verdicts,
-    Reason,
+    FaithfulnessScoreReason,
     Truths,
     Claims,
 )
@@ -149,12 +149,12 @@ class FaithfulnessMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=FaithfulnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: FaithfulnessScoreReason = await self.model.a_generate(prompt, schema=FaithfulnessScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -176,12 +176,12 @@ class FaithfulnessMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=FaithfulnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: FaithfulnessScoreReason = self.model.generate(prompt, schema=FaithfulnessScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/faithfulness/schema.py
+++ b/deepeval/metrics/faithfulness/schema.py
@@ -19,5 +19,5 @@ class Claims(BaseModel):
     claims: List[str]
 
 
-class Reason(BaseModel):
+class FaithfulnessScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -141,12 +141,12 @@ class HallucinationMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=HallucinationScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: HallucinationScoreReason = await self.model.a_generate(prompt, schema=HallucinationScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -172,12 +172,12 @@ class HallucinationMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=HallucinationScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: HallucinationScoreReason = self.model.generate(prompt, schema=HallucinationScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/hallucination/schema.py
+++ b/deepeval/metrics/hallucination/schema.py
@@ -11,5 +11,5 @@ class Verdicts(BaseModel):
     verdicts: List[HallucinationVerdict]
 
 
-class Reason(BaseModel):
+class HallucinationScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/json_correctness/json_correctness.py
+++ b/deepeval/metrics/json_correctness/json_correctness.py
@@ -17,7 +17,7 @@ from deepeval.metrics.utils import (
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.json_correctness.template import JsonCorrectnessTemplate
-from deepeval.metrics.json_correctness.schema import Reason
+from deepeval.metrics.json_correctness.schema import JsonCorrectnessScoreReason
 from deepeval.utils import get_or_create_event_loop
 
 DEFAULT_CORRECT_REASON = "The generated Json matches and is syntactically correct to the expected schema."
@@ -147,12 +147,12 @@ class JsonCorrectnessMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=JsonCorrectnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: JsonCorrectnessScoreReason = await self.model.a_generate(prompt, schema=JsonCorrectnessScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -176,12 +176,12 @@ class JsonCorrectnessMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=JsonCorrectnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: JsonCorrectnessScoreReason = self.model.generate(prompt, schema=JsonCorrectnessScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/json_correctness/schema.py
+++ b/deepeval/metrics/json_correctness/schema.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
 
 
-class Reason(BaseModel):
+class JsonCorrectnessScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -17,7 +17,7 @@ from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.knowledge_retention.schema import (
     Knowledge,
     KnowledgeRetentionVerdict,
-    Reason,
+    KnowledgeRetentionScoreReason,
 )
 from deepeval.utils import get_or_create_event_loop, prettify_list
 
@@ -136,7 +136,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
             return data["reason"]
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: KnowledgeRetentionScoreReason = await self.model.a_generate(prompt, schema=KnowledgeRetentionScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -163,7 +163,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
             return data["reason"]
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: KnowledgeRetentionScoreReason = self.model.generate(prompt, schema=KnowledgeRetentionScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/knowledge_retention/schema.py
+++ b/deepeval/metrics/knowledge_retention/schema.py
@@ -11,5 +11,5 @@ class KnowledgeRetentionVerdict(BaseModel):
     reason: Optional[str] = None
 
 
-class Reason(BaseModel):
+class KnowledgeRetentionScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/multimodal_metrics/multimodal_answer_relevancy/multimodal_answer_relevancy.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_answer_relevancy/multimodal_answer_relevancy.py
@@ -139,13 +139,13 @@ class MultimodalAnswerRelevancyMetric(BaseMultimodalMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=MultimodelAnswerRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(
-                    prompt=prompt, schema=Reason
+                res: MultimodelAnswerRelevancyScoreReason = await self.model.a_generate(
+                    prompt=prompt, schema=MultimodelAnswerRelevancyScoreReason
                 )
                 return res.reason
             except TypeError:
@@ -172,12 +172,12 @@ class MultimodalAnswerRelevancyMetric(BaseMultimodalMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=MultimodelAnswerRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt=prompt, schema=Reason)
+                res: MultimodelAnswerRelevancyScoreReason = self.model.generate(prompt=prompt, schema=MultimodelAnswerRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/multimodal_metrics/multimodal_answer_relevancy/schema.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_answer_relevancy/schema.py
@@ -15,5 +15,5 @@ class Verdicts(BaseModel):
     verdicts: List[AnswerRelevancyVerdict]
 
 
-class Reason(BaseModel):
+class MultimodelAnswerRelevancyScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/multimodal_metrics/multimodal_contextual_precision/multimodal_contextual_precision.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_contextual_precision/multimodal_contextual_precision.py
@@ -140,12 +140,12 @@ class MultimodalContextualPrecisionMetric(BaseMultimodalMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=MultimodelContextualPrecisionScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: MultimodelContextualPrecisionScoreReason = await self.model.a_generate(prompt, schema=MultimodelContextualPrecisionScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -167,12 +167,12 @@ class MultimodalContextualPrecisionMetric(BaseMultimodalMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=MultimodelContextualPrecisionScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: MultimodelContextualPrecisionScoreReason = self.model.generate(prompt, schema=MultimodelContextualPrecisionScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/multimodal_metrics/multimodal_contextual_precision/schema.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_contextual_precision/schema.py
@@ -11,5 +11,5 @@ class Verdicts(BaseModel):
     verdicts: List[ContextualPrecisionVerdict]
 
 
-class Reason(BaseModel):
+class MultimodelContextualPrecisionScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/multimodal_metrics/multimodal_contextual_recall/multimodal_contextual_recall.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_contextual_recall/multimodal_contextual_recall.py
@@ -144,12 +144,12 @@ class MultimodalContextualRecallMetric(BaseMultimodalMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=MultimodalContextualRecallScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: MultimodalContextualRecallScoreReason = await self.model.a_generate(prompt, schema=MultimodalContextualRecallScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -176,12 +176,12 @@ class MultimodalContextualRecallMetric(BaseMultimodalMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=MultimodalContextualRecallScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: MultimodalContextualRecallScoreReason = self.model.generate(prompt, schema=MultimodalContextualRecallScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/multimodal_metrics/multimodal_contextual_recall/schema.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_contextual_recall/schema.py
@@ -11,5 +11,5 @@ class Verdicts(BaseModel):
     verdicts: List[ContextualRecallVerdict]
 
 
-class Reason(BaseModel):
+class MultimodalContextualRecallScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/multimodal_metrics/multimodal_contextual_relevancy/multimodal_contextual_relevancy.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_contextual_relevancy/multimodal_contextual_relevancy.py
@@ -143,12 +143,12 @@ class MultimodalContextualRelevancyMetric(BaseMultimodalMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=MultimodelContextualRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: MultimodelContextualRelevancyScoreReason = await self.model.a_generate(prompt, schema=MultimodelContextualRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -175,12 +175,12 @@ class MultimodalContextualRelevancyMetric(BaseMultimodalMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=MultimodelContextualRelevancyScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: MultimodelContextualRelevancyScoreReason = self.model.generate(prompt, schema=MultimodelContextualRelevancyScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/multimodal_metrics/multimodal_contextual_relevancy/schema.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_contextual_relevancy/schema.py
@@ -12,5 +12,5 @@ class ContextualRelevancyVerdicts(BaseModel):
     verdicts: List[ContextualRelevancyVerdict]
 
 
-class Reason(BaseModel):
+class MultimodelContextualRelevancyScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/multimodal_metrics/multimodal_faithfulness/multimodal_faithfulness.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_faithfulness/multimodal_faithfulness.py
@@ -144,12 +144,12 @@ class MultimodalFaithfulnessMetric(BaseMultimodalMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=MultimodalFaithfulnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: MultimodalFaithfulnessScoreReason = await self.model.a_generate(prompt, schema=MultimodalFaithfulnessScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -171,12 +171,12 @@ class MultimodalFaithfulnessMetric(BaseMultimodalMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=MultimodalFaithfulnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: MultimodalFaithfulnessScoreReason = self.model.generate(prompt, schema=MultimodalFaithfulnessScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/multimodal_metrics/multimodal_faithfulness/schema.py
+++ b/deepeval/metrics/multimodal_metrics/multimodal_faithfulness/schema.py
@@ -19,5 +19,5 @@ class Claims(BaseModel):
     claims: List[str]
 
 
-class Reason(BaseModel):
+class MultimodalFaithfulnessScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/non_advice/non_advice.py
+++ b/deepeval/metrics/non_advice/non_advice.py
@@ -147,12 +147,12 @@ class NonAdviceMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=NonAdviceScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: NonAdviceScoreReason = await self.model.a_generate(prompt, schema=NonAdviceScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -174,12 +174,12 @@ class NonAdviceMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=NonAdviceScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: NonAdviceScoreReason = self.model.generate(prompt, schema=NonAdviceScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/non_advice/schema.py
+++ b/deepeval/metrics/non_advice/schema.py
@@ -15,5 +15,5 @@ class Advices(BaseModel):
     advices: List[str]
 
 
-class Reason(BaseModel):
+class NonAdviceScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/pii_leakage/pii_leakage.py
+++ b/deepeval/metrics/pii_leakage/pii_leakage.py
@@ -138,12 +138,12 @@ class PIILeakageMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=PIILeakageScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: PIILeakageScoreReason = await self.model.a_generate(prompt, schema=PIILeakageScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -165,12 +165,12 @@ class PIILeakageMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=PIILeakageScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: PIILeakageScoreReason = self.model.generate(prompt, schema=PIILeakageScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/pii_leakage/schema.py
+++ b/deepeval/metrics/pii_leakage/schema.py
@@ -15,5 +15,5 @@ class ExtractedPII(BaseModel):
     extracted_pii: List[str]
 
 
-class Reason(BaseModel):
+class PIILeakageScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/prompt_alignment/prompt_alignment.py
+++ b/deepeval/metrics/prompt_alignment/prompt_alignment.py
@@ -141,13 +141,13 @@ class PromptAlignmentMetric(BaseMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=PromptAlignmentScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(
-                    prompt=prompt, schema=Reason
+                res: PromptAlignmentScoreReason = await self.model.a_generate(
+                    prompt=prompt, schema=PromptAlignmentScoreReason
                 )
                 return res.reason
             except TypeError:
@@ -171,12 +171,12 @@ class PromptAlignmentMetric(BaseMetric):
             score=format(self.score, ".2f"),
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=PromptAlignmentScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt=prompt, schema=Reason)
+                res: PromptAlignmentScoreReason = self.model.generate(prompt=prompt, schema=PromptAlignmentScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/prompt_alignment/schema.py
+++ b/deepeval/metrics/prompt_alignment/schema.py
@@ -11,5 +11,5 @@ class Verdicts(BaseModel):
     verdicts: List[PromptAlignmentVerdict]
 
 
-class Reason(BaseModel):
+class PromptAlignmentScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/role_adherence/role_adherence.py
+++ b/deepeval/metrics/role_adherence/role_adherence.py
@@ -131,12 +131,12 @@ class RoleAdherenceMetric(BaseConversationalMetric):
             ],
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=RoleAdherenceScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: RoleAdherenceScoreReason = await self.model.a_generate(prompt, schema=RoleAdherenceScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -153,12 +153,12 @@ class RoleAdherenceMetric(BaseConversationalMetric):
             ],
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=RoleAdherenceScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: RoleAdherenceScoreReason = self.model.generate(prompt, schema=RoleAdherenceScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/role_adherence/schema.py
+++ b/deepeval/metrics/role_adherence/schema.py
@@ -12,5 +12,5 @@ class OutOfCharacterResponseVerdicts(BaseModel):
     verdicts: List[OutOfCharacterResponseVerdict]
 
 
-class Reason(BaseModel):
+class RoleAdherenceScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/role_violation/role_violation.py
+++ b/deepeval/metrics/role_violation/role_violation.py
@@ -149,12 +149,12 @@ class RoleViolationMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=RoleViolationScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: RoleViolationScoreReason = await self.model.a_generate(prompt, schema=RoleViolationScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -176,12 +176,12 @@ class RoleViolationMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=RoleViolationScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: RoleViolationScoreReason = self.model.generate(prompt, schema=RoleViolationScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/role_violation/schema.py
+++ b/deepeval/metrics/role_violation/schema.py
@@ -15,5 +15,5 @@ class RoleViolations(BaseModel):
     role_violations: List[str]
 
 
-class Reason(BaseModel):
+class RoleViolationScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/summarization/schema.py
+++ b/deepeval/metrics/summarization/schema.py
@@ -32,5 +32,5 @@ class Answers(BaseModel):
     answers: List[str]
 
 
-class Reason(BaseModel):
+class SummarizationScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -203,12 +203,12 @@ class SummarizationMetric(BaseMetric):
 """
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=FaithfulnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: FaithfulnessScoreReason = await self.model.a_generate(prompt, schema=FaithfulnessScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -252,12 +252,12 @@ class SummarizationMetric(BaseMetric):
 """
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=FaithfulnessScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: FaithfulnessScoreReason = self.model.generate(prompt, schema=FaithfulnessScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)

--- a/deepeval/metrics/toxicity/schema.py
+++ b/deepeval/metrics/toxicity/schema.py
@@ -16,5 +16,5 @@ class Verdicts(BaseModel):
     verdicts: List[ToxicityVerdict]
 
 
-class Reason(BaseModel):
+class ToxicityScoreReason(BaseModel):
     reason: str

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -140,12 +140,12 @@ class ToxicityMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt, schema=Reason)
+            res, cost = await self.model.a_generate(prompt, schema=ToxicityScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = await self.model.a_generate(prompt, schema=Reason)
+                res: ToxicityScoreReason = await self.model.a_generate(prompt, schema=ToxicityScoreReason)
                 return res.reason
             except TypeError:
                 res = await self.model.a_generate(prompt)
@@ -167,12 +167,12 @@ class ToxicityMetric(BaseMetric):
         )
 
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Reason)
+            res, cost = self.model.generate(prompt, schema=ToxicityScoreReason)
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: Reason = self.model.generate(prompt, schema=Reason)
+                res: ToxicityScoreReason = self.model.generate(prompt, schema=ToxicityScoreReason)
                 return res.reason
             except TypeError:
                 res = self.model.generate(prompt)


### PR DESCRIPTION
## Reason of change
In case of custom LLM model interface implementation (`DeepEvalBaseLLM`), `instructor` package may be used to make sure that LLM response is JSON formatted.
`instructor` mode `TOOLS` is known to be the most reliable mode of forcing LLM to produce JSON output.

If `schema` is passed as-is to `instructor` in `generate` or `a_generate` function, LLM request  `tools.function` name is the same as schema name - in case of `Reason` model, the function gets name `Reason`. If effect, LLM may switch to reasoning/thinking mode and **not use the tool** - just returning response in path
- `choices[0].message.content` (`"finish_reason": "stop"`)
- instead of `choices[0].tools_calls[0].function.arguments` (`"finish_reason": "tools_call"`)
This breaks instructor, which [raises exception](https://github.com/567-labs/instructor/blob/a54cccd522507f34dbb5ab8be484d68f60a012d9/instructor/function_calls.py#L607). 

## Motivation
- custom LLM model implementation is simplified,
- scope of change (names of internally used classes only) "shouldn't" break DeepEval package,
- DeepEval package is more resistant to responses produced by thinking/reasoning LLM models,
- DeepEval package is more reliable, making developers happy.

## Possible workarounds
1. Use "JSON" mode instead of "TOOLS", if schema type name is "Reason" (less token efficient and less reliable than "TOOLS")
2. Define a class with correct name, and pass it to instructor (requires additional logic in custom LLM model implementation):
```python
class AnswerRelevancyScoreReason(deepeval.metrics.answer_relevancy.schema.Reason):
    pass
```

## Before change (breaking instructor logic)
Request generated by `instructor` in TOOLS mode, when schema model name is "Reason".
```json
{
    "model": "anthropic.claude-3-haiku-20240307-v1:0",
    "messages": [
        {
            "role": "user",
            "content": "Given the answer relevancy score... JSON:\n"
        }
    ],
    "tools": [
        {
            "type": "function",
            "function": {
                "name": "Reason",
                "description": "Correctly extracted `Reason` with all the required parameters with correct types",
                "parameters": {
                    "properties": {
                        "reason": {
                            "title": "Reason",
                            "type": "string"
                        }
                    },
                    "required": ["reason"],
                    "type": "object"
                }
            }
        }
    ],
    "tool_choice": {
        "type": "function",
        "function": {
            "name": "Reason"
        }
    }   
}
```

LLM response (no tools_calls) - `instructor` raises an exception:
```json
{
    "choices": [
        {
            "finish_reason": "stop",
            "message": {
                "content": "{ \"reason\": \"The score is 1.00 because...\" }",
                "role": "assistant",
                "tool_calls": null
            }
        }
    ]
}
```
## After model change (tools_calls available - as expected)
Schema model name changed from "Reason" to "AnswerRelevancyScoreReason":
```json
{
    "model": "anthropic.claude-3-haiku-20240307-v1:0",
    "messages": [
        {
            "role": "user",
            "content": "Given the answer relevancy score... JSON:\n"
        }
    ],
    "tools": [
        {
            "type": "function",
            "function": {
                "name": "AnswerRelevancyScoreReason",
                "description": "Correctly extracted `AnswerRelevancyScoreReason` with all the required parameters with correct types",
                "parameters": {
                    "properties": {
                        "reason": {
                            "title": "Reason",
                            "type": "string"
                        }
                    },
                    "required": ["reason"],
                    "type": "object"
                }
            }
        }
    ],
    "tool_choice": {
        "type": "function",
        "function": {
            "name": "AnswerRelevancyScoreReason"
        }
    }   
```

LLM response with expected `tools_call`:

```json
{
    "choices": [
        {
            "finish_reason": "tool_calls",
            "message": {
                "content": "",
                "role": "assistant",
                "tool_calls": [
                    {
                        "function": {
                            "arguments": "{\"reason\": \"The score is 1.00 because ...\"}",
                            "name": "AnswerRelevancyScoreReason"
                        },
                        "type": "function"
                    }
                ]
            }
        }
    ]    
}
```
## Sample custom model implementation
This is just a part of simple implementation leveraging LiteLLM `completion` function, for demonstration purposes only:
```python
def generate(self, prompt: str, schema: Optional[BaseModel]) -> Union[BaseModel, str]:
        messages = [{"content": prompt, "role": "user"}]

        if schema:            
            sync_instructor = instructor.from_litellm(completion, mode=instructor.Mode.TOOLS)
            
            response = sync_instructor.chat.completions.create(
                model="anthropic.claude-3-haiku-20240307-v1:0",
                messages=messages,
                response_model=schema,                
            )

            return response
        else:
            response = completion(
                model="anthropic.claude-3-haiku-20240307-v1:0",
                messages=messages,
            )

        return response.choices[0].message.content
```