### PR TITLE
Fix EvaluationDataset.evaluate type hints to match all cases and specify return type

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -172,7 +172,14 @@ class EvaluationDataset:
     def __iter__(self):
         return iter(self.test_cases)
 
-    def evaluate(self, metrics: List[BaseMetric]):
+    def evaluate(
+        self, 
+        metrics: Union[
+            List[BaseMetric],
+            List[BaseConversationalMetric],
+            List[BaseMultimodalMetric],
+        ],
+    ) -> "EvaluationResult":
         from deepeval import evaluate
 
         if len(self.test_cases) == 0:

--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -10,7 +10,7 @@ import datetime
 import time
 import ast
 
-from deepeval.metrics import BaseMetric
+from deepeval.metrics import BaseMetric, BaseConversationalMetric, BaseMultimodalMetric
 from deepeval.confident.api import Api, Endpoints, HttpMethods
 from deepeval.dataset.utils import (
     convert_test_cases_to_goldens,

--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -173,7 +173,7 @@ class EvaluationDataset:
         return iter(self.test_cases)
 
     def evaluate(
-        self, 
+        self,
         metrics: Union[
             List[BaseMetric],
             List[BaseConversationalMetric],

--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -10,7 +10,11 @@ import datetime
 import time
 import ast
 
-from deepeval.metrics import BaseMetric, BaseConversationalMetric, BaseMultimodalMetric
+from deepeval.metrics import (
+    BaseConversationalMetric, 
+    BaseMetric,
+    BaseMultimodalMetric,
+)
 from deepeval.confident.api import Api, Endpoints, HttpMethods
 from deepeval.dataset.utils import (
     convert_test_cases_to_goldens,

--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -11,7 +11,7 @@ import time
 import ast
 
 from deepeval.metrics import (
-    BaseConversationalMetric, 
+    BaseConversationalMetric,
     BaseMetric,
     BaseMultimodalMetric,
 )


### PR DESCRIPTION
Just a little type hinting change to fix a wrong annotation which bugged me while using this method.

It is wrong to only accept a list of `BaseMetric`s, as the other two base metric types are also expected, which can be confirmed by taking a look at the deepeval.evaluate.evaluate() function which is directly invoked.

Also the function returns an `EvaluationResult` object, which I put in quotes in order not to cause circular dependecy import errors.