### PR TITLE
Update g_eval.py

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -282,7 +282,12 @@ class GEval(BaseMetric):
             res, cost = await self.model.a_generate_raw_response(
                 prompt, top_logprobs=self.top_logprobs
             )
-            self.evaluation_cost += cost
+            
+            if self.evaluation_cost is None:
+                evaluation_cost = 0.0
+            else:
+                self.evaluation_cost += cost
+    
             data = trimAndLoadJson(res.choices[0].message.content, self)
 
             reason = data["reason"]


### PR DESCRIPTION
This is a small bug that I met when using the g_eval. The compiler caomplained about :
  File "D:\ForschungsPraxis OriginalCodeFile\Master_Arbeit\Evaluation_forget\dataconvert\eva4Forget_v2.py", line 177, in <module>
    main()
  File "D:\ForschungsPraxis OriginalCodeFile\Master_Arbeit\Evaluation_forget\dataconvert\eva4Forget_v2.py", line 167, in main
    score_before = avg_relevancy(llm_before)
  File "D:\ForschungsPraxis OriginalCodeFile\Master_Arbeit\Evaluation_forget\dataconvert\eva4Forget_v2.py", line 164, in avg_relevancy
    scores.append(relevancy_metric.measure(tc).score)
  File "C:\Users\PC\anaconda3\envs\V\lib\site-packages\deepeval\metrics\g_eval\g_eval.py", line 88, in measure
    loop.run_until_complete(
  File "C:\Users\PC\anaconda3\envs\V\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "C:\Users\PC\anaconda3\envs\V\lib\site-packages\deepeval\metrics\g_eval\g_eval.py", line 163, in a_measure
    g_score, reason = await self._a_evaluate(
  File "C:\Users\PC\anaconda3\envs\V\lib\site-packages\deepeval\metrics\g_eval\g_eval.py", line 287, in _a_evaluate
    self.evaluation_cost += cost
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'float'

and by adding the phrase I idid in line 286, this problem is solved