### PR TITLE
Changed variable in snippet code to 'metric' instead of 'professionalism_metric'

### DIFF
--- a/docs/docs/metrics-conversational-g-eval.mdx
+++ b/docs/docs/metrics-conversational-g-eval.mdx
@@ -40,7 +40,7 @@ from deepeval.metrics import ConversationalGEval
 convo_test_case = ConversationalTestCase(
     turns=[Turn(role="...", content="..."), Turn(role="...", content="...")]
 )
-professionalism_metric = ConversationalGEval(
+metric = ConversationalGEval(
     name="Professionalism",
     criteria="Determine whether the assistant has acted professionally based on the content."
 )


### PR DESCRIPTION
This change ensures the GEval snippet actually works – metric is undefined otherwise