### PR TITLE
Fix(summarization): Correct schema usage in SummarizationMetric

### DIFF
--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -486,8 +486,8 @@ class SummarizationMetric(BaseMetric):
             return verdicts
         else:
             try:
-                res: SummarizationAlignmentVerdict = self.model.generate(
-                    prompt, schema=SummarizationAlignmentVerdict
+                res: Verdicts = self.model.generate(
+                    prompt, schema=Verdicts
                 )
                 verdicts = [item for item in res.verdicts]
                 return verdicts

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -486,9 +486,7 @@ class SummarizationMetric(BaseMetric):
             return verdicts
         else:
             try:
-                res: Verdicts = self.model.generate(
-                    prompt, schema=Verdicts
-                )
+                res: Verdicts = self.model.generate(prompt, schema=Verdicts)
                 verdicts = [item for item in res.verdicts]
                 return verdicts
             except TypeError:

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -18,8 +18,16 @@ from deepeval.metrics.utils import (
 from deepeval.metrics.summarization.template import SummarizationTemplate
 from deepeval.metrics.faithfulness.template import FaithfulnessTemplate
 from deepeval.metrics.indicator import metric_progress_indicator
-from deepeval.metrics.summarization.schema import *
-from deepeval.metrics.faithfulness.schema import *
+from deepeval.metrics.summarization.schema import (
+    ScoreType,
+    SummarizationAlignmentVerdict,
+    SummarizationCoverageVerdict,
+    Verdicts,
+    Questions,
+    Answers,
+    SummarizationScoreReason,
+)
+from deepeval.metrics.faithfulness.schema import Truths, Claims
 
 
 class SummarizationMetric(BaseMetric):
@@ -204,14 +212,14 @@ class SummarizationMetric(BaseMetric):
 
         if self.using_native_model:
             res, cost = await self.model.a_generate(
-                prompt, schema=FaithfulnessScoreReason
+                prompt, schema=SummarizationScoreReason
             )
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: FaithfulnessScoreReason = await self.model.a_generate(
-                    prompt, schema=FaithfulnessScoreReason
+                res: SummarizationScoreReason = await self.model.a_generate(
+                    prompt, schema=SummarizationScoreReason
                 )
                 return res.reason
             except TypeError:
@@ -257,14 +265,14 @@ class SummarizationMetric(BaseMetric):
 
         if self.using_native_model:
             res, cost = self.model.generate(
-                prompt, schema=FaithfulnessScoreReason
+                prompt, schema=SummarizationScoreReason
             )
             self.evaluation_cost += cost
             return res.reason
         else:
             try:
-                res: FaithfulnessScoreReason = self.model.generate(
-                    prompt, schema=FaithfulnessScoreReason
+                res: SummarizationScoreReason = self.model.generate(
+                    prompt, schema=SummarizationScoreReason
                 )
                 return res.reason
             except TypeError:
@@ -470,13 +478,13 @@ class SummarizationMetric(BaseMetric):
             summary_claims=self.claims, original_text="\n\n".join(self.truths)
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=Verdicts)
+            res, cost = self.model.generate(prompt, schema=SummarizationAlignmentVerdict)
             self.evaluation_cost += cost
             verdicts = [item for item in res.verdicts]
             return verdicts
         else:
             try:
-                res: Verdicts = self.model.generate(prompt, schema=Verdicts)
+                res: SummarizationAlignmentVerdict = self.model.generate(prompt, schema=SummarizationAlignmentVerdict)
                 verdicts = [item for item in res.verdicts]
                 return verdicts
             except TypeError:

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -478,13 +478,17 @@ class SummarizationMetric(BaseMetric):
             summary_claims=self.claims, original_text="\n\n".join(self.truths)
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt, schema=SummarizationAlignmentVerdict)
+            res, cost = self.model.generate(
+                prompt, schema=SummarizationAlignmentVerdict
+            )
             self.evaluation_cost += cost
             verdicts = [item for item in res.verdicts]
             return verdicts
         else:
             try:
-                res: SummarizationAlignmentVerdict = self.model.generate(prompt, schema=SummarizationAlignmentVerdict)
+                res: SummarizationAlignmentVerdict = self.model.generate(
+                    prompt, schema=SummarizationAlignmentVerdict
+                )
                 verdicts = [item for item in res.verdicts]
                 return verdicts
             except TypeError:


### PR DESCRIPTION
This PR solves the issue #1781


Changes made:
This pull request refactors the Pydantic schemas used in the SummarizationMetric to improve clarity and descriptiveness. The generic name Verdicts was ambiguous, and this change makes the code easier to understand and maintain.