### PR TITLE
fix(metrics/utils): fix init of AzureOpenAIModel

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -445,7 +445,7 @@ def initialize_model(
     elif should_use_local_model():
         return LocalModel(), True
     elif should_use_azure_openai():
-        return AzureOpenAIModel(model=model), True
+        return AzureOpenAIModel(model_name=model), True
     elif should_use_moonshot_model():
         return KimiModel(model=model), True
     elif should_use_grok_model():


### PR DESCRIPTION
AzureOpenAIModel uses "model_name" instead of "model" argument. 

FYI: This bug has been present in the repo for ~4 months so all versions released in that period are unusable by the users of Azure OpenAI deployments.