### PR TITLE
Fix(models): Ensure LiteLLMModel returns cost when schema is provided

### DIFF
--- a/deepeval/models/llms/litellm_model.py
+++ b/deepeval/models/llms/litellm_model.py
@@ -107,7 +107,7 @@ class LiteLLMModel(DeepEvalBaseLLM):
 
             if schema:
                 json_output = trim_and_load_json(content)
-                return schema(**json_output)  # Return just the schema instance
+                return schema(**json_output), cost  # Return both the schema instance and cost as defined as native model
             else:
                 return content, cost  # Return tuple with cost
         except Exception as e:
@@ -150,7 +150,7 @@ class LiteLLMModel(DeepEvalBaseLLM):
 
             if schema:
                 json_output = trim_and_load_json(content)
-                return schema(**json_output)  # Return just the schema instance
+                return schema(**json_output), cost  # Return both the schema instance and cost as defined as native model
             else:
                 return content, cost  # Return tuple with cost
         except Exception as e:


### PR DESCRIPTION
### Description

This PR fixes a `ValueError` that occurs when using a `deepeval.models.LiteLLMModel` with a metric that requires a schema (e.g., `AnswerRelevancyMetric`).

### The Bug

The `generate` and `a_generate` methods in `LiteLLMModel` did not return a `cost` value when a `schema` was provided, breaking the expected `(result, cost)` return signature for native models. This caused an "not enough values to unpack" error in downstream metric calculations.

Full traceback:

```
✨ You're running DeepEval's latest Answer Relevancy Metric! (using 
openai/OPEA/Mistral-Small-3.1-24B-Instruct-2503-int4-AutoRound-awq-sym 
(('OPEA/Mistral-Small-3.1-24B-Instruct-2503-int4-AutoRound-awq-sym', 'openai', None, None)), strict=False, async_mode=True)...
Evaluating 1 test case(s) in parallel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0:00:01
    🎯 Evaluating test case #0        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0:00:01
Traceback (most recent call last):
  File "/home/dylan/workspace/test_deepeval/bug.py", line 25, in <module>
    results = deepeval.evaluate(
              ^^^^^^^^^^^^^^^^^^
  File "/home/dylan/workspace/deepeval/deepeval/evaluate/evaluate.py", line 291, in evaluate
    test_results = loop.run_until_complete(
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dylan/.local/share/uv/python/cpython-3.12.11-linux-x86_64-gnu/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/dylan/workspace/deepeval/deepeval/evaluate/execute.py", line 555, in a_execute_test_cases
    await asyncio.gather(*tasks)
  File "/home/dylan/workspace/deepeval/deepeval/evaluate/execute.py", line 438, in execute_with_semaphore
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dylan/workspace/deepeval/deepeval/evaluate/execute.py", line 674, in a_execute_llm_test_cases
    await measure_metrics_with_indicator(
  File "/home/dylan/workspace/deepeval/deepeval/metrics/indicator.py", line 230, in measure_metrics_with_indicator
    await asyncio.gather(*tasks)
  File "/home/dylan/workspace/deepeval/deepeval/metrics/indicator.py", line 243, in safe_a_measure
    await metric.a_measure(
  File "/home/dylan/workspace/deepeval/deepeval/metrics/answer_relevancy/answer_relevancy.py", line 107, in a_measure
    self.statements: List[str] = await self._a_generate_statements(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dylan/workspace/deepeval/deepeval/metrics/answer_relevancy/answer_relevancy.py", line 249, in _a_generate_statements
    res, cost = await self.model.a_generate(prompt, schema=Statements)
    ^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)
```


### The Fix

I have updated the `generate` and `a_generate` methods in `deepeval/models/llms/litellm_model.py`. The methods now correctly return the cost alongside the schema instance, aligning with the expected `(result, cost)`.

### How to Test

The following code snippet reproduces the error on the `main` branch and runs successfully with this fix.

```python
import os
import deepeval
from deepeval.models import LiteLLMModel
from deepeval.metrics import AnswerRelevancyMetric
from deepeval.test_case import LLMTestCase

evaluation_model = LiteLLMModel(
    model="openai/OPEA/Mistral-Small-3.1-24B-Instruct-2503-int4-AutoRound-awq-sym", # or any other models
    base_url="http://localhost:8000/v1",
    api_key=os.getenv("OPENAI_API_KEY")
)

test_case = LLMTestCase(
    input="What is the primary function of the mitochondria?",
    actual_output="The mitochondria is the powerhouse of the cell."
)

answer_relevancy_metric = AnswerRelevancyMetric(
    threshold=0.7,
    model=evaluation_model
)

results = deepeval.evaluate(
    test_cases=[test_case], 
    metrics=[answer_relevancy_metric]
)

print(results)
```

Success output after fix:

```
✨ You're running DeepEval's latest Answer Relevancy Metric! (using 
openai/OPEA/Mistral-Small-3.1-24B-Instruct-2503-int4-AutoRound-awq-sym 
(('OPEA/Mistral-Small-3.1-24B-Instruct-2503-int4-AutoRound-awq-sym', 'openai', None, None)), strict=False, async_mode=True)...

======================================================================

Metrics Summary

 - ✅ Answer Relevancy (score: 1.0, threshold: 0.7, strict: False, evaluation model: openai/OPEA/Mistral-Small-3.1-24B-Instruct-2503-int4-AutoRound-awq-sym (('OPEA/Mistral-Small-3.1-24B-Instruct-2503-int4-AutoRound-awq-sym', 'openai', None, None)), reason: The score is 1.00 because the output is perfectly relevant to the input, providing a clear and accurate explanation of the primary function of the mitochondria., error: None)

For test case:

 - input: What is the primary function of the mitochondria?
 - actual output: The mitochondria is the powerhouse of the cell.
 - expected output: None
 - context: None
 - retrieval context: None

======================================================================

Overall Metric Pass Rates

Answer Relevancy: 100.00% pass rate

======================================================================
```
