### PR TITLE
Added missing temperature params

### DIFF
--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -268,6 +268,7 @@ class GPTModel(DeepEvalBaseLLM):
         completion = client.chat.completions.create(
             model=self.model_name,
             messages=[{"role": "user", "content": prompt}],
+            temperature=self.temperature
         )
         output = completion.choices[0].message.content
         cost = self.calculate_cost(
@@ -327,6 +328,7 @@ class GPTModel(DeepEvalBaseLLM):
         completion = await client.chat.completions.create(
             model=self.model_name,
             messages=[{"role": "user", "content": prompt}],
+            temperature=self.temperature
         )
         output = completion.choices[0].message.content
         cost = self.calculate_cost(


### PR DESCRIPTION
While investigating another issue, I noticed that there was a non-temperature controlled call in the GptModel generate / a_generate functions, which I believe happens when a schema is not specified. I believe this is a bug.

Not specifying temperature defaults to 1 (I'd previously thought it to be 0, and this was an intentional omission), per the [OpenAI completions.create docs](https://platform.openai.com/docs/api-reference/chat/create). It's more consistent with the library to have it be user controlled.

