### PR TITLE
Rename parameter 'misuses' to 'misuse_violations' in generate_reason

### DIFF
--- a/deepeval/metrics/misuse/misuse.py
+++ b/deepeval/metrics/misuse/misuse.py
@@ -135,7 +135,7 @@ class MisuseMetric(BaseMetric):
                 misuses.append(verdict.reason)
 
         prompt: dict = self.evaluation_template.generate_reason(
-            misuses=misuses,
+            misuse_violations=misuses,
             score=format(self.score, ".2f"),
         )
 
@@ -166,7 +166,7 @@ class MisuseMetric(BaseMetric):
                 misuses.append(verdict.reason)
 
         prompt: dict = self.evaluation_template.generate_reason(
-            misuses=misuses,
+            misuse_violations=misuses,
             score=format(self.score, ".2f"),
         )
 


### PR DESCRIPTION
### Summary
Fixed incorrect parameter names being passed to the `generate_reason` function in the `MisuseTemplate` class. This caused the misuse metric to throw an error when calling the `measure` function.

### Changes
Corrected the parameter names in the `generate_reason` function call.

### Related Issue
Fixes [#1861](https://github.com/confident-ai/deepeval/issues/1861)
