### PR TITLE
Enforce limit on generated inputs

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -628,6 +628,8 @@ class Synthesizer:
         synthetic_inputs: List[SyntheticData] = await self._a_generate_inputs(
             prompt
         )
+        # Limit the length of the synthetic inputs to the maximum allowed
+        synthetic_inputs = synthetic_inputs[:max_goldens_per_context]
         update_pbar(progress, pbar_generate_inputs_id, remove=False)
 
         # Qualify inputs


### PR DESCRIPTION
Resolves #1774 by ensuring the inputs generated by the model does not exceed the user-specified maximum.