### PR TITLE
Import Scorer class in IFEval constructor to avoid circular import

### DIFF
--- a/deepeval/benchmarks/ifeval/ifeval.py
+++ b/deepeval/benchmarks/ifeval/ifeval.py
@@ -8,7 +8,7 @@ from deepeval.benchmarks.base_benchmark import DeepEvalBaseBenchmark
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.schema import StringSchema
 from deepeval.telemetry import capture_benchmark_run
-from deepeval.scorer import Scorer
+# from deepeval.scorer import Scorer
 
 
 class IFEvalInstructionVerifier:
@@ -394,6 +394,7 @@ class IFEval(DeepEvalBaseBenchmark):
         verbose_mode: bool = False,
         **kwargs,
     ):
+        from deepeval.scorer import Scorer
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.n_problems = n_problems

--- a/deepeval/benchmarks/ifeval/ifeval.py
+++ b/deepeval/benchmarks/ifeval/ifeval.py
@@ -8,7 +8,6 @@ from deepeval.benchmarks.base_benchmark import DeepEvalBaseBenchmark
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.schema import StringSchema
 from deepeval.telemetry import capture_benchmark_run
-# from deepeval.scorer import Scorer
 
 
 class IFEvalInstructionVerifier:


### PR DESCRIPTION
## Fix circular import between deepeval.scorer and deepeval.benchmarks.ifeval

### Problem
ImportError: cannot import name 'Scorer' from partially initialized module 'deepeval.scorer' (most likely due to a circular import)

**Root Cause:**
1. `deepeval.scorer.scorer` imports `NumberSchema` from `deepeval.benchmarks.schema`
2. `deepeval.benchmarks.__init__.py` imports `IFEval` from `deepeval.benchmarks.ifeval.ifeval`
3. `deepeval.benchmarks.ifeval.ifeval` imports `Scorer` from `deepeval.scorer`

This creates a circular dependency: `scorer` → `benchmarks` → `ifeval` → `scorer`


### Solution
Move the `Scorer` import inside the `__init__` method of the `IFEval` class to break the circular dependency during module loading.

### Testing

```
The hypothesis contains 0 counts of 4-gram overlaps.
Therefore the BLEU score evaluates to 0, independently of
how many N-gram overlaps of lower order it contains.
Consider using lower n-gram order or use SmoothingFunction()
  warnings.warn(_msg)
BLEU-1 Score: 0.8333333333333334
```

### Fixes: #1805 


