### PR TITLE
[Ollama/docs] fix parameter name in model initialization

### DIFF
--- a/docs/integrations/models/ollama.mdx
+++ b/docs/integrations/models/ollama.mdx
@@ -48,7 +48,7 @@ from deepeval.models import OllamaModel
 from deepeval.metrics import AnswerRelevancyMetric
 
 model = OllamaModel(
-    model_name="deepseek-r1:1.5b",
+    model="deepseek-r1:1.5b",
     base_url="http://localhost:11434",
     temperature=0
 )


### PR DESCRIPTION
Just a quick update as the docs don't match the [correct parameter name](https://github.com/confident-ai/deepeval/blob/main/deepeval/models/llms/ollama_model.py#L12) at the moment.