### PR TITLE
 feat(simulator): make ConversationSimulator language configurable

### DIFF
--- a/deepeval/simulator/conversation_simulator.py
+++ b/deepeval/simulator/conversation_simulator.py
@@ -37,6 +37,7 @@ class ConversationSimulator:
         opening_message: Optional[str] = None,
         max_concurrent: int = 5,
         async_mode: bool = True,
+        language: str = "English",
     ):
         self.model_callback = model_callback
         self.is_callback_async = inspect.iscoroutinefunction(
@@ -48,7 +49,7 @@ class ConversationSimulator:
         self.opening_message = opening_message
         self.semaphore = asyncio.Semaphore(max_concurrent)
         self.async_mode = async_mode
-        self.language = "English"
+        self.language = language
         self.simulated_conversations: List[ConversationalTestCase] = []
         self.template = ConversationSimulatorTemplate
 


### PR DESCRIPTION
This is my first open-source contribution—thanks for bearing with me!

* **What changed**

  * Added a new `language: str = "English"` parameter to the `ConversationSimulator` constructor.
  * Stored it on `self.language` (it was previously hard-coded to `"English"`).
  * No other code was touched: the existing template calls already use `self.language` to drive prompt generation.

* **Why**
  By exposing the language at construction time, you can now run the simulator in any language without further modifications. Default behavior remains English for backwards compatibility.

---

*No changes to template methods or other logic were required—this PR simply unlocks true multilingual support by parametrizing the constructor.*
