### PR TITLE
Update deepseek docs, from model_name to model in the initialization.mdx

### DIFF
--- a/docs/integrations/models/deepseek.mdx
+++ b/docs/integrations/models/deepseek.mdx
@@ -31,7 +31,7 @@ from deepeval.models import DeepSeekModel
 from deepeval.metrics import AnswerRelevancyMetric
 
 model = DeepSeekModel(
-    model_name="deepseek-chat",
+    model="deepseek-chat",
     api_key="your-api-key",
     temperature=0
 )


### PR DESCRIPTION
Replaced **model_name** with **model** in DeepSeekModel() initialization to match the documented parameter name.