### PR TITLE
Reason-first in G-Eval

### DIFF
--- a/deepeval/metrics/g_eval/template.py
+++ b/deepeval/metrics/g_eval/template.py
@@ -81,8 +81,8 @@ class GEvalTemplate:
             ---
             **Example JSON:**
             {{
-                "score": {score_range[0]},
-                "reason": "your concise and informative reason here"
+                "reason": "your concise and informative reason here",
+                "score": {score_range[0]}
             }}
 
             JSON:
@@ -114,8 +114,8 @@ class GEvalTemplate:
 
             Example JSON:
             {{
-                "score": 0,
-                "reason": "The text does not follow the evaluation steps provided."
+                "reason": "The text does not follow the evaluation steps provided.",
+                "score": 0
             }}
             **
 
@@ -183,9 +183,9 @@ class GEvalTemplate:
             ---
             **Example JSON:**
             {{
+                "reason": "your concise and informative reason here",
                 "best_test_case_index": 0,
-                "best_test_case_id": "946b72fa-7fba-46e8-9ac6-e8cb83b79b2b",
-                "reason": "your concise and informative reason here"
+                "best_test_case_id": "946b72fa-7fba-46e8-9ac6-e8cb83b79b2b"
             }}
 
             JSON:


### PR DESCRIPTION
Hello 👋,

Thank you for your excellent work! We currently rely heavily on G-Eval for our different LLM judge use cases.

After reviewing the code, I noticed that LLM is prompted to generate the score before the reasoning, based on the output format in the prompt.

IMO it would be better to generate the reasoning content first, kind of CoT (even though some APIs like [Gemini](https://ai.google.dev/gemini-api/docs/thinking#set-budget) already use a thinking mode before generating required reasoning content in JSON). Doing this would likely lead to more accurate scores in the end, even for non-strict weighted summed scores.

This is also mentioned in this [paper](https://arxiv.org/pdf/2406.02863):

> We found that the order of presenting reasons and scores significantly influences LLMs’ scoring, with a ”reason-first” approach yielding more comprehensive evaluations. This insight is crucial for enhancing the accuracy and consistency of LLM-based evaluations.

would love to get your feedback on this. Thanks in advance!