### PR TITLE
Explicitly re-export benchmarks in __init__.py and reformat

### DIFF
--- a/deepeval/benchmarks/__init__.py
+++ b/deepeval/benchmarks/__init__.py
@@ -1,20 +1,20 @@
-from .big_bench_hard.big_bench_hard import BigBenchHard
-from .mmlu.mmlu import MMLU
-from .hellaswag.hellaswag import HellaSwag
-from .drop.drop import DROP
-from .truthful_qa.truthful_qa import TruthfulQA
-from .human_eval.human_eval import HumanEval
-from .squad.squad import SQuAD
-from .gsm8k.gsm8k import GSM8K
-from .math_qa.math_qa import MathQA
-from .logi_qa.logi_qa import LogiQA
-from .bool_q.bool_q import BoolQ
-from .arc.arc import ARC
-from .bbq.bbq import BBQ
-from .lambada.lambada import LAMBADA
-from .winogrande.winogrande import Winogrande
-from .equity_med_qa.equity_med_qa import EquityMedQA
-from .ifeval.ifeval import IFEval
+from .big_bench_hard.big_bench_hard import BigBenchHard as BigBenchHard
+from .mmlu.mmlu import MMLU as MMLU
+from .hellaswag.hellaswag import HellaSwag as HellaSwag
+from .drop.drop import DROP as DROP
+from .truthful_qa.truthful_qa import TruthfulQA as TruthfulQA
+from .human_eval.human_eval import HumanEval as HumanEval
+from .squad.squad import SQuAD as SQuAD
+from .gsm8k.gsm8k import GSM8K as GSM8K
+from .math_qa.math_qa import MathQA as MathQA
+from .logi_qa.logi_qa import LogiQA as LogiQA
+from .bool_q.bool_q import BoolQ as BoolQ
+from .arc.arc import ARC as ARC
+from .bbq.bbq import BBQ as BBQ
+from .lambada.lambada import LAMBADA as LAMBADA
+from .winogrande.winogrande import Winogrande as Winogrande
+from .equity_med_qa.equity_med_qa import EquityMedQA as EquityMedQA
+from .ifeval.ifeval import IFEval as IFEval
 
 __all__ = [
     "BigBenchHard",

--- a/deepeval/tracing/otel/exporter.py
+++ b/deepeval/tracing/otel/exporter.py
@@ -181,13 +181,19 @@ class ConfidentSpanExporter(SpanExporter):
                     current_trace.output = base_span_wrapper.trace_output
 
                 if base_span_wrapper.trace_environment:
-                    current_trace.environment = base_span_wrapper.trace_environment
+                    current_trace.environment = (
+                        base_span_wrapper.trace_environment
+                    )
 
                 if base_span_wrapper.trace_metric_collection:
-                    current_trace.metric_collection = base_span_wrapper.trace_metric_collection
-                
+                    current_trace.metric_collection = (
+                        base_span_wrapper.trace_metric_collection
+                    )
+
                 if base_span_wrapper.trace_llm_test_case:
-                    current_trace.llm_test_case = base_span_wrapper.trace_llm_test_case
+                    current_trace.llm_test_case = (
+                        base_span_wrapper.trace_llm_test_case
+                    )
 
                 trace_manager.add_span(base_span_wrapper.base_span)
                 trace_manager.add_span_to_trace(base_span_wrapper.base_span)
@@ -384,10 +390,14 @@ class ConfidentSpanExporter(SpanExporter):
         trace_metadata = span.attributes.get("confident.trace.metadata")
         trace_thread_id = span.attributes.get("confident.trace.thread_id")
         trace_user_id = span.attributes.get("confident.trace.user_id")
-        _trace_metric_collection = span.attributes.get("confident.trace.metric_collection")
+        _trace_metric_collection = span.attributes.get(
+            "confident.trace.metric_collection"
+        )
 
         trace_metric_collection = None
-        if _trace_metric_collection and isinstance(_trace_metric_collection, str):
+        if _trace_metric_collection and isinstance(
+            _trace_metric_collection, str
+        ):
             trace_metric_collection = _trace_metric_collection
 
         if trace_tags and isinstance(trace_tags, tuple):

--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -165,20 +165,23 @@ def check_model_from_gen_ai_attributes(span: ReadableSpan):
     return None
 
 
-
 def prepare_trace_llm_test_case(span: ReadableSpan) -> Optional[LLMTestCase]:
 
     test_case = LLMTestCase(input="")
-    
+
     _input = span.attributes.get("confident.trace.llm_test_case.input")
     if isinstance(_input, str):
         test_case.input = _input
-        
-    _actual_output = span.attributes.get("confident.trace.llm_test_case.actual_output")
+
+    _actual_output = span.attributes.get(
+        "confident.trace.llm_test_case.actual_output"
+    )
     if isinstance(_actual_output, str):
         test_case.actual_output = _actual_output
 
-    _expected_output = span.attributes.get("confident.trace.llm_test_case.expected_output")
+    _expected_output = span.attributes.get(
+        "confident.trace.llm_test_case.expected_output"
+    )
     if isinstance(_expected_output, str):
         test_case.expected_output = _expected_output
 
@@ -186,30 +189,40 @@ def prepare_trace_llm_test_case(span: ReadableSpan) -> Optional[LLMTestCase]:
     if isinstance(_context, list):
         if all(isinstance(item, str) for item in _context):
             test_case.context = _context
-        
-    _retrieval_context = span.attributes.get("confident.trace.llm_test_case.retrieval_context")
+
+    _retrieval_context = span.attributes.get(
+        "confident.trace.llm_test_case.retrieval_context"
+    )
     if isinstance(_retrieval_context, list):
         if all(isinstance(item, str) for item in _retrieval_context):
             test_case.retrieval_context = _retrieval_context
-    
+
     tools_called: List[ToolCall] = []
     expected_tools: List[ToolCall] = []
 
-    _tools_called = span.attributes.get("confident.trace.llm_test_case.tools_called")
+    _tools_called = span.attributes.get(
+        "confident.trace.llm_test_case.tools_called"
+    )
     if isinstance(_tools_called, list):
         for tool_call_json_str in _tools_called:
             if isinstance(tool_call_json_str, str):
                 try:
-                    tools_called.append(ToolCall.model_validate_json(tool_call_json_str))
+                    tools_called.append(
+                        ToolCall.model_validate_json(tool_call_json_str)
+                    )
                 except Exception as e:
                     pass
 
-    _expected_tools = span.attributes.get("confident.trace.llm_test_case.expected_tools")
+    _expected_tools = span.attributes.get(
+        "confident.trace.llm_test_case.expected_tools"
+    )
     if isinstance(_expected_tools, list):
         for tool_call_json_str in _expected_tools:
             if isinstance(tool_call_json_str, str):
                 try:
-                    expected_tools.append(ToolCall.model_validate_json(tool_call_json_str))
+                    expected_tools.append(
+                        ToolCall.model_validate_json(tool_call_json_str)
+                    )
                 except Exception as e:
                     pass
 

--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -605,7 +605,6 @@ class TraceManager:
             else None
         )
 
-
         return TraceApi(
             uuid=trace.uuid,
             baseSpans=base_spans,
@@ -618,7 +617,9 @@ class TraceManager:
             metadata=trace.metadata,
             name=trace.name,
             tags=trace.tags,
-            environment=self.environment if not trace.environment else trace.environment,
+            environment=(
+                self.environment if not trace.environment else trace.environment
+            ),
             threadId=trace.thread_id,
             userId=trace.user_id,
             input=trace.input,

--- a/tests/integrations/crewai/test_crewai_offline_eval.py
+++ b/tests/integrations/crewai/test_crewai_offline_eval.py
@@ -7,6 +7,7 @@ import time
 from deepeval.dataset import Golden, EvaluationDataset
 
 from dotenv import load_dotenv
+
 load_dotenv()
 
 os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")

--- a/tests/integrations/langgraph/test_langgraph_dataset.py
+++ b/tests/integrations/langgraph/test_langgraph_dataset.py
@@ -10,6 +10,7 @@ from deepeval.dataset import Golden
 from deepeval.evaluate.configs import AsyncConfig
 
 from dotenv import load_dotenv
+
 load_dotenv()
 
 task_completion = TaskCompletionMetric(

--- a/tests/otel/test_attributes.py
+++ b/tests/otel/test_attributes.py
@@ -152,9 +152,16 @@ def meta_agent(input: str):
         span.set_attribute("confident.trace.output", input)
 
         span.set_attribute("confident.trace.llm_test_case.input", "test_input")
-        span.set_attribute("confident.trace.llm_test_case.actual_output", "test_actual_output")
-        span.set_attribute("confident.trace.llm_test_case.expected_output", "test_expected_output")
-        span.set_attribute("confident.trace.metric_collection", "test_collection_1")
+        span.set_attribute(
+            "confident.trace.llm_test_case.actual_output", "test_actual_output"
+        )
+        span.set_attribute(
+            "confident.trace.llm_test_case.expected_output",
+            "test_expected_output",
+        )
+        span.set_attribute(
+            "confident.trace.metric_collection", "test_collection_1"
+        )
 
         llm_agent(input)
 


### PR DESCRIPTION

Explicitly re-exports benchmarks so that pyright and other typecheckers do not complain when you try to import them from this file.

Also lint was failing on this pr, so ran `uvx black .`
