### PR TITLE
Add missing type annotations to base_model.py

### DIFF
--- a/deepeval/models/base_model.py
+++ b/deepeval/models/base_model.py
@@ -9,7 +9,7 @@ class DeepEvalBaseModel(ABC):
         self.model = self.load_model(*args, **kwargs)
 
     @abstractmethod
-    def load_model(self, *args, **kwargs):
+    def load_model(self, *args, **kwargs) -> "DeepEvalBaseModel":
         """Loads a model, that will be responsible for scoring.
 
         Returns:
@@ -36,7 +36,7 @@ class DeepEvalBaseLLM(ABC):
         self.model = self.load_model(*args, **kwargs)
 
     @abstractmethod
-    def load_model(self, *args, **kwargs):
+    def load_model(self, *args, **kwargs) -> "DeepEvalBaseLLM":
         """Loads a model, that will be responsible for scoring.
 
         Returns:
@@ -109,7 +109,7 @@ class DeepEvalBaseEmbeddingModel(ABC):
         self.model = self.load_model(*args, **kwargs)
 
     @abstractmethod
-    def load_model(self, *args, **kwargs):
+    def load_model(self, *args, **kwargs) -> "DeepEvalBaseEmbeddingModel":
         """Loads a model, that will be responsible for generating text embeddings.
 
         Returns:


### PR DESCRIPTION

Previously if you inherited from any of these classes and added a type annotation for your overridden method it would cause a type error because the type checker was inferring this method to return `None`
