### PR TITLE
Allow any openai model and reorganize the capability list of known models.

### DIFF
--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -3,6 +3,8 @@ from deepeval.key_handler import ModelKeyValues, KEY_FILE_HANDLER
 from typing import Optional, Tuple, Union, Dict
 from openai import OpenAI, AsyncOpenAI
 from pydantic import BaseModel
+from dataclasses import dataclass, field
+from enum import Enum
 import logging
 import openai
 
@@ -25,192 +27,400 @@ def log_retry_error(retry_state: RetryCallState):
     )
 
 
-valid_gpt_models = [
-    "gpt-3.5-turbo",
-    "gpt-3.5-turbo-0125",
-    "gpt-3.5-turbo-1106",
-    "gpt-4-0125-preview",
-    "gpt-4-1106-preview",
-    "gpt-4-turbo",
-    "gpt-4-turbo-2024-04-09",
-    "gpt-4-turbo-preview",
-    "gpt-4o",
-    "gpt-4o-2024-05-13",
-    "gpt-4o-2024-08-06",
-    "gpt-4o-2024-11-20",
-    "gpt-4o-mini",
-    "gpt-4o-mini-2024-07-18",
-    "gpt-4-32k",
-    "gpt-4-32k-0613",
-    "gpt-4.1",
-    "gpt-4.1-mini",
-    "gpt-4.1-nano",
-    "gpt-4.5-preview",
-    "o1",
-    "o1-preview",
-    "o1-2024-12-17",
-    "o1-preview-2024-09-12",
-    "o1-mini",
-    "o1-mini-2024-09-12",
-    "o3-mini",
-    "o3-mini-2025-01-31",
-    "o4-mini",
-    "o4-mini-2025-04-16",
-    "gpt-4.5-preview-2025-02-27",
-    "gpt-5",
-    "gpt-5-2025-08-07",
-    "gpt-5-mini",
-    "gpt-5-mini-2025-08-07",
-    "gpt-5-nano",
-    "gpt-5-nano-2025-08-07",
-    "gpt-5-chat-latest",
-]
+@dataclass
+class ModelCapabilities:
+    """Defines the capabilities of a specific OpenAI model."""
+    supports_structured_outputs: bool = False
+    supports_json_mode: bool = False
+    supports_log_probs: bool = True
+    requires_temperature_1: bool = False
+    input_cost_per_token: Optional[float] = None
+    output_cost_per_token: Optional[float] = None
 
-unsupported_log_probs_gpt_models = [
-    "o1",
-    "o1-preview",
-    "o1-2024-12-17",
-    "o1-preview-2024-09-12",
-    "o1-mini",
-    "o1-mini-2024-09-12",
-    "o3-mini",
-    "o3-mini-2025-01-31",
-    "gpt-4.5-preview-2025-02-27",
-    "gpt-5",
-    "gpt-5-2025-08-07",
-    "gpt-5-mini",
-    "gpt-5-mini-2025-08-07",
-    "gpt-5-nano",
-    "gpt-5-nano-2025-08-07",
-    "gpt-5-chat-latest",
-]
 
-structured_outputs_models = [
-    "gpt-4o",
-    "gpt-4o-2024-05-13",
-    "gpt-4o-2024-08-06",
-    "gpt-4o-2024-11-20",
-    "gpt-4o-mini",
-    "gpt-4o-mini-2024-07-18",
-    "gpt-4.1",
-    "gpt-4.1-mini",
-    "gpt-4.1-nano",
-    "o1",
-    "o1-preview",
-    "o1-2024-12-17",
-    "o3-mini",
-    "o3-mini-2025-01-31",
-    "o4-mini",
-    "o4-mini-2025-04-16",
-    "gpt-4.5-preview-2025-02-27",
-    "gpt-5",
-    "gpt-5-2025-08-07",
-    "gpt-5-mini",
-    "gpt-5-mini-2025-08-07",
-    "gpt-5-nano"
-    "gpt-5-nano-2025-08-07"
-]
+@dataclass
+class OpenAIModelConfig:
+    """Configuration for an OpenAI model with its capabilities."""
+    name: str
+    capabilities: ModelCapabilities = field(default_factory=ModelCapabilities)
 
-json_mode_models = [
-    "gpt-3.5-turbo",
-    "gpt-3.5-turbo-0125",
-    "gpt-3.5-turbo-1106",
-    "gpt-4-0125-preview",
-    "gpt-4-1106-preview",
-    "gpt-4-turbo",
-    "gpt-4-turbo-2024-04-09",
-    "gpt-4-turbo-preview",
-    "gpt-4-32k",
-    "gpt-4-32k-0613",
-]
 
-model_pricing = {
-    "gpt-4o-mini": {"input": 0.150 / 1e6, "output": 0.600 / 1e6},
-    "gpt-4o": {"input": 2.50 / 1e6, "output": 10.00 / 1e6},
-    "gpt-4-turbo": {"input": 10.00 / 1e6, "output": 30.00 / 1e6},
-    "gpt-4-turbo-preview": {"input": 10.00 / 1e6, "output": 30.00 / 1e6},
-    "gpt-4-0125-preview": {"input": 10.00 / 1e6, "output": 30.00 / 1e6},
-    "gpt-4-1106-preview": {"input": 10.00 / 1e6, "output": 30.00 / 1e6},
-    "gpt-4": {"input": 30.00 / 1e6, "output": 60.00 / 1e6},
-    "gpt-4-32k": {"input": 60.00 / 1e6, "output": 120.00 / 1e6},
-    "gpt-3.5-turbo-1106": {"input": 1.00 / 1e6, "output": 2.00 / 1e6},
-    "gpt-3.5-turbo": {"input": 0.50 / 1e6, "output": 1.50 / 1e6},
-    "gpt-3.5-turbo-16k": {"input": 3.00 / 1e6, "output": 4.00 / 1e6},
-    "gpt-3.5-turbo-0125": {"input": 0.50 / 1e6, "output": 1.50 / 1e6},
-    "gpt-3.5-turbo-instruct": {"input": 1.50 / 1e6, "output": 2.00 / 1e6},
-    "o1": {"input": 15.00 / 1e6, "output": 60.00 / 1e6},
-    "o1-preview": {"input": 15.00 / 1e6, "output": 60.00 / 1e6},
-    "o1-2024-12-17": {"input": 15.00 / 1e6, "output": 60.00 / 1e6},
-    "o3-mini": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
-    "o3-mini-2025-01-31": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
-    "o4-mini": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
-    "o4-mini-2025-04-16": {"input": 1.10 / 1e6, "output": 4.40 / 1e6},
-    "gpt-4.1": {
-        "input": 2.00 / 1e6,
-        "output": 8.00 / 1e6,
-    },
-    "gpt-4.1-mini": {
-        "input": 0.4 / 1e6,
-        "output": 1.60 / 1e6,
-    },
-    "gpt-4.1-nano": {
-        "input": 0.1 / 1e6,
-        "output": 0.4 / 1e6,
-    },
-    "gpt-4.5-preview": {
-        "input": 75.00 / 1e6,
-        "output": 150.00 / 1e6,
-    },
-    "gpt-5": {
-        "input": 1.25 / 1e6,
-        "output": 10.00 / 1e6,
-    },
-    "gpt-5-2025-08-07": {
-        "input": 1.25 / 1e6,
-        "output": 10.00 / 1e6,
-    },
-    "gpt-5-mini": {
-        "input": 0.25 / 1e6,
-        "output": 2.00 / 1e6,
-    },
-    "gpt-5-mini-2025-08-07": {
-        "input": 0.25 / 1e6,
-        "output": 2.00 / 1e6,
-    },
-    "gpt-5-nano": {
-        "input": 0.05 / 1e6,
-        "output": 0.40 / 1e6,
-    },
-    "gpt-5-nano-2025-08-07": {
-        "input": 0.05 / 1e6,
-        "output": 0.40 / 1e6,
-    },
-    "gpt-5-chat-latest": {
-        "input": 1.25 / 1e6,
-        "output": 10.00 / 1e6,
-    },
-}
+class OpenAIModel(Enum):
+    """Enumeration of supported OpenAI models with type safety and embedded configurations."""
 
+    # GPT-3.5 models
+    GPT_3_5_TURBO = OpenAIModelConfig(
+        name="gpt-3.5-turbo",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=0.50 / 1e6,
+            output_cost_per_token=1.50 / 1e6
+        )
+    )
+    GPT_3_5_TURBO_0125 = OpenAIModelConfig(
+        name="gpt-3.5-turbo-0125",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=0.50 / 1e6,
+            output_cost_per_token=1.50 / 1e6
+        )
+    )
+    GPT_3_5_TURBO_1106 = OpenAIModelConfig(
+        name="gpt-3.5-turbo-1106",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=1.00 / 1e6,
+            output_cost_per_token=2.00 / 1e6
+        )
+    )
+
+    # GPT-4 models
+    GPT_4_0125_PREVIEW = OpenAIModelConfig(
+        name="gpt-4-0125-preview",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=10.00 / 1e6,
+            output_cost_per_token=30.00 / 1e6
+        )
+    )
+    GPT_4_1106_PREVIEW = OpenAIModelConfig(
+        name="gpt-4-1106-preview",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=10.00 / 1e6,
+            output_cost_per_token=30.00 / 1e6
+        )
+    )
+    GPT_4_TURBO = OpenAIModelConfig(
+        name="gpt-4-turbo",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=10.00 / 1e6,
+            output_cost_per_token=30.00 / 1e6
+        )
+    )
+    GPT_4_TURBO_2024_04_09 = OpenAIModelConfig(
+        name="gpt-4-turbo-2024-04-09",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=10.00 / 1e6,
+            output_cost_per_token=30.00 / 1e6
+        )
+    )
+    GPT_4_TURBO_PREVIEW = OpenAIModelConfig(
+        name="gpt-4-turbo-preview",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=10.00 / 1e6,
+            output_cost_per_token=30.00 / 1e6
+        )
+    )
+    GPT_4_32K = OpenAIModelConfig(
+        name="gpt-4-32k",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=60.00 / 1e6,
+            output_cost_per_token=120.00 / 1e6
+        )
+    )
+    GPT_4_32K_0613 = OpenAIModelConfig(
+        name="gpt-4-32k-0613",
+        capabilities=ModelCapabilities(
+            supports_json_mode=True,
+            input_cost_per_token=60.00 / 1e6,
+            output_cost_per_token=120.00 / 1e6
+        )
+    )
+
+    # GPT-4o models
+    GPT_4O = OpenAIModelConfig(
+        name="gpt-4o",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=2.50 / 1e6,
+            output_cost_per_token=10.00 / 1e6
+        )
+    )
+    GPT_4O_2024_05_13 = OpenAIModelConfig(
+        name="gpt-4o-2024-05-13",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=2.50 / 1e6,
+            output_cost_per_token=10.00 / 1e6
+        )
+    )
+    GPT_4O_2024_08_06 = OpenAIModelConfig(
+        name="gpt-4o-2024-08-06",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=2.50 / 1e6,
+            output_cost_per_token=10.00 / 1e6
+        )
+    )
+    GPT_4O_2024_11_20 = OpenAIModelConfig(
+        name="gpt-4o-2024-11-20",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=2.50 / 1e6,
+            output_cost_per_token=10.00 / 1e6
+        )
+    )
+    GPT_4O_MINI = OpenAIModelConfig(
+        name="gpt-4o-mini",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=0.150 / 1e6,
+            output_cost_per_token=0.600 / 1e6
+        )
+    )
+    GPT_4O_MINI_2024_07_18 = OpenAIModelConfig(
+        name="gpt-4o-mini-2024-07-18",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=0.150 / 1e6,
+            output_cost_per_token=0.600 / 1e6
+        )
+    )
+
+    # GPT-4.1 models
+    GPT_4_1 = OpenAIModelConfig(
+        name="gpt-4.1",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=2.00 / 1e6,
+            output_cost_per_token=8.00 / 1e6
+        )
+    )
+    GPT_4_1_MINI = OpenAIModelConfig(
+        name="gpt-4.1-mini",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=0.4 / 1e6,
+            output_cost_per_token=1.60 / 1e6
+        )
+    )
+    GPT_4_1_NANO = OpenAIModelConfig(
+        name="gpt-4.1-nano",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            input_cost_per_token=0.1 / 1e6,
+            output_cost_per_token=0.4 / 1e6
+        )
+    )
+
+    # GPT-4.5 models
+    GPT_4_5_PREVIEW = OpenAIModelConfig(
+        name="gpt-4.5-preview",
+        capabilities=ModelCapabilities(
+            input_cost_per_token=75.00 / 1e6,
+            output_cost_per_token=150.00 / 1e6
+        )
+    )
+    GPT_4_5_PREVIEW_2025_02_27 = OpenAIModelConfig(
+        name="gpt-4.5-preview-2025-02-27",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            input_cost_per_token=75.00 / 1e6,
+            output_cost_per_token=150.00 / 1e6
+        )
+    )
+
+    # O1 models
+    O1 = OpenAIModelConfig(
+        name="o1",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=15.00 / 1e6,
+            output_cost_per_token=60.00 / 1e6
+        )
+    )
+    O1_PREVIEW = OpenAIModelConfig(
+        name="o1-preview",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            input_cost_per_token=15.00 / 1e6,
+            output_cost_per_token=60.00 / 1e6
+        )
+    )
+    O1_2024_12_17 = OpenAIModelConfig(
+        name="o1-2024-12-17",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=15.00 / 1e6,
+            output_cost_per_token=60.00 / 1e6
+        )
+    )
+    O1_PREVIEW_2024_09_12 = OpenAIModelConfig(
+        name="o1-preview-2024-09-12",
+        capabilities=ModelCapabilities(
+            supports_log_probs=False,
+            input_cost_per_token=15.00 / 1e6,
+            output_cost_per_token=60.00 / 1e6
+        )
+    )
+    O1_MINI = OpenAIModelConfig(
+        name="o1-mini",
+        capabilities=ModelCapabilities(
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=3.00 / 1e6,
+            output_cost_per_token=12.00 / 1e6
+        )
+    )
+    O1_MINI_2024_09_12 = OpenAIModelConfig(
+        name="o1-mini-2024-09-12",
+        capabilities=ModelCapabilities(
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=3.00 / 1e6,
+            output_cost_per_token=12.00 / 1e6
+        )
+    )
+
+    # O3 models
+    O3_MINI = OpenAIModelConfig(
+        name="o3-mini",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=1.10 / 1e6,
+            output_cost_per_token=4.40 / 1e6
+        )
+    )
+    O3_MINI_2025_01_31 = OpenAIModelConfig(
+        name="o3-mini-2025-01-31",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=1.10 / 1e6,
+            output_cost_per_token=4.40 / 1e6
+        )
+    )
+
+    # O4 models
+    O4_MINI = OpenAIModelConfig(
+        name="o4-mini",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=1.10 / 1e6,
+            output_cost_per_token=4.40 / 1e6
+        )
+    )
+    O4_MINI_2025_04_16 = OpenAIModelConfig(
+        name="o4-mini-2025-04-16",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=1.10 / 1e6,
+            output_cost_per_token=4.40 / 1e6
+        )
+    )
+
+    # GPT-5 models
+    GPT_5 = OpenAIModelConfig(
+        name="gpt-5",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=1.25 / 1e6,
+            output_cost_per_token=10.00 / 1e6
+        )
+    )
+    GPT_5_2025_08_07 = OpenAIModelConfig(
+        name="gpt-5-2025-08-07",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=1.25 / 1e6,
+            output_cost_per_token=10.00 / 1e6
+        )
+    )
+    GPT_5_MINI = OpenAIModelConfig(
+        name="gpt-5-mini",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=0.25 / 1e6,
+            output_cost_per_token=2.00 / 1e6
+        )
+    )
+    GPT_5_MINI_2025_08_07 = OpenAIModelConfig(
+        name="gpt-5-mini-2025-08-07",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=0.25 / 1e6,
+            output_cost_per_token=2.00 / 1e6
+        )
+    )
+    GPT_5_NANO = OpenAIModelConfig(
+        name="gpt-5-nano",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=0.05 / 1e6,
+            output_cost_per_token=0.40 / 1e6
+        )
+    )
+    GPT_5_NANO_2025_08_07 = OpenAIModelConfig(
+        name="gpt-5-nano-2025-08-07",
+        capabilities=ModelCapabilities(
+            supports_structured_outputs=True,
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=0.05 / 1e6,
+            output_cost_per_token=0.40 / 1e6
+        )
+    )
+    GPT_5_CHAT_LATEST = OpenAIModelConfig(
+        name="gpt-5-chat-latest",
+        capabilities=ModelCapabilities(
+            supports_log_probs=False,
+            requires_temperature_1=True,
+            input_cost_per_token=1.25 / 1e6,
+            output_cost_per_token=10.00 / 1e6
+        )
+    )
+
+    @classmethod
+    def from_name(cls, name: str) -> Optional['OpenAIModel']:
+        """Get OpenAIModel enum from model name string."""
+        for model in cls:
+            if model.value.name == name:
+                return model
+        return None
+
+
+# Default model
 default_gpt_model = "gpt-4.1"
 
-# Thinking models that require temperature=1
-models_requiring_temperature_1 = [
-    "o1",
-    "o1-2024-12-17",
-    "o1-mini",
-    "o1-mini-2024-09-12",
-    "o3-mini",
-    "o3-mini-2025-01-31",
-    "o4-mini",
-    "o4-mini-2025-04-16",
-    "gpt-5",
-    "gpt-5-2025-08-07",
-    "gpt-5-mini",
-    "gpt-5-mini-2025-08-07",
-    "gpt-5-nano"
-    "gpt-5-nano-2025-08-07",
-    "gpt-5-chat-latest",
-]
+# Helper functions for backward compatibility
+def get_model_config(model_name: str) -> Optional[OpenAIModelConfig]:
+    """Get model configuration from enum or return None if not found."""
+    model_enum = OpenAIModel.from_name(model_name)
+    return model_enum.value if model_enum else None
+
+# Backward compatibility - create MODEL_REGISTRY from enum values
+MODEL_REGISTRY: Dict[str, OpenAIModelConfig] = {
+    model.value.name: model.value for model in OpenAIModel
+}
+
 
 retryable_exceptions = (
     openai.RateLimitError,
@@ -220,15 +430,51 @@ retryable_exceptions = (
 )
 
 
+# Helper functions for backward compatibility
+def get_model_capabilities(model_name: str) -> ModelCapabilities:
+    """Get capabilities for a model, returning defaults if not in registry."""
+    if model_name in MODEL_REGISTRY:
+        return MODEL_REGISTRY[model_name].capabilities
+    return ModelCapabilities()
+
+# Export lists for backward compatibility
+structured_outputs_models = [
+    name for name, config in MODEL_REGISTRY.items()
+    if config.capabilities.supports_structured_outputs
+]
+
+json_mode_models = [
+    name for name, config in MODEL_REGISTRY.items()
+    if config.capabilities.supports_json_mode
+]
+
+unsupported_log_probs_gpt_models = [
+    name for name, config in MODEL_REGISTRY.items()
+    if not config.capabilities.supports_log_probs
+]
+
+model_pricing = {
+    name: {
+        "input": config.capabilities.input_cost_per_token or 0,
+        "output": config.capabilities.output_cost_per_token or 0
+    }
+    for name, config in MODEL_REGISTRY.items()
+    if config.capabilities.input_cost_per_token is not None
+}
+
+
 class GPTModel(DeepEvalBaseLLM):
     def __init__(
         self,
-        model: Optional[str] = None,
+        model: Optional[Union[str, OpenAIModel]] = None,
         _openai_api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         cost_per_input_token: Optional[float] = None,
         cost_per_output_token: Optional[float] = None,
         temperature: float = 0,
+        supports_structured_outputs: Optional[bool] = None,
+        supports_json_mode: Optional[bool] = None,
+        supports_log_probs: Optional[bool] = None,
         **kwargs,
     ):
         model_name = None
@@ -250,16 +496,41 @@ class GPTModel(DeepEvalBaseLLM):
             )
         )
 
-        if isinstance(model, str):
+        # Handle both enum and string model inputs
+        if model:
             model_name = parse_model_name(model)
-            if model_name not in valid_gpt_models:
-                raise ValueError(
-                    f"Invalid model. Available GPT models: {', '.join(model for model in valid_gpt_models)}"
+            # Try to find in enum first
+            model_enum = OpenAIModel.from_name(model_name)
+            if model_enum:
+                self.model_config = model_enum.value
+            else:
+                # Create a default configuration for unknown models
+                self.model_config = OpenAIModelConfig(
+                    name=model_name,
+                    capabilities=ModelCapabilities(
+                        supports_structured_outputs=supports_structured_outputs or False,
+                        supports_json_mode=supports_json_mode or False,
+                        supports_log_probs=supports_log_probs if supports_log_probs is not None else True,
+                        input_cost_per_token=cost_per_input_token,
+                        output_cost_per_token=cost_per_output_token
+                    )
                 )
+                logging.info(f"Using model '{model_name}' not in registry. Using provided or default capabilities.")
         elif model is None:
             model_name = default_gpt_model
+            # Default to gpt-4.1
+            self.model_config = OpenAIModel.GPT_4_1.value
 
-        if model_name not in model_pricing:
+        # Override capabilities if explicitly provided
+        if supports_structured_outputs is not None:
+            self.model_config.capabilities.supports_structured_outputs = supports_structured_outputs
+        if supports_json_mode is not None:
+            self.model_config.capabilities.supports_json_mode = supports_json_mode
+        if supports_log_probs is not None:
+            self.model_config.capabilities.supports_log_probs = supports_log_probs
+
+        # Handle pricing
+        if self.model_config.capabilities.input_cost_per_token is None or self.model_config.capabilities.output_cost_per_token is None:
             if cost_per_input_token is None or cost_per_output_token is None:
                 raise ValueError(
                     f"No pricing available for `{model_name}`. "
@@ -268,20 +539,14 @@ class GPTModel(DeepEvalBaseLLM):
                     "    deepeval set-openai --model=[...] --cost_per_input_token=[...] --cost_per_output_token=[...]"
                 )
             else:
-                model_pricing[model_name] = {
-                    "input": float(cost_per_input_token),
-                    "output": float(cost_per_output_token),
-                }
-
-        elif model is None:
-            model_name = default_gpt_model
+                self.model_config.capabilities.input_cost_per_token = float(cost_per_input_token)
+                self.model_config.capabilities.output_cost_per_token = float(cost_per_output_token)
 
         self._openai_api_key = _openai_api_key
         self.base_url = base_url
-        # args and kwargs will be passed to the underlying model, in load_model function
 
         # Auto-adjust temperature for models that require it
-        if model_name in models_requiring_temperature_1:
+        if self.model_config.capabilities.requires_temperature_1:
             temperature = 1
 
         if temperature < 0:
@@ -304,7 +569,7 @@ class GPTModel(DeepEvalBaseLLM):
     ) -> Tuple[Union[str, Dict], float]:
         client = self.load_model(async_mode=False)
         if schema:
-            if self.model_name in structured_outputs_models:
+            if self.model_config.capabilities.supports_structured_outputs:
                 completion = client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -321,7 +586,7 @@ class GPTModel(DeepEvalBaseLLM):
                     completion.usage.completion_tokens,
                 )
                 return structured_output, cost
-            if self.model_name in json_mode_models:
+            if self.model_config.capabilities.supports_json_mode:
                 completion = client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -364,7 +629,7 @@ class GPTModel(DeepEvalBaseLLM):
     ) -> Tuple[Union[str, BaseModel], float]:
         client = self.load_model(async_mode=True)
         if schema:
-            if self.model_name in structured_outputs_models:
+            if self.model_config.capabilities.supports_structured_outputs:
                 completion = await client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -381,7 +646,7 @@ class GPTModel(DeepEvalBaseLLM):
                     completion.usage.completion_tokens,
                 )
                 return structured_output, cost
-            if self.model_name in json_mode_models:
+            if self.model_config.capabilities.supports_json_mode:
                 completion = await client.beta.chat.completions.parse(
                     model=self.model_name,
                     messages=[
@@ -430,13 +695,18 @@ class GPTModel(DeepEvalBaseLLM):
     ) -> Tuple[ChatCompletion, float]:
         # Generate completion
         client = self.load_model(async_mode=False)
-        completion = client.chat.completions.create(
-            model=self.model_name,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=self.temperature,
-            logprobs=True,
-            top_logprobs=top_logprobs,
-        )
+        completion_kwargs = {
+            "model": self.model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": self.temperature,
+        }
+
+        # Only add logprobs if the model supports it
+        if self.model_config.capabilities.supports_log_probs:
+            completion_kwargs["logprobs"] = True
+            completion_kwargs["top_logprobs"] = top_logprobs
+
+        completion = client.chat.completions.create(**completion_kwargs)
         # Cost calculation
         input_tokens = completion.usage.prompt_tokens
         output_tokens = completion.usage.completion_tokens
@@ -456,13 +726,18 @@ class GPTModel(DeepEvalBaseLLM):
     ) -> Tuple[ChatCompletion, float]:
         # Generate completion
         client = self.load_model(async_mode=True)
-        completion = await client.chat.completions.create(
-            model=self.model_name,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=self.temperature,
-            logprobs=True,
-            top_logprobs=top_logprobs,
-        )
+        completion_kwargs = {
+            "model": self.model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": self.temperature,
+        }
+
+        # Only add logprobs if the model supports it
+        if self.model_config.capabilities.supports_log_probs:
+            completion_kwargs["logprobs"] = True
+            completion_kwargs["top_logprobs"] = top_logprobs
+
+        completion = await client.chat.completions.create(**completion_kwargs)
         # Cost calculation
         input_tokens = completion.usage.prompt_tokens
         output_tokens = completion.usage.completion_tokens
@@ -493,9 +768,8 @@ class GPTModel(DeepEvalBaseLLM):
     ###############################################
 
     def calculate_cost(self, input_tokens: int, output_tokens: int) -> float:
-        pricing = model_pricing.get(self.model_name, model_pricing)
-        input_cost = input_tokens * pricing["input"]
-        output_cost = output_tokens * pricing["output"]
+        input_cost = input_tokens * (self.model_config.capabilities.input_cost_per_token or 0)
+        output_cost = output_tokens * (self.model_config.capabilities.output_cost_per_token or 0)
         return input_cost + output_cost
 
     ###############################################


### PR DESCRIPTION
I haven't done the final cleanup and test yet but wanted feedback if this is a welcome change first. It leaves the old capability lists intact for backwards compatibility 

1) Lets me use any OpenAI model, even if it's not in the list. This was a recurring problem I have when new models roll out and I don't want to wait on a deepeval release to add it to the list.
2) Reorganizes the capability lists into enums so we state each model once alongside their capabilities. The old lists are still available for backwards compatibility.