### PR TITLE
fix(openai_model): add missing commas in model lists to prevent silen…

### DIFF
--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -107,8 +107,8 @@ structured_outputs_models = [
     "gpt-5-2025-08-07",
     "gpt-5-mini",
     "gpt-5-mini-2025-08-07",
-    "gpt-5-nano"
-    "gpt-5-nano-2025-08-07"
+    "gpt-5-nano",
+    "gpt-5-nano-2025-08-07",
 ]
 
 json_mode_models = [
@@ -207,7 +207,7 @@ models_requiring_temperature_1 = [
     "gpt-5-2025-08-07",
     "gpt-5-mini",
     "gpt-5-mini-2025-08-07",
-    "gpt-5-nano"
+    "gpt-5-nano",
     "gpt-5-nano-2025-08-07",
     "gpt-5-chat-latest",
 ]


### PR DESCRIPTION
…t string concatenation

Python concatenates adjacent string literals; without commas the lists `structured_outputs_models` and `models_requiring_temperature_1` accidentally merged two entries into one. This can cause model-name capability checks to behave incorrectly.

No behavioral changes beyond the fix. Ran black on the file.