### PR TITLE
fix(openai): write input/output token costs to correct keys in CLI

### DIFF
--- a/deepeval/cli/main.py
+++ b/deepeval/cli/main.py
@@ -176,10 +176,10 @@ def set_openai_env(
     KEY_FILE_HANDLER.write_key(ModelKeyValues.USE_OPENAI_MODEL, "YES")
     KEY_FILE_HANDLER.write_key(ModelKeyValues.OPENAI_MODEL_NAME, model)
     KEY_FILE_HANDLER.write_key(
-        ModelKeyValues.OPENAI_COST_PER_INPUT_TOKEN, str(cost_per_output_token)
+        ModelKeyValues.OPENAI_COST_PER_INPUT_TOKEN, str(cost_per_input_token)
     )
     KEY_FILE_HANDLER.write_key(
-        ModelKeyValues.OPENAI_COST_PER_OUTPUT_TOKEN, str(cost_per_input_token)
+        ModelKeyValues.OPENAI_COST_PER_OUTPUT_TOKEN, str(cost_per_output_token)
     )
     print(
         f":raising_hands: Congratulations! You're now using OpenAI's `{model}` for all evals that require an LLM."


### PR DESCRIPTION
## What was fixed

The set-openai CLI wrote cost_per_input_token to OPENAI_COST_PER_OUTPUT_TOKEN and vice‑versa. This swaps them back to the correct keys.

## Why this needed to be fixed

Incorrect key mapping leads to misreported cost accounting and any downstream logic that reads these values will be inverted.

## How I tested the fix

```
dustfinger@primus:~/dev/deepeval$ poetry run deepeval set-openai \
  --model gpt-4o-mini \
  --cost_per_input_token 0.0005 \
  --cost_per_output_token 0.0015
🙌 Congratulations! You're now using OpenAI's `gpt-4o-mini` for all evals that require an LLM.
dustfinger@primus:~/dev/deepeval$ grep OPENAI_COST_PER_ .deepeval/.deepeval
{"USE_OPENAI_MODEL": "YES", "OPENAI_MODEL_NAME": "gpt-4o-mini", "OPENAI_COST_PER_INPUT_TOKEN": "0.0005", "OPENAI_COST_PER_OUTPUT_TOKEN": "0.0015"}
dustfinger@primus:~/dev/deepeval$ 
```