### PR TITLE
📝 Import `ConversationalGEval` in code example

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -110,7 +110,7 @@ Run `touch test_example.py` in your terminal and paste in the following code:
 ```python title="test_example.py"
 from deepeval import assert_test
 from deepeval.test_case import Turn, ConversationalTestCase
-from deepeval.metrics import GEval
+from deepeval.metrics import ConversationalGEval
 
 def test_professionalism():
     professionalism_metric = ConversationalGEval(


### PR DESCRIPTION
The "Multi-Turn" tab on the "Getting Started" includes a code example. Currently this code example does not work properly because it uses `ConversationalGEval`, which is never imported. These changes replace the unused `GEval` import with `ConversationalGEval`, which is presumably what was intended originally. This fixes the code example so that it works properly.