### PR TITLE
Improve polymorphism of DeepEvalBaseBenchmark

### DIFF
--- a/deepeval/benchmarks/arc/arc.py
+++ b/deepeval/benchmarks/arc/arc.py
@@ -48,7 +48,7 @@ class ARC(DeepEvalBaseBenchmark):
         else:
             self.confinement_instructions = confinement_instructions
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("ARC", self.n_problems):

--- a/deepeval/benchmarks/base_benchmark.py
+++ b/deepeval/benchmarks/base_benchmark.py
@@ -1,3 +1,4 @@
+from deepeval.models.base_model import DeepEvalBaseLLM
 from abc import ABC, abstractmethod
 from typing import List, TypeVar, Generic, List, Optional
 
@@ -17,4 +18,9 @@ class DeepEvalBaseBenchmark(ABC, Generic[T]):
     @abstractmethod
     def load_benchmark_dataset(self, *args, **kwargs) -> List[Golden]:
         """Load the benchmark dataset and initialize tasks."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> dict:
+        """Evaluate the tasks and return the results."""
         raise NotImplementedError

--- a/deepeval/benchmarks/bbq/bbq.py
+++ b/deepeval/benchmarks/bbq/bbq.py
@@ -39,7 +39,7 @@ class BBQ(DeepEvalBaseBenchmark):
         else:
             self.confinement_instructions = confinement_instructions
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("BBQ", len(self.tasks)):

--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -76,7 +76,7 @@ class BigBenchHard(DeepEvalBaseBenchmark):
             self.confinement_instructions_dict = confinement_instructions_dict
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, batch_size: Optional[int] = None
+        self, model: DeepEvalBaseLLM, *args, batch_size: Optional[int] = None, **kwargs
     ) -> Dict:
         import pandas as pd
 

--- a/deepeval/benchmarks/bool_q/bool_q.py
+++ b/deepeval/benchmarks/bool_q/bool_q.py
@@ -37,7 +37,7 @@ class BoolQ(DeepEvalBaseBenchmark):
         else:
             self.confinement_instructions = confinement_instructions
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("BoolQ", self.n_problems):

--- a/deepeval/benchmarks/drop/drop.py
+++ b/deepeval/benchmarks/drop/drop.py
@@ -44,7 +44,7 @@ class DROP(DeepEvalBaseBenchmark):
         self.verbose_mode: bool = verbose_mode
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, batch_size: Optional[int] = None
+        self, self, model: DeepEvalBaseLLM, *args, batch_size: int | None = None, **kwargs
     ) -> Dict:
         import pandas as pd
 

--- a/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
+++ b/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
@@ -34,7 +34,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
             initialize_model(model)
         )
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("EquityMedQA", len(self.tasks)):

--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -39,7 +39,7 @@ class GSM8K(DeepEvalBaseBenchmark):
         else:
             self.confinement_instructions = confinement_instructions
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("GSM8K", len(self.tasks)):

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -45,7 +45,7 @@ class HellaSwag(DeepEvalBaseBenchmark):
             self.confinement_instructions = confinement_instructions
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, batch_size: Optional[int] = None
+        self, model: DeepEvalBaseLLM, *args, batch_size: int | None = None, **kwargs
     ) -> Dict:
         import pandas as pd
 

--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -91,7 +91,7 @@ class HumanEval(DeepEvalBaseBenchmark):
         self.overall_score: Optional[float] = None
         self.verbose_mode: bool = (False,)
 
-    def evaluate(self, model: DeepEvalBaseLLM, k: int) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, k: int = 1, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("HumanEval", len(self.tasks)):

--- a/deepeval/benchmarks/ifeval/ifeval.py
+++ b/deepeval/benchmarks/ifeval/ifeval.py
@@ -403,7 +403,7 @@ class IFEval(DeepEvalBaseBenchmark):
         self.overall_score = None
         self.instruction_breakdown = None
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("IFEval", self.n_problems or "all"):

--- a/deepeval/benchmarks/lambada/lambada.py
+++ b/deepeval/benchmarks/lambada/lambada.py
@@ -37,7 +37,7 @@ class LAMBADA(DeepEvalBaseBenchmark):
         else:
             self.confinement_instructions = confinement_instructions
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("LAMBADA", self.n_problems):

--- a/deepeval/benchmarks/logi_qa/logi_qa.py
+++ b/deepeval/benchmarks/logi_qa/logi_qa.py
@@ -46,7 +46,7 @@ class LogiQA(DeepEvalBaseBenchmark):
             self.confinement_instructions = confinement_instructions
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, batch_size: Optional[int] = None
+        self, model: DeepEvalBaseLLM, *args, batch_size: int | None = None, **kwargs
     ) -> Dict:
         import pandas as pd
 

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -44,7 +44,7 @@ class MathQA(DeepEvalBaseBenchmark):
             self.confinement_instructions = confinement_instructions
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, batch_size: Optional[int] = None
+        self, model: DeepEvalBaseLLM, *args, batch_size: int | None = None, **kwargs
     ) -> Dict:
         import pandas as pd
 

--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -43,7 +43,7 @@ class MMLU(DeepEvalBaseBenchmark):
             self.confinement_instructions = confinement_instructions
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, batch_size: Optional[int] = None
+        self, model: DeepEvalBaseLLM, *args, batch_size: int | None = None, **kwargs
     ) -> Dict:
         import pandas as pd
 

--- a/deepeval/benchmarks/squad/squad.py
+++ b/deepeval/benchmarks/squad/squad.py
@@ -45,7 +45,7 @@ class SQuAD(DeepEvalBaseBenchmark):
         else:
             self.confinement_instructions = confinement_instructions
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("SQuAD", len(self.tasks)):

--- a/deepeval/benchmarks/truthful_qa/truthful_qa.py
+++ b/deepeval/benchmarks/truthful_qa/truthful_qa.py
@@ -53,7 +53,7 @@ class TruthfulQA(DeepEvalBaseBenchmark):
             self.confinement_instructions_dict = confinement_instructions_dict
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, batch_size: Optional[int] = None
+        self, model: DeepEvalBaseLLM, *args, batch_size: int | None = None, **kwargs
     ) -> Dict:
         import pandas as pd
 

--- a/deepeval/benchmarks/winogrande/winogrande.py
+++ b/deepeval/benchmarks/winogrande/winogrande.py
@@ -37,7 +37,7 @@ class Winogrande(DeepEvalBaseBenchmark):
         else:
             self.confinement_instructions = confinement_instructions
 
-    def evaluate(self, model: DeepEvalBaseLLM) -> Dict:
+    def evaluate(self, model: DeepEvalBaseLLM, *args, **kwargs) -> Dict:
         import pandas as pd
 
         with capture_benchmark_run("Winogrande", self.n_problems):


### PR DESCRIPTION

Currently, every instance of `DeepEvalBaseLLM` is expected to have an `evaluate` api that takes in a required `model` argument and then uses that model to output a dict.

This PR just codifies the interfaces and adds `kwargs` so that a script can call any benchmark with arbitrary kwargs (that may not apply to this benchmark, such as `batch_size`).

The main use case of this is suppose we have a list of benchmarks

```
benchmarks: list[DeepEvalBaseBenchmark] = [TruthfulQA(), SQuAD()]
kwargs = {"batch_size": 3}
chosen_benchmark_idx: int = ...
model = ...

benchmarks[chosen_benchmark_idx].evaluate(model, **kwargs)
```

This will allow us to run `SQuAD`, which does **NOT** have a `batch_size` argument without crashing, and if we choose to run `TruthfulQA`, then the `batch_size` will be parsed in the function.
