### PR TITLE
fix: Fix duplicate items in synthesizer generation

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -124,6 +124,7 @@ class Synthesizer:
         context_construction_config: Optional[ContextConstructionConfig] = None,
         _send_data=True,
     ):
+        self.synthetic_goldens = []
         self.synthesis_cost = 0 if self.using_native_model else None
         if context_construction_config is None:
             context_construction_config = ContextConstructionConfig(
@@ -204,7 +205,6 @@ class Synthesizer:
                     _send_data=False,
                     _reset_cost=False,
                 )
-                self.synthetic_goldens.extend(goldens)
                 if self.cost_tracking and self.using_native_model:
                     print(f"💰 API cost: {self.synthesis_cost:.6f}")
                 if _send_data == True:
@@ -297,7 +297,6 @@ class Synthesizer:
                 _pbar_id=pbar_id,
                 _reset_cost=False,
             )
-            self.synthetic_goldens.extend(goldens)
             if _reset_cost and self.cost_tracking and self.using_native_model:
                 print(f"💰 API cost: {self.synthesis_cost:.6f}")
             remove_pbars(
@@ -328,6 +327,7 @@ class Synthesizer:
         _reset_cost: bool = True,
     ) -> List[Golden]:
         if _reset_cost:
+            self.synthetic_goldens = []
             self.synthesis_cost = 0 if self.using_native_model else None
         goldens: List[Golden] = []
 
@@ -516,6 +516,7 @@ class Synthesizer:
         _reset_cost: bool = True,
     ) -> List[Golden]:
         if _reset_cost:
+            self.synthetic_goldens = []
             self.synthesis_cost = 0 if self.using_native_model else None
         semaphore = asyncio.Semaphore(self.max_concurrent)
         goldens: List[Golden] = []
@@ -716,7 +717,6 @@ class Synthesizer:
             + [pbar_generate_inputs_id, pbar_generate_goldens_id],
         )
         goldens.extend(results)
-        self.synthetic_goldens.extend(goldens)
 
     async def _a_generate_text_to_sql_from_context(
         self,
@@ -849,6 +849,7 @@ class Synthesizer:
             raise TypeError(
                 "`scenario`, `task`, and `input_format` in `styling_config` must not be None when generation goldens from scratch."
             )
+        self.synthetic_goldens = []
         self.synthesis_cost = 0 if self.using_native_model else None
 
         transformed_evolutions = self.transform_distribution(
@@ -913,7 +914,6 @@ class Synthesizer:
         self.synthetic_goldens.extend(goldens)
         if _send_data == True:
             pass
-        self.synthetic_goldens.extend(goldens)
         return goldens
 
     def transform_distribution(
@@ -947,6 +947,7 @@ class Synthesizer:
         max_goldens_per_golden: int = 2,
         include_expected_output: bool = True,
     ) -> List[Golden]:
+        self.synthetic_goldens = []
         if self.async_mode:
             loop = get_or_create_event_loop()
             return loop.run_until_complete(


### PR DESCRIPTION
## Problem

When using synthesizer.generate_goldens_from_docs(), the generated testset contained duplicate items where each item appeared twice. This was causing the actual testset size to be double the expected size.

## Root Cause

The issue was caused by:
1. The self.synthetic_goldens list not being reset at the beginning of generation methods
2. Multiple redundant extend() calls in the call chain that were adding the same goldens multiple times

## Solution

Following the maintainer's feedback to "reset the list each time", this PR implements a comprehensive fix:

### 1. Reset Points Added (5 locations):

- Line 127: generate_goldens_from_docs - Always resets at start
- Line 330: generate_goldens_from_contexts - Resets when _reset_cost=True
- Line 519: a_generate_goldens_from_contexts - Resets when _reset_cost=True
- Line 852: generate_goldens_from_scratch - Always resets at start
- Line 950: generate_goldens_from_goldens - Always resets at start

### 2. Duplicate Extends Removed (4 locations):

- Lines 207: Removed duplicate extend in generate_goldens_from_docs
- Lines 300: Removed duplicate extend in a_generate_goldens_from_docs
- Lines 719: Removed duplicate extend in _a_generate_from_context
- Line 916: Removed duplicate line in generate_goldens_from_scratch

## Why Both Changes Are Needed

- Resets: Ensure each generation starts with a clean state, preventing accumulation from previous runs
- Removing duplicates: Prevents the same goldens from being added multiple times within a single generation flow
- _reset_cost parameter: Controls when to reset - True for direct user calls, False for internal nested calls

## Testing

Tested with the following code and confirmed no duplicates are generated:

```python
synthesizer.generate_goldens_from_docs(
    document_paths=['example.txt'],
    context_construction_config=ContextConstructionConfig()
)
```

Result: Each item appears exactly once ✅

## Impact

- Users get a fresh list for each generation while maintaining stateful access
- No duplicate items in the generated testset
- Clean and predictable behavior across all generation methods

Fixes #1925 