### PR TITLE
LiteLLMModel - max retry and proxy environment variables

### DIFF
--- a/deepeval/models/llms/litellm_model.py
+++ b/deepeval/models/llms/litellm_model.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 import logging
 from tenacity import (
     retry,
+    stop_after_attempt,
     retry_if_exception_type,
     wait_exponential_jitter,
     RetryCallState,
@@ -28,6 +29,12 @@ retryable_exceptions = (
 
 
 class LiteLLMModel(DeepEvalBaseLLM):
+    EXP_BASE: int = 2
+    INITIAL_WAIT: int = 1
+    JITTER: int = 2
+    MAX_RETRIES: int = 6
+    MAX_WAIT: int = 10
+    
     def __init__(
         self,
         model: Optional[str] = None,
@@ -51,6 +58,7 @@ class LiteLLMModel(DeepEvalBaseLLM):
         self.api_key = (
             api_key
             or KEY_FILE_HANDLER.fetch_data(ModelKeyValues.LITELLM_API_KEY)
+            or os.getenv("LITELLM_PROXY_API_KEY")
             or os.getenv("OPENAI_API_KEY")
             or os.getenv("ANTHROPIC_API_KEY")
             or os.getenv("GOOGLE_API_KEY")
@@ -61,6 +69,7 @@ class LiteLLMModel(DeepEvalBaseLLM):
             api_base
             or KEY_FILE_HANDLER.fetch_data(ModelKeyValues.LITELLM_API_BASE)
             or os.getenv("LITELLM_API_BASE")
+            or os.getenv("LITELLM_PROXY_API_BASE")
         )
 
         if temperature < 0:
@@ -71,7 +80,8 @@ class LiteLLMModel(DeepEvalBaseLLM):
         super().__init__(model_name)
 
     @retry(
-        wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
+        wait=wait_exponential_jitter(initial=INITIAL_WAIT, exp_base=EXP_BASE, jitter=JITTER, max=MAX_WAIT),
+        stop=stop_after_attempt(MAX_RETRIES),
         retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
@@ -116,7 +126,8 @@ class LiteLLMModel(DeepEvalBaseLLM):
             raise e
 
     @retry(
-        wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
+        wait=wait_exponential_jitter(initial=INITIAL_WAIT, exp_base=EXP_BASE, jitter=JITTER, max=MAX_WAIT),
+        stop=stop_after_attempt(MAX_RETRIES),
         retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
@@ -161,7 +172,8 @@ class LiteLLMModel(DeepEvalBaseLLM):
             raise e
 
     @retry(
-        wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
+        wait=wait_exponential_jitter(initial=INITIAL_WAIT, exp_base=EXP_BASE, jitter=JITTER, max=MAX_WAIT),
+        stop=stop_after_attempt(MAX_RETRIES),
         retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
@@ -193,7 +205,8 @@ class LiteLLMModel(DeepEvalBaseLLM):
             return None, 0.0  # Return 0.0 cost on error
 
     @retry(
-        wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
+        wait=wait_exponential_jitter(initial=INITIAL_WAIT, exp_base=EXP_BASE, jitter=JITTER, max=MAX_WAIT),
+        stop=stop_after_attempt(MAX_RETRIES),
         retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )
@@ -225,7 +238,8 @@ class LiteLLMModel(DeepEvalBaseLLM):
             return None, 0.0  # Return 0.0 cost on error
 
     @retry(
-        wait=wait_exponential_jitter(initial=1, exp_base=2, jitter=2, max=10),
+        wait=wait_exponential_jitter(initial=INITIAL_WAIT, exp_base=EXP_BASE, jitter=JITTER, max=MAX_WAIT),
+        stop=stop_after_attempt(MAX_RETRIES),
         retry=retry_if_exception_type(retryable_exceptions),
         after=log_retry_error,
     )


### PR DESCRIPTION
Max retry - current implementation has not stop condition, so in case of error it will be executed indefinitely.
I've set max retry to 6 - I assume you will change it, based on your experience.

Additionally, I've added support of LiteLLM proxy environment variables.

Finally, I moved retry related values to class level variables, to make future change more simple.