### PR TITLE
ContextualRelevancy - handling issue with context containing no statements

### DIFF
--- a/deepeval/metrics/contextual_relevancy/template.py
+++ b/deepeval/metrics/contextual_relevancy/template.py
@@ -44,7 +44,8 @@ JSON:
 You should first extract statements found in the context, which are high level information found in the context, before deciding on a verdict and optionally a reason for each statement.
 The 'verdict' key should STRICTLY be either 'yes' or 'no', and states whether the statement is relevant to the input.
 Provide a 'reason' ONLY IF verdict is no. You MUST quote the irrelevant parts of the statement to back up your reason.
-
+If provided context contains no actual content or statements then: give \"no\" as a \"verdict\",
+put context into \"statement\", and \"No statements found in provided context.\" into \"reason\".
 **
 IMPORTANT: Please make sure to only return in JSON format.
 Example Context: "Einstein won the Nobel Prize for his discovery of the photoelectric effect. He won the Nobel Prize in 1968. There was a cat."


### PR DESCRIPTION
ContextualRelevancy metric is failing, if there is a `retrieval_context` item with no relevant information.
LLM returns no json in response, so the metric cannot be evaluated and properly parsed to `ContextualRelevancyVerdicts`.

## Sample Code Of Failing Test Case

Sample code uses LiteLLM and AWS Bedrock to call Anthropic Claude Sonnet 3.7.
First `retrieval_context` is some valid context generated previously by LLM.
Second `retrieval_context` contains no relevant information, just some numbers and characters.

```python
from deepeval import evaluate
from deepeval.models import LiteLLMModel
from deepeval.metrics import ContextualRelevancyMetric
from deepeval.test_case import LLMTestCase
from deepeval.evaluate.configs import DisplayConfig

model = LiteLLMModel(
    model = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
)

metric = ContextualRelevancyMetric(model=model, include_reason=False)

test_case = LLMTestCase(
    input="Can I put customer data on a thumbdrive?",
    retrieval_context=[
        (
            "# Customer data must not be stored on thumb drives or any other unencrypted "
            "removable media. Exceptions require written approval from the Data Protection "
            "Officer and must use company-approved encryption methods."
        ),
        "# !-- LOC: 12, (48,756,614,786) --\u003E"
    ],
)

evaluate(
    test_cases=[test_case],
    metrics=[metric],
    display_config=DisplayConfig(verbose_mode=True)
)
```
## LLM Response (before change, no json)
```json
{
    "choices": [
        {
            "finish_reason": "stop",     
            "message": {
                "content": "I'll analyze the statements in the context and determine their relevance to the input question about putting customer data on a thumbdrive.\n\nHowever, I notice that the context provided appears to be incomplete or contains only a location reference (\"LOC: 12, (48,756,614,786)\") without any actual content about customer data policies or thumb drives.\n\nWithout substantive statements in the context to evaluate, I cannot generate meaningful verdicts. I need actual statements from the context that discuss data handling policies, thumb drives, customer data, or related information.\n\nCould you please provide the complete context with the actual text content so I can properly evaluate the relevance of statements to your question about putting customer data on a thumbdrive?",
                "role": "assistant"
            }
        }
    ]
}
```

## LLM Response (after change, valid json)
```json
{
    "choices": [
        {
            "finish_reason": "tool_calls",
            "message": {
                "content": "{\"verdicts\": [{\"verdict\": \"no\", \"statement\": \"# !-- LOC: 12, (48,756,614,786) -->\", \"reason\": \"No statements found in provided context. The context only contains what appears to be a location or formatting marker rather than actual content about data handling policies.\"}]}",
                "role": "assistant",
            }
        }
    ]
}
```

