### PR TITLE
fix(telemetry): respect opt-out and ensure dir exists before writing

### DIFF
--- a/deepeval/telemetry.py
+++ b/deepeval/telemetry.py
@@ -133,7 +133,7 @@ if not telemetry_opt_out():
 if (
     os.getenv("ERROR_REPORTING") == "YES"
     and not blocked_by_firewall()
-    and not os.getenv("TELEMETRY_OPT_OUT")
+    and not telemetry_opt_out()
 ):
 
     def handle_exception(exc_type, exc_value, exc_traceback):
@@ -571,6 +571,12 @@ def read_telemetry_file() -> dict:
 
 def write_telemetry_file(data: dict):
     """Writes the given key-value pairs to the telemetry data file."""
+    # respect opt out
+    if telemetry_opt_out():
+        return
+
+    # ensure directory exists before write
+    os.makedirs(HIDDEN_DIR, exist_ok=True)
     with open(TELEMETRY_PATH, "w") as file:
         for key, value in data.items():
             file.write(f"{key}={value}\n")
@@ -584,6 +590,9 @@ def get_status() -> str:
 
 def get_unique_id() -> str:
     """Gets or generates a unique ID and updates the telemetry file."""
+    # respect opt out
+    if telemetry_opt_out():
+        return "telemetry-opted-out"
     data = read_telemetry_file()
     unique_id = data.get("DEEPEVAL_ID")
     if not unique_id:

--- a/tests/test_core/test_telemetry.py
+++ b/tests/test_core/test_telemetry.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+import deepeval.telemetry as telemetry_mod
+
+
+def test_telemetry_writes_create_dir_when_missing(tmp_path, monkeypatch):
+    # Ensure opt-out is not set
+    monkeypatch.delenv("DEEPEVAL_TELEMETRY_OPT_OUT", raising=False)
+
+    # Run from a clean CWD with no .deepeval
+    monkeypatch.chdir(tmp_path)
+    assert not os.path.exists(".deepeval")
+
+    # After the fix, this should NOT raise; it should create the dir and write the file
+    uid = telemetry_mod.get_unique_id()
+    assert isinstance(uid, str) and len(uid) > 0
+    assert os.path.exists(".deepeval/.deepeval_telemetry.txt")

--- a/tests/test_core/test_telemetry.py
+++ b/tests/test_core/test_telemetry.py
@@ -11,7 +11,6 @@ def test_telemetry_writes_create_dir_when_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     assert not os.path.exists(".deepeval")
 
-    # After the fix, this should NOT raise; it should create the dir and write the file
     uid = telemetry_mod.get_unique_id()
     assert isinstance(uid, str) and len(uid) > 0
     assert os.path.exists(".deepeval/.deepeval_telemetry.txt")


### PR DESCRIPTION
- Skip file writes entirely when DEEPEVAL_TELEMETRY_OPT_OUT=YES
- Ensure .deepeval directory exists before writing telemetry data
- Return sentinel "telemetry-opted-out" from get_unique_id() when opted out
- Replace TELEMETRY_OPT_OUT env check with telemetry_opt_out() for consistency
- Add test_core/test_telemetry.py to verify dir creation and file write