### PR TITLE
Fix benchmarks for Datasets 4.0.0

### DIFF
--- a/deepeval/benchmarks/arc/arc.py
+++ b/deepeval/benchmarks/arc/arc.py
@@ -130,7 +130,7 @@ class ARC(DeepEvalBaseBenchmark):
         if dataset_attr:
             if not hasattr(self, dataset_attr):
                 dataset = load_dataset(
-                    "ai2_arc", mode.value, trust_remote_code=True
+                    "ai2_arc", mode.value
                 )
                 setattr(self, dataset_attr, dataset)
             else:

--- a/deepeval/benchmarks/bbq/bbq.py
+++ b/deepeval/benchmarks/bbq/bbq.py
@@ -165,7 +165,7 @@ class BBQ(DeepEvalBaseBenchmark):
         if dataset_attr:
             if not hasattr(self, dataset_attr):
                 dataset = load_dataset(
-                    "heegyu/bbq", task.value, trust_remote_code=True
+                    "heegyu/bbq", task.value
                 )
                 setattr(self, dataset_attr, dataset)
             else:

--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -280,7 +280,7 @@ class BigBenchHard(DeepEvalBaseBenchmark):
         if dataset_attr:
             if not hasattr(self, dataset_attr):
                 dataset = load_dataset(
-                    "lukaemon/bbh", task.value, trust_remote_code=True
+                    "lukaemon/bbh", task.value
                 )
                 setattr(self, dataset_attr, dataset)
             else:

--- a/deepeval/benchmarks/bool_q/bool_q.py
+++ b/deepeval/benchmarks/bool_q/bool_q.py
@@ -113,7 +113,7 @@ class BoolQ(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("boolq", "default", trust_remote_code=True)
+            dataset = load_dataset("boolq", "default")
             self.dataset = dataset
 
         # Construct test set

--- a/deepeval/benchmarks/drop/drop.py
+++ b/deepeval/benchmarks/drop/drop.py
@@ -263,7 +263,7 @@ class DROP(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("ucinlp/drop", trust_remote_code=True)
+            dataset = load_dataset("ucinlp/drop")
             self.dataset = dataset
 
         # construct example dataset

--- a/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
+++ b/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
@@ -144,7 +144,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
         if dataset_attr:
             if not hasattr(self, dataset_attr):
                 dataset = load_dataset(
-                    "katielink/EquityMedQA", task.value, trust_remote_code=True
+                    "katielink/EquityMedQA", task.value
                 )
                 setattr(self, dataset_attr, dataset)
             else:

--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -150,7 +150,7 @@ class GSM8K(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("gsm8k", "main", trust_remote_code=True)
+            dataset = load_dataset("gsm8k", "main")
             self.dataset = dataset
 
         # Construct example dataset for n_shot inference

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -253,7 +253,7 @@ class HellaSwag(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("Rowan/hellaswag", trust_remote_code=True)
+            dataset = load_dataset("Rowan/hellaswag")
             self.dataset = dataset
 
         # If dataset has not been previously loaded, construct

--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -201,7 +201,7 @@ class HumanEval(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("openai_humaneval", trust_remote_code=True)
+            dataset = load_dataset("openai_humaneval")
             self.dataset = dataset
 
         # Filter tasks

--- a/deepeval/benchmarks/ifeval/ifeval.py
+++ b/deepeval/benchmarks/ifeval/ifeval.py
@@ -531,7 +531,7 @@ class IFEval(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("google/IFEval", trust_remote_code=True)
+            dataset = load_dataset("google/IFEval")
             self.dataset = dataset
 
         goldens: List[Golden] = []

--- a/deepeval/benchmarks/lambada/lambada.py
+++ b/deepeval/benchmarks/lambada/lambada.py
@@ -114,7 +114,7 @@ class LAMBADA(DeepEvalBaseBenchmark):
             dataset = self.dataset
         else:
             dataset = load_dataset(
-                "EleutherAI/lambada_openai", "default", trust_remote_code=True
+                "EleutherAI/lambada_openai", "default"
             )
             self.dataset = dataset
 

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -235,7 +235,7 @@ class MathQA(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("allenai/math_qa", trust_remote_code=True)
+            dataset = load_dataset("allenai/math_qa")
             self.dataset = dataset
 
         # Construct test set

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -169,7 +169,10 @@ class MathQA(DeepEvalBaseBenchmark):
             res: MultipleChoiceSchemaLower = model.generate(
                 prompt=prompt, schema=MultipleChoiceSchemaLower
             )
-            prediction = res.answer
+            if isinstance(res, (tuple, list)):
+                prediction = res[0].answer
+            else:
+                prediction = res.answer
         except TypeError:
             prompt += f"\n\n{self.confinement_instructions}"
             prediction = model.generate(prompt)
@@ -235,7 +238,7 @@ class MathQA(DeepEvalBaseBenchmark):
         if self.dataset:
             dataset = self.dataset
         else:
-            dataset = load_dataset("allenai/math_qa")
+            dataset = load_dataset("regisss/math_qa")
             self.dataset = dataset
 
         # Construct test set

--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -252,14 +252,14 @@ class MMLU(DeepEvalBaseBenchmark):
         from datasets import load_dataset
 
         dataset = load_dataset(
-            "lukaemon/mmlu", task.value, trust_remote_code=True
+            "cais/mmlu", task.value,
         )
         self.dataset = dataset
 
         # If dataset has not been previously loaded, construct
         # dataset of examples and save as instance var (to save time)
         if not self.shots_dataset:
-            train_set = dataset["train"]
+            train_set = dataset["dev"]
             shots_set = []
             for data in train_set:
                 shots_set.append(data)
@@ -267,9 +267,10 @@ class MMLU(DeepEvalBaseBenchmark):
 
         # Construct test set
         goldens: List[Golden] = []
+        choices = ["A", "B", "C", "D"]
         for data in dataset["test"]:
             input = MMLUTemplate.format_question(data, include_answer=False)
-            golden = Golden(input=input, expected_output=data["target"])
+            golden = Golden(input=input, expected_output=choices[data["answer"]])
             goldens.append(golden)
         return goldens
 

--- a/deepeval/benchmarks/mmlu/template.py
+++ b/deepeval/benchmarks/mmlu/template.py
@@ -20,14 +20,14 @@ class MMLUTemplate:
 
     @staticmethod
     def format_question(data: dict, include_answer: bool = True):
-        prompt = data["input"]
+        prompt = data["question"]
         choices = ["A", "B", "C", "D"]
         for j in range(len(choices)):
             choice = choices[j]
-            prompt += "\n{}. {}".format(choice, data[choice])
+            prompt += "\n{}. {}".format(choice, data["choices"][j])
         prompt += "\nAnswer:"
         if include_answer:
-            prompt += " {}\n\n".format(data["target"])
+            prompt += " {}\n\n".format(choices[data["answer"]])
         return prompt
 
     @staticmethod

--- a/deepeval/benchmarks/squad/squad.py
+++ b/deepeval/benchmarks/squad/squad.py
@@ -159,7 +159,7 @@ class SQuAD(DeepEvalBaseBenchmark):
     def load_benchmark_dataset(self, task: SQuADTask) -> List[Golden]:
         from datasets import load_dataset
 
-        dataset = load_dataset("rajpurkar/squad", trust_remote_code=True)
+        dataset = load_dataset("rajpurkar/squad")
         self.dataset = dataset
 
         # Construct test set

--- a/deepeval/benchmarks/winogrande/winogrande.py
+++ b/deepeval/benchmarks/winogrande/winogrande.py
@@ -114,7 +114,7 @@ class Winogrande(DeepEvalBaseBenchmark):
             dataset = self.dataset
         else:
             dataset = load_dataset(
-                "allenai/winogrande", "winogrande_xs", trust_remote_code=True
+                "allenai/winogrande", "winogrande_xs"
             )
             self.dataset = dataset
 


### PR DESCRIPTION
As per https://github.com/huggingface/datasets/pull/7592, `trust_remote_code` is no longer supported -- datasets which relied on custom initialization scripts cannot be used anymore.

This pull request:
- removes the boolean from `load_dataset` calls;
- updates MMLU to use an up-to-date Parquet dataset (along with required logic changes);
- updates MathQA to use an up-to-date Parquet dataset.

Please get back to me if further changes are necessary.