### PR TITLE
Use schema whenever we can for geval metrics

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -170,10 +170,14 @@ class GEval(BaseMetric):
             criteria=self.criteria, parameters=g_eval_params_str
         )
         if self.using_native_model:
-            res, cost = await self.model.a_generate(prompt)
+            res, cost = await self.model.a_generate(prompt, schema=Steps)
             self.evaluation_cost += cost
-            data = trimAndLoadJson(res, self)
-            return data["steps"]
+            if isinstance(res, Steps):
+                return res.steps
+            else:
+                # typehints are wrong, sometimes this is a str if schema is not honored in model
+                data = trimAndLoadJson(res, self)
+                return data["steps"]
         else:
             try:
                 res: Steps = await self.model.a_generate(prompt, schema=Steps)
@@ -194,10 +198,14 @@ class GEval(BaseMetric):
             criteria=self.criteria, parameters=g_eval_params_str
         )
         if self.using_native_model:
-            res, cost = self.model.generate(prompt)
+            res, cost = self.model.generate(prompt, schema=Steps)
             self.evaluation_cost += cost
-            data = trimAndLoadJson(res, self)
-            return data["steps"]
+            if isinstance(res, Steps):
+                return res.steps
+            else:
+                # typehints are wrong, sometimes res is a str if schema attribute is not honored in model
+                data = trimAndLoadJson(res, self)
+                return data["steps"]
         else:
             try:
                 res: Steps = self.model.generate(prompt, schema=Steps)
@@ -269,10 +277,14 @@ class GEval(BaseMetric):
             AttributeError
         ):  # This catches the case where a_generate_raw_response doesn't exist.
             if self.using_native_model:
-                res, cost = await self.model.a_generate(prompt)
+                res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
                 self.evaluation_cost += cost
-                data = trimAndLoadJson(res, self)
-                return data["score"], data["reason"]
+                if isinstance(res, ReasonScore):
+                    return res.score, res.reason
+                else:
+                    # typehints are wrong, sometimes res is a str if schema is not honored in model
+                    data = trimAndLoadJson(res, self)
+                    return data["score"], data["reason"]
             else:
                 try:
                     res: ReasonScore = await self.model.a_generate(
@@ -342,10 +354,14 @@ class GEval(BaseMetric):
         except AttributeError:
             # This catches the case where a_generate_raw_response doesn't exist.
             if self.using_native_model:
-                res, cost = self.model.generate(prompt)
+                res, cost = self.model.generate(prompt, schema=ReasonScore)
                 self.evaluation_cost += cost
-                data = trimAndLoadJson(res, self)
-                return data["score"], data["reason"]
+                if isinstance(res, ReasonScore):
+                    return res.score, res.reason
+                else:
+                    # typehints are wrong, sometimes res is a str if schema is not honored in model
+                    data = trimAndLoadJson(res, self)
+                    return data["score"], data["reason"]
             else:
                 try:
                     res: ReasonScore = self.model.generate(

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -171,11 +171,12 @@ class GEval(BaseMetric):
         )
         if self.using_native_model:
             res, cost = await self.model.a_generate(prompt, schema=Steps)
+            res: Steps | str  # Original typehint is wrong
             self.evaluation_cost += cost
             if isinstance(res, Steps):
                 return res.steps
             else:
-                # typehints are wrong, sometimes this is a str if schema is not honored in model
+
                 data = trimAndLoadJson(res, self)
                 return data["steps"]
         else:
@@ -199,11 +200,11 @@ class GEval(BaseMetric):
         )
         if self.using_native_model:
             res, cost = self.model.generate(prompt, schema=Steps)
+            res: Steps | str  # Original typehint is wrong
             self.evaluation_cost += cost
             if isinstance(res, Steps):
                 return res.steps
             else:
-                # typehints are wrong, sometimes res is a str if schema attribute is not honored in model
                 data = trimAndLoadJson(res, self)
                 return data["steps"]
         else:
@@ -277,12 +278,14 @@ class GEval(BaseMetric):
             AttributeError
         ):  # This catches the case where a_generate_raw_response doesn't exist.
             if self.using_native_model:
-                res, cost = await self.model.a_generate(prompt, schema=ReasonScore)
+                res, cost = await self.model.a_generate(
+                    prompt, schema=ReasonScore
+                )
+                res: ReasonScore | str  # Original typehint is wrong
                 self.evaluation_cost += cost
                 if isinstance(res, ReasonScore):
                     return res.score, res.reason
                 else:
-                    # typehints are wrong, sometimes res is a str if schema is not honored in model
                     data = trimAndLoadJson(res, self)
                     return data["score"], data["reason"]
             else:
@@ -355,11 +358,11 @@ class GEval(BaseMetric):
             # This catches the case where a_generate_raw_response doesn't exist.
             if self.using_native_model:
                 res, cost = self.model.generate(prompt, schema=ReasonScore)
+                res: ReasonScore | str  # Original typehint is wrong
                 self.evaluation_cost += cost
                 if isinstance(res, ReasonScore):
                     return res.score, res.reason
                 else:
-                    # typehints are wrong, sometimes res is a str if schema is not honored in model
                     data = trimAndLoadJson(res, self)
                     return data["score"], data["reason"]
             else:


### PR DESCRIPTION
I was running GEval metrics with `gpt-5-mini` and would randomly hit JSON errors. But `gpt-5-mini` is setup for structured outputs, which should pretty much never hit JSON parsing errors.

Turns out we're not giving the schema when running any native_models, causing it to not run in structured output mode.

I tested this with OpenAI models but I don't have the other native models setup to test against as well. It does look like the typehints aren't correct and the method can return a str or the pydantic model depending on how it's implemented. So I tried to handle that case.