### PR TITLE
fix(cli): restore --confident-api-key flag; persist key to dotenv by default

### DIFF
--- a/docs/tutorials/tutorial-setup.mdx
+++ b/docs/tutorials/tutorial-setup.mdx
@@ -66,9 +66,9 @@ Congratulations! You've successfully run your first LLM evaluation with DeepEval
 
 ## Setting Up Confident AI
 
-While DeepEval works great standalone, you can connect it to [Confident AI](https://www.confident-ai.com) — our cloud platform for dashboards, logging, collaboration, and more — built for LLM evaluation. **Best of all, it's free to get started!** _(No credit card required.)_
+While DeepEval works great standalone, you can connect it to [Confident AI](https://www.confident-ai.com) — our cloud platform for dashboards, logging, collaboration, and more — built for LLM evaluation. **It’s free to get started.**
 
-You can [sign up here](https://www.confident-ai.com), or you can run the following command
+You can [sign up here](https://www.confident-ai.com), or run:
 
 ```bash
 deepeval login
@@ -105,5 +105,30 @@ Or through the CLI:
 ```bash
 deepeval login --confident-api-key "your-confident-api-key"
 ```
+
+:::note Login persistence
+`deepeval login` persists your key to a dotenv file by default (.env.local).
+To change the target, use `--save`, e.g.:
+
+```bash
+# custom path
+deepeval login --confident-api-key "ck_..." --save dotenv:.env.custom
+```
+
+For compatibility, the key is saved under `api_key` and `CONFIDENT_API_KEY`.
+Secrets are never written to the JSON keystore.
+:::
+
+:::tip Logging out / rotating keys
+Use deepeval logout to clear the JSON keystore and remove saved keys from your dotenv file:
+
+```bash
+# default removes from .env.local
+deepeval logout
+
+# or specify a custom target
+deepeval logout --save dotenv:.myconf.env
+```
+:::
 
 You're all set! You can now evaluate LLMs locally and monitor them in Confident AI.


### PR DESCRIPTION
- Correct long flag registration (remove stray help text from option name)
- Login now always saves to dotenv by default (.env.local) unless --save overrides
- Write both aliases: api_key and CONFIDENT_API_KEY for compatibility
- Logout clears JSON keystore and removes both aliases from dotenv (default .env.local; override with --save)
- Improve help text for login/logout --save and --confident-api-key
- Avoid writing "None" values in set-openai/local-model/local-embeddings
- Add comprehensive tests for login/logout flows and optional param handling