### PR TITLE
feat(synthesizer): add markdown loaders and improve lazy imports

### DIFF
--- a/deepeval/synthesizer/chunking/doc_chunker.py
+++ b/deepeval/synthesizer/chunking/doc_chunker.py
@@ -1,47 +1,72 @@
-from typing import Optional, List, Dict, Union, Type
 import os
+
+from typing import Dict, List, Optional, Type, TYPE_CHECKING
+from types import SimpleNamespace
 
 from deepeval.models.base_model import DeepEvalBaseEmbeddingModel
 
-# check langchain availability
-try:
+
+if TYPE_CHECKING:
+    from chromadb.api.models.Collection import Collection
     from langchain_core.documents import Document as LCDocument
-    from langchain_text_splitters import TokenTextSplitter
     from langchain_text_splitters.base import TextSplitter
-    from langchain_community.document_loaders import (
-        PyPDFLoader,
-        TextLoader,
-        Docx2txtLoader,
-    )
     from langchain_community.document_loaders.base import BaseLoader
 
-    langchain_available = True
-except ImportError:
-    langchain_available = False
 
-# check chromadb availability
-try:
-    import chromadb
-    from chromadb import Metadata
-    from chromadb.api.models.Collection import Collection
-
-    chroma_db_available = True
-except ImportError:
-    chroma_db_available = False
+# Lazy import caches
+_langchain_ns = None
+_chroma_mod = None
+_langchain_import_error = None
+_chroma_import_error = None
 
 
-# Define a helper function to check availability
-def _check_chromadb_available():
-    if not chroma_db_available:
+def _get_langchain():
+    """Return a namespace of langchain classes, or raise ImportError with root cause."""
+    global _langchain_ns, _langchain_import_error
+    if _langchain_ns is not None:
+        return _langchain_ns
+    try:
+        from langchain_core.documents import Document as LCDocument  # type: ignore
+        from langchain_text_splitters import TokenTextSplitter  # type: ignore
+        from langchain_text_splitters.base import TextSplitter  # type: ignore
+        from langchain_community.document_loaders import (  # type: ignore
+            PyPDFLoader,
+            TextLoader,
+            Docx2txtLoader,
+        )
+        from langchain_community.document_loaders.base import BaseLoader  # type: ignore
+
+        _langchain_ns = SimpleNamespace(
+            LCDocument=LCDocument,
+            TokenTextSplitter=TokenTextSplitter,
+            TextSplitter=TextSplitter,
+            PyPDFLoader=PyPDFLoader,
+            TextLoader=TextLoader,
+            Docx2txtLoader=Docx2txtLoader,
+            BaseLoader=BaseLoader,
+        )
+        return _langchain_ns
+    except Exception as e:
+        _langchain_import_error = e
         raise ImportError(
-            "chromadb is required for this functionality. Install it via your package manager"
+            f"langchain, langchain_community, and langchain_text_splitters are required. Root cause: {e}"
         )
 
 
-def _check_langchain_available():
-    if not langchain_available:
+def _get_chromadb():
+    """Return the chromadb module, or raise ImportError with root cause."""
+    global _chroma_mod, _chroma_import_error
+    if _chroma_mod is not None:
+        return _chroma_mod
+    try:
+        import chromadb
+
+        _chroma_mod = chromadb
+        return _chroma_mod
+    except Exception as e:
+        _chroma_import_error = e
         raise ImportError(
-            "langchain, langchain_community, and langchain_text_splitters are required for this functionality. Install it via your package manager"
+            f"chromadb is required for this functionality. Root cause: {e}"
         )
 
 
@@ -50,22 +75,16 @@ class DocumentChunker:
         self,
         embedder: DeepEvalBaseEmbeddingModel,
     ):
-        _check_chromadb_available()
-        _check_langchain_available()
         self.text_token_count: Optional[int] = None  # set later
 
         self.source_file: Optional[str] = None
         self.chunks: Optional["Collection"] = None
-        self.sections: Optional[List[LCDocument]] = None
+        self.sections: Optional[List["LCDocument"]] = None
         self.embedder: DeepEvalBaseEmbeddingModel = embedder
         self.mean_embedding: Optional[float] = None
 
         # Mapping of file extensions to their respective loader classes
-        self.loader_mapping: Dict[str, Type[BaseLoader]] = {
-            ".pdf": PyPDFLoader,
-            ".txt": TextLoader,
-            ".docx": Docx2txtLoader,
-        }
+        self.loader_mapping: Dict[str, "Type[BaseLoader]"] = {}
 
     #########################################################
     ### Chunking Docs #######################################
@@ -74,7 +93,8 @@ class DocumentChunker:
     async def a_chunk_doc(
         self, chunk_size: int = 1024, chunk_overlap: int = 0
     ) -> "Collection":
-        _check_chromadb_available()
+        lc = _get_langchain()
+        chroma = _get_chromadb()
 
         # Raise error if chunk_doc is called before load_doc
         if self.sections is None or self.source_file is None:
@@ -85,13 +105,13 @@ class DocumentChunker:
         # Create ChromaDB client
         full_document_path, _ = os.path.splitext(self.source_file)
         document_name = os.path.basename(full_document_path)
-        client = chromadb.PersistentClient(path=f".vector_db/{document_name}")
+        client = chroma.PersistentClient(path=f".vector_db/{document_name}")
 
         collection_name = f"processed_chunks_{chunk_size}_{chunk_overlap}"
         try:
             collection = client.get_collection(name=collection_name)
         except Exception:
-            text_splitter: TextSplitter = TokenTextSplitter(
+            text_splitter: "TextSplitter" = lc.TokenTextSplitter(
                 chunk_size=chunk_size, chunk_overlap=chunk_overlap
             )
             # Collection doesn't exist, so create it and then add documents
@@ -108,7 +128,7 @@ class DocumentChunker:
                 batch_contents = contents[i:batch_end]
                 batch_embeddings = embeddings[i:batch_end]
                 batch_ids = ids[i:batch_end]
-                batch_metadatas: List["Metadata"] = [
+                batch_metadatas: List[dict] = [
                     {"source_file": self.source_file} for _ in batch_contents
                 ]
 
@@ -121,7 +141,8 @@ class DocumentChunker:
         return collection
 
     def chunk_doc(self, chunk_size: int = 1024, chunk_overlap: int = 0):
-        _check_chromadb_available()
+        lc = _get_langchain()
+        chroma = _get_chromadb()
 
         # Raise error if chunk_doc is called before load_doc
         if self.sections is None or self.source_file is None:
@@ -132,13 +153,13 @@ class DocumentChunker:
         # Create ChromaDB client
         full_document_path, _ = os.path.splitext(self.source_file)
         document_name = os.path.basename(full_document_path)
-        client = chromadb.PersistentClient(path=f".vector_db/{document_name}")
+        client = chroma.PersistentClient(path=f".vector_db/{document_name}")
 
         collection_name = f"processed_chunks_{chunk_size}_{chunk_overlap}"
         try:
             collection = client.get_collection(name=collection_name)
         except Exception:
-            text_splitter: TextSplitter = TokenTextSplitter(
+            text_splitter: "TextSplitter" = lc.TokenTextSplitter(
                 chunk_size=chunk_size, chunk_overlap=chunk_overlap
             )
             # Collection doesn't exist, so create it and then add documents
@@ -155,7 +176,7 @@ class DocumentChunker:
                 batch_contents = contents[i:batch_end]
                 batch_embeddings = embeddings[i:batch_end]
                 batch_ids = ids[i:batch_end]
-                batch_metadatas: List["Metadata"] = [
+                batch_metadatas: List[dict] = [
                     {"source_file": self.source_file} for _ in batch_contents
                 ]
 
@@ -172,17 +193,31 @@ class DocumentChunker:
     #########################################################
 
     def get_loader(self, path: str, encoding: Optional[str]) -> "BaseLoader":
+        lc = _get_langchain()
+        # set mapping lazily now that langchain classes exist
+        if not self.loader_mapping:
+            self.loader_mapping = {
+                ".pdf": lc.PyPDFLoader,
+                ".txt": lc.TextLoader,
+                ".docx": lc.Docx2txtLoader,
+                ".md": lc.TextLoader,
+                ".markdown": lc.TextLoader,
+                ".mdx": lc.TextLoader,
+            }
+
         # Find appropriate doc loader
         _, extension = os.path.splitext(path)
         extension = extension.lower()
-        loader: Optional[type[BaseLoader]] = self.loader_mapping.get(extension)
+        loader: Optional["Type[BaseLoader]"] = self.loader_mapping.get(
+            extension
+        )
         if loader is None:
             raise ValueError(f"Unsupported file format: {extension}")
 
-        # Load doc into sections and calculate total character count
-        if loader is TextLoader:
+        # Load doc into sections and calculate total token count
+        if loader is lc.TextLoader:
             return loader(path, encoding=encoding, autodetect_encoding=True)
-        elif loader is PyPDFLoader or loader is Docx2txtLoader:
+        elif loader in (lc.PyPDFLoader, lc.Docx2txtLoader):
             return loader(path)
         else:
             raise ValueError(f"Unsupported file format: {extension}")
@@ -200,5 +235,6 @@ class DocumentChunker:
         self.source_file = path
 
     def count_tokens(self, chunks: List["LCDocument"]):
-        counter = TokenTextSplitter(chunk_size=1, chunk_overlap=0)
+        lc = _get_langchain()
+        counter = lc.TokenTextSplitter(chunk_size=1, chunk_overlap=0)
         return len(counter.split_documents(chunks))

--- a/docs/docs/synthesizer-generate-from-docs.mdx
+++ b/docs/docs/synthesizer-generate-from-docs.mdx
@@ -41,10 +41,12 @@ The only difference between the `generate_goldens_from_docs()` and `generate_gol
 If you do not have an `OPENAI_API_KEY` and wish to synthesize goldens, you'll need to use [**custom embedding models**](/guides/guides-using-custom-embedding-models) in addition to custom LLMs.
 :::
 
-Before you begin, you must install `chromadb` as an additional dependency when generating from documents. The use of a vector database allows for efficient retrieval of chunks during context construction.
+Before you begin, you must install additional dependencies when generating from documents:
+- `chromadb`: required for chunk storage and retrieval in the context construction pipeline.
+- `langchain-core`, `langchain-community`, `langchain-text-splitters`: required for document parsing and chunking.
 
-```python
-pip install chromadb
+```bash
+pip install chromadb langchain-core langchain-community langchain-text-splitters
 ```
 
 Then, to generate synthetic `Golden`s from documents, simply provide a list of document paths:
@@ -58,9 +60,9 @@ synthesizer.generate_goldens_from_docs(
 )
 ```
 
-There are **ONE** mandatory and **THREE** optional parameters when using the `generate_goldens_from_docs` method:
+There is **ONE** mandatory and **THREE** optional parameters when using the `generate_goldens_from_docs` method:
 
-- `document_paths`: a list strings, representing the path to the documents from which contexts will be extracted from. Supported documents types include: `.txt`, `.docx`, and `.pdf`.
+- `document_paths`: a list of strings, representing the path to the documents from which contexts will be extracted from. Supported document types include: `.txt`, `.docx`, `.pdf`, `.md`, `.markdown`, and `.mdx`.
 - [Optional] `include_expected_output`: a boolean which when set to `True`, will additionally generate an `expected_output` for each synthetic `Golden`. Defaulted to `True`.
 - [Optional] `max_goldens_per_context`: the maximum number of goldens to be generated per context. Defaulted to 2.
 - [Optional] `context_construction_config`: an instance of type `ContextConstructionConfig` that allows you to [customize the quality and attributes of contexts constructed](#customize-context-construction) from your documents. Defaulted to the default `ContextConstructionConfig` values.
@@ -78,7 +80,7 @@ from deepeval.synthesizer.config import ContextConstructionConfig
 
 ...
 synthesizer.generate_goldens_from_docs(
-  document_paths=['example.txt', 'example.docx', 'example.pdf'],
+  document_paths=['example.txt', 'example.docx', 'example.pdf', 'example.md', 'example.mdx'],
   context_construction_config=ContextConstructionConfig()
 )
 ```
@@ -86,12 +88,12 @@ synthesizer.generate_goldens_from_docs(
 There are **SEVEN** optional parameters when creating a `ContextConstructionConfig`:
 
 - [Optional] `critic_model`: a string specifying which of OpenAI's GPT models to use to determine context `quality_score`s, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to the **model used in the `Synthesizer`**, else `gpt-4.1` when initialized as a standalone instance.
-- [Optional] `encoding`: the encoding to use to decode .txt files. Defaulted to auto detecting the encoding.
+- [Optional] `encoding`: the encoding to use to decode plain text–based files (`.txt`, `.md`, `.markdown`, `.mdx`). Defaulted to autodetecting the encoding.
 - [Optional] `max_contexts_per_document`: the maximum number of contexts to be generated per document. Defaulted to 3.
 - [Optional] `min_contexts_per_document`: the minimum number of contexts to be generated per document. Defaulted to 1.
 - [Optional] `max_context_length`: specifies the number of of text chunks to be generated per context (context length). Defaulted to 3.
 - [Optional] `min_context_length`: specifies the minimum number of text chunks to be generated per context (context length). Defaulted to 1.
-- [Optional] `chunk_size`: specifies the size of text chunks (in characters) to be considered during [document parsing](#synthesizer-generate-from-docs#document-parsing). Defaulted to 1024.
+- [Optional] `chunk_size`: specifies the size of text chunks (in tokens) to be considered during [document parsing](#synthesizer-generate-from-docs#document-parsing). Defaulted to 1024.
 - [Optional] `chunk_overlap`: an int that determines the overlap size between consecutive text chunks during [document parsing](#synthesizer-generate-from-docs#document-parsing). Defaulted to 0.
 - [Optional] `context_quality_threshold`: a float representing the minimum quality threshold for [context selection](synthesizer-generate-from-docs#context-selection). If the context quality is below threshold, the context will be rejected. Defaulted to `0.5`.
 - [Optional] `context_similarity_threshold`: a float representing the minimum similarity score required for [context grouping](synthesizer-generate-from-docs#context-grouping). Contexts with similarity scores below this threshold will be rejected. Defaulted to `0.5`.
@@ -106,15 +108,15 @@ To learn how to customize all other aspects of your generation pipeline, such as
 
 ## How Does Context Construction Work?
 
-The `generate_goldens_from_docs()` method has an additional context construction pipeline that precedes the [goldens generation pipeline](#synthesizer-introduction#how-does-it-work). This is because to generate goldens grounded in context, we first have to extract and construction groups of contexts found in provided documents.
+The `generate_goldens_from_docs()` method has an additional context construction pipeline that precedes the [goldens generation pipeline](#synthesizer-introduction#how-does-it-work). This is because to generate goldens grounded in context, we first have to extract and construct groups of contexts found in provided documents.
 
-The context construction pipeline consist of three main steps:
+The context construction pipeline consists of three main steps:
 
 - **Document Parsing**: Split documents into smaller, manageable chunks.
 - **Context Selection**: Select random chunks from the parsed, embedded documents.
 - **Context Grouping**: Group chunks that are similar in semantics (using cosine similarity) to create groups of contexts that are meaningful enough for subsequent generation.
 
-[Click here](#customize-context-construction) To learn how to customize every parameters used for the context construction pipeline.
+[Click here](#customize-context-construction) To learn how to customize every parameter used for the context construction pipeline.
 
 :::info
 In summary, the documents are first split into chunks and embedded to form a collection of nodes. Random nodes are then selected, and for each selected node, similar nodes are retrieved and grouped together to create contexts. These contexts are then used to generate synthetic goldens as described in previous sections.
@@ -122,7 +124,7 @@ In summary, the documents are first split into chunks and embedded to form a col
 
 ### Document Parsing
 
-In the initial **document parsing** step, each provided document is parsed using an **token-based text splitter**. This means the `chunk_size` and `chunk_overlap` parameters do not guarantee exact text chunk sizes. This approach ensures text chunks are meaningful and coherent, but might lead to variations in the expected size of each `context`.
+In the initial **document parsing** step, each provided document is parsed using a **token-based text splitter** (`TokenTextSplitter`). This means the `chunk_size` and `chunk_overlap` parameters do not guarantee exact character lengths but instead operate at the token level.
 
 These text chunks are then embedded by the `embedder` and stored in a vector database for subsequent selection and grouping.
 
@@ -149,7 +151,7 @@ The `critic_model` in the context construction pipeline can be different from th
 
 ### Context Grouping
 
-In the final **context grouping** step, each previously selected nodes are grouped with `max_context_length` other nodes with a cosine similarity score higher than the `context_similarity_threshold`. This ensure that each context is coherent for subsequent generation to happen smoothly.
+In the final **context grouping** step, each previously selected nodes are grouped with `max_context_length` other nodes with a cosine similarity score higher than the `context_similarity_threshold`. This ensures that each context is coherent for subsequent generation to happen smoothly.
 
 Similar to the context selection step, if the cosine similarity is still lower than the `context_similarity_threshold` after `max_retries`, the context with the highest similarity score will be used. Although this means that you might find context that have failed the filtering process being used, but you will be guaranteed to have context groups to be used for generation.
 

--- a/docs/docs/synthesizer-introduction.mdx
+++ b/docs/docs/synthesizer-introduction.mdx
@@ -90,7 +90,7 @@ from deepeval.synthesizer import Synthesizer
 
 ...
 synthesizer.generate_goldens_from_docs(
-    document_paths=['example.txt', 'example.docx', 'example.pdf'],
+    document_paths=['example.txt', 'example.docx', 'example.pdf', 'example.md', 'example.markdown', 'example.mdx'],
     include_expected_output=True
 )
 print(synthesizer.synthetic_goldens)

--- a/docs/guides/guides-using-synthesizer.mdx
+++ b/docs/guides/guides-using-synthesizer.mdx
@@ -34,7 +34,7 @@ from deepeval.synthesizer import Synthesizer
 
 synthesizer = Synthesizer()
 synthesizer.generate_goldens_from_docs(
-    document_paths=['example.txt', 'example.docx', 'example.pdf'],
+    document_paths=['example.txt', 'example.docx', 'example.pdf',  'example.md', 'example.markdown', 'example.mdx'],
 )
 ```
 
@@ -81,7 +81,7 @@ synthesizer.generate_goldens_from_contexts(
 
 ## Document Chunking
 
-In DeepEval, documents are divided into **fixed-size chunks**, which are then used to generate contexts for your goldens. This chunking process is critical because it directly influences the quality of the contexts, which are used to generated synthetic goldens. You can control this process using the following parameters:
+In DeepEval, documents are divided into **fixed-size chunks**, which are then used to generate contexts for your goldens. This chunking process is critical because it directly influences the quality of the contexts, which are used to generate synthetic goldens. You can control this process using the following parameters:
 
 - `chunk_size`: Defines the size of each chunk in tokens. Default is 1024.
 - `chunk_overlap`: Specifies the number of overlapping tokens between consecutive chunks. Default is 0 (no overlap).
@@ -96,7 +96,7 @@ from deepeval.synthesizer import Synthesizer
 
 synthesizer = Synthesizer()
 synthesizer.generate_goldens_from_docs(
-    document_paths=['example.txt', 'example.docx', 'example.pdf'],
+    document_paths=['example.txt', 'example.docx', 'example.pdf',  'example.md', 'example.markdown', 'example.mdx'],
     chunk_size=1024,
     chunk_overlap=0
 )
@@ -143,7 +143,7 @@ from deepeval.synthesizer import Synthesizer
 
 synthesizer = Synthesizer()
 synthesizer.generate_goldens_from_docs(
-    document_paths=['example.txt', 'example.docx', 'example.pdf'],
+    document_paths=['example.txt', 'example.docx', 'example.pdf',  'example.md', 'example.markdown', 'example.mdx'],
     num_evolutions=3,
     evolutions={
         Evolution.REASONING: 0.1,
@@ -194,7 +194,7 @@ from deepeval.synthesizer import Synthesizer
 
 # Generate goldens from documents
 goldens = synthesizer.generate_goldens_from_docs(
-  document_paths=['example.txt', 'example.docx', 'example.pdf']
+  document_paths=['example.txt', 'example.docx', 'example.pdf',  'example.md', 'example.markdown', 'example.mdx'],
 )
 
 # Access evolutions through the DataFrame
@@ -218,7 +218,7 @@ The first two qualification steps happen during **context generation**. Each chu
 - **Structure:** How well-organized and logical the content is.
 - **Relevance:** How closely the content relates to the main topic.
 
-:::note  
+:::note
 Scores range from 0 to 1. To pass, a chunk must achieve an average score of at least 0.5. A maximum of 3 retries is allowed for each chunk if it initially fails.
 :::
 
@@ -244,7 +244,7 @@ from deepeval.synthesizer import Synthesizer
 
 # Generate goldens from documents
 goldens = synthesizer.generate_goldens_from_docs(
-  document_paths=['example.txt', 'example.docx', 'example.pdf']
+  document_paths=['example.txt', 'example.docx', 'example.pdf',  'example.md', 'example.markdown', 'example.mdx'],
 )
 
 # Access quality scores through the DataFrame

--- a/docs/integrations/vector-databases/chroma.mdx
+++ b/docs/integrations/vector-databases/chroma.mdx
@@ -10,6 +10,11 @@ sidebar_label: Chroma
 
 DeepEval allows you to easily evaluate and optimize your Chroma retriever by **tuning hyperparameters** like `n_results` (more commonly known as top-K) and the `embedding model` used in your Chroma retrieval pipeline.
 
+:::caution
+Chroma is not only an optional retriever you can evaluate, it is also a **required dependency** for the `deepeval.synthesizer.generate_goldens_from_docs()` method.
+This method uses Chroma as its built-in backend for chunk storage and retrieval during context construction. If you plan to generate goldens from documents, make sure to install `chromadb`:
+:::
+
 :::info
 To get started, install Chroma through the CLI using the following command:
 
@@ -98,7 +103,7 @@ By default, Chroma utilizes `cosine similarity` to find similar chunks.
 To evaluate your Chroma retriever, you'll first need to prepare an `input` query and generate a response from your RAG pipeline in order to create an `LLMTestCase`. You'll also need to extract the contexts retrieved from your Chroma collection during generation and prepare the expected LLM response to complete the `LLMTestCase`.
 
 :::information
-By default, `input` and `actual_output` are required for all metrics. However, `retrieval_context`, `context`, and `expected_output` are optional, and different metrics may or may not require additional parameters. To check the specific requirements, [visit the metrics section](/docs/metrics-introduction).  
+By default, `input` and `actual_output` are required for all metrics. However, `retrieval_context`, `context`, and `expected_output` are optional, and different metrics may or may not require additional parameters. To check the specific requirements, [visit the metrics section](/docs/metrics-introduction).
 :::
 
 After you've prepared your `LLMTestCase`, evaluating your Chroma retriever is as easy passing the test case along with your selection of metrics into DeepEval's `evaluate` function.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3691,6 +3691,23 @@ files = [
 dev = ["build", "flake8", "mypy", "pytest", "twine"]
 
 [[package]]
+name = "pysqlite3-binary"
+version = "0.5.4"
+description = "DB-API 2.0 interface for Sqlite 3.x"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pysqlite3_binary-0.5.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df084f3da52bc92204357cd6ba68f98a8ef8e55a9e8dac3c4d96029ee56fb57b"},
+    {file = "pysqlite3_binary-0.5.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf257ca54a0b94dce14324b29960fae5b1d57a669ce327b92fe245049abf2854"},
+    {file = "pysqlite3_binary-0.5.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb551d736ac3a049b3a91332dbcb0df506eaed58add8a95acfd264dc45ce3fa8"},
+    {file = "pysqlite3_binary-0.5.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb3653a0eb0ef5db2d0ed49d43b11ab4be24fdf5b2e65a39650fc59348e30dc6"},
+    {file = "pysqlite3_binary-0.5.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7e41f169994c140064e3757f9785f5f460e72607f1d9a5244853d4de3cc4f2"},
+    {file = "pysqlite3_binary-0.5.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7146a400deb786b064fd299aa79589a81e532f6dccc38b7986744ace484afdc"},
+    {file = "pysqlite3_binary-0.5.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4be1927a02d8079f1bf8e46af641798341e9bd1a3c5e57fa6f83207a0a8fa66"},
+    {file = "pysqlite3_binary-0.5.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8d25d8568978669c8ba53f32d10fb779176f25d720cda148b28baaf6ef0a20c"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
@@ -5430,4 +5447,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <4.0"
-content-hash = "2afd8d61b190e684a0d1933bbbbe7b0e780a8b5f82aa6028fb025ae6c607055c"
+content-hash = "9e6fcd4fc633890aa11dfcc6d39028eeeeeb78b77a2d84df4e2ac797d74e873b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ tiktoken = "*"
 pypdf = "*"
 docx2txt = "*"
 pandas = "*"
+pysqlite3-binary = "^0.5.4"
 
 [tool.black]
 line-length = 80

--- a/tests/test_core/conftest.py
+++ b/tests/test_core/conftest.py
@@ -1,0 +1,6 @@
+try:
+    import sys, pysqlite3 as sqlite3  # type: ignore
+    sys.modules["sqlite3"] = sqlite3
+    sys.modules["sqlite3.dbapi2"] = sqlite3.dbapi2
+except Exception:
+    pass

--- a/tests/test_core/test_synthesizer/test_doc_chunker.py
+++ b/tests/test_core/test_synthesizer/test_doc_chunker.py
@@ -1,0 +1,329 @@
+import pytest
+from pathlib import Path
+
+from deepeval.synthesizer.chunking.doc_chunker import DocumentChunker
+
+
+##########################
+# Helpers / Test Doubles #
+##########################
+
+
+class StubEmbedder:
+    """A minimal stand-in for DeepEvalBaseEmbeddingModel used in tests.
+
+    This stub avoids calling a real embedding model by returning fixed length
+    dummy vectors. It supports both synchronous and asynchronous methods so
+    that DocumentChunker can run without depending on external services.
+    """
+
+    def embed_texts(self, xs):
+        return [[0.0] * 4 for _ in xs]
+
+    def a_embed_texts(self, xs):
+        raise NotImplementedError
+
+    def embed_text(self, x):
+        return [0.0] * 4
+
+    async def a_embed_text(self, x):
+        return [0.0] * 4
+
+
+class StubAsyncEmbedder(StubEmbedder):
+    """An async variant of StubEmbedder.
+
+    Unlike StubEmbedder, this implementation provides a working asynchronous
+    `a_embed_texts` method that returns dummy embeddings, so that async
+    chunking methods, such as DocumentChunker.a_chunk_doc, can be tested.
+    """
+
+    async def a_embed_texts(self, xs):
+        return [[0.0] * 4 for _ in xs]
+
+
+class FakeCollection:
+    """A fake ChromaDB collection used in tests.
+
+    This fake captures calls to ``add`` so tests can inspect the documents,
+    embeddings, metadata, and IDs passed during chunking without requiring a
+    real ChromaDB backend.
+    """
+
+    def __init__(self):
+        self.add_calls = []
+
+    def add(self, documents, embeddings, metadatas, ids):
+        self.add_calls.append((documents, embeddings, metadatas, ids))
+
+
+class FakeClient:
+    """A fake ChromaDB client that manages FakeCollections in memory.
+
+    It implements ``get_collection`` and ``create_collection`` so that tests
+    can simulate both cache hits and cache misses when DocumentChunker tries
+    to retrieve or create a collection.
+    """
+
+    def __init__(self):
+        self.collections = {}
+
+    def get_collection(self, name):
+        if name not in self.collections:
+            raise RuntimeError("not found")
+        return self.collections[name]
+
+    def create_collection(self, name):
+        c = FakeCollection()
+        self.collections[name] = c
+        return c
+
+
+class FakeChromaMod:
+    """A fake Chroma module shim with only PersistentClient.
+
+    This lets tests monkeypatch ``_chroma_mod`` with a fake implementation that
+    always returns the provided FakeClient instance.
+    """
+
+    def __init__(self, client):
+        self._client = client
+
+    def PersistentClient(self, path):
+        return self._client
+
+
+###########################
+# Markdown / Loader tests #
+###########################
+
+
+@pytest.mark.parametrize("ext", [".md", ".markdown", ".mdx"])
+def test_markdown_family_preserves_table(tmp_path, ext):
+    """Verify that markdown family extensions (.md, .markdown, .mdx)
+    are all loaded via the TextLoader and that table formatting is
+    preserved in the loaded document sections.
+    """
+    p = tmp_path / f"sample{ext}"
+    p.write_text("# T\n\n| A | B |\n| - | - |\n| 1 | 2 |\n", encoding="utf-8")
+    dc = DocumentChunker(StubEmbedder())
+    dc.load_doc(str(p), encoding="utf-8")
+    assert dc.sections
+    assert any("| A | B |" in d.page_content for d in dc.sections)
+
+
+def test_unsupported_extension(tmp_path):
+    """Ensure that get_loader raises ValueError when asked to load
+    a file with an unsupported extension.
+    """
+    p = tmp_path / "weird.xyz"
+    p.write_text("hello", encoding="utf-8")
+    dc = DocumentChunker(StubEmbedder())
+    with pytest.raises(ValueError):
+        dc.get_loader(str(p), encoding="utf-8")
+
+
+def test_textloader_autodetect_encoding(tmp_path):
+    """Confirm that the TextLoader correctly autodetects encodings.
+    This test writes a UTF-8 BOM-prefixed file and verifies that the
+    loader strips the BOM and returns the expected text content.
+    """
+    # UTF-8 BOM content should still parse correctly via autodetect
+    p = tmp_path / "bom.md"
+    p.write_bytes(b"\xef\xbb\xbfHello")
+    dc = DocumentChunker(StubEmbedder())
+    dc.load_doc(str(p), encoding=None)
+    assert any("Hello" in d.page_content for d in dc.sections)
+
+
+def test_count_tokens_runs(tmp_path):
+    """Check that DocumentChunker.count_tokens runs successfully after
+    loading a text file, and that it produces a positive integer token count.
+    """
+    p = tmp_path / "a.md"
+    p.write_text("a b c", encoding="utf-8")
+    dc = DocumentChunker(StubEmbedder())
+    dc.load_doc(str(p), encoding="utf-8")
+    assert isinstance(dc.text_token_count, int)
+    assert dc.text_token_count > 0
+
+
+#############################################################
+# Lazy import behavior (dependency required only when used) #
+#############################################################
+
+
+def test_lazy_imports_langchain_required_on_loader(monkeypatch):
+    """Verify that attempting to load a document requires LangChain.
+
+    This test monkeypatches ``_get_langchain`` to raise ImportError,
+    simulating a missing LangChain installation. When
+    ``DocumentChunker.get_loader`` is called, it should propagate
+    the ImportError since LangChain is required for loader creation.
+    """
+    # simulate LangChain missing by stubbing the getter to raise
+    monkeypatch.setattr(
+        "deepeval.synthesizer.chunking.doc_chunker._get_langchain",
+        lambda: (_ for _ in ()).throw(ImportError("no langchain")),
+    )
+    dc = DocumentChunker(StubEmbedder())
+    with pytest.raises(ImportError):
+        dc.get_loader("x.md", encoding="utf-8")
+
+
+def test_lazy_imports_chromadb_required_on_chunk(monkeypatch, tmp_path):
+    """Verify that attempting to chunk a document requires ChromaDB.
+
+    After loading a markdown file via LangChain, this test monkeypatches
+    ``_get_chromadb`` to raise ImportError, simulating a missing ChromaDB
+    installation. When ``DocumentChunker.chunk_doc`` is called, it should
+    propagate the ImportError since ChromaDB is required for chunking.
+    """
+    p = tmp_path / "x.md"
+    p.write_text("hello", encoding="utf-8")
+    dc = DocumentChunker(StubEmbedder())
+    # make sure loading (LangChain path) works
+    dc.load_doc(str(p), encoding="utf-8")
+
+    # now simulate chromadb missing only for the chunking path
+    monkeypatch.setattr(
+        "deepeval.synthesizer.chunking.doc_chunker._get_chromadb",
+        lambda: (_ for _ in ()).throw(ImportError("no chroma")),
+    )
+    with pytest.raises(ImportError):
+        dc.chunk_doc()
+
+
+###############################
+# Chroma integration (mocked) #
+###############################
+
+
+def test_chunk_doc_raises_if_not_loaded():
+    """Ensure that calling chunk_doc before load_doc raises ValueError.
+
+    DocumentChunker requires a loaded document before chunking. This test
+    verifies that attempting to chunk prematurely fails with the correct error.
+    """
+    dc = DocumentChunker(StubEmbedder())
+    with pytest.raises(ValueError):
+        dc.chunk_doc()
+
+
+def test_chunk_doc_batches_and_metadata(monkeypatch, tmp_path):
+    """Verify batching behavior and metadata when chunking a large document.
+
+    - Creates a large markdown file to force multiple batches.
+    - Monkeypatches Chroma to use a FakeClient/FakeCollection.
+    - Confirms that:
+      * Each batch size does not exceed the hard limit (5461).
+      * All documents, IDs, and metadata lists are aligned in length.
+      * Each metadata entry contains a ``source_file`` key.
+    """
+    # prepare many chunks to force batching
+    p = tmp_path / "big.md"
+    p.write_text(("x\n" * 6000), encoding="utf-8")  # many tiny chunks
+    dc = DocumentChunker(StubEmbedder())
+    dc.load_doc(str(p), encoding="utf-8")
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(
+        "deepeval.synthesizer.chunking.doc_chunker._chroma_mod",
+        FakeChromaMod(fake_client),
+        raising=True,
+    )
+
+    collection = dc.chunk_doc(chunk_size=1, chunk_overlap=0)
+    assert isinstance(collection, FakeCollection)
+    assert collection.add_calls, "expected chunks to be added"
+    assert all(len(docs) <= 5461 for docs, *_ in collection.add_calls)
+    for docs, _emb, metas, ids in collection.add_calls:
+        assert len(docs) == len(metas) == len(ids)
+        assert all(isinstance(m, dict) and "source_file" in m for m in metas)
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_doc_works(monkeypatch, tmp_path):
+    """Verify that a_chunk_doc works end 2 end with async embedding.
+
+    - Uses StubAsyncEmbedder to provide async embeddings.
+    - Monkeypatches Chroma with a FakeClient.
+    - Confirms that chunks are added to the fake collection without error.
+    """
+    p = tmp_path / "big_async.md"
+    p.write_text(("x\n" * 2000), encoding="utf-8")
+    dc = DocumentChunker(StubAsyncEmbedder())
+    dc.load_doc(str(p), encoding="utf-8")
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(
+        "deepeval.synthesizer.chunking.doc_chunker._chroma_mod",
+        FakeChromaMod(fake_client),
+        raising=True,
+    )
+
+    collection = await dc.a_chunk_doc(chunk_size=1, chunk_overlap=0)
+    assert isinstance(collection, FakeCollection)
+    assert collection.add_calls
+
+
+def test_chunk_doc_uses_existing_collection(monkeypatch, tmp_path):
+    """Ensure chunk_doc reuses an existing collection if present.
+
+    - Prepopulates FakeClient with a collection named for the default chunk
+      parameters.
+    - Verifies that DocumentChunker returns the existing collection rather than
+      creating a new one, and does not perform additional adds.
+    """
+    p = tmp_path / "a.md"
+    p.write_text("hello", encoding="utf-8")
+    dc = DocumentChunker(StubEmbedder())
+    dc.load_doc(str(p), encoding="utf-8")
+
+    fake_client = FakeClient()
+    existing = FakeCollection()
+    fake_client.collections["processed_chunks_1024_0"] = existing
+
+    monkeypatch.setattr(
+        "deepeval.synthesizer.chunking.doc_chunker._chroma_mod",
+        FakeChromaMod(fake_client),
+        raising=True,
+    )
+
+    returned = dc.chunk_doc()
+    assert returned is existing
+    assert existing.add_calls == []  # no new adds on cache hit
+
+
+def test_persistent_path_and_collection_name(monkeypatch, tmp_path):
+    """Confirm persistent client path and collection naming conventions.
+
+    - Loads a file with version suffix in its name.
+    - Monkeypatches Chroma client to capture the path argument.
+    - Asserts that:
+      * PersistentClient path is derived from the file basename (no extension).
+      * Collection name includes both chunk_size and chunk_overlap values.
+    """
+    p = tmp_path / "notes.v1.md"
+    p.write_text("data", encoding="utf-8")
+    dc = DocumentChunker(StubEmbedder())
+    dc.load_doc(str(p), encoding="utf-8")
+
+    captured = {}
+    fake_client = FakeClient()
+
+    class CapturingChroma:
+        def PersistentClient(self, path):
+            captured["path"] = path
+            return fake_client
+
+    monkeypatch.setattr(
+        "deepeval.synthesizer.chunking.doc_chunker._chroma_mod",
+        CapturingChroma(),
+        raising=True,
+    )
+
+    dc.chunk_doc(chunk_size=123, chunk_overlap=7)
+
+    assert captured["path"].endswith(".vector_db/notes.v1")
+    assert "processed_chunks_123_7" in fake_client.collections


### PR DESCRIPTION
* Refactor `DocumentChunker` to use lazy getters (`_get_langchain`, `_get_chromadb`) instead of module-level imports and global flags.
* Add markdown family support in loaders: `.md`, `.markdown`, `.mdx`.
* Switch type hints to quoted forward refs and gate heavy types behind `TYPE_CHECKING`.
* Use `TokenTextSplitter` via lazy import; remove direct annotations on instances.
* Store Chroma metadata as plain dicts
* Defer loader mapping initialization until first use.

docs:

* Update `synthesizer-generate-from-docs.mdx` to list required deps (`chromadb`, `langchain-core`, `langchain-community`, `langchain-text-splitters`), clarify token-based chunking, and add markdown formats to examples.
* Update `synthesizer-introduction.mdx` and `guides-using-synthesizer.mdx` to include markdown formats and fix minor copy/grammar.
* Add explicit note in `integrations/vector-databases/chroma.mdx` that `generate_goldens_from_docs()` **requires** Chroma.

test:

* Add comprehensive `test_doc_chunker.py` covering:

  * markdown loader behavior and encoding autodetect,
  * lazy import error paths (LangChain/Chroma),
  * chunking preconditions, batching, metadata,
  * async chunking path,
  * collection cache hits and persistent path/collection naming.
* Add `tests/test_core/conftest.py` shim to substitute `pysqlite3` for `sqlite3` in CI environments with older SQLite.

build:

* Add `pysqlite3-binary` to `pyproject.toml` and lockfile to satisfy Chroma’s sqlite >= 3.35 requirement in constrained environments.