### PR TITLE
Fix/synthesizer index shadowing

### DIFF
--- a/deepeval/models/llms/amazon_bedrock_model.py
+++ b/deepeval/models/llms/amazon_bedrock_model.py
@@ -117,24 +117,27 @@ class AmazonBedrockModel(DeepEvalBaseLLM):
     def get_converse_request_body(self, prompt: str) -> dict:
         # Inline parameter translation with defaults
         param_mapping = {
-            "max_tokens": "maxTokens", 
+            "max_tokens": "maxTokens",
             "top_p": "topP",
             "top_k": "topK",
             "stop_sequences": "stopSequences",
         }
-        
+
         # Start with defaults for required parameters
         translated_kwargs = {
             "maxTokens": self.generation_kwargs.get("max_tokens", 1000),
             "topP": self.generation_kwargs.get("top_p", 0),
         }
-        
+
         # Add any other parameters from generation_kwargs
         for key, value in self.generation_kwargs.items():
-            if key not in ["max_tokens", "top_p"]:  # Skip already handled defaults
+            if key not in [
+                "max_tokens",
+                "top_p",
+            ]:  # Skip already handled defaults
                 aws_key = param_mapping.get(key, key)
                 translated_kwargs[aws_key] = value
-        
+
         return {
             "messages": [{"role": "user", "content": [{"text": prompt}]}],
             "inferenceConfig": {

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -569,7 +569,7 @@ class Synthesizer:
         include_expected_output: bool,
         max_goldens_per_context: int,
         source_files: Optional[List[str]],
-        index: int,
+        context_index: int,
         progress: Optional[Progress] = None,
         pbar_id: Optional[int] = None,
         context_scores: Optional[List[float]] = None,
@@ -591,7 +591,7 @@ class Synthesizer:
         # Add pbars
         pbar_generate_goldens_id = add_pbar(
             progress,
-            f"\t⚡ Generating goldens from context #{index}",
+            f"\t⚡ Generating goldens from context #{context_index}",
             total=1 + max_goldens_per_context,
         )
         pbar_generate_inputs_id = add_pbar(
@@ -635,7 +635,7 @@ class Synthesizer:
 
         # Helper function to process each input in parallel
         async def process_input(
-            index: int,
+            input_index: int,
             data: SyntheticData,
             progress: Optional[Progress] = None,
         ):
@@ -646,7 +646,7 @@ class Synthesizer:
                 num_evolutions=self.evolution_config.num_evolutions,
                 evolutions=self.evolution_config.evolutions,
                 progress=progress,
-                pbar_evolve_input_id=pbar_evolve_input_ids[index],
+                pbar_evolve_input_id=pbar_evolve_input_ids[input_index],
                 remove_pbar=False,
             )
 
@@ -664,7 +664,7 @@ class Synthesizer:
                 )
                 evolved_input = res.input
                 update_pbar(
-                    progress, pbar_evolve_input_ids[index], remove=False
+                    progress, pbar_evolve_input_ids[input_index], remove=False
                 )
 
             # Generate expected output
@@ -677,7 +677,7 @@ class Synthesizer:
                 )
                 expected_output = await self._a_generate(expected_output_prompt)
                 update_pbar(
-                    progress, pbar_evolve_input_ids[index], remove=False
+                    progress, pbar_evolve_input_ids[input_index], remove=False
                 )
 
             # Create Golden
@@ -686,13 +686,13 @@ class Synthesizer:
                 context=context,
                 expected_output=expected_output,
                 source_file=(
-                    source_files[index]
-                    if source_files is not None and index < len(source_files)
+                    source_files[context_index]
+                    if source_files is not None and context_index < len(source_files)
                     else None
                 ),
                 additional_metadata={
                     "evolutions": evolutions_used,
-                    "synthetic_input_quality": scores[index],
+                    "synthetic_input_quality": scores[input_index],
                     # "context_quality": (
                     #     context_scores[data_index]
                     #     if context_scores is not None

--- a/tests/test_core/test_models/test_amazon_bedrock_param_translation.py
+++ b/tests/test_core/test_models/test_amazon_bedrock_param_translation.py
@@ -1,0 +1,171 @@
+import copy
+from typing import Any, Dict, Optional
+
+import pytest
+
+from deepeval.models.llms.amazon_bedrock_model import AmazonBedrockModel
+
+
+def _mk_model(gen_kwargs: Optional[Dict[str, Any]], temperature: float = 0.5):
+    # avoid network/client setup: bypass __init__ and set only what we need
+    m = AmazonBedrockModel.__new__(AmazonBedrockModel)
+    m.temperature = temperature
+    m.generation_kwargs = gen_kwargs or {}
+    return m
+
+
+def test_snake_case_is_translated_and_removed_max_tokens_top_p():
+    """Ensure that `max_tokens` and `top_p` are translated into
+    `maxTokens` and `topP` in the request payload, and that the
+    original snake_case keys are removed. Also verifies that the
+    message body contains the prompt text unchanged.
+    """
+    model = _mk_model({"max_tokens": 1234, "top_p": 0.42})
+    body = model.get_converse_request_body("hi")
+
+    # minimal smoke-check on message body
+    assert body["messages"][0]["content"][0]["text"] == "hi"
+
+    cfg = body["inferenceConfig"]
+    # canonical keys exist
+    assert cfg["maxTokens"] == 1234
+    assert cfg["topP"] == 0.42
+    # Snake-case keys must NOT be present
+    assert "max_tokens" not in cfg
+    assert "top_p" not in cfg
+
+
+def test_stop_sequences_and_top_k_aliases_are_translated_and_snake_removed():
+    """Verify that `stop_sequences` -> `stopSequences` and `top_k` -> `topK`
+    are properly translated in the payload, and that the snake_case
+    keys are not present.
+    """
+    model = _mk_model(
+        {
+            "stop_sequences": ["END", "STOP"],
+            "top_k": 7,
+        }
+    )
+    body = model.get_converse_request_body("hi")
+    cfg = body["inferenceConfig"]
+
+    assert cfg["stopSequences"] == ["END", "STOP"]
+    assert "stop_sequences" not in cfg
+
+    assert cfg["topK"] == 7
+    assert "top_k" not in cfg
+
+
+@pytest.mark.parametrize(
+    "gen_kwargs,expected_max_tokens",
+    [
+        ({}, 1000),  # default
+        ({"max_tokens": 2222}, 2222),  # snake provided
+        ({"maxTokens": 3333}, 3333),  # camel provided
+        ({"max_tokens": 1111, "maxTokens": 4444}, 4444),  # camel should win
+    ],
+)
+def test_max_tokens_defaults_and_precedence(gen_kwargs, expected_max_tokens):
+    """Check that `maxTokens` defaults to 1000 if not supplied,
+    and that precedence rules are correct:
+    - snake_case overrides default,
+    - camelCase overrides snake_case,
+    - no duplicate keys remain.
+    """
+    model = _mk_model(gen_kwargs)
+    cfg = model.get_converse_request_body("hi")["inferenceConfig"]
+    assert cfg["maxTokens"] == expected_max_tokens
+    # ensure no snake duplicate
+    assert "max_tokens" not in cfg
+
+
+@pytest.mark.parametrize(
+    "gen_kwargs,expected_top_p",
+    [
+        ({}, 0),  # default
+        ({"top_p": 0.2}, 0.2),
+        ({"topP": 0.3}, 0.3),
+        ({"top_p": 0.1, "topP": 0.9}, 0.9),  # camel should win
+    ],
+)
+def test_top_p_defaults_and_precedence(gen_kwargs, expected_top_p):
+    """Check that `topP` defaults to 0 if not supplied,
+    and that precedence rules are correct:
+    - snake_case overrides default,
+    - camelCase overrides snake_case,
+    - no duplicate keys remain.
+    """
+    model = _mk_model(gen_kwargs)
+    cfg = model.get_converse_request_body("hi")["inferenceConfig"]
+    assert cfg["topP"] == expected_top_p
+    assert "top_p" not in cfg
+
+
+@pytest.mark.parametrize(
+    "gen_kwargs,expected_stop_sequences",
+    [
+        ({"stop_sequences": ["END"]}, ["END"]),
+        ({"stopSequences": ["A", "B"]}, ["A", "B"]),
+        # camel should win if both present
+        ({"stop_sequences": ["X"], "stopSequences": ["C", "D"]}, ["C", "D"]),
+    ],
+)
+def test_stop_sequences_precedence(gen_kwargs, expected_stop_sequences):
+    """Validate that `stopSequences` precedence is handled correctly:
+    - snake_case is translated,
+    - camelCase is passed through,
+    - if both forms are provided, camelCase wins,
+    - no snake_case remains in the payload.
+    """
+    model = _mk_model(gen_kwargs)
+    cfg = model.get_converse_request_body("hi")["inferenceConfig"]
+    assert cfg["stopSequences"] == expected_stop_sequences
+    assert "stop_sequences" not in cfg
+
+
+@pytest.mark.parametrize(
+    "gen_kwargs,expected_top_k",
+    [
+        ({"top_k": 5}, 5),
+        ({"topK": 9}, 9),
+        # camel should win if both present
+        ({"top_k": 3, "topK": 8}, 8),
+    ],
+)
+def test_top_k_precedence(gen_kwargs, expected_top_k):
+    """Validate that `topK` precedence is handled correctly:
+    - snake_case is translated,
+    - camelCase is passed through,
+    - if both forms are provided, camelCase wins,
+    - no snake_case remains in the payload.
+    """
+    model = _mk_model(gen_kwargs)
+    cfg = model.get_converse_request_body("hi")["inferenceConfig"]
+    assert cfg["topK"] == expected_top_k
+    assert "top_k" not in cfg
+
+
+def test_generation_kwargs_is_not_mutated():
+    """Ensure that the original `generation_kwargs` dictionary provided
+    by the user is not mutated when building the request body.
+    """
+    original = {"max_tokens": 500, "stop_sequences": ["END"]}
+    snapshot = copy.deepcopy(original)
+
+    model = _mk_model(original)
+    _ = model.get_converse_request_body("hi")
+
+    assert (
+        original == snapshot
+    ), "get_converse_request_body must not mutate input dict"
+
+
+def test_temperature_source_of_truth_is_documented_behavior():
+    """Check that `temperature` from `generation_kwargs` overrides the
+    model's default temperature. This documents the current precedence
+    rule so it is explicit and test enforced.
+    """
+    # kwargs override the model default today
+    model = _mk_model({"temperature": 0.9}, temperature=0.2)
+    cfg = model.get_converse_request_body("hi")["inferenceConfig"]
+    assert cfg["temperature"] == 0.9


### PR DESCRIPTION
Rename nested loop variables to prevent source_files misattribution across contexts.
Inner 'index' variable was shadowing outer context index, causing wrong file assignment.

Fixes #2009