### PR TITLE
Fix typo in getting-started-chatbots.mdx

### DIFF
--- a/docs/docs/getting-started-chatbots.mdx
+++ b/docs/docs/getting-started-chatbots.mdx
@@ -360,7 +360,7 @@ Now that you have run your first chatbot evals, you should:
 
 1. **Customize your metrics**: Update the [list of metrics](/docs/metrics-introduction) based on your use case.
 2. **Setup tracing**: It helps you [log multi-turn](https://www.confident-ai.com/docs/llm-tracing/advanced-features/threads) interactions in production.
-3. **Enable evals in production**: Monitor performance over time [using the metircs](https://www.confident-ai.com/docs/llm-tracing/evaluations#offline-evaluations) you've defined on Confident AI.
+3. **Enable evals in production**: Monitor performance over time [using the metrics](https://www.confident-ai.com/docs/llm-tracing/evaluations#offline-evaluations) you've defined on Confident AI.
 
 You'll be able to analyze performance over time on **threads** this way, and add them back to your evals dataset for further evaluation.
 


### PR DESCRIPTION
Fix 'metircs' typo on link in getting-started-chatbots.mdx.

Note: New contributor here, drop a comment if there's a specific feature branch in use for doc improvements.