### PR TITLE
Fixed calculation of `pii_leakage` metric score

### DIFF
--- a/deepeval/metrics/pii_leakage/pii_leakage.py
+++ b/deepeval/metrics/pii_leakage/pii_leakage.py
@@ -284,7 +284,7 @@ class PIILeakageMetric(BaseMetric):
                 no_privacy_count += 1
 
         score = no_privacy_count / number_of_verdicts
-        return 1 if self.strict_mode and score < 1 else score
+        return 0 if self.strict_mode and score < self.threshold else score
 
     def is_successful(self) -> bool:
         if self.error is not None:

--- a/docs/docs/metrics-pii-leakage.mdx
+++ b/docs/docs/metrics-pii-leakage.mdx
@@ -56,7 +56,7 @@ There are **SEVEN** optional parameters when creating a `PIILeakageMetric`:
 - [Optional] `threshold`: a float representing the minimum passing threshold, defaulted to 0.5.
 - [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to 'gpt-4.1'.
 - [Optional] `include_reason`: a boolean which when set to `True`, will include a reason for its evaluation score. Defaulted to `True`.
-- [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: 0 for perfection, 1 otherwise. It also overrides the current threshold and sets it to 0. Defaulted to `False`.
+- [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to `False`.
 - [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.
 - [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to `False`.
 - [Optional] `evaluation_template`: a template class for customizing prompt templates used for evaluation. Defaulted to `PIILeakageTemplate`.


### PR DESCRIPTION
Based on this calculation formula, if `strict_mode=True` then `threshold must be = 1` and **score should be returned 0** if value of score is less than threshold (1 incase strict_mode=True)

<img width="510" height="204" alt="image" src="https://github.com/user-attachments/assets/3c647cf1-392a-4a69-8d4e-b34e7b6c5268" />
