### PR TITLE
Fixed sidebar headings not visible clearly in darkmode

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -421,7 +421,7 @@ html[data-theme="light"] .sidebar-icon {
 }
 
 html[data-theme="dark"] .sidebar-icon {
-  color: black;
+  color: white;
   font-weight: 500;
 }
 
@@ -494,6 +494,13 @@ html[data-theme="dark"] .menu {
 
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link:first-of-type {
   color: black; // Example: orange text
+  font-weight: 600 !important;
+  font-size: 15px;
+}
+
+/* Dark mode */
+[data-theme='dark'] .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link:first-of-type {
+  color: white; // or any high-contrast color
   font-weight: 600 !important;
   font-size: 15px;
 }


### PR DESCRIPTION
Before

<img width="782" height="341" alt="image" src="https://github.com/user-attachments/assets/77465dc0-3b05-4612-a0b6-cf51b8173266" />


After

<img width="781" height="340" alt="image" src="https://github.com/user-attachments/assets/4bd4bf0b-9eaf-4cc4-b5b3-7aef2a588937" />
