### PR TITLE
Fixed failing `deepeval login` for python=3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Let's pretend your LLM application is a RAG based customer support chatbot; here
 
 ## Installation
 
+Deepeval works with **Python>=3.9+**.
+
 ```
 pip install -U deepeval
 ```

--- a/deepeval/constants.py
+++ b/deepeval/constants.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 KEY_FILE: str = ".deepeval"
 HIDDEN_DIR: str = ".deepeval"
@@ -29,7 +30,7 @@ class ProviderSlug(str, Enum):
     OLLAMA = "ollama"
 
 
-def slugify(value: str | ProviderSlug) -> str:
+def slugify(value: Union[str, ProviderSlug]) -> str:
     return (
         value.value
         if isinstance(value, ProviderSlug)


### PR DESCRIPTION
`deepeval login` is failing for **python=3.9**. Since, we are currently supporting [python>=3.9](https://github.com/confident-ai/deepeval/blob/d9df2a255085915a686c4afe03599180ea277b75/pyproject.toml#L19) we can't use `str | ProviderSlug`  this syntax.
