### PR TITLE
docs: add CLI guide, document MultimodalGEval evaluation_template, and fix broken links

### DIFF
--- a/docs/docs/cli.mdx
+++ b/docs/docs/cli.mdx
@@ -1,0 +1,282 @@
+---
+title: Command-line interface (CLI)
+description: Configure DeepEval from the terminal — providers, credentials, debug, and more.
+sidebar_position: 30
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# DeepEval CLI
+
+DeepEval ships a typed CLI for common tasks:
+- logging in/out and viewing test runs
+- enabling/disabling debug
+- selecting an LLM/embeddings provider (OpenAI, Azure OpenAI, Gemini, Grok, DeepSeek, LiteLLM, local/Ollama)
+- setting/unsetting provider-specific options (model, endpoint, deployment, etc.)
+
+The CLI supports optional persistence to `.env` files.
+
+## Install / update
+
+```bash
+pip install -U deepeval
+```
+
+Then:
+```bash
+deepeval --help
+```
+
+---
+
+## Where settings are read/written
+
+* **Dotenv**: DeepEval loads `.env` / `.env.local` from the current working directory.
+  You can point dotenv loading to another folder via `ENV_DIR_PATH=/path/to/project`.
+* **Hidden keystore**: Non-secret settings are stored in `.deepeval/.deepeval` under the current working directory (no override env var yet).
+  A future UX pass will make these locations configurable and consistent.
+
+---
+
+## Persistence & secrets: how it works
+
+All `set-*` / `unset-*` commands follow the same rules:
+
+* **Non-secrets**, such as model name, endpoint, deployment, etc., are written to a hidden JSON keystore at `.deepeval/.deepeval`.
+* **Secrets** (API keys) are **never** written to that JSON keystore.
+* Pass `--save=dotenv[:path]` to also write settings, including secrets, to a dotenv file with a default path of: `.env.local`.
+  Make sure your dotenv files are git-ignored in your project.
+* If `--save` is omitted, only the in-process environment and JSON store are updated.
+* Unsetting one provider only removes that provider’s keys. If another provider’s credentials remain, such as `OPENAI_API_KEY`, it may still be selected by default.
+
+> Tip: you can set a default save target via `DEEPEVAL_DEFAULT_SAVE=dotenv:.env.local` so you don’t have to pass `--save` each time.
+
+---
+
+## Quick start
+
+```bash
+# 1. Log in auto persists to .env.local unless you override --save
+deepeval login --confident-api-key YOUR_KEY
+
+# 2. Pick a provider and model
+deepeval set-openai --model gpt-4o-mini --save=dotenv
+
+# 3. (Optional) Turn on richer logs for troubleshooting
+deepeval set-debug --log-level DEBUG --verbose
+
+# 4. Run tests as usual (Python), then view the latest run:
+deepeval view
+```
+
+To undo:
+
+```bash
+deepeval unset-openai --save=dotenv
+deepeval unset-debug --save=dotenv
+deepeval logout --save=dotenv
+```
+
+---
+
+## Core commands
+
+### `login` / `logout`
+
+* `deepeval login [--confident-api-key ...] [--save=dotenv[:path]]`
+  Interactive or flag-based login. Writes keys to dotenv (defaults to `.env.local` unless overridden).
+* `deepeval logout [--save=dotenv[:path]]`
+  Clears keys from the JSON keystore and removes them from the chosen dotenv file.
+
+### `view`
+
+* `deepeval view`
+  Opens the latest test run in your browser. If needed, uploads artifacts first.
+
+---
+
+## Debug controls
+
+Use these to turn on structured logs, gRPC wire tracing, and Confident tracing (all optional).
+
+```bash
+deepeval set-debug \
+  --log-level DEBUG \
+  --verbose \
+  --retry-before-level INFO \
+  --retry-after-level ERROR \
+  --grpc --grpc-verbosity DEBUG --grpc-trace list_tracers \
+  --trace-verbose --trace-env staging --trace-flush \
+  --error-reporting --ignore-errors \
+  --save=dotenv
+```
+
+* **Immediate effect** in the current process
+* **Optional persistence** via `--save=dotenv[:path]`
+* **No-op guard**: if nothing would change, the command exits quietly
+
+To restore defaults and clean persisted values:
+
+```bash
+deepeval unset-debug --save=dotenv
+```
+
+**Flags (summary):**
+
+* Logs: `--log-level`, `--verbose/--no-verbose`
+* Retry log levels: `--retry-before-level`, `--retry-after-level` (accepts names `DEBUG|INFO|WARNING|ERROR|CRITICAL|NOTSET` or numbers)
+* gRPC: `--grpc/--no-grpc`, `--grpc-verbosity`, `--grpc-trace`
+* Tracing: `--trace-verbose/--no-trace-verbose`, `--trace-env`, `--trace-flush`
+* Other: `--error-reporting/--no-error-reporting`, `--ignore-errors/--no-ignore-errors`
+* Persistence: `--save=dotenv[:path]`
+
+---
+
+## Provider configuration: the pattern
+
+All provider commands come in pairs:
+
+* `deepeval set-<provider> [provider-specific flags] [--save=dotenv[:path]]`
+* `deepeval unset-<provider> [--save=dotenv[:path]]`
+
+This switches the active provider:
+
+* It sets `USE_<PROVIDER>_MODEL = True` for the chosen provider, and
+* Turns all other `USE_*` flags off so that only one provider is enabled at a time.
+
+When you **set** a provider, the CLI enables that provider’s `USE_<PROVIDER>_MODEL` flag and disables all other `USE_*` flags. When you **unset** a provider, it disables only that provider’s `USE_*` flag and leaves all others as is. If you only use the CLI, this effectively means no provider will remain active after an unset. However, if you have manually set flags or edited env vars yourself, it is possible to end up with multiple providers enabled. In that case, unsetting one provider leaves the others untouched. A future UX improvement will make this behavior more intuitive and consistent.
+
+
+### What’s available?
+
+| Provider (LLM)   | Set command        | Unset command        | Typical flags you’ll see                                                                                                        |
+| ---------------- | ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI           | `set-openai`       | `unset-openai`       | `--model`, optional cost overrides if using custom models                                                                       |
+| Azure OpenAI     | `set-azure-openai` | `unset-azure-openai` | `--openai-api-key`, `--openai-endpoint`, `--openai-api-version`, `--openai-model-name`, `--deployment-name`, `--model-version?` |
+| Gemini           | `set-gemini`       | `unset-gemini`       | Either `--google-api-key` **or** (`--project-id` + `--location`), optional `--model-name`                                       |
+| Grok             | `set-grok`         | `unset-grok`         | `--model-name`, `--api-key`, optional `--temperature`                                                                           |
+| DeepSeek         | `set-deepseek`     | `unset-deepseek`     | `--model-name`, `--api-key`, optional `--temperature`                                                                           |
+| LiteLLM router   | `set-litellm`      | `unset-litellm`      | `model_name` (arg), optional `--api-key`, `--api-base`                                                                          |
+| Local HTTP model | `set-local-model`  | `unset-local-model`  | `--model-name`, `--base-url`, optional `--api-key`, `--format`                                                                  |
+| Ollama (local)   | `set-ollama`       | `unset-ollama`       | `model_name` (arg), optional `--base-url`                                                                                       |
+
+**Embeddings:**
+
+| Provider (Embeddings) | Set command                  | Unset command                  | Typical flags                                      |
+| --------------------- | ---------------------------- | ------------------------------ | -------------------------------------------------- |
+| Azure OpenAI          | `set-azure-openai-embedding` | `unset-azure-openai-embedding` | `--embedding-deployment-name`                      |
+| Local (HTTP)          | `set-local-embeddings`       | `unset-local-embeddings`       | `--model-name`, `--base-url`, optional `--api-key` |
+| Ollama                | `set-ollama-embeddings`      | `unset-ollama-embeddings`      | `model_name` (arg), optional `--base-url`          |
+
+> **Consistency note**: Flags vary a bit today (some use positional args vs. options). We will converge them in a future release. To avoid churn, this page documents the pattern and points to `--help` for exact flags.
+
+### Common examples
+
+< Tabs>
+< TabItem value="openai" label="OpenAI">
+
+```bash
+# Use a known OpenAI model
+deepeval set-openai --model gpt-4o-mini --save=dotenv
+
+# Remove OpenAI config
+deepeval unset-openai --save=dotenv
+```
+
+</TabItem>
+< TabItem value="azure" label="Azure OpenAI">
+
+```bash
+deepeval set-azure-openai \
+  --openai-api-key $AZURE_OPENAI_KEY \
+  --openai-endpoint https://my-endpoint.openai.azure.com \
+  --openai-api-version 2024-06-01 \
+  --openai-model-name gpt-4o-mini \
+  --deployment-name my-gpt4o-mini \
+  --save=dotenv
+
+deepeval set-azure-openai-embedding \
+  --embedding-deployment-name text-embedding-3-large \
+  --save=dotenv
+
+deepeval unset-azure-openai --save=dotenv
+deepeval unset-azure-openai-embedding --save=dotenv
+```
+
+</TabItem>
+< TabItem value="ollama" label="Ollama (local)">
+
+```bash
+deepeval set-ollama mistral --base-url http://localhost:11434 --save=dotenv
+deepeval set-ollama-embeddings nomic-embed-text --save=dotenv
+
+deepeval unset-ollama --save=dotenv
+deepeval unset-ollama-embeddings --save=dotenv
+```
+
+</TabItem>
+</Tabs>
+
+> **Secrets**: Set API keys via CLI flags when supported, or by editing your dotenv file directly. Secrets are never written to the JSON keystore.
+
+---
+
+## Retry policy (where CLI meets settings)
+
+The CLI "debug" options include **retry log levels**:
+
+* `--retry-before-level` (default **INFO**)
+* `--retry-after-level` (default **ERROR**)
+
+DeepEval’s retry behavior is controlled by environment settings which you can place in `.env.local`:
+
+```bash
+# Providers whose own SDK should handle retries. Retries for these providers will not be managed by DeepEval
+# Default: empty list (DeepEval manages retries where supported)
+DEEPEVAL_SDK_RETRY_PROVIDERS="['azure']"   # or "['*']"
+
+# Log levels (validator accepts names or numeric)
+DEEPEVAL_RETRY_BEFORE_LOG_LEVEL=INFO
+DEEPEVAL_RETRY_AFTER_LOG_LEVEL=ERROR
+
+# Backoff settings
+DEEPEVAL_RETRY_MAX_ATTEMPTS=2
+DEEPEVAL_RETRY_INITIAL_SECONDS=1.0
+DEEPEVAL_RETRY_EXP_BASE=2.0
+DEEPEVAL_RETRY_JITTER=2.0
+DEEPEVAL_RETRY_CAP_SECONDS=5.0
+```
+
+You can also set the two retry log-level values via:
+
+```bash
+deepeval set-debug --retry-before-level INFO --retry-after-level ERROR --save=dotenv
+```
+
+---
+
+## `deepeval test` namespace
+
+The CLI includes a `test` sub-app for running E2E examples and fixtures. Usage varies, please consult the built-in help for details:
+
+```bash
+deepeval test --help
+deepeval test <command> --help
+```
+
+---
+
+## Troubleshooting
+
+* **Nothing printed?** For `set-*` / `unset-*` / `set-debug`, a clean no-output exit often means indicates **no changes** were detected.
+* **Provider still active after unsetting?** Unsetting turns off target provider `USE_*` flags; if a provider remains enabled and properly configured it will become the active provider. If no provider is enabled, but OpenAI credentials are present, OpenAI may be used as a fallback. To force a provider, run the corresponding `set-<provider>` command.
+* **Dotenv edits not picked up?** DeepEval loads dotenv files from the current working directory by default, or `ENV_DIR_PATH` if set. Ensure your Python process runs in that context.
+
+---
+
+## See also
+
+* Python API quickstart (evaluations)
+* Metrics & templates
+* Config & environment variables

--- a/docs/docs/metrics-llm-evals.mdx
+++ b/docs/docs/metrics-llm-evals.mdx
@@ -94,7 +94,7 @@ This is an example of [end-to-end evaluation](/docs/evaluation-end-to-end-llm-ev
 
 ### Evaluation Steps
 
-Providing `evaluation_steps` tells `GEval` to follow your `evaluation_steps` for evaluation instead of first generating one from `criteria`, which allows for more controllable metric scores (more info [here](<(#how-is-it-calculated)>)):
+Providing `evaluation_steps` tells `GEval` to follow your `evaluation_steps` for evaluation instead of first generating one from `criteria`, which allows for more controllable metric scores (more info [here](#how-is-it-calculated)):
 
 ```python
 ...

--- a/docs/docs/metrics-toxicity.mdx
+++ b/docs/docs/metrics-toxicity.mdx
@@ -16,7 +16,7 @@ import MetricTagsDisplayer from "@site/src/components/MetricTagsDisplayer";
 The toxicity metric is another **referenceless** metric that uses uses LLM-as-a-judge to evaluate toxicness in your LLM outputs. This is particularly useful for a fine-tuning use case.
 
 :::tip Did Your Know?
-You can run evaluations **DURING** fine-tuning using `deepeval`'s [Hugging Face integration](integrations/frameworks/huggingface)?
+You can run evaluations **DURING** fine-tuning using `deepeval`'s [Hugging Face integration](/docs/integrations/frameworks/huggingface)?
 :::
 
 ## Required Arguments

--- a/docs/docs/multimodal-metrics-g-eval.mdx
+++ b/docs/docs/multimodal-metrics-g-eval.mdx
@@ -14,7 +14,7 @@ import MetricTagsDisplayer from "@site/src/components/MetricTagsDisplayer";
 
 The multimodal G-Eval is an adopted version of `deepeval`'s popular [`GEval` metric](/docs/metrics-llm-evals) but for evaluating multimodality LLM interactions instead.
 
-It is currently the best way to define custom criteria to evaluate text + images in `deepeval`. By defining a custom `MultimodalGEval`, you can easily determine how well your MLLMs are generating, editing, and referncing images for example.
+It is currently the best way to define custom criteria to evaluate text + images in `deepeval`. By defining a custom `MultimodalGEval`, you can easily determine how well your MLLMs are generating, editing, and referencing images for example.
 
 ## Required Arguments
 
@@ -26,12 +26,12 @@ To use the `MultimodalGEval`, you'll have to provide the following arguments whe
 You'll also need to supply any additional arguments such as `expected_output` and `context` if your evaluation criteria depends on these parameters.
 
 :::tip
-The `input`s and `actual_output`s of an `MLLMTestCase` is a list of strings and/or `MLLMImage` objects.
+The `input`s and `actual_output`s of an `MLLMTestCase` are lists of strings and/or `MLLMImage` objects.
 :::
 
 ## Usage
 
-To create a custom metric that uses MLLMs for evaluation, simply instantiate an `MultimodalGEval` class and **define an evaluation criteria in everyday language**:
+To create a custom metric that uses MLLMs for evaluation, simply instantiate a `MultimodalGEval` class and **define an evaluation criteria in everyday language**:
 
 ```python
 from deepeval.metrics import MultimodalGEval
@@ -49,14 +49,14 @@ m_test_case = MLLMTestCase(
 )
 text_image_coherence = MultimodalGEval(
     name="Text-Image Coherence",
-    criteria="Determine whether the images and text is coherence in the actual output.",
+    criteria="Determine whether the images and text are coherent in the actual output.",
     evaluation_params=[MLLMTestCaseParams.ACTUAL_OUTPUT],
 )
 
 evaluate(test_cases=[m_test_case], metrics=[text_image_coherence])
 ```
 
-There are **THREE** mandatory and **SEVEN** optional parameters required when instantiating an `MultimodalGEval` class:
+There are **THREE** mandatory and **EIGHT** optional parameters required when instantiating an `MultimodalGEval` class:
 
 - `name`: name of custom metric.
 - `criteria`: a description outlining the specific evaluation aspects for each test case.
@@ -65,6 +65,11 @@ There are **THREE** mandatory and **SEVEN** optional parameters required when in
 - [Optional] `rubric`: a list of `Rubric`s that allows you to [confine the range](/docs/metrics-llm-evals#rubric) of the final metric score.
 - [Optional] `threshold`: the passing threshold, defaulted to 0.5.
 - [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to 'gpt-4.1'.
+- [Optional] `evaluation_template`: a **class** typed as `Type[MultimodalGEvalTemplate]` that controls how prompts/messages are generated for this metric. Defaults to `MultimodalGEvalTemplate`. It is used by:
+  - `generate_evaluation_steps`
+  - `generate_evaluation_results`
+  - `generate_strict_evaluation_results`
+
 - [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to `False`.
 - [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.
 - [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to `False`.
@@ -85,10 +90,103 @@ text_image_coherence = MultimodalGEval(
     evaluation_steps=[
         "Evaluate whether the images and the accompanying text in the actual output logically match and support each other.",
         "Check if the visual elements (images) enhance or contradict the meaning conveyed by the text.",
-        "If there is a lack of coherence, identify where and how the text and images diverge or create confusion.,
+        "If there is a lack of coherence, identify where and how the text and images diverge or create confusion.",
     ],
     evaluation_params=[MLLMTestCaseParams.ACTUAL_OUTPUT],
 )
+```
+
+
+### Custom evaluation templates (`evaluation_template`)
+
+`MultimodalGEval` now accepts an `evaluation_template` parameter so you can customize how prompts are generated for both
+evaluation steps and scoring prompts, without forking the metric.
+
+- Pass a **class**, not an instance: `evaluation_template: Type[MultimodalGEvalTemplate]`.
+- Default is `MultimodalGEvalTemplate`.
+- Runtime behavior:
+  - **Non‑strict** mode: uses `evaluation_template.generate_evaluation_results` (optionally includes your rubric).
+  - **Strict** mode: uses `evaluation_template.generate_strict_evaluation_results`.
+  - The "explain the steps" helper uses `evaluation_template.generate_evaluation_steps`.
+
+**Return shapes:** The default template returns a string for `generate_evaluation_steps` and a list of prompt segments/messages
+(strings and/or message dicts, depending on the model adapter) for the `generate_*_evaluation_results` methods. Custom templates
+should follow the same shapes unless your selected model requires a different input format.
+
+**JSON contract (default template):**
+
+- `generate_evaluation_steps` prompts the model to return JSON like:
+  ```json
+  { "steps": ["..."] }
+  ```
+- `generate_evaluation_results` prompts for:
+  ```json
+  { "score": <int>, "reason": "<concise, grounded explanation without quoting the score>" }
+  ```
+  The default score range is `(0, 10)`; the rubric (if provided) guides how to pick a value.
+- `generate_strict_evaluation_results` requests a binary score (0 or 1):
+  ```json
+  { "score": 0 | 1, "reason": "<very concise justification without quoting the score>" }
+  ```
+
+If you override the template, keep the JSON fields consistent so downstream parsing and scoring continue to work.
+
+#### Minimal example
+
+```python
+import os
+from deepeval import assert_test
+from deepeval.test_case import MLLMTestCase, MLLMTestCaseParams, MLLMImage
+from deepeval.metrics.multimodal_metrics.multimodal_g_eval.multimodal_g_eval import MultimodalGEval
+from deepeval.metrics.multimodal_metrics.multimodal_g_eval.template import MultimodalGEvalTemplate
+
+class MyMMTemplate(MultimodalGEvalTemplate):
+    @staticmethod
+    def generate_evaluation_steps(parameters: str, criteria: str):
+        base = MultimodalGEvalTemplate.generate_evaluation_steps(criteria=criteria, parameters=parameters)
+        return "[MyMMTemplate]\n" + base  # string
+
+    @staticmethod
+    def generate_evaluation_results(*, evaluation_steps, test_case_list, parameters, rubric, score_range, _additional_context):
+        base = MultimodalGEvalTemplate.generate_evaluation_results(
+            evaluation_steps=evaluation_steps,
+            test_case_list=test_case_list,
+            parameters=parameters,
+            rubric=rubric,
+            score_range=score_range,
+            _additional_context=_additional_context,
+        )
+        # Prepend a system message; return list of prompt segments/messages
+        return [{"role": "system", "content": "[MyMMTemplate]"}] + list(base)
+
+    @staticmethod
+    def generate_strict_evaluation_results(*, evaluation_steps, test_case_list, parameters, _additional_context):
+        base = MultimodalGEvalTemplate.generate_strict_evaluation_results(
+            evaluation_steps=evaluation_steps,
+            test_case_list=test_case_list,
+            parameters=parameters,
+            _additional_context=_additional_context,
+        )
+        return [{"role": "system", "content": "[MyMMTemplate]"}] + list(base)
+
+metric = MultimodalGEval(
+    name="MM Correctness (custom template)",
+    criteria="Decide if the actual output correctly answers the question given the image.",
+    evaluation_params=[MLLMTestCaseParams.ACTUAL_OUTPUT, MLLMTestCaseParams.EXPECTED_OUTPUT],
+    model="gpt-4o-mini",
+    strict_mode=False,  # set True to exercise generate_strict_evaluation_results
+    evaluation_template=MyMMTemplate,  # <-- pass the CLASS
+)
+
+# Simple test case: requires internet access for the image
+tc = MLLMTestCase(
+    input=["What fruit is shown in the image?", MLLMImage(url="https://upload.wikimedia.org/wikipedia/commons/8/8a/Banana-Single.jpg")],
+    actual_output=["A banana."],
+    expected_output=["A banana."],
+)
+
+assert_test(tc, [metric])
+
 ```
 
 ### Rubric

--- a/docs/guides/guides-red-teaming.mdx
+++ b/docs/guides/guides-red-teaming.mdx
@@ -13,7 +13,7 @@ import Equation from "@site/src/components/Equation";
 Ensuring the **security of your LLM application** is critical to the safety of your users, brand, and organization. DeepEval makes it easy to red-team your LLM, allowing you to detect critical risks and vulnerabilities within just a few lines of code.
 
 :::info
-DeepEval allows you to scan for 40+ different LLM [vulnerabilities](red-teaming-vulnerabilities) and offers 10+ [attack enhancements](/docs/red-teaming-attack-enhancements) strategies to optimize your attacks.
+DeepEval allows you to scan for 40+ different LLM [vulnerabilities](/docs/red-teaming-vulnerabilities) and offers 10+ [attack enhancements](/docs/red-teaming-attack-enhancements) strategies to optimize your attacks.
 :::
 
 ## Quick Summary
@@ -197,7 +197,7 @@ print("Red Teaming Results: ", results)
 ```
 
 :::tip
-While it might be tempting to conduct an exhaustive scan, targeting the **highest-priority vulnerabilities** is more effective when resources and time are limited. Scanning for all [vulnerabilities](red-teaming-vulnerabilities), utilizing every [attack enhancements](/docs/red-teaming-attack-enhancements), and generating the maximum number of attacks per vulnerability may not yield the most efficient results, and will detract you from your goal.
+While it might be tempting to conduct an exhaustive scan, targeting the **highest-priority vulnerabilities** is more effective when resources and time are limited. Scanning for all [vulnerabilities](/docs/red-teaming-vulnerabilities), utilizing every [attack enhancements](/docs/red-teaming-attack-enhancements), and generating the maximum number of attacks per vulnerability may not yield the most efficient results, and will detract you from your goal.
 :::
 
 ### Tips for Effective Red-Teaming Scans

--- a/docs/integrations/models/ollama.mdx
+++ b/docs/integrations/models/ollama.mdx
@@ -7,7 +7,7 @@ sidebar_label: Ollama
 DeepEval allows you to use any model from Ollama to run evals, either through the CLI or directly in python.
 
 :::note
-Before getting started, make sure your Ollama model is installed and running. See the full list of available models [here](<](https://ollama.com/search)>).
+Before getting started, make sure your Ollama model is installed and running. See the full list of available models [here](https://ollama.com/search).
 
 ```bash
 ollama run deepseek-r1:1.5b

--- a/docs/tutorials/summarization-agent/development.mdx
+++ b/docs/tutorials/summarization-agent/development.mdx
@@ -15,7 +15,7 @@ In this section, we're going to create our **meeting summarization agent** using
 We will implement our summarizer with variables of **model and summary prompt** in a `MeetingSummarizer` class. This will be helpful for future evaluations and iterations on our summarizer.
 
 :::tip
-If you already have an LLM-based summarization agent that you want to evaluate, feel free to skip to the [**evaluation section of this tutorial**](tutorial-summarization-evaluation).
+If you already have an LLM-based summarization agent that you want to evaluate, feel free to skip to the [**evaluation section of this tutorial**](evaluation).
 :::
 
 ## Creating Meeting Summarizer
@@ -494,4 +494,4 @@ Finally, they discussed UI strategies for low-confidence responses, agreeing tha
 
 We now have a summarization agent that generates responses in our desired format. Now it's time to evaluate how good this agent works. Many developers stop at a quick glance of the output and assume it's good enough. But **LLMs are probabilistic and prone to inconsistency** — eyeballing results won't catch subtle regressions, logical errors, or hallucinated action items. That's why rigorous evaluation is essential.
 
-In the next section we are going to see [how to evaluate your summarization agent](tutorial-summarization-evaluation) using `deepeval`.
+In the next section we are going to see [how to evaluate your summarization agent](evaluation) using `deepeval`.

--- a/docs/tutorials/summarization-agent/improvement.mdx
+++ b/docs/tutorials/summarization-agent/improvement.mdx
@@ -278,4 +278,4 @@ class MeetingSummarizer:
 
 This setup allows you to change your model for these tasks anytime you want. You now have a robust summarization agent for generating summaries and action items.
 
-In the next section we'll see how to [prepare your summarization agent for deployment](tutorial-summarization-deployment).
+In the next section we'll see how to [prepare your summarization agent for deployment](evals-in-prod).

--- a/docs/tutorials/summarization-agent/introduction.mdx
+++ b/docs/tutorials/summarization-agent/introduction.mdx
@@ -96,5 +96,5 @@ Below is an example of what a deliverable from a meeting summarization platform 
 In the next section, we'll build this summarization agent from scratch using OpenAI API.
 
 :::tip
-If you already have an LLM agent to evaluate, you can skip to [Evaluation Section](tutorial-summarization-evaluation) of this tutorial.
+If you already have an LLM agent to evaluate, you can skip to [Evaluation Section](evaluation) of this tutorial.
 :::


### PR DESCRIPTION
- **Add new cli page:** `docs/docs/cli.mdx`: CLI documentation covering install, persistence & secrets, provider switching semantics, debug flags, retry policy envs, examples, and troubleshooting.
- **Multimodal G-Eval docs:** update `docs/docs/multimodal-metrics-g-eval.mdx` to introduce `evaluation_template: Type[MultimodalGEvalTemplate]`; explain how it feeds `generate_evaluation_steps`, `generate_evaluation_results`, and `generate_strict_evaluation_results`. 
  - explains expected return shapes and JSON contracts
  - add a minimal customization example; fix param counts.
- **Link fixes:** correct broken/relative links in:
  - `metrics-llm-evals.mdx` (bad anchor markup)
  - `metrics-toxicity.mdx` (Hugging Face integration path)
  - `guides-red-teaming.mdx` (use `/docs/red-teaming-vulnerabilities`)
  - `integrations/models/ollama.mdx` (Ollama search URL)
  - summarization tutorial pages (update cross-page slugs)
