### PR TITLE
Fixed Info & Caution sections not rendering properly in Docs (DarkMode)

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -93,8 +93,8 @@ html[data-theme="dark"] {
   }
 
   .alert--warning {
-    --ifm-alert-background-color: hsl(50, 100%, 90%) !important;
-    --ifm-alert-border-color: #ffdc42 !important;
+    --ifm-alert-background-color: #2a1f00 !important;
+    --ifm-alert-border-color: #facc15 !important;
   }
 }
 

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -71,6 +71,12 @@ html[data-theme="dark"] {
   --ifm-background-surface-color: #13171e;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 
+  .alert--info {
+    --ifm-alert-background-color: #1e293b !important;  /* deep navy */
+    --ifm-alert-border-color: #3b82f6 !important;      /* vivid blue border */
+    color: #dbeafe !important;                         /* light blue text */
+  }
+
   .alert--success {
     --ifm-alert-background-color: #022c22 !important;
     --ifm-alert-border-color: #12be84 !important;


### PR DESCRIPTION

Before

<img width="772" height="530" alt="image" src="https://github.com/user-attachments/assets/7217951c-83a8-4b3c-bf90-e1ebf2b410af" />


After

<img width="784" height="535" alt="image" src="https://github.com/user-attachments/assets/26282347-9dfe-4368-ae84-b58ab1caf7f1" />
