### PR TITLE
Added functionality for minimizing the sidebar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -129,6 +129,11 @@ module.exports = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+	  docs: {
+      sidebar: {
+        hideable: true,
+      },
+     },
       image: "img/social_card.png",
       navbar: {
         logo: {


### PR DESCRIPTION
By enabling the `themeConfig.docs.sidebar.hideable` option, we can make the entire sidebar hideable, allowing users to better focus on the content.

Same as the one in Official Docusaurus Docs: https://docusaurus.io/docs/sidebar