### PR TITLE
Updated `async_mode=True` by default for Hallucination Metric

### DIFF
--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -30,7 +30,7 @@ class HallucinationMetric(BaseMetric):
         threshold: float = 0.5,
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
         include_reason: bool = True,
-        async_mode: bool = False,
+        async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
         evaluation_template: Type[


### PR DESCRIPTION
[Docs](https://deepeval.com/docs/metrics-hallucination#usage) are already correctly saying default value is True.