### PR TITLE
feat: Add per-task timeouts to `observed_callback` in execute.py

### DIFF
--- a/deepeval/evaluate/execute.py
+++ b/deepeval/evaluate/execute.py
@@ -842,6 +842,7 @@ def execute_agentic_test_cases(
                                 coro,
                                 timeout=settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS,
                             )
+                        )
                     else:
                         observed_callback(golden.input)
                     current_trace: Trace = current_trace_context.get()

--- a/deepeval/evaluate/execute.py
+++ b/deepeval/evaluate/execute.py
@@ -836,7 +836,12 @@ def execute_agentic_test_cases(
                 ):
                     if asyncio.iscoroutinefunction(observed_callback):
                         loop = get_or_create_event_loop()
-                        loop.run_until_complete(observed_callback(golden.input))
+                        coro = observed_callback(golden.input)
+                        loop.run_until_complete(
+                            asyncio.wait_for(
+                                coro,
+                                timeout=settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS,
+                            )
                     else:
                         observed_callback(golden.input)
                     current_trace: Trace = current_trace_context.get()
@@ -1190,7 +1195,10 @@ async def _a_execute_agentic_test_case(
             _pbar_callback_id=pbar_tags_id,
         ):
             if asyncio.iscoroutinefunction(observed_callback):
-                await observed_callback(golden.input)
+                await asyncio.wait_for(
+                    observed_callback(golden.input),
+                    timeout=settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS,
+                )
             else:
                 observed_callback(golden.input)
             current_trace: Trace = current_trace_context.get()

--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -208,7 +208,13 @@ class TraceManager:
                 else:
                     # print(f"Ending trace: {trace.root_spans}")
                     self.environment = Environment.TESTING
-                    trace.root_spans = [trace.root_spans[0].children[0]]
+                    if (
+                        trace.root_spans
+                        and len(trace.root_spans) > 0
+                        and trace.root_spans[0].children
+                        and len(trace.root_spans[0].children) > 0
+                    ):
+                        trace.root_spans = [trace.root_spans[0].children[0]]
                     for root_span in trace.root_spans:
                         root_span.parent_uuid = None
 

--- a/tests/test_core/test_evaluation/test_execute/test_observed_callback_timeout.py
+++ b/tests/test_core/test_evaluation/test_execute/test_observed_callback_timeout.py
@@ -1,0 +1,77 @@
+import asyncio
+import pytest
+
+from deepeval.evaluate.execute import (
+    execute_agentic_test_cases,
+    a_execute_agentic_test_cases,
+)
+from deepeval.dataset import Golden
+from deepeval.config.settings import get_settings
+
+
+def test_observed_callback_times_out_sync_path(monkeypatch):
+    """
+    Ensures async observed_callback in the sync path is bounded by
+    DEEPEVAL_PER_TASK_TIMEOUT_SECONDS and raises asyncio.TimeoutError.
+    """
+    settings = get_settings()
+    original = settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS
+    try:
+        # Make the timeout tiny so the test is fast
+        settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS = 1
+
+        async def slow_callback(_):
+            # Sleep well past the configured timeout
+            await asyncio.sleep(5)
+
+        goldens = [Golden(input="hello")]
+
+        with pytest.raises(asyncio.TimeoutError):
+            execute_agentic_test_cases(
+                goldens=goldens,
+                observed_callback=slow_callback,
+            )
+    finally:
+        # restore global setting to avoid leaking to other tests
+        settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS = original
+
+
+@pytest.mark.asyncio
+async def test_observed_callback_times_out_async_path(monkeypatch):
+    """
+    Ensures async observed_callback in the async path is bounded by
+    DEEPEVAL_PER_TASK_TIMEOUT_SECONDS and raises asyncio.TimeoutError.
+    """
+    settings = get_settings()
+    original = settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS
+    try:
+        # Make the timeout tiny so the test is fast
+        settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS = 1
+
+        async def slow_callback(_):
+            # Sleep well past the configured timeout
+            await asyncio.sleep(5)
+
+        goldens = [Golden(input="hello")]
+
+        with pytest.raises(asyncio.TimeoutError):
+            await a_execute_agentic_test_cases(
+                goldens=goldens,
+                observed_callback=slow_callback,
+            )
+    finally:
+        # restore global setting to avoid leaking to other tests
+        settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS = original
+
+
+def test_observed_callback_sync_callback_unaffected():
+    """
+    Sanity check: synchronous callbacks still run fine and do not raise.
+    """
+
+    def sync_callback(_):
+        return "ok"
+
+    goldens = [Golden(input="hello")]
+    # should not raise
+    execute_agentic_test_cases(goldens=goldens, observed_callback=sync_callback)


### PR DESCRIPTION
fixes #2126