### PR TITLE
fix: broken doc code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ for golden in dataset.goldens:
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_customer_chatbot(test_case: LLMTestCase):
     answer_relevancy_metric = AnswerRelevancyMetric(threshold=0.5)

--- a/docs/blog/rag-evaluation-deepeval-guide.md
+++ b/docs/blog/rag-evaluation-deepeval-guide.md
@@ -538,7 +538,7 @@ metrics = [
 ]
 
 # 5. Use pytest.mark.parametrize to iterate over the dataset and run tests
-@pytest.mark.parametrize("test_case", dataset.test_case)
+@pytest.mark.parametrize("test_case", dataset.test_cases)
 def test_rag_application_performance(test_case: LLMTestCase):
     # Use assert_test to run all specified metrics on the test_case
     # If any metric fails its threshold, assert_test will raise an AssertionError

--- a/docs/docs/evaluation-introduction.mdx
+++ b/docs/docs/evaluation-introduction.mdx
@@ -160,7 +160,7 @@ for golden in dataset.goldens:
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_customer_chatbot(test_case: LLMTestCase):
     assert_test(test_case, [AnswerRelevancyMetric()])

--- a/docs/guides/guides-rag-evaluation.mdx
+++ b/docs/guides/guides-rag-evaluation.mdx
@@ -307,7 +307,7 @@ for goldens in dataset.goldens:
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_rag(test_case: LLMTestCase):
     # metrics is the list of RAG metrics as shown in previous sections

--- a/docs/guides/guides-regression-testing-in-cicd.mdx
+++ b/docs/guides/guides-regression-testing-in-cicd.mdx
@@ -36,7 +36,7 @@ dataset = EvaluationDataset(
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_example(test_case: LLMTestCase):
     metric = AnswerRelevancyMetric(threshold=0.5)

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -2746,7 +2746,7 @@ from deepeval.metrics import AnswerRelevancyMetric
 # Loop through test cases using Pytest
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_customer_chatbot(test_case: LLMTestCase):
     assert_test(test_case, [AnswerRelevancyMetric(threshold=0.5)])
@@ -14683,7 +14683,7 @@ dataset = EvaluationDataset(test_cases=[...])
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_customer_chatbot(test_case: LLMTestCase):
     answer_relevancy_metric = AnswerRelevancyMetric()
@@ -16103,7 +16103,7 @@ dataset = EvaluationDataset(test_cases=[...])
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_customer_chatbot(test_case: LLMTestCase):
     hallucination_metric = HallucinationMetric(threshold=0.3)
@@ -21696,7 +21696,7 @@ dataset = EvaluationDataset(test_cases=[...])
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_rag(test_case: LLMTestCase):
     # metrics is the list of RAG metrics as shown in previous sections

--- a/examples/getting_started/test_example.py
+++ b/examples/getting_started/test_example.py
@@ -12,7 +12,7 @@ dataset = EvaluationDataset(alias="My dataset", test_cases=[])
 
 @pytest.mark.parametrize(
     "test_case",
-    dataset,
+    dataset.test_cases,
 )
 def test_everything(test_case: LLMTestCase):
     test_case = LLMTestCase(


### PR DESCRIPTION
I was trying out this library using some of the examples such as the one below.

```python
@pytest.mark.parametrize(
    "test_case",
    dataset,
)
def test_customer_chatbot(test_case: LLMTestCase):
    assert_test(test_case, [AnswerRelevancyMetric()])
```

I was getting this error: `TypeError: 'EvaluationDataset' object is not iterable`

I believe this is because of a mistake in the docs. This PR attempts to fix all occurences of this docs typo.

Thanks