### PR TITLE
feat(execute): add per-task timeouts to semaphore-guarded awaits

### DIFF
--- a/deepeval/evaluate/execute.py
+++ b/deepeval/evaluate/execute.py
@@ -490,14 +490,10 @@ async def a_execute_test_cases(
 
     async def execute_with_semaphore(func: Callable, *args, **kwargs):
         async with semaphore:
-            try:
-                return await asyncio.wait_for(
-                    func(*args, **kwargs),
-                    timeout=settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-
-                raise
+            return await asyncio.wait_for(
+                func(*args, **kwargs),
+                timeout=_per_task_timeout(),
+            )
 
     global_test_run_cache_manager.disable_write_cache = (
         cache_config.write_cache is False
@@ -1286,14 +1282,10 @@ async def a_execute_agentic_test_cases(
 
     async def execute_with_semaphore(func: Callable, *args, **kwargs):
         async with semaphore:
-            try:
-                return await asyncio.wait_for(
-                    func(*args, **kwargs),
-                    timeout=settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-
-                raise
+            return await asyncio.wait_for(
+                func(*args, **kwargs),
+                timeout=_per_task_timeout(),
+            )
 
     test_run_manager = global_test_run_manager
     test_run_manager.save_to_disk = cache_config.write_cache
@@ -2553,14 +2545,10 @@ async def _a_evaluate_traces(
 
     async def execute_evals_with_semaphore(func: Callable, *args, **kwargs):
         async with semaphore:
-            try:
-                return await asyncio.wait_for(
-                    func(*args, **kwargs),
-                    timeout=settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-
-                raise
+            return await asyncio.wait_for(
+                func(*args, **kwargs),
+                timeout=_per_task_timeout(),
+            )
 
     eval_tasks = []
     # Here, we will work off a fixed-set copy to avoid surprises from potential
@@ -2626,14 +2614,10 @@ async def _evaluate_test_case_pairs(
 
     async def execute_with_semaphore(func: Callable, *args, **kwargs):
         async with semaphore:
-            try:
-                return await asyncio.wait_for(
-                    func(*args, **kwargs),
-                    timeout=settings.DEEPEVAL_PER_TASK_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-
-                raise
+            return await asyncio.wait_for(
+                func(*args, **kwargs),
+                timeout=_per_task_timeout(),
+            )
 
     tasks = []
     for count, test_case_pair in enumerate(test_case_pairs):

--- a/tests/test_core/test_evaluation/test_execute/test_execute_per_task_timeout.py
+++ b/tests/test_core/test_evaluation/test_execute/test_execute_per_task_timeout.py
@@ -42,15 +42,10 @@ class StalledMetric(BaseMetric):
 
 
 @pytest.mark.asyncio
-async def test_per_task_timeout_via_a_execute_test_cases(monkeypatch):
+async def test_per_task_timeout_via_a_execute_test_cases(monkeypatch, settings):
     """Test that per-task timeout works in a_execute_test_cases"""
-    # Import settings to patch it
-    from deepeval.config.settings import get_settings
-
-    settings = get_settings()
-
-    # Set small timeout for the test
-    monkeypatch.setattr(settings, "DEEPEVAL_PER_TASK_TIMEOUT_SECONDS", 2)
+    with settings.edit(persist=False):
+        settings.DEEPEVAL_PER_ATTEMPT_TIMEOUT_SECONDS = 2
 
     tc = LLMTestCase(input="hello", actual_output="test")
     metric = StalledMetric()


### PR DESCRIPTION
Adds per-task timeouts to all semaphore-guarded awaits in `execute.py` using 
`asyncio.wait_for` and the existing `DEEPEVAL_PER_TASK_TIMEOUT_SECONDS`.

Fixes #2125
