### PR TITLE
fixed the bug for Expected_tools was empty

### DIFF
--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -152,19 +152,14 @@ class ToolCorrectnessMetric(BaseMetric):
 
     # Calculate score
     def _calculate_score(self):
-        if self.should_exact_match:
+        # Fix: handle empty expected_tools to avoid ZeroDivisionError
+        if len(self.expected_tools) == 0:
+            score = 1.0 if len(self.tools_called) == 0 else 0.0
+        elif self.should_exact_match:
             score = self._calculate_exact_match_score()
         elif self.should_consider_ordering:
             _, weighted_length = self._compute_weighted_lcs()
-            if (
-                len(self.tools_called) == len(self.expected_tools)
-                and len(self.expected_tools) == 0
-            ):
-                score = 1.0
-            elif len(self.expected_tools) == 0:
-                score = 0.0
-            else:
-                score = weighted_length / len(self.expected_tools)
+            score = weighted_length / len(self.expected_tools)
         else:
             score = self._calculate_non_exact_match_score()
         return 0 if self.strict_mode and score < self.threshold else score

--- a/tests/test_metrics/test_tool_correctness_metric_empty_expected.py
+++ b/tests/test_metrics/test_tool_correctness_metric_empty_expected.py
@@ -1,0 +1,26 @@
+import pytest
+from deepeval.metrics import ToolCorrectnessMetric
+from deepeval.test_case import LLMTestCase, ToolCall
+
+def test_tool_correctness_empty_expected_and_called():
+    metric = ToolCorrectnessMetric()
+    test_case = LLMTestCase(
+        input="What is an elephant?",
+        actual_output="...",
+        tools_called=[],
+        expected_tools=[]
+    )
+    metric.measure(test_case)
+    assert metric.score == 1.0, f"Expected score 1.0, got {metric.score}"
+
+def test_tool_correctness_empty_expected_nonempty_called():
+    metric = ToolCorrectnessMetric()
+    tool_call = ToolCall(name="search", input_parameters={}, output=None)
+    test_case = LLMTestCase(
+        input="What is an elephant?",
+        actual_output="...",
+        tools_called=[tool_call],
+        expected_tools=[]
+    )
+    metric.measure(test_case)
+    assert metric.score == 0.0, f"Expected score 0.0, got {metric.score}"


### PR DESCRIPTION
## Summary:
This pull request resolves a bug in [ToolCorrectnessMetric](https://github.com/confident-ai/deepeval/blob/main/deepeval/metrics/tool_correctness/tool_correctness.py) where a ZeroDivisionError occurred if expected_tools was empty. The metric now correctly returns:

1.0 when both tools_called and expected_tools are empty.
0.0 when tools_called is not empty but expected_tools is.
## Changes Made:
Refactored [_calculate_score](https://github.com/confident-ai/deepeval/blob/main/deepeval/metrics/tool_correctness/tool_correctness.py) to handle empty [expected_tools](https://automatic-adventure-pjqj6j5j5jj37jr6.github.dev/) for all matching modes.
Added unit tests to cover these edge cases.

## Checklist:
 Follows project coding style and guidelines.
 Includes new or updated tests.
 Documentation updated if needed.
 All tests pass locally, and I also added the testcases in the test folder.
## Issue Reference:
Fixes #1234 

## Additional Notes:
Please let me know if further changes or documentation are required.