### PR TITLE
Saving trace in Pydanic AI instrumentator for accessing in the future 

### DIFF
--- a/deepeval/tracing/__init__.py
+++ b/deepeval/tracing/__init__.py
@@ -4,6 +4,7 @@ from .context import (
     update_retriever_span,
     update_llm_span,
 )
+from .trace_context import TraceContext
 from .types import BaseSpan, Trace
 from .tracing import observe, trace_manager
 from .offline_evals import evaluate_thread, evaluate_trace, evaluate_span
@@ -15,6 +16,7 @@ __all__ = [
     "update_llm_span",
     "BaseSpan",
     "Trace",
+    "TraceContext",
     "observe",
     "trace_manager",
     "evaluate_thread",

--- a/deepeval/tracing/__init__.py
+++ b/deepeval/tracing/__init__.py
@@ -4,7 +4,7 @@ from .context import (
     update_retriever_span,
     update_llm_span,
 )
-from .trace_context import TraceContext
+from .trace_context import trace
 from .types import BaseSpan, Trace
 from .tracing import observe, trace_manager
 from .offline_evals import evaluate_thread, evaluate_trace, evaluate_span
@@ -16,8 +16,8 @@ __all__ = [
     "update_llm_span",
     "BaseSpan",
     "Trace",
-    "TraceContext",
     "observe",
+    "trace",
     "trace_manager",
     "evaluate_thread",
     "evaluate_trace",

--- a/deepeval/tracing/trace_context.py
+++ b/deepeval/tracing/trace_context.py
@@ -1,0 +1,21 @@
+from typing import Optional
+from .context import current_trace_context
+from .tracing import trace_manager
+
+class TraceContext:
+
+    def __init__(self):
+
+        current_trace = current_trace_context.get()
+        if not current_trace:
+            _current_trace = trace_manager.start_new_trace()
+            current_trace_context.set(_current_trace)
+
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def get_uuid(self):
+        return current_trace_context.get().uuid

--- a/deepeval/tracing/trace_context.py
+++ b/deepeval/tracing/trace_context.py
@@ -1,21 +1,14 @@
-from typing import Optional
 from .context import current_trace_context
 from .tracing import trace_manager
+from contextlib import contextmanager
 
-class TraceContext:
+@contextmanager
+def trace():
+    current_trace = current_trace_context.get()
 
-    def __init__(self):
+    if not current_trace:
+        current_trace = trace_manager.start_new_trace()
+        current_trace_context.set(current_trace)
 
-        current_trace = current_trace_context.get()
-        if not current_trace:
-            _current_trace = trace_manager.start_new_trace()
-            current_trace_context.set(_current_trace)
-
-    def __enter__(self):
-        return self
+    yield current_trace
     
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        return False
-
-    def get_uuid(self):
-        return current_trace_context.get().uuid

--- a/tests/test_integrations/test_pydanticai/simple_agent.py
+++ b/tests/test_integrations/test_pydanticai/simple_agent.py
@@ -29,12 +29,13 @@ agent = Agent(
 
 
 async def execute_simple_agent():
-    result = await agent.run("What are the LLMs?")
-    print("===============Simple agent output:===============")
-    print(result)
+    with TraceContext() as trace:
+        result = await agent.run("What are the LLMs?")
+        print("===============Simple agent output:===============")
+        print(result)
+        print("===============Trace ID:===============")
+        print(trace.get_uuid())
 
 
 if __name__ == "__main__":
-    execute_simple_agent()
-
-execute_simple_agent()
+    asyncio.run(execute_simple_agent())

--- a/tests/test_integrations/test_pydanticai/simple_agent.py
+++ b/tests/test_integrations/test_pydanticai/simple_agent.py
@@ -35,3 +35,5 @@ def execute_simple_agent():
 
 if __name__ == "__main__":
     execute_simple_agent()
+
+execute_simple_agent()

--- a/tests/test_integrations/test_pydanticai/simple_agent.py
+++ b/tests/test_integrations/test_pydanticai/simple_agent.py
@@ -1,5 +1,5 @@
 import asyncio
-from deepeval.tracing import TraceContext
+from deepeval.tracing import trace
 from pydantic_ai import Agent
 from deepeval.integrations.pydantic_ai.instrumentator import (
     ConfidentInstrumentationSettings,
@@ -29,13 +29,57 @@ agent = Agent(
 
 
 async def execute_simple_agent():
-    with TraceContext() as trace:
-        result = await agent.run("What are the LLMs?")
-        print("===============Simple agent output:===============")
-        print(result)
-        print("===============Trace ID:===============")
-        print(trace.get_uuid())
+    with trace() as current_trace:
+        result_1 = await agent.run("What are the LLMs?")
+        print("===============Result 1: trace ID===============")
+        print(current_trace.uuid) # ok
 
+        result_2 = await agent.run("What are the LLMs?")
+        print("===============Result 2: Trace ID:===============")
+        print(current_trace.uuid) # ok
+
+def execute_simple_agent_sync():
+
+    with trace() as current_trace:
+        result_1 = agent.run_sync("What are the LLMs?")
+        print("===============Result 1: trace ID===============")
+        print(current_trace.uuid) # ok
+
+# Test nested trace() calls
+def test_nested_traces():
+    with trace() as outer_trace:
+        outer_uuid = outer_trace.uuid
+        print(f"Outer trace UUID: {outer_uuid}") # ok
+        
+        result_1 = agent.run_sync("Query 1")
+        print(f"After agent run 1: {outer_trace.uuid}") # ok
+        
+        # Nested trace context
+        with trace() as inner_trace:
+            # Should reuse the same trace (based on trace_context.py logic)
+            print(f"Inner trace UUID: {inner_trace.uuid}") # ok
+            
+            result_2 = agent.run_sync("Query 2")
+            print(f"After agent run 2: {inner_trace.uuid}") # ok
+
+# Test concurrent agent runs
+async def test_concurrent_agents():
+    with trace() as current_trace:
+        initial_uuid = current_trace.uuid
+        
+        # Run multiple agents concurrently
+        results = await asyncio.gather(
+            agent.run("Query 1"),
+            agent.run("Query 2"),
+            agent.run("Query 3"),
+        )
+        
+        print(f"Initial: {initial_uuid}")
+        print(f"Final: {current_trace.uuid}") # print trace uuid of the last agent run
 
 if __name__ == "__main__":
-    asyncio.run(execute_simple_agent())
+    # asyncio.run(execute_simple_agent())
+    # execute_simple_agent_sync()
+    # test_nested_traces()
+    # asyncio.run(test_concurrent_agents())
+    pass

--- a/tests/test_integrations/test_pydanticai/simple_agent.py
+++ b/tests/test_integrations/test_pydanticai/simple_agent.py
@@ -76,10 +76,3 @@ async def test_concurrent_agents():
         
         print(f"Initial: {initial_uuid}")
         print(f"Final: {current_trace.uuid}") # print trace uuid of the last agent run
-
-if __name__ == "__main__":
-    # asyncio.run(execute_simple_agent())
-    # execute_simple_agent_sync()
-    # test_nested_traces()
-    # asyncio.run(test_concurrent_agents())
-    pass

--- a/tests/test_integrations/test_pydanticai/simple_agent.py
+++ b/tests/test_integrations/test_pydanticai/simple_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+from deepeval.tracing import TraceContext
 from pydantic_ai import Agent
 from deepeval.integrations.pydantic_ai.instrumentator import (
     ConfidentInstrumentationSettings,

--- a/tests/test_integrations/test_pydanticai/simple_agent.py
+++ b/tests/test_integrations/test_pydanticai/simple_agent.py
@@ -27,8 +27,8 @@ agent = Agent(
 )
 
 
-def execute_simple_agent():
-    result = asyncio.run(agent.run("What are the LLMs?"))
+async def execute_simple_agent():
+    result = await agent.run("What are the LLMs?")
     print("===============Simple agent output:===============")
     print(result)
 


### PR DESCRIPTION
This will allow us to access the Trace ID in future to access the annotation. Not the best solutions, but it is very hard to find a way to callback trace ID for a given `run` context in Pydantic AI agent. 