### PR TITLE
Fix incorrect score normalization in GEval metric.

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -97,7 +97,7 @@ class GEval(BaseMetric):
                     test_case, _additional_context=_additional_context
                 )
                 self.score = (
-                    float(g_score) / self.score_range_span
+                    (float(g_score) - self.score_range[0]) / self.score_range_span
                     if not self.strict_mode
                     else int(g_score)
                 )
@@ -140,7 +140,7 @@ class GEval(BaseMetric):
                 test_case, _additional_context=_additional_context
             )
             self.score = (
-                float(g_score) / self.score_range_span
+                (float(g_score) - self.score_range[0]) / self.score_range_span
                 if not self.strict_mode
                 else int(g_score)
             )

--- a/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
+++ b/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
@@ -299,12 +299,11 @@ class MultiTurnMCPUseMetric(BaseConversationalMetric):
         tool_accuracy_score: List[ToolScore],
         args_accuracy_score: List[ArgsScore],
     ) -> float:
-        tool_score = sum(score.score for score in tool_accuracy_score) / len(
-            tool_accuracy_score
-        )
-        args_score = sum(score.score for score in args_accuracy_score) / len(
-            args_accuracy_score
-        )
+        if not tool_accuracy_score or not args_accuracy_score:
+            # No tasks or scores to evaluate, return default score (can be changed to 0.0 if desired)
+            return 1.0
+        tool_score = sum(score.score for score in tool_accuracy_score) / len(tool_accuracy_score)
+        args_score = sum(score.score for score in args_accuracy_score) / len(args_accuracy_score)
         return min(tool_score, args_score)
 
     def _generate_reason(

--- a/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
+++ b/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
@@ -299,11 +299,12 @@ class MultiTurnMCPUseMetric(BaseConversationalMetric):
         tool_accuracy_score: List[ToolScore],
         args_accuracy_score: List[ArgsScore],
     ) -> float:
-        if not tool_accuracy_score or not args_accuracy_score:
-            # No tasks or scores to evaluate, return default score (can be changed to 0.0 if desired)
-            return 1.0
-        tool_score = sum(score.score for score in tool_accuracy_score) / len(tool_accuracy_score)
-        args_score = sum(score.score for score in args_accuracy_score) / len(args_accuracy_score)
+        tool_score = sum(score.score for score in tool_accuracy_score) / len(
+            tool_accuracy_score
+        )
+        args_score = sum(score.score for score in args_accuracy_score) / len(
+            args_accuracy_score
+        )
         return min(tool_score, args_score)
 
     def _generate_reason(


### PR DESCRIPTION
## Summary:
This pull request resolves a bug in [g_Eval/g_eval.py](https://github.com/confident-ai/deepeval/blob/main/deepeval/metrics/g_eval/g_eval.py) where a G_Eval score currently mis-normalises the evaluation score in both measure() and a_measure().
The code currently divides directly by self.score_range_span:
```bash
 self.score = (float(g_score) / self.score_range_span) if not self.strict_mode else int(g_score)
```
This causes normalisation errors when the minimum score in the range is not 0.
For example, if score_range=(1,5), g_score=1 incorrectly becomes 0.25 instead of 0.0, and g_score=5 incorrectly becomes 1.25 instead of 1.0.

## Changes Made:
Updated formula in [measure()](https://github.com/confident-ai/deepeval/blob/main/deepeval/metrics/g_eval/g_eval.py) and [a_measure()](https://github.com/confident-ai/deepeval/blob/main/deepeval/metrics/g_eval/g_eval.py) for all values:
Now subtracts the lower bound before division.
```bash
self.score = (
    (float(g_score) - self.score_range[0]) / self.score_range_span
    if not self.strict_mode
    else int(g_score)
)
```

## Checklist:
 Follows project coding style and guidelines.
 Updated the Formula for Normalisation.
 Documentation updated if needed.
 All tests pass locally, and I also added the testcases in the test folder.
## Issue Reference:
Fixes #2118 

## Additional Notes:
Please let me know if further changes or documentation are required.