### PR TITLE
chore(logging): downgrade optional-deps messages to warnings in verbose mode

### DIFF
--- a/deepeval/integrations/crewai/handler.py
+++ b/deepeval/integrations/crewai/handler.py
@@ -28,9 +28,18 @@ try:
     crewai_installed = True
 except ImportError as e:
     if get_settings().DEEPEVAL_VERBOSE_MODE:
-        logger.error(
-            "Optional crewai dependencies missing: %s", e, exc_info=True
-        )
+        if isinstance(e, ModuleNotFoundError):
+            logger.warning(
+                "Optional crewai dependency not installed: %s",
+                e.name,
+                stacklevel=2,
+            )
+        else:
+            logger.warning(
+                "Optional crewai import failed: %s",
+                e,
+                stacklevel=2,
+            )
 
     crewai_installed = False
 

--- a/deepeval/integrations/pydantic_ai/instrumentator.py
+++ b/deepeval/integrations/pydantic_ai/instrumentator.py
@@ -25,9 +25,18 @@ try:
     dependency_installed = True
 except ImportError as e:
     if get_settings().DEEPEVAL_VERBOSE_MODE:
-        logger.error(
-            "Optional tracing dependencies missing: %s", e, exc_info=True
-        )
+        if isinstance(e, ModuleNotFoundError):
+            logger.warning(
+                "Optional tracing dependency not installed: %s",
+                e.name,
+                stacklevel=2,
+            )
+        else:
+            logger.warning(
+                "Optional tracing import failed: %s",
+                e,
+                stacklevel=2,
+            )
     dependency_installed = False
 
 


### PR DESCRIPTION
- Switch `error` to `warning` for missing optional deps
- Show missing module via `ModuleNotFoundError.name`, otherwise log `ImportError` message
- Add `stacklevel=2`; no traceback
- Only emit when `DEEPEVAL_VERBOSE_MODE` is enabled