### PR TITLE
fix: add o4-mini to unsupported logprobs models list

### DIFF
--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -70,6 +70,8 @@ unsupported_log_probs_gpt_models = [
     "o1-mini-2024-09-12",
     "o3-mini",
     "o3-mini-2025-01-31",
+    "o4-mini",
+    "o4-mini-2025-04-16",
     "gpt-4.5-preview-2025-02-27",
     "gpt-5",
     "gpt-5-2025-08-07",


### PR DESCRIPTION
# Summary

Fixes G-Eval metric evaluation failures when using o4-mini model by adding it to the list of models that don't support logprobs.

# Problem

When running G-Eval metrics (e.g, professional_tone) with the o4-mini model, evaluations were failing with a 403 error:

```
Error code: 403 - {'error': {'message': 'You are not allowed to request logprobs from this model', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```

# Root Cause

The o4-mini model (and its dated variant o4-mini-2025-04-16) were not included in the unsupported_log_probs_gpt_models list in deepeval/models/llms/openai_model.py.

- G-Eval metrics use logprobs for weighted scoring to improve accuracy. However, OpenAI's reasoning models (o1, o3, o4, etc.) don't support the logprobs API parameter. The code already had a fallback mechanism via the `no_log_prob_support()` function, but it wasn't aware that o4-mini should be treated as an unsupported model.

# Solution

  Added `o4-mini` and `o4-mini-2025-04-16` to the `unsupported_log_probs_gpt_models` list. This ensures:
  - G-Eval metrics detect when `o4-mini` is being used
  - The evaluation automatically falls back to standard scoring without logprobs
  - Metrics complete successfully with proper scores and reasoning

# Changes

  - Updated `deepeval/models/llms/openai_model.py` to include o4-mini and o4-mini-2025-04-16 in the unsupported logprobs models list

