### PR TITLE
fix(evaluate/utils): compare span status to `TraceSpanApiStatus.SUCCESS` in `extract_span_test_results`

### DIFF
--- a/deepeval/evaluate/utils.py
+++ b/deepeval/evaluate/utils.py
@@ -5,8 +5,6 @@ import os
 import time
 
 from deepeval.utils import format_turn
-from deepeval.test_case.conversational_test_case import Turn
-from deepeval.test_run.api import TurnApi
 from deepeval.test_run.test_run import TestRunResultDisplay
 from deepeval.dataset import Golden
 from deepeval.metrics import (
@@ -523,7 +521,7 @@ def extract_span_test_results(span_api: BaseApiSpan) -> List[TestResult]:
         test_results.append(
             TestResult(
                 name=span_api.name,
-                success=span_api.status == "SUCCESS",
+                success=span_api.status == TraceSpanApiStatus.SUCCESS,
                 metrics_data=span_api.metrics_data,
                 input=span_api.input,
                 actual_output=span_api.output,

--- a/tests/test_core/test_evaluation/test_results_extraction.py
+++ b/tests/test_core/test_evaluation/test_results_extraction.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from deepeval.evaluate.utils import extract_span_test_results
+from deepeval.tracing.api import TraceSpanApiStatus
+
+
+def test_extract_span_result_success_with_enum_status():
+    span_enum = SimpleNamespace(
+        name="span",
+        status=TraceSpanApiStatus.SUCCESS,
+        metrics_data=[
+            SimpleNamespace(
+                name="m",
+                success=True,
+                score=1,
+                threshold=None,
+                strict_mode=False,
+                evaluation_model=None,
+                error=None,
+                evaluationCost=None,
+                verboseLogs=None,
+            )
+        ],
+        input=None,
+        output=None,
+        expected_output=None,
+        context=None,
+        retrieval_context=None,
+    )
+
+    res = extract_span_test_results(span_enum)[0]
+    assert res.success is True


### PR DESCRIPTION
Fixes the status is always False bug when extracting span test results