### PR TITLE
Fix ArgumentCorrectnessMetric scoring logic for empty tool calls

### DIFF
--- a/deepeval/metrics/argument_correctness/argument_correctness.py
+++ b/deepeval/metrics/argument_correctness/argument_correctness.py
@@ -76,7 +76,7 @@ class ArgumentCorrectnessMetric(BaseMetric):
             else:
                 if len(test_case.tools_called) == 0:
                     self.verdicts = []
-                    self.score = 1.0
+                    self.score = 0.0
                     self.reason = "No tool calls provided"
                 else:
                     self.verdicts: List[ArgumentCorrectnessVerdict] = (
@@ -119,7 +119,7 @@ class ArgumentCorrectnessMetric(BaseMetric):
         ):
             if len(test_case.tools_called) == 0:
                 self.verdicts = []
-                self.score = 1.0
+                self.score = 0.0
                 self.reason = "No tool calls provided"
             else:
                 self.verdicts: List[ArgumentCorrectnessVerdict] = (


### PR DESCRIPTION
## Issue
Fixes #2242

## Problem
The `ArgumentCorrectnessMetric` incorrectly assigns a score of `1.0` (perfect score) when `tools_called` is empty. This is illogical because:
- There are no tool calls to evaluate for correctness
- An empty set should not be considered "perfectly correct"
- The metric measures argument correctness, and with no arguments, there's nothing to measure as correct

## Solution
Changed the score from `1.0` to `0.0` when `tools_called` is empty in both:
- Synchronous `measure()` method (line 79)
- Asynchronous `a_measure()` method (line 120)

## Changes
- Updated `argument_correctness.py`: Set `self.score = 0.0` instead of `1.0` when no tool calls are provided

## Testing
The fix ensures that when evaluating test cases with no tool calls, the metric correctly returns a score of 0.0 instead of 1.0.
