### PR TITLE
Update `bool | None` -> `Optional[bool]`

### DIFF
--- a/deepeval/utils.py
+++ b/deepeval/utils.py
@@ -751,7 +751,7 @@ custom_console = Console(theme=my_theme)
 
 
 def format_error_text(
-    exc: BaseException, *, with_stack: bool | None = None
+    exc: BaseException, *, with_stack: Optional[bool] = None
 ) -> str:
     if with_stack is None:
         with_stack = logging.getLogger("deepeval").isEnabledFor(logging.DEBUG)


### PR DESCRIPTION
The `bool | None` syntax is not valid in `python3.9`, which is marked as supported in the current [pyproject.toml](https://github.com/confident-ai/deepeval/blob/main/pyproject.toml#L19).

This line (introduced in 3.6.8) causes errors when attempting to use this package with py39.