### PR TITLE
fix(drop): enforce schema-aware batching and remove invalid kwarg

### DIFF
--- a/deepeval/models/base_model.py
+++ b/deepeval/models/base_model.py
@@ -68,7 +68,9 @@ class DeepEvalBaseLLM(ABC):
         Returns:
             A list of strings.
         """
-        raise AttributeError
+        raise NotImplementedError(
+            "batch_generate is not implemented for this model"
+        )
 
     @abstractmethod
     def get_model_name(self, *args, **kwargs) -> str:


### PR DESCRIPTION
- Remove obsolete `type=` arg in `batch_predict()` to match `predict()`.
- Treat DROP batch eval as requiring `batch_generate(prompts, schemas)` and fail with clear logs. Raise `DeepEvalError` on unsupported cases.
- Switch base `DeepEvalBaseLLM.batch_generate` to raise `NotImplementedError` for clearer intent.
- fix ruff complaints

Fixes #2277.