### PR TITLE
fix(tracing): return custom mask result in TaskManager.mask

### DIFF
--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -144,7 +144,7 @@ class TraceManager:
 
     def mask(self, data: Any):
         if self.custom_mask_fn is not None:
-            self.custom_mask_fn(data)
+            return self.custom_mask_fn(data)
         else:
             return data
 


### PR DESCRIPTION
TaskManager.mask didn’t return the result of `custom_mask_fn`, causing `None` to propagate whenever a custom mask was configured. Now it returns the function’s value.