### PR TITLE
fix(openai_agents/callback_handler): add missing imports, replace wildcard to avoid NameError & Ruff F405

### DIFF
--- a/deepeval/openai_agents/callback_handler.py
+++ b/deepeval/openai_agents/callback_handler.py
@@ -1,13 +1,21 @@
+from time import perf_counter
+
 from deepeval.tracing.tracing import (
     Observer,
     current_span_context,
     trace_manager,
 )
-from deepeval.openai_agents.extractors import *
+from deepeval.openai_agents.extractors import (
+    update_span_properties,
+    update_trace_properties_from_span_data,
+)
 from deepeval.tracing.context import current_trace_context
 from deepeval.tracing.utils import make_json_serializable
-from time import perf_counter
-from deepeval.tracing.types import TraceSpanStatus
+from deepeval.tracing.types import (
+    BaseSpan,
+    LlmSpan,
+    TraceSpanStatus,
+)
 
 try:
     from agents.tracing import Span, Trace, TracingProcessor
@@ -18,6 +26,7 @@ try:
         GenerationSpanData,
         GuardrailSpanData,
         HandoffSpanData,
+        MCPListToolsSpanData,
         ResponseSpanData,
         SpanData,
     )


### PR DESCRIPTION


- Add explicit imports for symbols that were referenced but not imported and would crash at runtime:

  - `BaseSpan`, `LlmSpan` (used in root-span creation and LLM type checks).
  - `MCPListToolsSpanData` (used in `get_span_kind`).
  - `update_span_properties`, `update_trace_properties_from_span_data` (used in `on_span_end`, also resolves Ruff F405).
- Replace `from ...extractors import *` with explicit imports and normalize import order.
- Additional Ruff fixes.