### PR TITLE
Fix: Ensure AmazonBedrockModel handles non-text messages gracefully

### DIFF
--- a/deepeval/models/llms/amazon_bedrock_model.py
+++ b/deepeval/models/llms/amazon_bedrock_model.py
@@ -84,7 +84,13 @@ class AmazonBedrockModel(DeepEvalBaseLLM):
                 messages=payload["messages"],
                 inferenceConfig=payload["inferenceConfig"],
             )
-            message = response["output"]["message"]["content"][0]["text"]
+            message = next(
+                (
+                    item["text"]
+                    for item in response["output"]["message"]["content"]
+                    if "text" in item
+                )
+            )
             cost = self.calculate_cost(
                 response["usage"]["inputTokens"],
                 response["usage"]["outputTokens"],


### PR DESCRIPTION
## Description

We recently encountered an issue where the AmazonBedrockModel did not correctly handle responses containing reasoning messages.

The context for this is that we spiked out using OpenAI's new OSS models in our application: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-openai.html

- gpt-oss-20b
- gpt-oss-120b

Upon attempting to integrate these models into our evaluation pipeline, we discovered that the existing implementation of `AmazonBedrockModel's a_generate()` method assumed that the first content item in the response would always contain [a 'text' field](https://github.com/confident-ai/deepeval/blob/8291dca20ac893c018012c77d47f3de477a34788/deepeval/models/llms/amazon_bedrock_model.py#L87). However, the response we received included reasoning messages that lacked this field, leading to a KeyError.

Here's an example content block from the Bedrock response that caused the issue:

```
response['output']['message']['content']

[
   {
      "reasoningContent":{
         "reasoningText":{
            "text":"The user asks: \"Write a haiku about AI.\" That\\'s straightforward. Provide a haiku (5-7-5 syllable). Should be about AI. No policy issues. Just produce."
         }
      }
   },
   {
      "text":"Silent code humming,  \nLearning the world’s whispered thoughts—  \nDreams in silicon."
   }
]
```

To resolve this, the logic in `a_generate()` that handles parsing the message from the response can be updated to ensure that it correctly identifies and extracts the first object in the content block that contains a 'text' key. This ensures it ignores reasoning messages or other non-text content.


## Example of full response received with reasoning content in first index

```
   "ResponseMetadata":{
      "RequestId":"b1d54689-2a61-45c4-8424-4c54757f986e",
      "HTTPStatusCode":200,
      "HTTPHeaders":{
         "date":"Thu, 27 Nov 2025 12:05:02 GMT",
         "content-type":"application/json",
         "content-length":"504",
         "connection":"keep-alive",
         "x-amzn-requestid":"b1d54689-2a61-45c4-8424-4c54757f986e"
      },
      "RetryAttempts":0
   },
   "output":{
      "message":{
         "role":"assistant",
         "content":[
            {
               "reasoningContent":{
                  "reasoningText":{
                     "text":"The user wants a haiku about AI. Simple. Provide a haiku (5-7-5 syllable). Should be about AI. Provide maybe a short explanation? Probably just the haiku. Let's produce."
                  }
               }
            },
            {
               "text":"Silent code awakens,  \nthoughts of silicon whisper—  \nmind beyond the screen."
            }
         ]
      }
   },
   "stopReason":"end_turn",
   "usage":{
      "inputTokens":76,
      "outputTokens":72,
      "totalTokens":148
   },
   "metrics":{
      "latencyMs":498
   }
}

```

## Script that replicates the issue 

```
import os
import asyncio
from aiobotocore.session import get_session
from dotenv import load_dotenv

region = os.environ.get("AWS_BEDROCK_REGION", "eu-north-1")
model_id = "openai.gpt-oss-120b-1:0"

load_dotenv()

async def main():
    session = get_session()
    async with session.create_client(
        "bedrock-runtime",
        region_name=region,
        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
        aws_session_token=os.environ.get("AWS_SESSION_TOKEN"),
    ) as client:

        prompt = "Write a haiku about AI."

        messages = [{"role": "user", "content": [{ "text": prompt }]}]
        response = await client.converse(
            modelId=model_id,
            messages=messages,
            inferenceConfig={
                "maxTokens": 300,
                "temperature": 0.0,
            }
        )

        # This replicates the message parsing logic from https://github.com/confident-ai/deepeval/blob/8291dca20ac893c018012c77d47f3de477a34788/deepeval/models/llms/amazon_bedrock_model.py#L87 
        response["output"]["message"]["content"][0]["text"]

if __name__ == "__main__":
    asyncio.run(main())
```