### PR TITLE
fix(test-run): sync JSON writes to avoid corruption on NFS

### DIFF
--- a/deepeval/prompt/prompt.py
+++ b/deepeval/prompt/prompt.py
@@ -7,9 +7,6 @@ from enum import Enum
 from typing import Optional, List, Dict, Type, Literal
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
 from rich.console import Console
-import time
-import json
-import os
 from pydantic import BaseModel, ValidationError
 import asyncio
 import threading
@@ -364,6 +361,8 @@ class Prompt:
                 f.seek(0)
                 f.truncate()
                 json.dump(cache_data, f, cls=CustomEncoder)
+                f.flush()
+                os.fsync(f.fileno())
         except portalocker.exceptions.LockException:
             # If we can't acquire the lock, silently skip caching
             pass

--- a/deepeval/test_run/cache.py
+++ b/deepeval/test_run/cache.py
@@ -90,6 +90,8 @@ class CachedTestRun(BaseModel):
             # Pydantic version below 2.0
             body = self.dict(by_alias=True, exclude_none=True)
         json.dump(body, f, cls=CustomEncoder)
+        f.flush()
+        os.fsync(f.fileno())
         return self
 
     # load from file (this happens initially during a test run)

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -406,9 +406,10 @@ class TestRun(BaseModel):
         try:
             body = self.model_dump(by_alias=True, exclude_none=True)
         except AttributeError:
-            # Pydantic version below 2.0
             body = self.dict(by_alias=True, exclude_none=True)
         json.dump(body, f, cls=TestRunEncoder)
+        f.flush()
+        os.fsync(f.fileno())
         return self
 
     @classmethod
@@ -515,6 +516,8 @@ class TestRunManager:
                             )
                         wrapper_data = {save_under_key: test_run_data}
                         json.dump(wrapper_data, file, cls=TestRunEncoder)
+                        file.flush()
+                        os.fsync(file.fileno())
                     else:
                         self.test_run.save(file)
             except portalocker.exceptions.LockException:
@@ -527,6 +530,8 @@ class TestRunManager:
                     LATEST_TEST_RUN_FILE_PATH, mode="w"
                 ) as file:
                     json.dump({LATEST_TEST_RUN_LINK_KEY: link}, file)
+                    file.flush()
+                    os.fsync(file.fileno())
             except portalocker.exceptions.LockException:
                 pass
 

--- a/tests/test_core/helpers.py
+++ b/tests/test_core/helpers.py
@@ -1,8 +1,10 @@
 import time
 import uuid
+from types import SimpleNamespace
 from datetime import datetime, timezone
 
 from deepeval.tracing.api import TraceApi, TraceSpanApiStatus
+from tests.test_core.stubs import RecordingPortalockerLock
 
 
 def ts_iso8601_utc(ts: float) -> str:
@@ -60,3 +62,16 @@ def reset_settings_env(monkeypatch, *, skip_keys: set[str] = set()):
 
     # don’t carry default save across tests, keep things clean
     monkeypatch.delenv("DEEPEVAL_DEFAULT_SAVE", raising=False)
+
+
+def _make_fake_portalocker():
+    """
+    Minimal portalocker replacement for tests that need to inspect file writes.
+    """
+    return SimpleNamespace(
+        Lock=RecordingPortalockerLock,
+        LOCK_EX=1,
+        LOCK_SH=2,
+        LOCK_NB=4,
+        exceptions=SimpleNamespace(LockException=RuntimeError),
+    )

--- a/tests/test_core/stubs.py
+++ b/tests/test_core/stubs.py
@@ -1,3 +1,4 @@
+import io
 import time
 import asyncio
 from types import SimpleNamespace
@@ -297,3 +298,54 @@ class _FakeTrace:
         self.status = TraceSpanStatus.SUCCESS
         self.error = None
         self.uuid = "trace-uuid"
+
+
+##################
+# File I/O stubs #
+##################
+
+
+class RecordingFile(io.StringIO):
+    """
+    Test stub that records flush() calls and exposes a fake fileno(),
+    used to verify that we call flush() and os.fsync(fd) correctly.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.flushed = False
+        self.closed_flag = False
+        # Arbitrary fake file descriptor; tests only check identity equality
+        self._fd = 42
+
+    def flush(self):
+        self.flushed = True
+        return super().flush()
+
+    def fileno(self):
+        return self._fd
+
+    def close(self):
+        self.closed_flag = True
+        return super().close()
+
+
+class RecordingPortalockerLock:
+    """
+    Minimal drop-in for portalocker.Lock used in tests.
+
+    It always returns a new RecordingFile and exposes the most recently
+    created one via the class attribute `last_file` so tests can assert on it.
+    """
+
+    last_file = None
+
+    def __init__(self, *args, **kwargs):
+        self.file = RecordingFile()
+        RecordingPortalockerLock.last_file = self.file
+
+    def __enter__(self):
+        return self.file
+
+    def __exit__(self, exc_type, exc, tb):
+        self.file.close()

--- a/tests/test_core/test_prompts/test_prompt.py
+++ b/tests/test_core/test_prompts/test_prompt.py
@@ -1,0 +1,65 @@
+import types
+
+import pytest
+
+from tests.test_core.stubs import RecordingPortalockerLock
+import deepeval.prompt.prompt as prompt_mod
+from tests.test_core.helpers import _make_fake_portalocker
+
+
+@pytest.mark.parametrize(
+    "cache_key_attr", ["VERSION_CACHE_KEY", "LABEL_CACHE_KEY"]
+)
+def test_write_to_cache_flushes_and_syncs(
+    monkeypatch, tmp_path, cache_key_attr
+):
+    """
+    Ensure Prompt._write_to_cache flushes and fsyncs after json.dump.
+
+    This specifically protects against truncated JSON when multiple processes
+    write to prompt cache on network filesystems.
+    """
+
+    fake_portalocker = _make_fake_portalocker()
+    monkeypatch.setattr(
+        prompt_mod, "portalocker", fake_portalocker, raising=False
+    )
+
+    # Use a temp directory for the cache path
+    cache_path = tmp_path / "prompt_cache.json"
+    monkeypatch.setattr(
+        prompt_mod, "CACHE_FILE_NAME", str(cache_path), raising=False
+    )
+    monkeypatch.setattr(prompt_mod, "HIDDEN_DIR", str(tmp_path), raising=False)
+
+    # Track fsync calls inside this module
+    fsync_calls = []
+
+    def fake_fsync(fd):
+        fsync_calls.append(fd)
+
+    monkeypatch.setattr(prompt_mod.os, "fsync", fake_fsync)
+
+    # We don't need a real Prompt instance, just something with .alias
+    dummy_self = types.SimpleNamespace(alias="my-alias")
+
+    # Get the cache key constant (VERSION_CACHE_KEY or LABEL_CACHE_KEY)
+    cache_key = getattr(prompt_mod, cache_key_attr)
+
+    # Call the real method implementation, bound to our dummy object
+    prompt_mod.Prompt._write_to_cache(
+        dummy_self,
+        cache_key=cache_key,
+        version="v1",
+    )
+
+    # Assert file was flushed and synced
+    f = RecordingPortalockerLock.last_file
+    assert f is not None, "RecordingPortalockerLock did not capture a file"
+    assert (
+        f.flushed
+    ), "Prompt._write_to_cache should call f.flush() after json.dump"
+    assert (
+        fsync_calls
+    ), "Prompt._write_to_cache should call os.fsync(f.fileno())"
+    assert fsync_calls[-1] == f.fileno()

--- a/tests/test_core/test_run/test_file_sync.py
+++ b/tests/test_core/test_run/test_file_sync.py
@@ -1,0 +1,88 @@
+import types
+
+
+import deepeval.test_run.test_run as tr
+import deepeval.test_run.cache as cache_mod
+from tests.test_core.stubs import RecordingFile
+
+
+def _make_dummy_self():
+    """
+    Minimal stand-in for TestRun / CachedTestRun.
+
+    The save() methods only care that .model_dump() or .dict()
+    produce something JSON-serializable, so we provide just that.
+    """
+
+    class Dummy:
+        def model_dump(self, **kwargs):
+            return {"dummy": True}
+
+    return Dummy()
+
+
+def test_test_run_save_flushes_and_syncs(monkeypatch):
+    """
+    TestRun.save(self, f) must flush Python buffers and fsync OS buffers.
+
+    This fails on current main, because TestRun.save() only calls json.dump
+    and never flushes or fsyncs. It passes after you add:
+
+        f.flush()
+        os.fsync(f.fileno())
+    """
+    fsynced = {"called": False}
+
+    def fake_fsync(fd: int) -> None:
+        fsynced["called"] = True
+
+    # Patch os.fsync as seen from the test_run module
+    monkeypatch.setattr(
+        tr, "os", types.SimpleNamespace(**vars(tr.os)), raising=False
+    )
+    monkeypatch.setattr(tr.os, "fsync", fake_fsync, raising=False)
+
+    f = RecordingFile()
+    dummy_self = _make_dummy_self()
+
+    # Call the real implementation on a dummy "self"
+    tr.TestRun.save(dummy_self, f)
+
+    assert (
+        f.flushed
+    ), "TestRun.save() should call f.flush() after json.dump(...)"
+    assert fsynced["called"], "TestRun.save() should call os.fsync(f.fileno())"
+
+
+def test_cached_test_run_save_flushes_and_syncs(monkeypatch):
+    """
+    CachedTestRun.save(self, f) must also flush and fsync.
+
+    This mirrors the same durability requirement for the cached
+    on-disk representation.
+    """
+    fsynced = {"called": False}
+
+    def fake_fsync(fd: int) -> None:
+        fsynced["called"] = True
+
+    # Patch os.fsync as seen from the cache module
+    monkeypatch.setattr(
+        cache_mod,
+        "os",
+        types.SimpleNamespace(**vars(cache_mod.os)),
+        raising=False,
+    )
+    monkeypatch.setattr(cache_mod.os, "fsync", fake_fsync, raising=False)
+
+    f = RecordingFile()
+    dummy_self = _make_dummy_self()
+
+    cache_mod.CachedTestRun.save(dummy_self, f)
+
+    assert (
+        f.flushed
+    ), "CachedTestRun.save() should call f.flush() after json.dump(...)"
+    assert fsynced[
+        "called"
+    ], "CachedTestRun.save() should call os.fsync(f.fileno())"


### PR DESCRIPTION
Ensure all lock protected JSON writes for test runs and prompt cache explicitly flush and fsync before releasing portalocker locks, preventing truncated or partially written files in parallel runs on network storage.

- Update TestRun.save and CachedTestRun.save to call flush() and os.fsync()
- Harden TestRunManager.save_test_run and save_final_test_run_link JSON writes
- Harden Prompt._write_to_cache JSON writes for the prompt cache
- Add tests asserting flush & fsync behavior for test runs and prompt cache

Fixes #2322.