### PR TITLE
fix(metrics): enforce valid JSON templates and discourage fences

### DIFF
--- a/deepeval/metrics/conversational_g_eval/template.py
+++ b/deepeval/metrics/conversational_g_eval/template.py
@@ -10,10 +10,10 @@ Evaluation Criteria:
 {criteria}
 
 **
-IMPORTANT: Please make sure to only return in JSON format, with the "steps" key as a list of strings. No words or explanation is needed.
+IMPORTANT: Please make sure to only return in valid and parseable JSON format, with the "steps" key as a list of strings. No words or explanation is needed. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra text, commentary, or formatting.
 Example JSON:
 {{
-    "steps": <list_of_strings>
+    "steps": ["Check if the answer addresses the user query.", "Verify factual correctness where applicable.", "Assess clarity and coherence of the answer."]
 }}
 **
 
@@ -65,7 +65,7 @@ JSON:
     {parameters}
 
     ---
-    IMPORTANT: You MUST return only a valid JSON object with the exact keys `"score"` and `"reason"`. No additional text, commentary, or formatting.
+    IMPORTANT: You MUST return only in valid and parseable JSON format, with the exact keys `"score"` and `"reason"`. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra text, commentary, or formatting.
 
     ---
     Example JSON:

--- a/deepeval/metrics/dag/templates.py
+++ b/deepeval/metrics/dag/templates.py
@@ -18,7 +18,7 @@ DAG Traversal:
 {verbose_steps}
 
 **
-IMPORTANT: Please make sure to only return in JSON format, with the 'reason' key providing the reason.
+IMPORTANT: Please make sure to only return in valid and parseable JSON format, with the 'reason' key providing the reason. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra text.
 Example JSON:
 {{
     "reason": "The score is <metric_name_score> because <your_reason>."
@@ -41,7 +41,7 @@ class TaskNodeTemplate:
 ===END OF INSTRUCTIONS===
 
 **
-IMPORTANT: Please make sure to only return in JSON format, with the 'output' key as the output from the instructions.
+IMPORTANT: Please make sure to only return in valid and parseable JSON format, with the 'output' key as the output from the instructions. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra text.
 Example JSON:
 {{
     "output": "your output goes here"
@@ -60,10 +60,10 @@ class BinaryJudgementTemplate:
 {text}
 
 **
-IMPORTANT: Please make sure to only return a json with two keys: `verdict` (True or False), and the 'reason' key providing the reason. The verdict must be a boolean only, either True or False.
+IMPORTANT: Please make sure to only return in valid and parseable JSON format, with two keys: "verdict" (a boolean true or false) and "reason" (a string explanation). Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra text.
 Example JSON:
 {{
-    "verdict": True,
+    "verdict": true,
     "reason": "..."
 }}
 **
@@ -82,10 +82,10 @@ class NonBinaryJudgementTemplate:
 {text}
 
 **
-IMPORTANT: Please make sure to only return a json with two keys: 'verdict' {options} and 'reason' providing the reason.
+IMPORTANT: Please make sure to only return in valid and parseable JSON format, with two keys: "verdict" and "reason". The "verdict" must be a string equal to one of the following options: {options}. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra text.
 Example JSON:
 {{
-    "verdict": {options},
+    "verdict": "<one_of_the_options>",
     "reason": "..."
 }}
 **

--- a/deepeval/metrics/g_eval/template.py
+++ b/deepeval/metrics/g_eval/template.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 import textwrap
 
 
@@ -6,16 +6,16 @@ class GEvalTemplate:
     @staticmethod
     def generate_evaluation_steps(parameters: str, criteria: str):
         return textwrap.dedent(
-            f"""Given an evaluation criteria which outlines how you should judge the {parameters}, generate 3-4 concise evaluation steps based on the criteria below. You MUST make it clear how to evaluate {parameters} in relation to one another.
+            f"""Given an evaluation criteria which outlines how you should judge the {parameters}, generate 3-4 concise evaluation steps based on the criteria below. You MUST make it clear how to evaluate {parameters} in relation to one another. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra text.
 
             Evaluation Criteria:
             {criteria}
 
             **
-            IMPORTANT: Please make sure to only return in JSON format, with the "steps" key as a list of strings. No words or explanation is needed.
+            IMPORTANT: Please make sure to only return in valid and parseable JSON format, with the "steps" key as a list of strings. No words or explanation is needed.
             Example JSON:
             {{
-                "steps": <list_of_strings>
+                "steps": ["Check if the answer addresses the user query.", "Verify factual correctness where applicable.", "Assess clarity and coherence of the answer."]
             }}
             **
 
@@ -53,7 +53,7 @@ class GEvalTemplate:
         )
 
         return textwrap.dedent(
-            f"""You are an evaluator. Given the following {dependencies}, assess the response below and return a JSON object with two fields:
+            f"""You are an evaluator. Given the following {dependencies}, assess the response below and return in valid JSON format, with two fields:
 
             - `"score"`: an integer between {score_range[0]} and {score_range[1]}, {score_explanation}.
             - `"reason"`: a brief explanation for why the score was given. This must mention specific strengths or shortcomings, referencing relevant details from the input. Do **not** quote the score itself in the explanation.
@@ -63,7 +63,7 @@ class GEvalTemplate:
             - Mention key details from the test case parameters.
             - Be concise, clear, and focused on the evaluation logic.
 
-            Only return valid JSON. Do **not** include any extra commentary or text.
+            Only return in valid and parseable JSON format. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra commentary or text.
 
             ---
 
@@ -102,7 +102,7 @@ class GEvalTemplate:
             else ""
         )
         return textwrap.dedent(
-            f"""Given the evaluation steps, return a JSON with two keys: 1) a `score` key that is STRICTLY EITHER 1 (follows the criteria 100% outlined in the evaluation steps), OR 0 (does not follow the criteria), and 2) a `reason` key, a reason for the given score, but DO NOT QUOTE THE SCORE in your reason. Please mention specific information from {parameters} in your reason, but be very concise with it!
+            f"""Given the evaluation steps, return in valid JSON format, with two keys: 1) a `score` key that is STRICTLY EITHER 1 (follows the criteria 100% outlined in the evaluation steps), OR 0 (does not follow the criteria), and 2) a `reason` key, a reason for the given score, but DO NOT QUOTE THE SCORE in your reason. Please mention specific information from {parameters} in your reason, but be very concise with it!
 
             Evaluation Steps:
             {evaluation_steps}
@@ -110,7 +110,7 @@ class GEvalTemplate:
             {test_case_content}
             {additional_context}
             **
-            IMPORTANT: Please make sure to only return in JSON format, with the "score" and "reason" key. No words or explanation is needed.
+            IMPORTANT: Please make sure to only return in valid and parseable JSON format, with the "score" and "reason" key. Do not wrap the JSON in markdown code fences (for example ```json ... ```), and do not include any extra commentary or text.
 
             Example JSON:
             {{

--- a/tests/test_core/helpers.py
+++ b/tests/test_core/helpers.py
@@ -1,8 +1,10 @@
+import json
 import time
 import uuid
 from datetime import datetime, timezone
 
 from deepeval.tracing.api import TraceApi, TraceSpanApiStatus
+from tests.test_core.stubs import AlwaysJsonModel
 
 
 def ts_iso8601_utc(ts: float) -> str:
@@ -60,3 +62,13 @@ def reset_settings_env(monkeypatch, *, skip_keys: set[str] = set()):
 
     # don’t carry default save across tests, keep things clean
     monkeypatch.delenv("DEEPEVAL_DEFAULT_SAVE", raising=False)
+
+
+def _extract_example_json(template_text: str) -> dict:
+    """
+    Mirror how AlwaysJsonModel pulls the first JSON block after
+    an "Example JSON:" anchor and ensure it is valid JSON.
+    """
+    extractor = AlwaysJsonModel.balanced_json_after_anchor("Example JSON:")
+    json_str = extractor(template_text)
+    return json.loads(json_str)

--- a/tests/test_core/test_metrics/test_conversational_g_eval.py
+++ b/tests/test_core/test_metrics/test_conversational_g_eval.py
@@ -1,0 +1,80 @@
+import pytest
+
+from tests.test_core.helpers import _extract_example_json
+from deepeval.metrics.conversational_g_eval.template import (
+    ConversationalGEvalTemplate,
+)
+
+
+def test_conversational_g_eval_generate_evaluation_steps_example_json_is_valid():
+    """Example JSON in ConversationalGEvalTemplate.generate_evaluation_steps must parse.
+
+    On current main, the example used a placeholder like <list_of_strings>,
+    which is not valid JSON and would cause json.loads(..) to fail. This test
+    guards that the example remains real, valid JSON:
+
+        {"steps": ["step 1", "step 2"]}
+    """
+    template = ConversationalGEvalTemplate.generate_evaluation_steps(
+        parameters="role and content",
+        criteria="check conversational quality and helpfulness",
+    )
+    data = _extract_example_json(template)
+    assert isinstance(data, dict)
+    assert "steps" in data
+    assert isinstance(data["steps"], list)
+    # Optional sanity check that it isn't empty
+    assert len(data["steps"]) >= 1
+
+
+def test_conversational_g_eval_generate_evaluation_results_example_json_is_valid():
+    """Example JSON in ConversationalGEvalTemplate.generate_evaluation_results must parse.
+
+    This ensures the documented example under "Example JSON:" is valid and
+    matches the expected "score"/"reason" schema.
+    """
+    template = ConversationalGEvalTemplate.generate_evaluation_results(
+        evaluation_steps="1) check; 2) score",
+        test_case_content="conversation snippet here",
+        turns=[
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ],
+        parameters="role and content",
+        rubric=None,
+    )
+    data = _extract_example_json(template)
+    assert isinstance(data, dict)
+    assert "score" in data
+    assert "reason" in data
+    # Example JSON uses an integer score and a string reason
+    assert isinstance(data["score"], int)
+    assert isinstance(data["reason"], str)
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        ConversationalGEvalTemplate.generate_evaluation_steps(
+            parameters="role and content",
+            criteria="check conversational quality and helpfulness",
+        ),
+        ConversationalGEvalTemplate.generate_evaluation_results(
+            evaluation_steps="1) check; 2) score",
+            test_case_content="conversation snippet here",
+            turns=[
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+            parameters="role and content",
+            rubric=None,
+        ),
+    ],
+)
+def test_conversational_g_eval_templates_discourage_markdown_fences(
+    template: str,
+):
+    """Conversational GEval templates should explicitly ask for valid JSON without fences."""
+    lower = template.lower()
+    assert "valid and parseable json" in lower
+    assert "markdown code fences" in lower

--- a/tests/test_core/test_metrics/test_g_eval.py
+++ b/tests/test_core/test_metrics/test_g_eval.py
@@ -1,0 +1,53 @@
+import pytest
+
+from tests.test_core.helpers import _extract_example_json
+from deepeval.metrics.g_eval.template import GEvalTemplate
+
+
+def test_g_eval_generate_evaluation_steps_example_json_is_valid():
+    """
+    Example JSON in GEvalTemplate.generate_evaluation_steps must parse.
+
+    Previously this example used a placeholder like <list_of_strings>,
+    which is not valid JSON and caused json.loads to fail. This test
+    guarantees the example is real, parseable JSON with the expected shape.
+    """
+    template = GEvalTemplate.generate_evaluation_steps(
+        parameters="answer and reference",
+        criteria="check factual correctness",
+    )
+    data = _extract_example_json(template)
+    assert isinstance(data, dict)
+    assert "steps" in data
+    assert isinstance(data["steps"], list)
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        GEvalTemplate.generate_evaluation_steps(
+            parameters="answer and reference",
+            criteria="check factual correctness",
+        ),
+        GEvalTemplate.generate_evaluation_results(
+            evaluation_steps="1) check; 2) score",
+            test_case_content="model output here",
+            parameters="answer and reference",
+        ),
+        GEvalTemplate.generate_strict_evaluation_results(
+            evaluation_steps="1) check; 2) score",
+            test_case_content="model output here",
+            parameters="answer and reference",
+        ),
+    ],
+)
+def test_g_eval_templates_emphasize_valid_json_and_only_json(template: str):
+    """
+    GEval templates should clearly ask for valid, parseable JSON,
+    and for returning ONLY the JSON.
+    """
+    lower = template.lower()
+    # New, stronger instruction you added
+    assert "valid and parseable json" in lower
+    # All three templates include "only return ..." in their IMPORTANT blocks
+    assert "only return" in lower


### PR DESCRIPTION
- Update DAG metric templates to use valid JSON examples (true/false, string verdicts) and explicitly forbid markdown code fences
- Strengthen GEval and Conversational GEval templates to require "valid and parseable JSON" and avoid markdown code fences and extra text
- Validate with tests

Fixes #2332