### PR TITLE
fix(models): restore provider prefixed model name parsing

### DIFF
--- a/deepeval/models/utils.py
+++ b/deepeval/models/utils.py
@@ -28,9 +28,9 @@ def parse_model_name(model_name: Optional[str] = None) -> str:
     if model_name is None:
         return None
 
-    # if "/" in model_name:
-    #     _, parsed_model_name = model_name.split("/", 1)
-    #     return parsed_model_name
+    if "/" in model_name:
+        _, parsed_model_name = model_name.split("/", 1)
+        return parsed_model_name
     return model_name
 
 


### PR DESCRIPTION
Re-enable parse_model_name to strip "<provider>/<model>" prefixes instead of returning the raw string. This code was accidentally commented out in f10080c6a17ca214d3ad200fd4cdefc319c8e6bb