### PR TITLE
fix: update pytest plugin reference to "deepeval" in cli/test.py

### DIFF
--- a/deepeval/cli/test.py
+++ b/deepeval/cli/test.py
@@ -160,7 +160,7 @@ def run(
         pytest_args.extend(["--identifier", identifier])
 
     # Add the deepeval plugin file to pytest arguments
-    pytest_args.extend(["-p", "plugins"])
+    pytest_args.extend(["-p", "deepeval"])
     # Append the extra arguments collected by allow_extra_args=True
     # Pytest will raise its own error if the arguments are invalid (error:
     if ctx.args:


### PR DESCRIPTION
Changed the pytest plugin argument from "plugins" to "deepeval" to align with the recent update to the plugin entry point in pyproject.toml. This ensures the correct plugin is loaded when running tests via the CLI.