### PR TITLE
chore(ci): add optional model deps to dev deps for CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ pandas = "*"
 pysqlite3-binary = "^0.5.4"
 pre-commit = "^4.3.0"
 ruff = "^0.13.0"
+ollama = "*"
+anthropic = "*"
+google-genai = "^1.9.0"
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
Adding our optional dependencies to our dev dependencies so that the CI can install them for tests that require them.