### PR TITLE
fix: include generation_kwargs in generate_raw_response methods

### DIFF
--- a/deepeval/models/llms/litellm_model.py
+++ b/deepeval/models/llms/litellm_model.py
@@ -289,6 +289,7 @@ class LiteLLMModel(DeepEvalBaseLLM):
                 "top_logprobs": top_logprobs,
             }
             completion_params.update(self.kwargs)
+            completion_params.update(self.generation_kwargs)
 
             response = completion(**completion_params)
             cost = self.calculate_cost(response)
@@ -335,6 +336,7 @@ class LiteLLMModel(DeepEvalBaseLLM):
                 "top_logprobs": top_logprobs,
             }
             completion_params.update(self.kwargs)
+            completion_params.update(self.generation_kwargs)
 
             response = await acompletion(**completion_params)
             cost = self.calculate_cost(response)


### PR DESCRIPTION
The generate_raw_response() and a_generate_raw_response() methods were missing the update for self.generation_kwargs, while the generate() and a_generate() methods correctly included it.

This caused custom parameters like extra_headers passed via generation_kwargs to be ignored when these methods were called, leading to authentication failures with custom LLM endpoints that require additional headers.

## Error observed

```
Error in LiteLLM generate_raw_response: litellm.AuthenticationError:
AuthenticationError: OpenAIException - Error code: 401 -
{'fault': {'faultstring': 'Failed to Resolve Variable',
'detail': {'errorcode': 'steps.jwt.FailedToResolveVariable'}}}
```

## How to reproduce

1. Create a LiteLLMModel with custom extra_headers in generation_kwargs:

   ```python from deepeval.models import LiteLLMModel

   model = LiteLLMModel( model="openai/gpt-4o-mini", base_url="https://your-custom-endpoint.com/v1", api_key="placeholder", generation_kwargs={ "extra_headers": {"api-key": "your-auth-token"} } ) ```

2. Use this model with a metric that calls generate_raw_response() (e.g., metrics using logprobs)

3. Observe that the extra_headers are not included in the request, causing HTTP 401 authentication errors

## Fix

Add `completion_params.update(self.generation_kwargs)` after `completion_params.update(self.kwargs)` in both generate_raw_response() and a_generate_raw_response() methods, matching the pattern used in generate() and a_generate().