### PR TITLE
bug/issue-2401: batch scoring on DROP Benchmark

### DIFF
--- a/deepeval/benchmarks/drop/drop.py
+++ b/deepeval/benchmarks/drop/drop.py
@@ -282,7 +282,9 @@ class DROP(DeepEvalBaseBenchmark):
             expected_output = DROPTemplate.parse_str_to_list(
                 golden.expected_output, DELIMITER
             )
-            score = self.scorer.quasi_contains_score(expected_output, prediction)
+            score = self.scorer.quasi_contains_score(
+                expected_output, prediction
+            )
             res.append({"prediction": prediction, "score": score})
 
         return res


### PR DESCRIPTION
Closes #2401 

Logic works similar to scoring with batch_predict=None. Tested and it works.

Example of bug:
Prediction: '2', Answer: '2, 2-yards'
Prediction wanted model to return the full '2, 2-yards' instead of correctly marking '2' as correct. Batch prediction used `quasi_exact_match_score` instead of `quasi_contains_score` like the predict function.