### PR TITLE
Bug/issue-2407: MMLU batch_predict type

### DIFF
--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -225,7 +225,9 @@ class MMLU(DeepEvalBaseBenchmark):
                 prompts=prompts, schemas=[MultipleChoiceSchema for i in prompts]
             )
             if not isinstance(responses, list):
-                raise TypeError("batch_generate must return List[MultipleChoiceSchema]")
+                raise TypeError(
+                    "batch_generate must return List[MultipleChoiceSchema]"
+                )
 
             predictions = [res.answer for res in responses]
         except TypeError:


### PR DESCRIPTION
Closes #2407 

Bug in MMLU where only List[List[BaseModel]] or List[Tuple(BaseModel)] would work rather than List[BaseModel] as expected and used in all other benchmarks