### PR TITLE
fix(gemini): restore Vertex AI ADC support

### DIFF
--- a/tests/test_core/test_models/test_gemini_model.py
+++ b/tests/test_core/test_models/test_gemini_model.py
@@ -76,3 +76,50 @@ def test_gemini_model_defaults_key_from_settings_and_unwraps_secret(
     # Client must see the Settings key, as a plain string
     assert isinstance(api_key, str)
     assert api_key == "env-secret-key"
+
+
+@patch("deepeval.models.llms.gemini_model.require_dependency")
+def test_gemini_vertexai_allows_adc_when_no_service_account_key(
+    mock_require_dep,
+    settings,
+):
+    """
+    Vertex AI mode should allow Application Default Credentials (ADC)
+
+    With GOOGLE_GENAI_USE_VERTEXAI enabled and project/location set,
+    GeminiModel should create a Vertex client even when no service account
+    key is provided. In that case, credentials should be None and resolved via ADC.
+    """
+    fake_genai = _make_fake_genai_module()
+
+    def _fake_require_dependency(name, *args, **kwargs):
+        # ADC path should only need the genai module and not require oauth2
+        # just to allow default creds.
+        if name == "google.genai":
+            return fake_genai
+        raise AssertionError(f"Unexpected dependency requested: {name}")
+
+    mock_require_dep.side_effect = _fake_require_dependency
+
+    with settings.edit(persist=False):
+        settings.GOOGLE_GENAI_USE_VERTEXAI = True
+        settings.GOOGLE_CLOUD_PROJECT = "test-project"
+        settings.GOOGLE_CLOUD_LOCATION = "us-central1"
+        settings.GOOGLE_SERVICE_ACCOUNT_KEY = None
+
+    model = GeminiModel(
+        model="gemini-1.5-pro",
+        project="test-project",
+        location="us-central1",
+        service_account_key=None,
+    )
+
+    client = model.model
+
+    # assert that we are building a Vertex client rather than API-key mode
+    assert client.kwargs.get("vertexai") is True
+    assert client.kwargs.get("project") == "test-project"
+    assert client.kwargs.get("location") == "us-central1"
+
+    # credentials should be absent/None so the SDK resolves via ADC.
+    assert client.kwargs.get("credentials") is None


### PR DESCRIPTION
Allow Gemini Vertex AI mode to fall back to Application Default Credentials (ADC) when no service account key is provided, instead of requiring `GOOGLE_SERVICE_ACCOUNT_KEY`.

- Only parse/validate `GOOGLE_SERVICE_ACCOUNT_KEY` and construct explicit service-account credentials when a key is present
- Add regression test to ensure Vertex mode works with `credentials=None` (ADC path) and doesn’t require oauth2 imports

Fixes: #2409