### PR TITLE
fix(gemini): update defaults and docs due to retired model IDs

### DIFF
--- a/deepeval/models/llms/gemini_model.py
+++ b/deepeval/models/llms/gemini_model.py
@@ -22,7 +22,7 @@ from deepeval.models.llms.constants import GEMINI_MODELS_DATA
 if TYPE_CHECKING:
     from google.genai import Client
 
-default_gemini_model = "gemini-1.5-pro"
+default_gemini_model = "gemini-2.5-pro"
 
 # consistent retry rules
 retry_gemini = create_retry_decorator(PS.GOOGLE)

--- a/docs/guides/guides-using-custom-llms.mdx
+++ b/docs/guides/guides-using-custom-llms.mdx
@@ -315,7 +315,7 @@ safety_settings = {
 
 #TODO : Add values for project and location below
 custom_model_gemini = ChatVertexAI(
-    model_name="gemini-1.0-pro-002"
+    model_name="gemini-2.5-flash"
     , safety_settings=safety_settings
     , project= "<project-id>"
     , location= "<region>" #example : us-central1
@@ -635,7 +635,7 @@ This is because the `CustomMistral7B` model is implemented through HF `transform
 
 :::
 
-### `gemini-1.5-flash` through Vertex AI
+### `gemini-2.5-flash` through Vertex AI
 
 Begin by installing the `instructor` package via pip:
 
@@ -653,7 +653,7 @@ from deepeval.models import DeepEvalBaseLLM
 
 class CustomGeminiFlash(DeepEvalBaseLLM):
     def __init__(self):
-        self.model = genai.GenerativeModel(model_name="models/gemini-1.5-flash")
+        self.model = genai.GenerativeModel(model_name="models/gemini-2.5-flash")
 
     def load_model(self):
         return self.model

--- a/docs/integrations/models/gemini.mdx
+++ b/docs/integrations/models/gemini.mdx
@@ -12,7 +12,7 @@ Run the following command in your terminal to configure your deepeval environmen
 
 ```bash
 deepeval set-gemini \
-    --model=<model> # e.g. "gemini-2.0-flash-001"
+    --model=<model> # e.g. "gemini-2.5-flash"
 ```
 
 :::info
@@ -31,14 +31,14 @@ See [Flags and Configs -> Persisting CLI settings](/docs/evaluation-flags-and-co
 
 ### Python
 
-Alternatively, you can specify your model directly in code using `GeminiModel` from `deepeval`'s model collection. By default, `model` is set to `gemini-1.5-pro`.
+Alternatively, you can specify your model directly in code using `GeminiModel` from `deepeval`'s model collection. By default, `model` is set to `gemini-2.5-pro`.
 
 ```python
 from deepeval.models import GeminiModel
 from deepeval.metrics import AnswerRelevancyMetric
 
 model = GeminiModel(
-    model="gemini-1.5-pro",
+    model="gemini-2.5-pro",
     api_key="Your Gemini API Key",
     temperature=0
 )
@@ -67,17 +67,13 @@ This list only displays some of the available models. For a comprehensive list, 
 
 Below is a list of commonly used Gemini models:
 
-`gemini-1.5-pro`
-`gemini-1.5-pro-002`
-`gemini-1.5-flash`
-`gemini-1.5-flash-002`
-`gemini-1.5-flash-8b`
-`gemini-2.0-flash`
-`gemini-2.0-flash-lite`
+`gemini-3-pro-preview`
+`gemini-3-flash-preview`
 `gemini-2.5-pro`
 `gemini-2.5-flash`
 `gemini-2.5-flash-lite`
-`gemini-3-pro`
-`gemini-3-pro-preview`
-`gemini-pro`
-`gemini-pro-vision`
+`gemini-2.0-flash`
+`gemini-2.0-flash-lite`
+`gemini-pro-latest`
+`gemini-flash-latest`
+`gemini-flash-lite-latest`

--- a/docs/integrations/models/vertex-ai.mdx
+++ b/docs/integrations/models/vertex-ai.mdx
@@ -24,7 +24,7 @@ Run the following command in your terminal to configure your deepeval environmen
 
 ```bash
 deepeval set-gemini \
-    --model-name=<model> \ # e.g. "gemini-2.0-flash-001"
+    --model=<model> \ # e.g. "gemini-2.5-flash"
     --project=<project_id> \
     --location=<location> # e.g. "us-central1"
 ```
@@ -45,14 +45,14 @@ See [Flags and Configs -> Persisting CLI settings](/docs/evaluation-flags-and-co
 
 ### Python
 
-Alternatively, you can specify your model directly in code using `GeminiModel` from DeepEval's model collection. By default, `model` is set to `gemini-1.5-pro`.
+Alternatively, you can specify your model directly in code using `GeminiModel` from DeepEval's model collection. By default, `model` is set to `gemini-2.5-pro`.
 
 ```python
 from deepeval.models import GeminiModel
 from deepeval.metrics import AnswerRelevancyMetric
 
 model = GeminiModel(
-    model="gemini-1.5-pro",
+    model="gemini-2.5-pro",
     project="Your Project ID",
     location="us-central1",
     temperature=0
@@ -86,20 +86,13 @@ This list only displays some of the available models. For a comprehensive list, 
 
 Below is a list of commonly used Gemini models:
 
-`gemini-2.0-pro-exp-02-05`  
-`gemini-2.0-flash`  
-`gemini-2.0-flash-001`  
-`gemini-2.0-flash-002`  
-`gemini-2.0-flash-lite`  
-`gemini-2.0-flash-lite-001`  
-`gemini-1.5-pro`  
-`gemini-1.5-pro-001`  
-`gemini-1.5-pro-002`  
-`gemini-1.5-flash`  
-`gemini-1.5-flash-001`  
-`gemini-1.5-flash-002`  
-`gemini-1.0-pro`  
-`gemini-1.0-pro-001`  
-`gemini-1.0-pro-002`  
-`gemini-1.0-pro-vision`  
-`gemini-1.0-pro-vision-001`
+`gemini-3-pro-preview`
+`gemini-3-flash-preview`
+`gemini-2.5-pro`
+`gemini-2.5-flash`
+`gemini-2.5-flash-lite`
+`gemini-2.0-flash`
+`gemini-2.0-flash-lite`
+`gemini-pro-latest`
+`gemini-flash-latest`
+`gemini-flash-lite-latest`


### PR DESCRIPTION
- Bump Gemini default model from gemini-1.5-pro to gemini-2.5-pro.
- Refresh Gemini and Vertex AI docs to remove retired 1.0/1.5 model IDs and add current stable/preview models and *-latest aliases.
- Update custom LLM guide examples to use gemini-2.5-flash / gemini-2.5-flash Vertex examples.