### PR TITLE
fix: propagate optimizer_model to algorithm

### DIFF
--- a/deepeval/optimizer/prompt_optimizer.py
+++ b/deepeval/optimizer/prompt_optimizer.py
@@ -131,6 +131,7 @@ class PromptOptimizer:
 
     def _configure_algorithm(self) -> None:
         """Configure the algorithm with scorer, rewriter, and callbacks."""
+        self.algorithm.optimizer_model = self.optimizer_model
         self.algorithm.scorer = Scorer(
             model_callback=self.model_callback,
             metrics=self.metrics,


### PR DESCRIPTION
# Description
Hello! I've been experimenting with DeepEval lately—y'all have done a very good job on this project.
However, I noticed a blocker while experimenting with MIPROv2, especially when using a custom LLM implementing DeepEvalBaseLLM. Even though I passed the optimizer_model to the PromptOptimizer constructor, I ran into the following exception:
`[MIPROv2] • error DeepEvalError: MIPROv2 requires an optimizer_model for instruction proposal. Set it via PromptOptimizer. • halted before first iteration`

# Root Cause
After digging into the source, I found that self.algorithm.optimizer_model was remaining None because it wasn't being assigned during the configuration step in PromptOptimizer. Since MIPROv2 relies on a proposer phase before the main optimization loop, it needs this model to be explicitly set on the algorithm instance.
I’ve submitted this PR as a quick fix to ensure the model is correctly propagated. If you have a better architectural idea for handling this assignment, I'd be glad to help adjust it!

# Reproductible Case
I prepared a mock case that reproduces the issue without requiring any external API keys or complex setups:
```python
from deepeval.models.base_model import DeepEvalBaseLLM
from deepeval.optimizer import PromptOptimizer
from deepeval.optimizer.algorithms import MIPROV2
from deepeval.dataset import Golden
from deepeval.prompt import Prompt
from deepeval.metrics import BaseMetric
from deepeval.test_case import LLMTestCase

class MockLLM(DeepEvalBaseLLM):
    def __init__(self):
        pass
    def load_model(self):
        return self
    def generate(self, prompt: str) -> str:
        return "response"
    async def a_generate(self, prompt: str) -> str:
        return "response"
    def get_model_name(self):
        return "LLM"

mock_model = MockLLM()
goldens = [Golden(input="Hi", expected_output="Hello"),Golden(input="Hru?", expected_output="Fine, U?")]
prompt = Prompt(text_template="You are a mock assistant.")

class MockMetric(BaseMetric):
    def __init__(self):
        self.threshold = 0.5
    def measure(self, test_case: LLMTestCase):
        self.score = 1.0
        return self.score
    async def a_measure(self, test_case: LLMTestCase):
        return self.measure(test_case)
    def is_successful(self):
        return True
    @property
    def __name__(self):
        return "Metric"

def model_callback(prompt: Prompt,thread_id: str) -> str:
    return "Mocked output"

optimizer = PromptOptimizer(
    algorithm=MIPROV2(),
    optimizer_model=mock_model,
    model_callback=model_callback,
    metrics=[MockMetric()]
)
try:
    result = optimizer.optimize(prompt=prompt, goldens=goldens)
    print(result.text_template)
except Exception as e:
    print(f"\nBUG: {e}")
    print("\nEvidence: Even though 'optimizer_model' was passed to PromptOptimizer,")
    print(f"the algorithm instance has optimizer_model = {optimizer.algorithm.optimizer_model}")
```