### PR TITLE
docs: fix incorrect import path for MMLUTask in benchmarks docs

### DIFF
--- a/docs/docs/benchmarks-MMLU.mdx
+++ b/docs/docs/benchmarks-MMLU.mdx
@@ -29,7 +29,7 @@ The code below evaluates a custom `mistral_7b` model ([click here to learn how t
 
 ```python
 from deepeval.benchmarks import MMLU
-from deepeval.benchmarks.mmlu.task import MMLUTask
+from deepeval.benchmarks.tasks import MMLUTask
 
 # Define benchmark with specific tasks and shots
 benchmark = MMLU(

--- a/docs/docs/benchmarks-introduction.mdx
+++ b/docs/docs/benchmarks-introduction.mdx
@@ -204,7 +204,7 @@ A task for an LLM benchmark is a challenge or problem is designed to assess an L
 
 ```python
 from deepeval.benchmarks import MMLU
-from deepeval.benchmarks.task import MMLUTask
+from deepeval.benchmarks.tasks import MMLUTask
 
 tasks = [MMLUTask.HIGH_SCHOOL_COMPUTER_SCIENCE, MMLUTask.ASTRONOMY]
 benchmark = MMLU(tasks=tasks)


### PR DESCRIPTION
## Summary
- Fixed incorrect import path `from deepeval.benchmarks.task import MMLUTask` to `from deepeval.benchmarks.tasks import MMLUTask` in benchmarks-introduction.mdx
- Updated benchmarks-MMLU.mdx to use the centralized tasks module for consistency

## Problem
The documentation showed an import path that doesn't exist:
```python
from deepeval.benchmarks.task import MMLUTask  # ModuleNotFoundError
```

## Solution
Use the correct centralized tasks module:
```python
from deepeval.benchmarks.tasks import MMLUTask  # Works correctly
```

Fixes #1284