### PR TITLE
docs: add migration note for ConversationRelevancyMetric → TurnRelevancyMetric

### DIFF
--- a/docs/docs/metrics-turn-relevancy.mdx
+++ b/docs/docs/metrics-turn-relevancy.mdx
@@ -21,6 +21,20 @@ import MetricTagsDisplayer from '@site/src/components/MetricTagsDisplayer';
   rag={true}
 />
 
+:::note Migration from v3.6.x
+If you're upgrading from DeepEval v3.6.x or earlier, note that `ConversationRelevancyMetric` has been renamed to `TurnRelevancyMetric`. Simply update your imports:
+
+```python
+# Before (v3.6.x and earlier)
+from deepeval.metrics import ConversationRelevancyMetric
+
+# After (v3.7.x+)
+from deepeval.metrics import TurnRelevancyMetric
+```
+
+The API and functionality remain the same.
+:::
+
 The turn relevancy metric is a conversational metric that determines whether your LLM chatbot is able to consistently generate relevant responses **throughout a conversation**.
 
 ## Required Arguments


### PR DESCRIPTION
## Summary
Added a migration note to the Turn Relevancy docs page to help users upgrading from DeepEval v3.6.x or earlier.

## Problem
Users upgrading from older versions encounter `ImportError: cannot import name 'ConversationRelevancyMetric'` with no explanation of what changed or how to fix it.

## Solution
Added a `:::note` admonition at the top of the Turn Relevancy docs page explaining:
- The metric was renamed from `ConversationRelevancyMetric` to `TurnRelevancyMetric`
- Example showing the old vs new import
- Clarification that the API remains the same

Fixes #2321