### PR TITLE
feat(gemini): add explicit use_vertexai override for client selection

### DIFF
--- a/deepeval/models/llms/gemini_model.py
+++ b/deepeval/models/llms/gemini_model.py
@@ -65,6 +65,7 @@ class GeminiModel(DeepEvalBaseLLM):
         project: Optional[str] = None,
         location: Optional[str] = None,
         service_account_key: Optional[Union[str, Dict[str, str]]] = None,
+        use_vertexai: Optional[bool] = None,
         generation_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
@@ -93,7 +94,11 @@ class GeminiModel(DeepEvalBaseLLM):
             location if location is not None else settings.GOOGLE_CLOUD_LOCATION
         )
         self.location = str(location).strip() if location is not None else None
-        self.use_vertexai = settings.GOOGLE_GENAI_USE_VERTEXAI
+        self.use_vertexai = (
+            use_vertexai
+            if use_vertexai is not None
+            else settings.GOOGLE_GENAI_USE_VERTEXAI
+        )
 
         self.service_account_key: Optional[SecretStr] = None
         if service_account_key is None:

--- a/docs/integrations/models/vertex-ai.mdx
+++ b/docs/integrations/models/vertex-ai.mdx
@@ -61,13 +61,14 @@ model = GeminiModel(
 answer_relevancy = AnswerRelevancyMetric(model=model)
 ```
 
-There are **ZERO** mandatory and **SIX** optional parameters when creating an `GeminiModel` through Vertex AI:
+There are **ZERO** mandatory and **SEVEN** optional parameters when creating an `GeminiModel` through Vertex AI:
 
 - [Optional] `model`: A string specifying the name of the Gemini model to use. Defaults to `GEMINI_MODEL_NAME` if not passed; raises an error at runtime if unset.
 - [Optional] `temperature`: A float specifying the model temperature. Defaults to `TEMPERATURE` if not passed; falls back to `0.0` if unset.
 - [Optional] `project`: A string specifying the Google Cloud project ID for Vertex AI. Defaults to `GOOGLE_CLOUD_PROJECT` if not passed.
 - [Optional] `location`: A string specifying the Google Cloud location for Vertex AI. Defaults to `GOOGLE_CLOUD_LOCATION` if not passed.
 - [Optional] `service_account_key`: A **JSON string** containing the service account key for authentication when using Vertex AI. This string can be either the path to a service account key file or the raw JSON string. Defaults to `GOOGLE_SERVICE_ACCOUNT_KEY` if not passed.
+- [Optional] `use_vertexai`: A boolean to explicitly force Vertex AI (`True`) or Gemini API-key mode (`False`); if not passed, defaults to `GOOGLE_GENAI_USE_VERTEXAI` and otherwise falls back to auto-detection via `project` and `location`.
 - [Optional] `generation_kwargs`: A dictionary of additional generation parameters supported by your model provider.
 
 :::note


### PR DESCRIPTION
- Allow GeminiModel(use_vertexai=...) to force Vertex AI or API-key mode
- add test for settings override behavior, and document the new parameter.