### PR TITLE
Fixed Return Type Annotations

### DIFF
--- a/deepeval/annotation/annotation.py
+++ b/deepeval/annotation/annotation.py
@@ -14,7 +14,7 @@ def send_annotation(
     explanation: Optional[str] = None,
     user_id: Optional[str] = None,
     type: Optional[AnnotationType] = AnnotationType.THUMBS_RATING,
-) -> str:
+) -> None:
     api_annotation = APIAnnotation(
         rating=rating,
         traceUuid=trace_uuid,
@@ -50,7 +50,7 @@ async def a_send_annotation(
     explanation: Optional[str] = None,
     type: Optional[AnnotationType] = AnnotationType.THUMBS_RATING,
     user_id: Optional[str] = None,
-) -> str:
+) -> None:
     api_annotation = APIAnnotation(
         rating=rating,
         traceUuid=trace_uuid,


### PR DESCRIPTION
### **Fixed Return Type Annotations**
   - **File**: `deepeval/annotation/annotation.py`
   - **Issue**: Functions `send_annotation()` and `a_send_annotation()` had incorrect return type `-> str` but don't return anything
   - **Fix**: Changed return type to `-> None` to match actual behavior