### PR TITLE
Fix variable name from 'golden' to 'goldens'

### DIFF
--- a/docs/docs/metrics-task-completion.mdx
+++ b/docs/docs/metrics-task-completion.mdx
@@ -58,7 +58,7 @@ task_completion = TaskCompletionMetric(threshold=0.7, model="gpt-4o")
 
 # Loop through dataset
 for goldens in dataset.evals_iterator(metrics=[task_completion]):
-    trip_planner_agent(golden.input)
+    trip_planner_agent(goldens.input)
 ```
 
 There are **SEVEN** optional parameters when creating a `TaskCompletionMetric`:


### PR DESCRIPTION
golden is typo 
for goldens in dataset_item:
  trip_planner_agent(goldens.input) # it is correct
  # trip_planner_agent(golden.input) # it is incorrect