### PR TITLE
Able to change cache folder path 

### DIFF
--- a/deepeval/config/settings.py
+++ b/deepeval/config/settings.py
@@ -316,6 +316,13 @@ class Settings(BaseSettings):
         description="If set, export a timestamped JSON of the latest test run into this folder (created if missing).",
     )
 
+    # When set, overrides the default DeepEval cache directory
+    DEEPEVAL_CACHE_FOLDER: Optional[Path] = Field(
+        ".deepeval",
+        description="Path to the directory used by DeepEval to store cache files. If set, this overrides the default cache location. The directory will be created if it does not exist.",
+    )
+
+
     # Display / Truncation
     DEEPEVAL_MAXLEN_TINY: Optional[int] = Field(
         40,
@@ -1015,7 +1022,7 @@ class Settings(BaseSettings):
     def _coerce_yes_no(cls, v):
         return None if v is None else parse_bool(v, default=False)
 
-    @field_validator("DEEPEVAL_RESULTS_FOLDER", "ENV_DIR_PATH", mode="before")
+    @field_validator("DEEPEVAL_RESULTS_FOLDER", "ENV_DIR_PATH", "DEEPEVAL_CACHE_FOLDER", mode="before")
     @classmethod
     def _coerce_path(cls, v):
         if v is None:

--- a/deepeval/constants.py
+++ b/deepeval/constants.py
@@ -1,8 +1,9 @@
 from enum import Enum
 from typing import Union
+import os
 
 KEY_FILE: str = ".deepeval"
-HIDDEN_DIR: str = ".deepeval"
+HIDDEN_DIR: str = os.getenv("DEEPEVAL_CACHE_FOLDER", ".deepeval")
 PYTEST_RUN_TEST_NAME: str = "CONFIDENT_AI_RUN_TEST_NAME"
 LOGIN_PROMPT = "\n✨👀 Looking for a place for your LLM test data to live 🏡❤️ ? Use [rgb(106,0,255)]Confident AI[/rgb(106,0,255)] to get & share testing reports, experiment with models/prompts, and catch regressions for your LLM system. Just run [cyan]'deepeval login'[/cyan] in the CLI."
 


### PR DESCRIPTION
PR for issue: #2443 
I implemented the simplest solution by allowing the HIDDEN_DIR constant to be overridden via an environment variable.

Ideally, the cache path should be taken directly from the settings object, but that currently causes circular import issues since settings already depends on constants. I also preferred not to remove HIDDEN_DIR, as it is used in many places in the codebase.

If you think there’s a better approach, I’m open to talk on it

