### PR TITLE
refactor: use subprocess.run for robust path handling on Windows

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -12,6 +12,7 @@ import os
 import gc
 import tempfile
 import logging
+import subprocess
 
 from deepeval.synthesizer.utils import (
     print_synthesizer_status,
@@ -29,7 +30,6 @@ from deepeval.models.base_model import (
 )
 from deepeval.utils import update_pbar, add_pbar, remove_pbars
 from deepeval.config.settings import get_settings
-
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,18 @@ def safe_rmtree(
             gc.collect()
             time.sleep(1)
             if sys.platform == "win32":
-                os.system(f'attrib -r -s -h "{path}\\*" /s /d')
+                subprocess.run(
+                    [
+                        "attrib",
+                        "-r",
+                        "-s",
+                        "-h",
+                        os.path.join(path, "*"),
+                        "/s",
+                        "/d",
+                    ],
+                    capture_output=True,
+                )
             kwargs["ignore_errors"] = True
             original_rmtree(path, *args, **kwargs)
             print_synthesizer_status(


### PR DESCRIPTION
Refactored the `safe_rmtree` function to utilize `subprocess.run` with proper argument lists, replacing the unsafe `os.system` calls. Handling paths with spaces correctly on Windows was a priority here, as the previous string interpolation approach could easily fail or be exploited. Since `shutil.rmtree` is globally patched in this module, I decided to make this logic as robust as possible to ensure the entire cleanup lifecycle remains stable across different environments.