### PR TITLE
Fix: AzureOpenAIModel sends unsupported temperature for reasoning models

### DIFF
--- a/deepeval/models/llms/azure_model.py
+++ b/deepeval/models/llms/azure_model.py
@@ -138,6 +138,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
         )
 
         self.model_data = OPENAI_MODELS_DATA.get(model)
+
+        # Omit temperature for models that don't support it
+        if self.model_data and self.model_data.supports_temperature is False:
+            temperature = None
+
         cost_per_input_token, cost_per_output_token = require_costs(
             self.model_data,
             model,
@@ -149,7 +154,7 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
         self.model_data.input_price = cost_per_input_token
         self.model_data.output_price = cost_per_output_token
 
-        if temperature < 0:
+        if temperature is not None and temperature < 0:
             raise DeepEvalError("Temperature must be >= 0.")
         self.temperature = temperature
 
@@ -188,7 +193,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
                     model=self.deployment_name,
                     messages=[{"role": "user", "content": content}],
                     response_format=schema,
-                    temperature=self.temperature,
+                    **(
+                        {"temperature": self.temperature}
+                        if self.temperature is not None
+                        else {}
+                    ),
                     **self.generation_kwargs,
                 )
                 structured_output: BaseModel = completion.choices[
@@ -206,7 +215,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
                         {"role": "user", "content": content},
                     ],
                     response_format={"type": "json_object"},
-                    temperature=self.temperature,
+                    **(
+                        {"temperature": self.temperature}
+                        if self.temperature is not None
+                        else {}
+                    ),
                     **self.generation_kwargs,
                 )
                 json_output = trim_and_load_json(
@@ -223,7 +236,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
             messages=[
                 {"role": "user", "content": content},
             ],
-            temperature=self.temperature,
+            **(
+                {"temperature": self.temperature}
+                if self.temperature is not None
+                else {}
+            ),
             **self.generation_kwargs,
         )
         output = completion.choices[0].message.content
@@ -254,7 +271,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
                     model=self.deployment_name,
                     messages=[{"role": "user", "content": content}],
                     response_format=schema,
-                    temperature=self.temperature,
+                    **(
+                        {"temperature": self.temperature}
+                        if self.temperature is not None
+                        else {}
+                    ),
                     **self.generation_kwargs,
                 )
                 structured_output: BaseModel = completion.choices[
@@ -272,7 +293,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
                         {"role": "user", "content": content},
                     ],
                     response_format={"type": "json_object"},
-                    temperature=self.temperature,
+                    **(
+                        {"temperature": self.temperature}
+                        if self.temperature is not None
+                        else {}
+                    ),
                     **self.generation_kwargs,
                 )
                 json_output = trim_and_load_json(
@@ -289,7 +314,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
             messages=[
                 {"role": "user", "content": content},
             ],
-            temperature=self.temperature,
+            **(
+                {"temperature": self.temperature}
+                if self.temperature is not None
+                else {}
+            ),
             **self.generation_kwargs,
         )
         output = completion.choices[0].message.content
@@ -323,7 +352,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
         completion = client.chat.completions.create(
             model=self.deployment_name,
             messages=[{"role": "user", "content": content}],
-            temperature=self.temperature,
+            **(
+                {"temperature": self.temperature}
+                if self.temperature is not None
+                else {}
+            ),
             logprobs=True,
             top_logprobs=top_logprobs,
             **self.generation_kwargs,
@@ -351,7 +384,11 @@ class AzureOpenAIModel(DeepEvalBaseLLM):
         completion = await client.chat.completions.create(
             model=self.deployment_name,
             messages=[{"role": "user", "content": content}],
-            temperature=self.temperature,
+            **(
+                {"temperature": self.temperature}
+                if self.temperature is not None
+                else {}
+            ),
             logprobs=True,
             top_logprobs=top_logprobs,
             **self.generation_kwargs,

--- a/tests/test_core/test_azure_model_temperature.py
+++ b/tests/test_core/test_azure_model_temperature.py
@@ -1,0 +1,39 @@
+import pytest
+
+from deepeval.models.llms.azure_model import AzureOpenAIModel
+
+
+# Shared dummy credentials so __init__ does not raise on missing params.
+_AZURE_KWARGS = dict(
+    api_key="fake-key",
+    base_url="https://fake.openai.azure.com",
+    deployment_name="fake-deployment",
+    api_version="2024-02-01",
+)
+
+
+class TestAzureModelTemperature:
+    def test_reasoning_model_temperature_is_none(self):
+        """o3-mini has supports_temperature=False; temperature must be None."""
+        model = AzureOpenAIModel(model="o3-mini", **_AZURE_KWARGS)
+        assert model.temperature is None
+
+    def test_standard_model_temperature_is_set(self):
+        """gpt-4o supports temperature; it should default to 0.0."""
+        model = AzureOpenAIModel(model="gpt-4o", **_AZURE_KWARGS)
+        assert model.temperature is not None
+        assert model.temperature == 0.0
+
+    def test_explicit_temperature_preserved_for_standard_model(self):
+        """User-supplied temperature is kept for models that support it."""
+        model = AzureOpenAIModel(
+            model="gpt-4o", temperature=0.7, **_AZURE_KWARGS
+        )
+        assert model.temperature == pytest.approx(0.7)
+
+    def test_explicit_temperature_overridden_for_reasoning_model(self):
+        """Even if user passes temperature, reasoning models get None."""
+        model = AzureOpenAIModel(
+            model="o3-mini", temperature=0.5, **_AZURE_KWARGS
+        )
+        assert model.temperature is None


### PR DESCRIPTION
Fixes an issue where `AzureOpenAIModel` sends `temperature=0.0` to models marked `supports_temperature=False` in `OPENAI_MODELS_DATA`, which can cause Azure API errors.

The OpenAI model wrapper already special-cases `supports_temperature=False` in `openai_model.py`. `AzureOpenAIModel` previously always included `temperature` in requests.

On Azure, some reasoning deployments reject unsupported parameters, so the correct behavior is to omit `temperature` rather than forcing a value.

## Changes

- In `AzureOpenAIModel.__init__`, if `supports_temperature is False`, set `self.temperature = None`
- Allow `temperature=None` through validation
- Conditionally omit `temperature` from request kwargs when `self.temperature is None`

## Tests

Added `tests/test_core/test_azure_model_temperature.py` covering:
- `supports_temperature=False` model → temperature is `None`
- Standard model default remains `0.0`
- Explicit temperature preserved for standard models
- Explicit temperature overridden to `None` for `supports_temperature=False` models