### PR TITLE
fix(cli): guard against None span in upload_and_open_link after login

### DIFF
--- a/deepeval/cli/utils.py
+++ b/deepeval/cli/utils.py
@@ -58,7 +58,7 @@ def render_login_message():
     print(pyfiglet.Figlet(font="big_money-ne").renderText("Confident AI"))
 
 
-def upload_and_open_link(_span: Span):
+def upload_and_open_link(_span: Optional[Span] = None):
     last_test_run_data = global_test_run_manager.get_latest_test_run_data()
     if last_test_run_data:
         confident_api_key = get_confident_api_key()
@@ -76,7 +76,8 @@ def upload_and_open_link(_span: Span):
                     print(
                         "\n🎉🥳 Congratulations! You've successfully logged in! :raising_hands: "
                     )
-                    _span.set_attribute("completed", True)
+                    if _span is not None:
+                        _span.set_attribute("completed", True)
                     break
                 else:
                     print("❌ API Key cannot be empty. Please try again.\n")


### PR DESCRIPTION
## Summary

Fixes a crash in `deepeval view` when the user logs in with a Confident AI API key. The telemetry span passed into `upload_and_open_link()` can be `None` (e.g. when `capture_view_event()` does not create a span), and the code called `_span.set_attribute("completed", True)` without checking, causing:

```
AttributeError: 'NoneType' object has no attribute 'set_attribute'
```

## Changes

- **`deepeval/cli/utils.py`**
  - Type `_span` as `Optional[Span] = None` to reflect that callers may pass `None`.
  - Guard: only call `_span.set_attribute("completed", True)` when `_span is not None`.

## Testing

- Ran `deepeval view`, entered API key at prompt; command now completes without crashing (upload or "No test run found" message as appropriate).

Closes #2495
