### PR TITLE
Add MLLMDocument to support PDF inputs in LLMTestCase

### DIFF
--- a/deepeval/dataset/golden.py
+++ b/deepeval/dataset/golden.py
@@ -1,8 +1,8 @@
 import re
 from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from typing import Optional, Dict, List
-from deepeval.test_case import ToolCall, Turn, MLLMImage
-from deepeval.test_case.llm_test_case import _MLLM_IMAGE_REGISTRY
+from deepeval.test_case import ToolCall, Turn, MLLMImage, MLLMDocument
+from deepeval.test_case.llm_test_case import _MLLM_IMAGE_REGISTRY, _MLLM_DOCUMENT_REGISTRY
 
 
 class Golden(BaseModel):
@@ -49,7 +49,7 @@ class Golden(BaseModel):
         if self.multimodal is True:
             return self
 
-        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]"
+        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]|\[DEEPEVAL:DOCUMENT:(.*?)\]"
         auto_detect = (
             any(
                 [
@@ -76,7 +76,7 @@ class Golden(BaseModel):
         return self
 
     def _get_images_mapping(self) -> Dict[str, MLLMImage]:
-        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]"
+        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]|\[DEEPEVAL:DOCUMENT:(.*?)\]"
         image_ids = set()
 
         def extract_ids_from_string(s: Optional[str]) -> None:
@@ -101,6 +101,9 @@ class Golden(BaseModel):
         for img_id in image_ids:
             if img_id in _MLLM_IMAGE_REGISTRY:
                 images_mapping[img_id] = _MLLM_IMAGE_REGISTRY[img_id]
+        for doc_id in image_ids:
+            if doc_id in _MLLM_DOCUMENT_REGISTRY:
+                images_mapping[doc_id] = _MLLM_DOCUMENT_REGISTRY[doc_id]       
 
         return images_mapping if len(images_mapping) > 0 else None
 
@@ -138,7 +141,7 @@ class ConversationalGolden(BaseModel):
         if self.multimodal is True:
             return self
 
-        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]"
+        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]|\[DEEPEVAL:DOCUMENT:(.*?)\]"
         if self.scenario:
             if re.search(pattern, self.scenario) is not None:
                 self.multimodal = True
@@ -165,7 +168,7 @@ class ConversationalGolden(BaseModel):
         return self
 
     def _get_images_mapping(self) -> Dict[str, MLLMImage]:
-        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]"
+        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]|\[DEEPEVAL:DOCUMENT:(.*?)\]"
         image_ids = set()
 
         def extract_ids_from_string(s: Optional[str]) -> None:
@@ -193,5 +196,8 @@ class ConversationalGolden(BaseModel):
         for img_id in image_ids:
             if img_id in _MLLM_IMAGE_REGISTRY:
                 images_mapping[img_id] = _MLLM_IMAGE_REGISTRY[img_id]
+        for doc_id in image_ids:
+            if doc_id in _MLLM_DOCUMENT_REGISTRY:
+                images_mapping[doc_id] = _MLLM_DOCUMENT_REGISTRY[doc_id]        
 
         return images_mapping if len(images_mapping) > 0 else None

--- a/deepeval/test_case/__init__.py
+++ b/deepeval/test_case/__init__.py
@@ -4,6 +4,7 @@ from .llm_test_case import (
     ToolCall,
     ToolCallParams,
     MLLMImage,
+    MLLMDocument,
 )
 from .conversational_test_case import (
     ConversationalTestCase,
@@ -32,6 +33,7 @@ __all__ = [
     "MCPResourceCall",
     "MCPToolCall",
     "MLLMImage",
+    "MLLMDocument", 
     "ArenaTestCase",
     "Contestant",
 ]

--- a/deepeval/test_case/conversational_test_case.py
+++ b/deepeval/test_case/conversational_test_case.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Dict, Literal
 from copy import deepcopy
 from enum import Enum
 
-from deepeval.test_case import ToolCall, MLLMImage
+from deepeval.test_case import ToolCall, MLLMImage, MLLMDocument
 from deepeval.test_case.mcp import (
     MCPServer,
     MCPPromptCall,
@@ -18,7 +18,7 @@ from deepeval.test_case.mcp import (
     MCPToolCall,
     validate_mcp_servers,
 )
-from deepeval.test_case.llm_test_case import _MLLM_IMAGE_REGISTRY
+from deepeval.test_case.llm_test_case import _MLLM_IMAGE_REGISTRY, _MLLM_DOCUMENT_REGISTRY
 
 
 class TurnParams(Enum):
@@ -174,7 +174,7 @@ class ConversationalTestCase(BaseModel):
         if self.multimodal is True:
             return self
 
-        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]"
+        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]|\[DEEPEVAL:DOCUMENT:(.*?)\]"
         if self.scenario:
             if re.search(pattern, self.scenario) is not None:
                 self.multimodal = True
@@ -238,7 +238,7 @@ class ConversationalTestCase(BaseModel):
         return data
 
     def _get_images_mapping(self) -> Dict[str, MLLMImage]:
-        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]"
+        pattern = r"\[DEEPEVAL:IMAGE:(.*?)\]|\[DEEPEVAL:DOCUMENT:(.*?)\]"
         image_ids = set()
 
         def extract_ids_from_string(s: Optional[str]) -> None:
@@ -265,5 +265,8 @@ class ConversationalTestCase(BaseModel):
         for img_id in image_ids:
             if img_id in _MLLM_IMAGE_REGISTRY:
                 images_mapping[img_id] = _MLLM_IMAGE_REGISTRY[img_id]
+        for doc_id in image_ids:
+            if doc_id in _MLLM_DOCUMENT_REGISTRY:
+                images_mapping[doc_id] = _MLLM_DOCUMENT_REGISTRY[doc_id]
 
         return images_mapping if len(images_mapping) > 0 else None


### PR DESCRIPTION
Currently LLMTestCase.input only accepts plain strings, making it 
impossible to include PDF documents when evaluating agents that use 
file inputs.

This adds MLLMDocument following the exact same pattern as MLLMImage:

```python
from deepeval.test_case import LLMTestCase, MLLMDocument

pdf = MLLMDocument(url="./contract.pdf", local=True)
test_case = LLMTestCase(
    input=f"What does this contract say about payment terms? {pdf}",
    actual_output="Payment is due within 30 days."
)
```

Changes:
- MLLMDocument class in test_case/llm_test_case.py with its own registry
- Exported from test_case/__init__.py alongside MLLMImage
- multimodal auto-detection updated in LLMTestCase, ConversationalTestCase, and Golden
- convert_to_multi_modal_array and check_if_multimodal updated in utils.py

Closes #2511