### PR TITLE
Fix duplicate example contexts in FilterTemplate.evaluate_context

### DIFF
--- a/deepeval/synthesizer/templates/template.py
+++ b/deepeval/synthesizer/templates/template.py
@@ -542,7 +542,7 @@ class FilterTemplate:
             "relevance": 0.5
         }}
 
-        Example context: "Artificial intelligence is rapidly changing various sectors, from healthcare to finance, by enhancing efficiency and enabling better decision-making."
+        Example context: "The French Revolution, which began in 1789, was a period of radical political and societal change in France that fundamentally transformed the country's political landscape."
         Example JSON:
         {{
             "clarity": 1,
@@ -551,7 +551,7 @@ class FilterTemplate:
             "relevance": 1
         }}
 
-        Example context: "Artificial intelligence is rapidly changing various sectors, from healthcare to finance, by enhancing efficiency and enabling better decision-making."
+        Example context: "Things change over time and people adapt accordingly in various ways."
         Example JSON:
         {{
             "clarity": 0.4,


### PR DESCRIPTION
The evaluate_context method had the same example context repeated 
three times with different scores, which is inconsistent.

Replaced the two duplicate examples with distinct contexts so each 
example has unique input and output.

Fixes #2039