### PR TITLE
fix: fall back to Synthesizer model when ContextConstructionConfig.critic_model is not set

### DIFF
--- a/deepeval/synthesizer/config.py
+++ b/deepeval/synthesizer/config.py
@@ -66,5 +66,6 @@ class ContextConstructionConfig:
     max_retries: int = 3
 
     def __post_init__(self):
-        self.critic_model, _ = initialize_model(self.critic_model)
+        if self.critic_model is not None:
+            self.critic_model, _ = initialize_model(self.critic_model)
         self.embedder = initialize_embedding_model(self.embedder)

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -169,6 +169,8 @@ class Synthesizer:
             context_construction_config = ContextConstructionConfig(
                 critic_model=self.model
             )
+        if context_construction_config.critic_model is None:
+            context_construction_config.critic_model = self.model
 
         if self.async_mode:
             loop = get_or_create_event_loop()
@@ -272,6 +274,8 @@ class Synthesizer:
             context_construction_config = ContextConstructionConfig(
                 critic_model=self.model
             )
+        if context_construction_config.critic_model is None:
+            context_construction_config.critic_model = self.model
         if _reset_cost:
             self.synthesis_cost = 0 if self.using_native_model else None
             self.synthetic_goldens = []
@@ -1677,6 +1681,8 @@ class Synthesizer:
             context_construction_config = ContextConstructionConfig(
                 critic_model=self.model
             )
+        if context_construction_config.critic_model is None:
+            context_construction_config.critic_model = self.model
 
         if self.async_mode:
             loop = get_or_create_event_loop()
@@ -1778,6 +1784,8 @@ class Synthesizer:
             context_construction_config = ContextConstructionConfig(
                 critic_model=self.model
             )
+        if context_construction_config.critic_model is None:
+            context_construction_config.critic_model = self.model
         if _reset_cost:
             self.synthesis_cost = 0 if self.using_native_model else None
             self.synthetic_conversational_goldens = []


### PR DESCRIPTION
## Description

When users pass a `ContextConstructionConfig` to `Synthesizer.generate_goldens_from_docs()` without explicitly setting `critic_model`, the config previously initialized a new default model (e.g. GPTModel) instead of using the model passed to the `Synthesizer` constructor.

This fix ensures `ContextConstructionConfig.critic_model` falls back to `Synthesizer.model` when not explicitly provided, so users only need to specify their custom model once.

Closes #1468

## Changes

- **`deepeval/synthesizer/config.py`**: Skip auto-initializing `critic_model` in `__post_init__` when it is `None`, allowing the caller to provide a fallback
- **`deepeval/synthesizer/synthesizer.py`**: In all 4 methods that accept `context_construction_config` (`generate_goldens_from_docs`, `a_generate_goldens_from_docs`, `generate_conversational_goldens_from_docs`, `a_generate_conversational_goldens_from_docs`), fall back to `self.model` when `critic_model` is `None`

## Before

```python
synthesizer = Synthesizer(model=azure_openai_llm, embedder=azure_embedding_model)
# Had to pass model again in config:
synthesizer.generate_goldens_from_docs(
    document_paths=['example.txt'],
    context_construction_config=ContextConstructionConfig(
        critic_model=azure_openai_llm,  # redundant
        chunk_size=100,
    )
)
```

## After

```python
synthesizer = Synthesizer(model=azure_openai_llm, embedder=azure_embedding_model)
# critic_model automatically falls back to synthesizer.model:
synthesizer.generate_goldens_from_docs(
    document_paths=['example.txt'],
    context_construction_config=ContextConstructionConfig(
        chunk_size=100,
    )
)
```