### PR TITLE
fix: execute HumanEval test assertions against generated functions

### DIFF
--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -55,6 +55,20 @@ def secure_exec(code_str, global_vars=None, local_vars=None):
             "TypeError": TypeError,
             "IndexError": IndexError,
             "KeyError": KeyError,
+            "AssertionError": AssertionError,
+            "StopIteration": StopIteration,
+            "isinstance": isinstance,
+            "hasattr": hasattr,
+            "getattr": getattr,
+            "type": type,
+            "hash": hash,
+            "frozenset": frozenset,
+            "repr": repr,
+            "print": print,
+            "True": True,
+            "False": False,
+            "None": None,
+            "math": __import__("math"),
         }
     }
     safe_globals.update(global_vars)
@@ -188,10 +202,12 @@ class HumanEval(DeepEvalBaseBenchmark):
             c = 0
             for function in functions:
                 try:
-                    secure_exec(function)
-                    secure_exec(golden.expected_output)
+                    full_code = function + "\n" + golden.expected_output
+                    secure_exec(full_code)
                     c += 1
-                except AssertionError as e:
+                except AssertionError:
+                    pass
+                except Exception:
                     pass
             self.c[task.value] = c
             self.functions[task.value] = functions


### PR DESCRIPTION
## Description

The HumanEval benchmark's `predict` method was not actually running the test assertions against the generated functions. The generated function code and test code were executed in separate `secure_exec` calls with isolated namespaces, so the test could never call the generated function. This meant the benchmark only checked if the code compiled, not if it was functionally correct.

Closes #1102

## Changes

- **`deepeval/benchmarks/human_eval/human_eval.py`**:
  - Combine generated function code and test code into a single string before executing, so tests can call the generated function
  - Catch `Exception` in addition to `AssertionError` to handle runtime errors in generated code (matching original HumanEval behavior)
  - Add commonly needed builtins to the sandbox (`math`, `isinstance`, `AssertionError`, `frozenset`, `hash`, etc.) required by HumanEval test cases

## Before

```python
# Function and test ran in separate namespaces — test could never call the function
secure_exec(function)           # defines the function in namespace A
secure_exec(golden.expected_output)  # tries to call function in namespace B → always fails
```

## After

```python
# Function and test combined and executed together
full_code = function + '\n' + golden.expected_output
secure_exec(full_code)  # test can call the generated function
```