### PR TITLE
fix: close ChromaDB client before rmtree to avoid Windows file lock

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -88,6 +88,16 @@ def close_chroma_clients():
     time.sleep(1)
 
 
+def _release_chroma_client(client):
+    """Release ChromaDB client resources to avoid file locks on Windows."""
+    try:
+        if hasattr(client, "_system") and hasattr(client._system, "stop"):
+            client._system.stop()
+    except Exception:
+        pass
+    gc.collect()
+
+
 atexit.register(close_chroma_clients)
 shutil.rmtree = safe_rmtree
 
@@ -301,6 +311,7 @@ class ContextGenerator:
             return contexts, source_files, scores
 
         finally:
+            _release_chroma_client(client)
             if os.path.exists(temp_root):
                 shutil.rmtree(temp_root)
 
@@ -457,6 +468,7 @@ class ContextGenerator:
             return contexts, source_files, scores
 
         finally:
+            _release_chroma_client(client)
             if os.path.exists(temp_root):
                 shutil.rmtree(temp_root)
 


### PR DESCRIPTION
## Description

On Windows, `shutil.rmtree` fails with `PermissionError: [WinError 32]` when trying to delete the temporary ChromaDB directory because the `PersistentClient` still holds open file handles on the SQLite database.

This fix explicitly stops the ChromaDB client's internal system before attempting to remove the temp directory, releasing all file handles.

Closes #1526

## Changes

- **`deepeval/synthesizer/chunking/context_generator.py`**:
  - Added `_release_chroma_client()` helper that calls `client._system.stop()` to release file handles
  - Called it in the `finally` block of both `generate_contexts()` and `a_generate_contexts()` before `shutil.rmtree`

## Root Cause

ChromaDB's `PersistentClient` keeps an open connection to `chroma.sqlite3`. On Linux/macOS, files can be deleted while open; on Windows, this raises `PermissionError`. The existing `safe_rmtree` retry logic helps but doesn't address the root cause—the open file handle.

## Testing

- Backward compatible: `_release_chroma_client` uses `hasattr` checks and catches all exceptions, so it's a no-op on older ChromaDB versions
- The existing `safe_rmtree` retry logic remains as a fallback