### PR TITLE
fix: guard ZeroDivisionError in calculate_weighted_summed_score

### DIFF
--- a/deepeval/metrics/g_eval/utils.py
+++ b/deepeval/metrics/g_eval/utils.py
@@ -300,10 +300,14 @@ def calculate_weighted_summed_score(
         for score, prob in token_linear_probability.items():
             sum_of_weighted_scores += score * prob
 
+        # If all tokens were filtered out, fall back to the raw score
+        if sum_linear_probability == 0:
+            return raw_score
+
         # Scale the sum of linear probability to 1
         weighted_summed_score = sum_of_weighted_scores / sum_linear_probability
         return weighted_summed_score
-    except:
+    except Exception:
         raise
 
 


### PR DESCRIPTION
When all token logprobs are filtered out (below 1% probability threshold or non-numeric), sum_linear_probability remains 0, causing a division by zero. This commonly occurs with Gemini models that distribute probability mass differently than GPT models.

Fall back to the raw score when no tokens survive filtering, consistent with how callers already handle other exceptions.

Fixes #2523