### PR TITLE
Fix equation formula for Goal Accuracy Score

### DIFF
--- a/docs/docs/metrics-goal-accuracy.mdx
+++ b/docs/docs/metrics-goal-accuracy.mdx
@@ -82,7 +82,7 @@ The `GoalAccuracyMetric` score is calculated using the following steps:
 - Find **goal accuracy scores** for each of the goal-steps pairs using the evaluation model.
 - Find **plan quality and plan adherence scores** for each of the goal-step pairs using the evaluation model.
 
-<Equation formula="\text{Goal Accuracy Score} = \frac{\text{Goal Accuracy Score + Plan Evaluation Score}}{\text{2}}" />
+<Equation formula="\text{Goal Accuracy Score} = \frac{\text{Goal Evaluation Score + Plan Evaluation Score}}{\text{2}}" />
 
 :::info
 The `GoalAccuracyMetric` extracts the task from user's messages in each interaction and evalutes the steps taken by the LLM agent to find it's plan and how accurately it has finished the task or reached the goal in that interaction.


### PR DESCRIPTION
Reason for the Update:
The original formula contained a logical error known as a circular dependency. It used the exact same term, "Goal Accuracy Score," as both the final result on the left side of the equation and as a variable being added on the right side.

The Fix:
To correct this and accurately reflect the underlying code implementation, the variable in the numerator was renamed to "Goal Evaluation Score." The corrected formula now clearly shows that the final metric is a straightforward arithmetic mean of two distinct assessments: the quality of the agent's execution (Goal Evaluation Score) and the quality of its reasoning (Plan Evaluation Score).