### PR TITLE
fix: prevent double-wrapping in KnowledgeRetentionMetric extraction

### DIFF
--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -271,7 +271,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
                 prompt=prompt,
                 schema_cls=Knowledge,
                 extract_schema=lambda s: s,
-                extract_json=lambda data: Knowledge(data=data),
+                extract_json=lambda data: Knowledge(**data),
             )
 
         return knowledges
@@ -300,7 +300,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
                 prompt=prompt,
                 schema_cls=Knowledge,
                 extract_schema=lambda s: s,
-                extract_json=lambda data: Knowledge(data=data),
+                extract_json=lambda data: Knowledge(**data),
             )
 
         return knowledges

--- a/tests/test_metrics/test_knowledge_retention_extract.py
+++ b/tests/test_metrics/test_knowledge_retention_extract.py
@@ -1,0 +1,72 @@
+"""Unit tests for KnowledgeRetentionMetric knowledge extraction.
+
+Verifies that the extract_json lambda in _generate_knowledges /
+_a_generate_knowledges correctly constructs Knowledge objects from
+the parsed LLM JSON without double-wrapping.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from deepeval.metrics.knowledge_retention.schema import Knowledge
+
+
+class TestKnowledgeExtraction:
+    """Regression tests for the double-wrap bug (issue #2512).
+
+    The LLM returns JSON like ``{"data": {"Full Name": "Emily Chen"}}``.
+    After ``trimAndLoadJson``, the result is a Python dict with a ``"data"``
+    key.  The ``extract_json`` lambda must unpack this dict via
+    ``Knowledge(**data)`` so that ``Knowledge.data`` receives the inner dict,
+    not the outer one.
+    """
+
+    def test_knowledge_from_dict_with_data_key(self):
+        """Knowledge(**data) should work when data has a 'data' key."""
+        raw = {"data": {"Full Name": "Emily Chen"}}
+        knowledge = Knowledge(**raw)
+        assert knowledge.data == {"Full Name": "Emily Chen"}
+
+    def test_knowledge_from_dict_with_list_values(self):
+        """Knowledge should accept list-of-strings values."""
+        raw = {
+            "data": {
+                "Dietary Restrictions": ["Vegetarian", "Peanut Allergy"],
+                "Current Location": "Berlin",
+            }
+        }
+        knowledge = Knowledge(**raw)
+        assert knowledge.data["Dietary Restrictions"] == [
+            "Vegetarian",
+            "Peanut Allergy",
+        ]
+        assert knowledge.data["Current Location"] == "Berlin"
+
+    def test_knowledge_from_empty_data(self):
+        """An empty data dict should be accepted."""
+        raw = {"data": {}}
+        knowledge = Knowledge(**raw)
+        assert knowledge.data == {}
+
+    def test_knowledge_from_none_data(self):
+        """None data should be accepted (field is Optional)."""
+        raw = {"data": None}
+        knowledge = Knowledge(**raw)
+        assert knowledge.data is None
+
+    def test_double_wrap_raises_validation_error(self):
+        """Passing the outer dict as-is to data= must fail validation.
+
+        This is the exact bug: ``Knowledge(data=data)`` where ``data``
+        is ``{"data": {"Full Name": "Emily Chen"}}`` produces a nested
+        dict whose inner value is another dict, violating the type
+        ``Dict[str, Union[str, List[str]]]``.
+        """
+        raw = {"data": {"Full Name": "Emily Chen"}}
+        with pytest.raises(ValidationError):
+            Knowledge(data=raw)
+
+    def test_knowledge_rejects_extra_fields(self):
+        """ConfigDict(extra='forbid') should reject unexpected keys."""
+        with pytest.raises(ValidationError):
+            Knowledge(data={"Name": "Alice"}, unexpected_field="bad")


### PR DESCRIPTION
## Summary

Fixes #2512.

In `KnowledgeRetentionMetric._generate_knowledges` and `_a_generate_knowledges`, the `extract_json` lambda used `Knowledge(data=data)` where `data` is the parsed JSON dict `{"data": {"Full Name": "Emily Chen"}}`. This double-wraps the data: `Knowledge.data` ends up as `{"data": {"Full Name": "Emily Chen"}}` instead of `{"Full Name": "Emily Chen"}`.

### Changes

- **`deepeval/metrics/knowledge_retention/knowledge_retention.py`**: Changed `Knowledge(data=data)` to `Knowledge(**data)` in both sync and async methods. The `**data` unpacking correctly maps `{"data": {...}}` to the `data` keyword argument.

- **`tests/test_metrics/test_knowledge_retention_extract.py`**: Added 6 unit tests covering correct construction, edge cases, and a regression test that verifies the old `Knowledge(data=data)` pattern raises `ValidationError`.

## Test plan

- [x] `pytest tests/test_metrics/test_knowledge_retention_extract.py -v` — all 6 tests pass