### PR TITLE
fix: add Amazon Bedrock model support in initialize_model()

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -559,6 +559,13 @@ def should_use_grok_model():
     return value.lower() == "yes" if value is not None else False
 
 
+def should_use_amazon_bedrock_model():
+    if SETTINGS.USE_AWS_BEDROCK_MODEL:
+        return True
+    value = KEY_FILE_HANDLER.fetch_data(ModelKeyValues.USE_AWS_BEDROCK_MODEL)
+    return value.lower() == "yes" if value is not None else False
+
+
 ###############################################
 # LLM
 ###############################################
@@ -598,6 +605,8 @@ def initialize_model(
         return DeepSeekModel(model=model), True
     elif should_use_anthropic_model():
         return AnthropicModel(model=model), True
+    elif should_use_amazon_bedrock_model():
+        return AmazonBedrockModel(model=model), True
     elif isinstance(model, str) or model is None:
         return GPTModel(model=model), True
 


### PR DESCRIPTION
## Summary

Adds Amazon Bedrock model initialization support to `initialize_model()` in `deepeval/metrics/utils.py`.

**Problem:** The `initialize_model()` function checks for OpenAI, Anthropic, Gemini, Azure, DeepSeek, and other providers, but skips Amazon Bedrock. Users who configure `USE_AWS_BEDROCK_MODEL=YES` get silently routed to the default GPT model instead.

**Fix:**
- Added `should_use_amazon_bedrock_model()` helper (mirrors existing pattern for other providers)
- Added Bedrock check in `initialize_model()` before the default GPT fallback

Related to #2533.

## Test plan

- [x] Verified `should_use_amazon_bedrock_model()` follows the same pattern as `should_use_anthropic_model()`, `should_use_deepseek_model()`, etc.
- [x] `black --check deepeval/metrics/utils.py` passes