### PR TITLE
fix: use WeakValueDictionary for _MLLM_IMAGE_REGISTRY to prevent memory leak (#2546)

### DIFF
--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -13,6 +13,7 @@ import re
 import os
 import mimetypes
 import base64
+import weakref
 from dataclasses import dataclass, field
 from urllib.parse import urlparse, unquote
 from deepeval.utils import make_model_config
@@ -25,7 +26,7 @@ from deepeval.test_case.mcp import (
     validate_mcp_servers,
 )
 
-_MLLM_IMAGE_REGISTRY: Dict[str, "MLLMImage"] = {}
+_MLLM_IMAGE_REGISTRY: weakref.WeakValueDictionary[str, "MLLMImage"] = weakref.WeakValueDictionary()
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Replace `_MLLM_IMAGE_REGISTRY` from a plain `dict` to `weakref.WeakValueDictionary` to prevent unbounded memory growth when processing many multimodal test cases.

## Root cause

Every `MLLMImage.__post_init__` adds `self` to the module-level `_MLLM_IMAGE_REGISTRY` dict, but entries are never removed. Each entry with local files holds the full base64-encoded image data in memory. In batch evaluation scenarios with hundreds/thousands of images, this causes significant memory bloat for the entire process lifetime.

## Fix

```python
import weakref
_MLLM_IMAGE_REGISTRY: weakref.WeakValueDictionary[str, "MLLMImage"] = weakref.WeakValueDictionary()
```

Entries are automatically garbage-collected when no other references to the `MLLMImage` exist. Since `MLLMImage` is a `dataclass` (not `__slots__`), it supports weak references by default.

Fixes #2546