### PR TITLE
fix: preserve metric snapshots when async metric tasks fail in indicator

### DIFF
--- a/deepeval/metrics/indicator.py
+++ b/deepeval/metrics/indicator.py
@@ -19,7 +19,6 @@ from deepeval.telemetry import capture_metric_type
 from deepeval.utils import update_pbar
 from deepeval.config.settings import get_settings
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -166,6 +165,12 @@ async def measure_metrics_with_indicator(
     pbar_eval_id: Optional[int] = None,
     _in_component: bool = False,
 ):
+    async def wait_for_metric_tasks(tasks):
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+
     if show_indicator:
         with Progress(
             SpinnerColumn(style="rgb(106,0,255)"),
@@ -193,7 +198,7 @@ async def measure_metrics_with_indicator(
                         _in_component=_in_component,
                     )
                 )
-            await asyncio.gather(*tasks)
+            await wait_for_metric_tasks(tasks)
     else:
         tasks = []
         for metric in metrics:
@@ -236,7 +241,7 @@ async def measure_metrics_with_indicator(
                     )
                 )
 
-        await asyncio.gather(*tasks)
+        await wait_for_metric_tasks(tasks)
 
 
 async def safe_a_measure(

--- a/tests/test_core/test_evaluation/test_execute/test_metric_snapshot_consistency.py
+++ b/tests/test_core/test_evaluation/test_execute/test_metric_snapshot_consistency.py
@@ -1,0 +1,107 @@
+import asyncio
+
+import pytest
+
+from deepeval.evaluate.execute import _a_execute_llm_test_cases
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+from deepeval.test_run.test_run import TestRun, TestRunManager
+
+
+class SlowMetric(BaseMetric):
+    def __init__(self):
+        self.threshold = 0.5
+        self.score = None
+        self.reason = None
+        self.success = None
+        self.error = None
+        self.strict_mode = False
+        self.evaluation_model = None
+        self.evaluation_cost = None
+        self.verbose_logs = None
+        self.skipped = False
+
+    @property
+    def __name__(self):
+        return "SlowMetric"
+
+    async def a_measure(self, test_case, *args, **kwargs):
+        await asyncio.sleep(0.2)
+        self.score = 1.0
+        self.reason = "slow-done"
+        self.success = True
+
+    def is_successful(self):
+        return bool(self.success)
+
+
+class BoomMetric(BaseMetric):
+    def __init__(self):
+        self.threshold = 0.5
+        self.score = None
+        self.reason = None
+        self.success = None
+        self.error = None
+        self.strict_mode = False
+        self.evaluation_model = None
+        self.evaluation_cost = None
+        self.verbose_logs = None
+        self.skipped = False
+
+    @property
+    def __name__(self):
+        return "BoomMetric"
+
+    async def a_measure(self, test_case, *args, **kwargs):
+        raise RuntimeError("boom")
+
+    def is_successful(self):
+        return bool(self.success)
+
+
+@pytest.mark.asyncio
+async def test_async_metric_snapshot_waits_for_siblings():
+    slow = SlowMetric()
+    boom = BoomMetric()
+
+    trm = TestRunManager()
+    tr = TestRun(identifier="snapshot-consistency")
+    trm.set_test_run(tr)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await _a_execute_llm_test_cases(
+            metrics=[slow, boom],
+            test_case=LLMTestCase(input="x", actual_output="y"),
+            test_run_manager=trm,
+            test_results=[],
+            count=0,
+            test_run=tr,
+            ignore_errors=False,
+            skip_on_missing_params=False,
+            use_cache=False,
+            show_indicator=False,
+            _use_bar_indicator=False,
+            _is_assert_test=False,
+            progress=None,
+            pbar_id=None,
+        )
+
+    recorded = trm.get_test_run()
+    assert recorded is not None
+    assert len(recorded.test_cases) == 1
+
+    metric_data_by_name = {
+        metric_data.name: metric_data
+        for metric_data in recorded.test_cases[0].metrics_data or []
+    }
+
+    slow_snapshot = metric_data_by_name["SlowMetric"]
+    assert slow_snapshot.score == 1.0
+    assert slow_snapshot.reason == "slow-done"
+    assert slow_snapshot.success is True
+
+    await asyncio.sleep(0.3)
+
+    assert slow.score == 1.0
+    assert slow.reason == "slow-done"
+    assert slow.success is True


### PR DESCRIPTION
## Summary

`measure_metrics_with_indicator` used bare `asyncio.gather(*tasks)`. If one metric raises an exception, sibling metric tasks could be canceled before completing. The caller then snapshots the metric state in `finally`, which could leave unfinished metrics with `None` values.

This change uses `return_exceptions=True`, waits for all metric tasks to finish, and re-raises the first exception. This preserves existing error propagation while ensuring metric snapshots reflect the final task state.

## Context

PRs #2136 and #2247 applied the same pattern in `execute.py`, but the two gather calls in `indicator.py` were still using bare `asyncio.gather(...)`. This change closes that remaining gap.

Related: #2128, #2298

## Changes

- add `wait_for_metric_tasks` in `deepeval/metrics/indicator.py`
- update both gather call sites in `measure_metrics_with_indicator`
- add a regression test showing that a slow metric's final state is captured even when a sibling metric raises