### PR TITLE
fix: include tool and trace state in evaluation cache keys

### DIFF
--- a/deepeval/test_run/cache.py
+++ b/deepeval/test_run/cache.py
@@ -18,7 +18,6 @@ from deepeval.utils import (
 from deepeval.metrics import BaseMetric
 from deepeval.constants import HIDDEN_DIR
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -66,6 +65,54 @@ class CachedTestCase(BaseModel):
         default_factory=lambda: []
     )
     hyperparameters: Optional[str] = Field(None)
+
+    @staticmethod
+    def create_cache_key(
+        test_case: LLMTestCase, hyperparameters: Union[Dict, None] = None
+    ) -> str:
+        def normalize_cache_value(value):
+            if isinstance(value, BaseModel):
+                return {
+                    key: normalize_cache_value(val)
+                    for key, val in value.model_dump(
+                        by_alias=True, exclude_none=True
+                    ).items()
+                }
+            if isinstance(value, Enum):
+                return value.value
+            if isinstance(value, dict):
+                return {
+                    key: normalize_cache_value(val)
+                    for key, val in value.items()
+                }
+            if isinstance(value, list):
+                return [normalize_cache_value(item) for item in value]
+            if isinstance(value, tuple):
+                return tuple(normalize_cache_value(item) for item in value)
+            return value
+
+        cache_dict = {
+            LLMTestCaseParams.INPUT.value: test_case.input,
+            LLMTestCaseParams.ACTUAL_OUTPUT.value: test_case.actual_output,
+            LLMTestCaseParams.EXPECTED_OUTPUT.value: test_case.expected_output,
+            LLMTestCaseParams.CONTEXT.value: test_case.context,
+            LLMTestCaseParams.RETRIEVAL_CONTEXT.value: test_case.retrieval_context,
+            LLMTestCaseParams.TOOLS_CALLED.value: test_case.tools_called,
+            LLMTestCaseParams.EXPECTED_TOOLS.value: test_case.expected_tools,
+            LLMTestCaseParams.MCP_SERVERS.value: test_case.mcp_servers,
+            LLMTestCaseParams.MCP_TOOLS_CALLED.value: (
+                test_case.mcp_tools_called
+            ),
+            LLMTestCaseParams.MCP_RESOURCES_CALLED.value: (
+                test_case.mcp_resources_called
+            ),
+            LLMTestCaseParams.MCP_PROMPTS_CALLED.value: (
+                test_case.mcp_prompts_called
+            ),
+            "_trace_dict": getattr(test_case, "_trace_dict", None),
+            "hyperparameters": hyperparameters,
+        }
+        return serialize(normalize_cache_value(cache_dict))
 
 
 class CustomEncoder(json.JSONEncoder):
@@ -118,15 +165,9 @@ class TestRunCacheManager:
             return None
 
         cached_test_run = self.get_cached_test_run()
-        cache_dict = {
-            LLMTestCaseParams.INPUT.value: test_case.input,
-            LLMTestCaseParams.ACTUAL_OUTPUT.value: test_case.actual_output,
-            LLMTestCaseParams.EXPECTED_OUTPUT.value: test_case.expected_output,
-            LLMTestCaseParams.CONTEXT.value: test_case.context,
-            LLMTestCaseParams.RETRIEVAL_CONTEXT.value: test_case.retrieval_context,
-            "hyperparameters": hyperparameters,
-        }
-        test_case_cache_key = serialize(cache_dict)
+        test_case_cache_key = CachedTestCase.create_cache_key(
+            test_case, hyperparameters
+        )
         cached_test_case = cached_test_run.get_cached_api_test_case(
             test_case_cache_key
         )
@@ -141,15 +182,9 @@ class TestRunCacheManager:
     ):
         if self.disable_write_cache or portalocker is None:
             return
-        cache_dict = {
-            LLMTestCaseParams.INPUT.value: test_case.input,
-            LLMTestCaseParams.ACTUAL_OUTPUT.value: test_case.actual_output,
-            LLMTestCaseParams.EXPECTED_OUTPUT.value: test_case.expected_output,
-            LLMTestCaseParams.CONTEXT.value: test_case.context,
-            LLMTestCaseParams.RETRIEVAL_CONTEXT.value: test_case.retrieval_context,
-            "hyperparameters": hyperparameters,
-        }
-        test_case_cache_key = serialize(cache_dict)
+        test_case_cache_key = CachedTestCase.create_cache_key(
+            test_case, hyperparameters
+        )
         cached_test_run = self.get_cached_test_run(from_temp=to_temp)
         cached_test_run.test_cases_lookup_map[test_case_cache_key] = (
             new_cache_test_case

--- a/tests/test_core/test_run/test_cache_keys.py
+++ b/tests/test_core/test_run/test_cache_keys.py
@@ -1,0 +1,100 @@
+from deepeval.test_case import LLMTestCase, ToolCall
+from deepeval.test_run.cache import CachedTestCase
+
+
+def test_cache_key_differs_for_different_tools_called():
+    tc1 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+        tools_called=[
+            ToolCall(name="get_weather", input_parameters={}, output=None)
+        ],
+        expected_tools=[
+            ToolCall(name="get_weather", input_parameters={}, output=None)
+        ],
+    )
+
+    tc2 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+        tools_called=[
+            ToolCall(name="search_web", input_parameters={}, output=None),
+            ToolCall(name="get_weather", input_parameters={}, output=None),
+        ],
+        expected_tools=[
+            ToolCall(name="get_weather", input_parameters={}, output=None)
+        ],
+    )
+
+    key1 = CachedTestCase.create_cache_key(tc1)
+    key2 = CachedTestCase.create_cache_key(tc2)
+
+    assert key1 != key2
+
+
+def test_cache_key_differs_for_different_trace_dict():
+    tc1 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+    )
+    tc1._trace_dict = {"spans": [{"name": "llm_call", "output": "sunny"}]}
+
+    tc2 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+    )
+    tc2._trace_dict = {
+        "spans": [{"name": "tool_call", "output": "weather_api_result"}]
+    }
+
+    key1 = CachedTestCase.create_cache_key(tc1)
+    key2 = CachedTestCase.create_cache_key(tc2)
+
+    assert key1 != key2
+
+
+def test_cache_key_matches_for_same_execution_state():
+    tc1 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+        tools_called=[
+            ToolCall(name="get_weather", input_parameters={}, output=None)
+        ],
+        expected_tools=[
+            ToolCall(name="get_weather", input_parameters={}, output=None)
+        ],
+    )
+    tc1._trace_dict = {"spans": [{"name": "llm_call", "output": "sunny"}]}
+
+    tc2 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+        tools_called=[
+            ToolCall(name="get_weather", input_parameters={}, output=None)
+        ],
+        expected_tools=[
+            ToolCall(name="get_weather", input_parameters={}, output=None)
+        ],
+    )
+    tc2._trace_dict = {"spans": [{"name": "llm_call", "output": "sunny"}]}
+
+    key1 = CachedTestCase.create_cache_key(tc1)
+    key2 = CachedTestCase.create_cache_key(tc2)
+
+    assert key1 == key2
+
+
+def test_cache_key_matches_for_text_only_case():
+    tc1 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+    )
+    tc2 = LLMTestCase(
+        input="What is the weather?",
+        actual_output="It's sunny",
+    )
+
+    key1 = CachedTestCase.create_cache_key(tc1)
+    key2 = CachedTestCase.create_cache_key(tc2)
+
+    assert key1 == key2


### PR DESCRIPTION
## Summary

The evaluation cache key originally only considered the text fields on `LLMTestCase`: `input`, `actual_output`, `expected_output`, `context`, and `retrieval_context`.

For tool-based and trace-based evaluation, that was incomplete. Metrics such as `ToolCorrectnessMetric` and trace-level metrics also depend on execution-state fields like `tools_called`, `expected_tools`, MCP call data, and `_trace_dict`. Two test cases with the same text but different tool calls or trace structure could therefore produce the same cache key and reuse stale metric results.

This change moves cache key construction into `CachedTestCase.create_cache_key()` and includes the execution-state fields that affect scoring.

## Changes

- add `CachedTestCase.create_cache_key()` in `deepeval/test_run/cache.py`
- replace inline cache-key construction in `get_cached_test_case()` and `cache_test_case()`
- include tool, MCP, and trace fields in the cache key
- normalize nested values before serialization so key generation stays deterministic

## Context

Tool-calling and trace-level metrics evaluate fields such as `tools_called`, `expected_tools`, and `_trace_dict`. Because those fields were not part of the cache key, changing only the execution state between runs could still return cached scores from a previous run.

This updates the cache key format, so existing cache entries will miss on the first run after upgrade. That is intentional, a one-time re-evaluation is safer than serving stale results.



## Tests

- add `tests/test_core/test_run/test_cache_keys.py`
- cover tool differentiation, trace differentiation, identity, and text-only cases