### PR TITLE
fix(ragas): update capture_metric_type call for new telemetry signature

### DIFF
--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -82,7 +82,7 @@ class RAGASContextualPrecisionMetric(BaseMetric):
         dataset = Dataset.from_dict(data)
 
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False
+            self.__name__, _track=self._track, async_mode=False, in_component=False
         ):
             # Evaluate the dataset using Ragas
             scores = evaluate(
@@ -162,7 +162,7 @@ class RAGASContextualRecallMetric(BaseMetric):
         }
         dataset = Dataset.from_dict(data)
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False
+            self.__name__, _track=self._track, async_mode=False, in_component=False
         ):
             scores = evaluate(dataset, [context_recall], llm=chat_model)
             context_recall_score = scores["context_recall"][0]
@@ -233,7 +233,7 @@ class RAGASContextualEntitiesRecall(BaseMetric):
         dataset = Dataset.from_dict(data)
 
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False
+            self.__name__, _track=self._track, async_mode=False, in_component=False
         ):
             scores = evaluate(
                 dataset,
@@ -383,7 +383,7 @@ class RAGASAnswerRelevancyMetric(BaseMetric):
         dataset = Dataset.from_dict(data)
 
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False
+            self.__name__, _track=self._track, async_mode=False, in_component=False
         ):
             scores = evaluate(
                 dataset,
@@ -457,7 +457,7 @@ class RAGASFaithfulnessMetric(BaseMetric):
         }
         dataset = Dataset.from_dict(data)
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False
+            self.__name__, _track=self._track, async_mode=False, in_component=False
         ):
             scores = evaluate(dataset, metrics=[faithfulness], llm=chat_model)
             faithfulness_score = scores["faithfulness"][0]
@@ -526,7 +526,7 @@ class RagasMetric(BaseMetric):
             RAGASFaithfulnessMetric(model=self.model, _track=False),
         ]
 
-        with capture_metric_type(self.__name__, async_mode=False):
+        with capture_metric_type(self.__name__, async_mode=False, in_component=False):
             for metric in metrics:
                 score = metric.measure(test_case)
                 score_breakdown[metric.__name__] = score

--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -82,7 +82,10 @@ class RAGASContextualPrecisionMetric(BaseMetric):
         dataset = Dataset.from_dict(data)
 
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False, in_component=False
+            self.__name__,
+            _track=self._track,
+            async_mode=False,
+            in_component=False,
         ):
             # Evaluate the dataset using Ragas
             scores = evaluate(
@@ -162,7 +165,10 @@ class RAGASContextualRecallMetric(BaseMetric):
         }
         dataset = Dataset.from_dict(data)
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False, in_component=False
+            self.__name__,
+            _track=self._track,
+            async_mode=False,
+            in_component=False,
         ):
             scores = evaluate(dataset, [context_recall], llm=chat_model)
             context_recall_score = scores["context_recall"][0]
@@ -233,7 +239,10 @@ class RAGASContextualEntitiesRecall(BaseMetric):
         dataset = Dataset.from_dict(data)
 
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False, in_component=False
+            self.__name__,
+            _track=self._track,
+            async_mode=False,
+            in_component=False,
         ):
             scores = evaluate(
                 dataset,
@@ -383,7 +392,10 @@ class RAGASAnswerRelevancyMetric(BaseMetric):
         dataset = Dataset.from_dict(data)
 
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False, in_component=False
+            self.__name__,
+            _track=self._track,
+            async_mode=False,
+            in_component=False,
         ):
             scores = evaluate(
                 dataset,
@@ -457,7 +469,10 @@ class RAGASFaithfulnessMetric(BaseMetric):
         }
         dataset = Dataset.from_dict(data)
         with capture_metric_type(
-            self.__name__, _track=self._track, async_mode=False, in_component=False
+            self.__name__,
+            _track=self._track,
+            async_mode=False,
+            in_component=False,
         ):
             scores = evaluate(dataset, metrics=[faithfulness], llm=chat_model)
             faithfulness_score = scores["faithfulness"][0]
@@ -526,7 +541,9 @@ class RagasMetric(BaseMetric):
             RAGASFaithfulnessMetric(model=self.model, _track=False),
         ]
 
-        with capture_metric_type(self.__name__, async_mode=False, in_component=False):
+        with capture_metric_type(
+            self.__name__, async_mode=False, in_component=False
+        ):
             for metric in metrics:
                 score = metric.measure(test_case)
                 score_breakdown[metric.__name__] = score


### PR DESCRIPTION
## Summary
Fixes a function signature mismatch introduced in DeepEval 3.9.1.

`capture_metric_type()` now requires the `in_component` argument, but the RAGAS metrics module was still calling it without that parameter.

## Changes
- Updated the RAGAS metric telemetry call to pass `in_component`
- Checked for similar call sites

Fixes #2562