### PR TITLE
fix: guard trimAndLoadJson against None input

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -391,6 +391,12 @@ def trimAndLoadJson(
     input_string: str,
     metric: Optional[BaseMetric] = None,
 ) -> Any:
+    if input_string is None:
+        error_str = "Evaluation LLM returned None. Please use a better evaluation model."
+        if metric is not None:
+            metric.error = error_str
+        raise ValueError(error_str)
+
     start = input_string.find("{")
     end = input_string.rfind("}") + 1
 

--- a/tests/test_core/test_utils.py
+++ b/tests/test_core/test_utils.py
@@ -5,6 +5,7 @@ from tenacity.wait import wait_base
 from tenacity.stop import stop_after_attempt, stop_base
 from deepeval.utils import read_env_int, read_env_float, shorten, update_pbar
 from deepeval.evaluate.utils import _is_metric_successful
+from deepeval.metrics.utils import trimAndLoadJson
 from deepeval.models.retry_policy import dynamic_wait, dynamic_stop
 from tests.test_core.stubs import DummyProgress
 
@@ -220,3 +221,30 @@ def test_update_pbar_noops_when_task_removed_between_callbacks():
     n = len(progress.records)
     update_pbar(progress, pbar_id=123, remove=True)  # should no-op after fix
     assert len(progress.records) == n
+
+
+#####################
+# trimAndLoadJson   #
+#####################
+
+
+def test_trimAndLoadJson_none_raises():
+    with pytest.raises(ValueError, match="returned None"):
+        trimAndLoadJson(None)
+
+
+def test_trimAndLoadJson_none_sets_metric_error():
+    metric = SimpleNamespace(error=None, __name__="test")
+    with pytest.raises(ValueError):
+        trimAndLoadJson(None, metric=metric)
+    assert "None" in metric.error
+
+
+def test_trimAndLoadJson_valid():
+    result = trimAndLoadJson('some prefix {"key": "value"} suffix')
+    assert result == {"key": "value"}
+
+
+def test_trimAndLoadJson_invalid_json_raises():
+    with pytest.raises(ValueError, match="invalid JSON"):
+        trimAndLoadJson("not json at all")


### PR DESCRIPTION
## Summary
Fixes #2554.
**Root cause:** `trimAndLoadJson` calls `.find()` on its `input_string` parameter without checking for `None`. When the evaluation LLM returns no output, callers pass `None` and the function crashes with `AttributeError: 'NoneType' object has no attribute 'find'`.
**Fix:** Added a None guard at the top of the function that raises a clear `ValueError` (and sets `metric.error`) instead of crashing.

## Changes
- `deepeval/metrics/utils.py`: None check before string operations in `trimAndLoadJson`
- `tests/test_core/test_utils.py`: tests for None input, metric error propagation, valid JSON, and invalid JSON

## Testing
- Added test for None input raising ValueError with descriptive message
- Added test confirming metric.error is set when metric is provided
- Added test for valid JSON extraction (existing behavior preserved)
- Added test for invalid JSON raising ValueError