### PR TITLE
Add test_case_id support to ConfidentSpanExporter

### DIFF
--- a/deepeval/tracing/otel/exporter.py
+++ b/deepeval/tracing/otel/exporter.py
@@ -245,9 +245,13 @@ class ConfidentSpanExporter(SpanExporter):
             )
 
         # set the trace test case id and turn id
-        if base_span_wrapper.trace_test_case_id:
+        if base_span_wrapper.trace_test_case_id and isinstance(
+            base_span_wrapper.trace_test_case_id, str
+        ):
             current_trace.test_case_id = base_span_wrapper.trace_test_case_id
-        if base_span_wrapper.trace_turn_id:
+        if base_span_wrapper.trace_turn_id and isinstance(
+            base_span_wrapper.trace_turn_id, str
+        ):
             current_trace.turn_id = base_span_wrapper.trace_turn_id
 
         # set the trace metric collection


### PR DESCRIPTION
## Summary
- Adds `confident.trace.test_case_id` span attribute extraction to `ConfidentSpanExporter`, enabling `testCaseId` propagation for the OTel tracing path
- Without this, traces sent via the OTel exporter always have `testCaseId: null`, making it impossible to link traces to test cases in ConfidentAI evaluation runs (AI Connections)

## Changes
- Added `trace_test_case_id` field to `BaseSpanWrapper` dataclass
- Extract `confident.trace.test_case_id` from span attributes in `__set_trace_attributes`
- Set `test_case_id` on the `Trace` object in `_set_current_trace_attributes_from_base_span_wrapper`

Follows the exact same pattern as all other `confident.trace.*` attributes (`thread_id`, `user_id`, `environment`, etc.).

## Context
The native `@observe` path can set `test_case_id` via `update_current_trace()`, but the OTel exporter path had no equivalent. This is needed for applications using OTel-based instrumentation (e.g. `pydantic_ai.Agent.instrument_all()`) that fan spans out to multiple backends via a shared `TracerProvider`.

## Open question
Both the `@observe` and OTel paths now include `testCaseId` in the payload sent to `POST /v1/traces`, but looking at the [API docs](https://www.confident-ai.com/docs/api-reference/tracing/create-trace), `testCaseId` doesn't appear to be a supported field on that endpoint. In the UI, I can see the conversational thread and the test cases being executed, but the traces are not linked to the test cases, which is what I'd expect to happen. Is `testCaseId` on `POST /v1/traces` currently supported by the backend, or is this a feature that is planned to come?

## Test plan
- [x] Set `confident.trace.test_case_id` attribute on a root span, export through `ConfidentSpanExporter`, confirm `TraceApi` payload includes `"testCaseId": "<value>"`


🤖 Generated with [Claude Code](https://claude.com/claude-code)