### PR TITLE
feat: allow default model to be set via DEEPEVAL_DEFAULT_MODEL env var

### DIFF
--- a/deepeval/config/settings.py
+++ b/deepeval/config/settings.py
@@ -303,6 +303,10 @@ class Settings(BaseSettings):
         None,
         description="Identifier/tag to help identify your test run on Confident AI.",
     )
+    DEEPEVAL_DEFAULT_MODEL: Optional[str] = Field(
+        None,
+        description="Default model name used across all providers when no provider-specific model is set (e.g. 'gpt-4.1', 'claude-3-7-sonnet-latest').",
+    )
 
     #
     # Storage & Output

--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -58,7 +58,12 @@ class AnthropicModel(DeepEvalBaseLLM):
         else:
             self.api_key = settings.ANTHROPIC_API_KEY
 
-        model = model or settings.ANTHROPIC_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL or default_model
+        model = (
+            model
+            or settings.ANTHROPIC_MODEL_NAME
+            or settings.DEEPEVAL_DEFAULT_MODEL
+            or default_model
+        )
 
         if temperature is not None:
             temperature = float(temperature)

--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -58,7 +58,7 @@ class AnthropicModel(DeepEvalBaseLLM):
         else:
             self.api_key = settings.ANTHROPIC_API_KEY
 
-        model = model or settings.ANTHROPIC_MODEL_NAME or default_model
+        model = model or settings.ANTHROPIC_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL or default_model
 
         if temperature is not None:
             temperature = float(temperature)

--- a/deepeval/models/llms/gemini_model.py
+++ b/deepeval/models/llms/gemini_model.py
@@ -72,7 +72,7 @@ class GeminiModel(DeepEvalBaseLLM):
 
         settings = get_settings()
 
-        model = model or settings.GEMINI_MODEL_NAME or default_gemini_model
+        model = model or settings.GEMINI_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL or default_gemini_model
         self.model_data = GEMINI_MODELS_DATA.get(model)
 
         # Get API key from settings if not provided

--- a/deepeval/models/llms/gemini_model.py
+++ b/deepeval/models/llms/gemini_model.py
@@ -72,7 +72,12 @@ class GeminiModel(DeepEvalBaseLLM):
 
         settings = get_settings()
 
-        model = model or settings.GEMINI_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL or default_gemini_model
+        model = (
+            model
+            or settings.GEMINI_MODEL_NAME
+            or settings.DEEPEVAL_DEFAULT_MODEL
+            or default_gemini_model
+        )
         self.model_data = GEMINI_MODELS_DATA.get(model)
 
         # Get API key from settings if not provided

--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -67,7 +67,7 @@ class GPTModel(DeepEvalBaseLLM):
         if api_key is None and "api_key" in alias_values:
             api_key = alias_values["api_key"]
 
-        model = model or settings.OPENAI_MODEL_NAME
+        model = model or settings.OPENAI_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL
         if model is None:
             model = DEFAULT_GPT_MODEL
 

--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -67,7 +67,11 @@ class GPTModel(DeepEvalBaseLLM):
         if api_key is None and "api_key" in alias_values:
             api_key = alias_values["api_key"]
 
-        model = model or settings.OPENAI_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL
+        model = (
+            model
+            or settings.OPENAI_MODEL_NAME
+            or settings.DEEPEVAL_DEFAULT_MODEL
+        )
         if model is None:
             model = DEFAULT_GPT_MODEL
 

--- a/deepeval/models/llms/openrouter_model.py
+++ b/deepeval/models/llms/openrouter_model.py
@@ -80,7 +80,11 @@ class OpenRouterModel(DeepEvalBaseLLM):
         **kwargs,
     ):
         settings = get_settings()
-        model = model or settings.OPENROUTER_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL
+        model = (
+            model
+            or settings.OPENROUTER_MODEL_NAME
+            or settings.DEEPEVAL_DEFAULT_MODEL
+        )
         if model is None:
             model = DEFAULT_OPENROUTER_MODEL
 

--- a/deepeval/models/llms/openrouter_model.py
+++ b/deepeval/models/llms/openrouter_model.py
@@ -80,7 +80,7 @@ class OpenRouterModel(DeepEvalBaseLLM):
         **kwargs,
     ):
         settings = get_settings()
-        model = model or settings.OPENROUTER_MODEL_NAME
+        model = model or settings.OPENROUTER_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL
         if model is None:
             model = DEFAULT_OPENROUTER_MODEL
 


### PR DESCRIPTION
## Problem

There is no way to set a default model across all providers via environment variable. Users who want to pin a specific model (e.g. in CI or Docker) have to use provider-specific vars (`OPENAI_MODEL_NAME`, `ANTHROPIC_MODEL_NAME`, etc.) and must know which provider is active.

Closes #2602

## Solution

Adds `DEEPEVAL_DEFAULT_MODEL` to the central `Settings` model (pydantic-settings, so it is read from env automatically). Each provider's `__init__` reads it as a fallback between the provider-specific setting and the hardcoded default:

```
model = model or settings.<PROVIDER>_MODEL_NAME or settings.DEEPEVAL_DEFAULT_MODEL or <hardcoded_default>
```

Providers updated: `GPTModel`, `AnthropicModel`, `GeminiModel`, `OpenRouterModel`.

## Usage

```bash
export DEEPEVAL_DEFAULT_MODEL=gpt-4.1-mini
```

or in `.env`:

```
DEEPEVAL_DEFAULT_MODEL=gpt-4.1-mini
```

Provider-specific vars (`OPENAI_MODEL_NAME`, etc.) still take precedence, and explicit constructor args still win over everything.

## Changes

- `deepeval/config/settings.py` — new `DEEPEVAL_DEFAULT_MODEL: Optional[str]` field
- `deepeval/models/llms/openai_model.py` — read `DEEPEVAL_DEFAULT_MODEL` before falling back to `DEFAULT_GPT_MODEL`
- `deepeval/models/llms/anthropic_model.py` — read `DEEPEVAL_DEFAULT_MODEL` before falling back to hardcoded default
- `deepeval/models/llms/gemini_model.py` — read `DEEPEVAL_DEFAULT_MODEL` before falling back to hardcoded default
- `deepeval/models/llms/openrouter_model.py` — read `DEEPEVAL_DEFAULT_MODEL` before falling back to `DEFAULT_OPENROUTER_MODEL`