### PR TITLE
Fix Optional field and nested model handling in schema construction

### DIFF
--- a/deepeval/prompt/utils.py
+++ b/deepeval/prompt/utils.py
@@ -1,7 +1,17 @@
 import re
 import uuid
 from jinja2 import Template
-from typing import Any, Dict, Type, Optional, List, Match, Union, get_origin, get_args
+from typing import (
+    Any,
+    Dict,
+    Type,
+    Optional,
+    List,
+    Match,
+    Union,
+    get_origin,
+    get_args,
+)
 from pydantic import BaseModel, create_model
 
 from deepeval.prompt.api import (
@@ -242,10 +252,7 @@ def _process_model(
                 )
                 fields.append(item_field)
             continue
-        elif (
-            hasattr(annotation, "__mro__")
-            and BaseModel in annotation.__mro__
-        ):
+        elif hasattr(annotation, "__mro__") and BaseModel in annotation.__mro__:
             field_type = "OBJECT"
             parent_field = OutputSchemaField(
                 id=field_id,

--- a/deepeval/prompt/utils.py
+++ b/deepeval/prompt/utils.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 from jinja2 import Template
-from typing import Any, Dict, Type, Optional, List, Match, get_origin, get_args
+from typing import Any, Dict, Type, Optional, List, Match, Union, get_origin, get_args
 from pydantic import BaseModel, create_model
 
 from deepeval.prompt.api import (
@@ -175,7 +175,15 @@ def _process_model(
         field_id = str(uuid.uuid4())
         annotation = field_info.annotation
         field_type = "STRING"
+
+        # Unwrap Optional[X] (Union[X, None]) to its inner type
         origin = get_origin(annotation)
+        if origin is Union:
+            args = [a for a in get_args(annotation) if a is not type(None)]
+            if len(args) == 1:
+                annotation = args[0]
+                origin = get_origin(annotation)
+
         if annotation == str:
             field_type = "STRING"
         elif annotation == int:
@@ -235,8 +243,8 @@ def _process_model(
                 fields.append(item_field)
             continue
         elif (
-            hasattr(annotation, "__bases__")
-            and BaseModel in annotation.__bases__
+            hasattr(annotation, "__mro__")
+            and BaseModel in annotation.__mro__
         ):
             field_type = "OBJECT"
             parent_field = OutputSchemaField(


### PR DESCRIPTION
## Summary

Fixes two bugs in `_process_model()` (`deepeval/prompt/utils.py`) that caused incorrect schema generation for structured outputs.

**Bug 1 — Optional types misidentified as STRING (#2609):**
`Optional[List[int]]` has `get_origin() → Union`, not `list`, so it fell through the type dispatch to the default `field_type = "STRING"`. Fixed by unwrapping `Optional[X]` (`Union[X, None]`) before dispatching.

**Bug 2 — Nested Pydantic models not recognized (#2608):**
`BaseModel in annotation.__bases__` only checks direct parents. A model like `class Derived(BasePayload)` where `BasePayload(BaseModel)` was not recognized. Changed to `BaseModel in annotation.__mro__` which checks the full inheritance chain — matching the pattern already used for array item types on line 208.

## Changes

- Added `Union` import
- Added Optional unwrapping (6 lines) before the type dispatch chain
- Changed `__bases__` → `__mro__` for nested model detection (1 line)

## Test plan

- `Optional[List[int]]` fields now correctly generate ARRAY schema instead of STRING
- `Optional[str]` fields still correctly generate STRING
- Models inheriting from intermediate BaseModel subclasses are now detected as OBJECT

Closes #2609, closes #2608