### PR TITLE
Fix Turn._mcp_interaction always False (Pydantic v2 PrivateAttr)

### DIFF
--- a/deepeval/test_case/conversational_test_case.py
+++ b/deepeval/test_case/conversational_test_case.py
@@ -60,7 +60,14 @@ class Turn(BaseModel):
             "additionalMetadata", "additional_metadata"
         ),
     )
-    _mcp_interaction: bool = PrivateAttr(default=False)
+    @property
+    def _mcp_interaction(self) -> bool:
+        """Whether this turn involves any MCP interactions."""
+        return (
+            self.mcp_tools_called is not None
+            or self.mcp_resources_called is not None
+            or self.mcp_prompts_called is not None
+        )
 
     def __repr__(self):
         attrs = [f"role={self.role!r}", f"content={self.content!r}"]
@@ -97,7 +104,6 @@ class Turn(BaseModel):
                 GetPromptResult,
             )
 
-            data["_mcp_interaction"] = True
             if mcp_tools_called is not None:
                 if not isinstance(mcp_tools_called, list) or not all(
                     isinstance(tool_called, MCPToolCall)

--- a/deepeval/test_case/conversational_test_case.py
+++ b/deepeval/test_case/conversational_test_case.py
@@ -60,6 +60,7 @@ class Turn(BaseModel):
             "additionalMetadata", "additional_metadata"
         ),
     )
+
     @property
     def _mcp_interaction(self) -> bool:
         """Whether this turn involves any MCP interactions."""


### PR DESCRIPTION
## Summary

`Turn._mcp_interaction` was always `False` regardless of whether MCP tools/resources/prompts were called, causing `MultiTurnMCPUseMetric` and `MCPTaskCompletionMetric` to produce near-zero scores.

**Root cause:** In Pydantic v2, `PrivateAttr` fields are excluded from the validated data dict. Setting `data["_mcp_interaction"] = True` in a `model_validator(mode="before")` has no effect — the key is silently dropped after validation.

**Fix:** Replace the `PrivateAttr` + broken validator with a `@property` that derives the value from the existing fields:

```python
@property
def _mcp_interaction(self) -> bool:
    return (
        self.mcp_tools_called is not None
        or self.mcp_resources_called is not None
        or self.mcp_prompts_called is not None
    )
```

This is simpler, correct, and has no Pydantic version dependency issues.

Closes #2579