### PR TITLE
Fix Pydantic Multi-turn I/O

### DIFF
--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -472,6 +472,17 @@ def _extract_non_thinking_part_of_last_message(message: dict) -> dict:
     return None
 
 
+def _is_user_text_message(m: dict) -> bool:
+    """Check if a user message contains actual text content (not tool responses)."""
+    parts = m.get("parts")
+    if parts and isinstance(parts, list):
+        return any(
+            isinstance(p, dict) and p.get("type") == "text" for p in parts
+        )
+    content = m.get("content")
+    return isinstance(content, str)
+
+
 def check_pydantic_ai_agent_input_output(
     span: ReadableSpan,
 ) -> Tuple[Optional[Any], Optional[Any]]:
@@ -481,22 +492,20 @@ def check_pydantic_ai_agent_input_output(
     # Get normalized messages once
     normalized = normalize_pydantic_ai_messages(span)
 
-    # Input (pydantic_ai.all_messages) - slice up to and including the first 'user' message
+    # Input (pydantic_ai.all_messages) - find the last user message with text content
     if normalized:
         try:
-            first_user_idx = None
+            last_user_text_idx = None
             for i, m in enumerate(normalized):
-                role = None
                 if isinstance(m, dict):
                     role = m.get("role") or m.get("author")
-                if role == "user":
-                    first_user_idx = i
-                    break
+                    if role == "user" and _is_user_text_message(m):
+                        last_user_text_idx = i
 
             input_val = (
                 normalized
-                if first_user_idx is None
-                else normalized[: first_user_idx + 1]
+                if last_user_text_idx is None
+                else [normalized[last_user_text_idx]]
             )
         except Exception:
             pass

--- a/tests/test_integrations/test_exporter/readable_spans.py
+++ b/tests/test_integrations/test_exporter/readable_spans.py
@@ -180,3 +180,92 @@ llm_readable_span = ReadableSpan(
 )
 
 llm_span_list = [llm_readable_span]
+
+# Create a multi-turn span context
+multi_turn_span_context = SpanContext(
+    trace_id=3,
+    span_id=3,
+    is_remote=False,
+    trace_flags=TraceFlags(0x01),
+)
+
+# Create the multi-turn readable span
+multi_turn_readable_span = ReadableSpan(
+    name="multi_turn_span",
+    context=multi_turn_span_context,
+    attributes={
+        "agent_name": "test_agent",
+        "model_name": "gpt-4",
+        "confident.span.name": "test_agent",
+        "confident.span.type": "agent",
+        "confident.trace.name": "multi_turn_trace",
+        "pydantic_ai.all_messages": """[
+    {
+        "role": "user",
+        "parts": [
+            {
+                "type": "text",
+                "content": "What is the report name?"
+            }
+        ]
+    },
+    {
+        "role": "assistant",
+        "parts": [
+            {
+                "type": "tool_call",
+                "id": "call_abc",
+                "name": "get_report",
+                "arguments": "{\\"id\\": \\"123\\"}"
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "parts": [
+            {
+                "type": "tool_call_response",
+                "id": "call_abc",
+                "name": "get_report",
+                "result": "Report: All Applications"
+            }
+        ]
+    },
+    {
+        "role": "assistant",
+        "parts": [
+            {
+                "type": "text",
+                "content": "The report name is All Applications."
+            }
+        ]
+    },
+    {
+        "role": "user",
+        "parts": [
+            {
+                "type": "text",
+                "content": "What are the columns in the report?"
+            }
+        ]
+    },
+    {
+        "role": "assistant",
+        "parts": [
+            {
+                "type": "text",
+                "content": "The report contains 68 columns."
+            }
+        ]
+    }
+]""",
+        "gen_ai.system_instructions": '[{"type": "text", "content": "You are a data analysis assistant."}]',
+        "gen_ai.operation.name": "chat",
+        "final_result": "The report contains 68 columns.",
+    },
+    status=Status(StatusCode.OK),
+    start_time=2000000000,
+    end_time=2000001000,
+)
+
+multi_turn_span_list = [multi_turn_readable_span]

--- a/tests/test_integrations/test_exporter/test_pydantic_ai.py
+++ b/tests/test_integrations/test_exporter/test_pydantic_ai.py
@@ -3,6 +3,7 @@ from deepeval.tracing.otel.exporter import ConfidentSpanExporter
 from tests.test_integrations.test_exporter.readable_spans import (
     list_of_readable_spans,
     llm_span_list,
+    multi_turn_span_list,
 )
 from deepeval.tracing.trace_test_manager import trace_testing_manager
 
@@ -24,6 +25,32 @@ async def test_pydantic_ai_trace():
         assert (
             actual_dict["output"]["content"] == "Final response text"
         ), f"Expected output content to be 'Final response text', got {actual_dict['output']['content']}"
+
+    finally:
+        trace_testing_manager.test_name = None
+        trace_testing_manager.test_dict = None
+
+
+async def test_multi_turn_trace():
+    try:
+        trace_testing_manager.test_name = "any_name"
+        exporter.export(multi_turn_span_list)
+        actual_dict = await trace_testing_manager.wait_for_test_dict()
+
+        # Assert that the trace input is the last user text message
+        assert (
+            actual_dict["input"][0]["role"] == "System Instruction"
+        ), f"Expected first input role to be 'System Instruction', got {actual_dict['input'][0]['role']}"
+
+        assert (
+            actual_dict["input"][1]["content"]
+            == "What are the columns in the report?"
+        ), f"Expected input to be the follow-up question, got {actual_dict['input'][1]['content']}"
+
+        # Assert that the output is the final result
+        assert (
+            actual_dict["output"] == "The report contains 68 columns."
+        ), f"Expected output to be final result, got {actual_dict['output']}"
 
     finally:
         trace_testing_manager.test_name = None


### PR DESCRIPTION
Fixed multi-turn Pydantic trace input to use the last user text message instead of the first. Previously, follow-up questions in a conversation would incorrectly display the initial question as the trace input.