### PR TITLE
fix(test_case): retain MLLMImage strong ref in parse_multimodal_string

### DIFF
--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -148,10 +148,11 @@ class MLLMImage:
 
             img_id = m.group(1)
 
-            if img_id not in _MLLM_IMAGE_REGISTRY:
-                MLLMImage(url=img_id, _id=img_id)
+            img = _MLLM_IMAGE_REGISTRY.get(img_id)
+            if img is None:
+                img = MLLMImage(url=img_id, _id=img_id)
 
-            result.append(_MLLM_IMAGE_REGISTRY[img_id])
+            result.append(img)
             last_end = end
 
         if last_end < len(s):


### PR DESCRIPTION
## Summary

- Fixes a `KeyError` in `MLLMImage.parse_multimodal_string` when parsing `[DEEPEVAL:IMAGE:<id>]` markers whose images are not already registered
- `_MLLM_IMAGE_REGISTRY` is a `WeakValueDictionary`. The previous code created an `MLLMImage` without binding it to a name, so its refcount dropped to 0 immediately after `__post_init__`, the weak entry was evicted, and the subsequent `_MLLM_IMAGE_REGISTRY[img_id]` lookup raised `KeyError`.
- Bind the newly created `MLLMImage` to a local `img` and append it directly, keeping it alive for the caller. Registry behavior is unchanged.