### PR TITLE
fix: prevent duplicate test-case rows on pytest retry

### DIFF
--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -169,7 +169,7 @@ class TestRun(BaseModel):
     def add_test_case(
         self, api_test_case: Union[LLMApiTestCase, ConversationalApiTestCase]
     ):
-        
+
         target_list = (
             self.conversational_test_cases
             if isinstance(api_test_case, ConversationalApiTestCase)

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -169,10 +169,26 @@ class TestRun(BaseModel):
     def add_test_case(
         self, api_test_case: Union[LLMApiTestCase, ConversationalApiTestCase]
     ):
-        if isinstance(api_test_case, ConversationalApiTestCase):
-            self.conversational_test_cases.append(api_test_case)
+        
+        target_list = (
+            self.conversational_test_cases
+            if isinstance(api_test_case, ConversationalApiTestCase)
+            else self.test_cases
+        )
+
+        replaced_cost: Union[float, None] = None
+        for i, existing in enumerate(target_list):
+            if existing.name == api_test_case.name:
+                replaced_cost = existing.evaluation_cost
+                target_list[i] = api_test_case
+                break
         else:
-            self.test_cases.append(api_test_case)
+            target_list.append(api_test_case)
+
+        # Back out the replaced attempt's cost before adding the new one,
+        # so a retry doesn't double-count its evaluation_cost on the run total.
+        if replaced_cost is not None and self.evaluation_cost is not None:
+            self.evaluation_cost -= replaced_cost
 
         if api_test_case.evaluation_cost is not None:
             if self.evaluation_cost is None:

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -170,10 +170,25 @@ class TestRun(BaseModel):
     def add_test_case(
         self, api_test_case: Union[LLMApiTestCase, ConversationalApiTestCase]
     ):
-        if isinstance(api_test_case, ConversationalApiTestCase):
-            self.conversational_test_cases.append(api_test_case)
+        target_list = (
+            self.conversational_test_cases
+            if isinstance(api_test_case, ConversationalApiTestCase)
+            else self.test_cases
+        )
+
+        replaced_cost: Union[float, None] = None
+        for i, existing in enumerate(target_list):
+            if existing.name == api_test_case.name:
+                replaced_cost = existing.evaluation_cost
+                target_list[i] = api_test_case
+                break
         else:
-            self.test_cases.append(api_test_case)
+            target_list.append(api_test_case)
+
+        # Back out the replaced attempt's cost before adding the new one,
+        # so a retry doesn't double-count its evaluation_cost on the run total.
+        if replaced_cost is not None and self.evaluation_cost is not None:
+            self.evaluation_cost -= replaced_cost
 
         if api_test_case.evaluation_cost is not None:
             if self.evaluation_cost is None:

--- a/tests/test_core/test_run/test_test_run_retry_overwrite.py
+++ b/tests/test_core/test_run/test_test_run_retry_overwrite.py
@@ -22,13 +22,14 @@ import pytest
 from deepeval.test_run.api import LLMApiTestCase, ConversationalApiTestCase
 from deepeval.test_run.test_run import TestRun
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _llm(name: str, success: bool, cost: Optional[float] = None) -> LLMApiTestCase:
+def _llm(
+    name: str, success: bool, cost: Optional[float] = None
+) -> LLMApiTestCase:
     # LLMApiTestCase uses pydantic Field(alias=...) for several fields.
     # Without populate_by_name=True in the model config, aliases must be
     # used at construction time — not the Python attribute names.
@@ -122,7 +123,9 @@ class TestLLMRetryOverwrite:
         run = _fresh_run()
         run.add_test_case(_llm("test_a", success=False, cost=0.01))  # attempt 1
         run.add_test_case(_llm("test_b", success=True, cost=0.05))  # unique
-        run.add_test_case(_llm("test_a", success=True, cost=0.02))  # attempt 2 (retry)
+        run.add_test_case(
+            _llm("test_a", success=True, cost=0.02)
+        )  # attempt 2 (retry)
 
         assert len(run.test_cases) == 2
         assert run.evaluation_cost == pytest.approx(0.07)  # 0.02 + 0.05

--- a/tests/test_core/test_run/test_test_run_retry_overwrite.py
+++ b/tests/test_core/test_run/test_test_run_retry_overwrite.py
@@ -1,0 +1,158 @@
+"""Tests for the pytest.mark.flaky / rerun-failures retry-overwrite fix.
+
+When assert_test() is retried (e.g. via pytest-rerunfailures or
+pytest.mark.flaky), add_test_case() used to append a new row for every
+attempt, causing the Confident AI dashboard to show each retry as a
+separate entry.  After the fix, a second call with the same test-case
+name replaces the previous entry so only the final result is kept.
+
+Covers:
+- LLM: same name twice → one row, latest result wins
+- LLM: two different names → two rows (normal case unchanged)
+- LLM: evaluation_cost is not double-counted on replace
+- Conversational: same name twice → one row, latest result wins
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from deepeval.test_run.api import LLMApiTestCase, ConversationalApiTestCase
+from deepeval.test_run.test_run import TestRun
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _llm(name: str, success: bool, cost: Optional[float] = None) -> LLMApiTestCase:
+    # LLMApiTestCase uses pydantic Field(alias=...) for several fields.
+    # Without populate_by_name=True in the model config, aliases must be
+    # used at construction time — not the Python attribute names.
+    return LLMApiTestCase(
+        name=name,
+        input="q",
+        success=success,
+        evaluationCost=cost,
+    )
+
+
+def _conv(
+    name: str, success: bool, cost: Optional[float] = None
+) -> ConversationalApiTestCase:
+    # metricsData has no default and must be supplied via its alias.
+    return ConversationalApiTestCase(
+        name=name,
+        success=success,
+        metricsData=[],
+        evaluationCost=cost,
+    )
+
+
+def _fresh_run() -> TestRun:
+    """Return a TestRun with empty lists and no accumulated cost."""
+    # test_file uses alias testFile when populate_by_name is not enabled.
+    return TestRun(testFile="test_file.py")
+
+
+# ---------------------------------------------------------------------------
+# LLM test cases
+# ---------------------------------------------------------------------------
+
+
+class TestLLMRetryOverwrite:
+    def test_retry_produces_single_row(self):
+        """Second call with the same name replaces the first row."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False))
+        run.add_test_case(_llm("test_foo", success=True))
+
+        assert len(run.test_cases) == 1
+        assert run.test_cases[0].success is True
+
+    def test_distinct_names_produce_two_rows(self):
+        """Two different names → two rows (existing behaviour unchanged)."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=True))
+        run.add_test_case(_llm("test_bar", success=False))
+
+        assert len(run.test_cases) == 2
+
+    def test_retry_does_not_double_count_cost(self):
+        """Run-level cost reflects only the *last* attempt's cost."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=0.01))
+        run.add_test_case(_llm("test_foo", success=True, cost=0.02))
+
+        assert run.evaluation_cost == pytest.approx(0.02)
+
+    def test_retry_latest_cost_none_clears_previous(self):
+        """If the retry reports no cost, the previous cost is backed out."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=0.01))
+        run.add_test_case(_llm("test_foo", success=True, cost=None))
+
+        # Previous 0.01 is subtracted; new attempt adds nothing.
+        assert run.evaluation_cost == pytest.approx(0.0)
+
+    def test_first_attempt_cost_none_retry_sets_cost(self):
+        """First attempt has no cost; retry introduces a cost → cost is set."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=None))
+        run.add_test_case(_llm("test_foo", success=True, cost=0.05))
+
+        assert run.evaluation_cost == pytest.approx(0.05)
+
+    def test_multiple_retries_keep_only_last(self):
+        """Three attempts with the same name → one row, last success wins."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=0.01))
+        run.add_test_case(_llm("test_foo", success=False, cost=0.02))
+        run.add_test_case(_llm("test_foo", success=True, cost=0.03))
+
+        assert len(run.test_cases) == 1
+        assert run.test_cases[0].success is True
+        assert run.evaluation_cost == pytest.approx(0.03)
+
+    def test_cost_accumulates_correctly_for_distinct_tests_with_retry(self):
+        """Mixed scenario: one retried test + one unique test → correct total."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_a", success=False, cost=0.01))  # attempt 1
+        run.add_test_case(_llm("test_b", success=True, cost=0.05))  # unique
+        run.add_test_case(_llm("test_a", success=True, cost=0.02))  # attempt 2 (retry)
+
+        assert len(run.test_cases) == 2
+        assert run.evaluation_cost == pytest.approx(0.07)  # 0.02 + 0.05
+
+
+# ---------------------------------------------------------------------------
+# Conversational test cases
+# ---------------------------------------------------------------------------
+
+
+class TestConversationalRetryOverwrite:
+    def test_retry_produces_single_row(self):
+        """Second call with the same name replaces the first row."""
+        run = _fresh_run()
+        run.add_test_case(_conv("conv_test", success=False))
+        run.add_test_case(_conv("conv_test", success=True))
+
+        assert len(run.conversational_test_cases) == 1
+        assert run.conversational_test_cases[0].success is True
+
+    def test_retry_does_not_double_count_cost(self):
+        run = _fresh_run()
+        run.add_test_case(_conv("conv_test", success=False, cost=0.01))
+        run.add_test_case(_conv("conv_test", success=True, cost=0.02))
+
+        assert run.evaluation_cost == pytest.approx(0.02)
+
+    def test_distinct_names_produce_two_rows(self):
+        run = _fresh_run()
+        run.add_test_case(_conv("conv_a", success=True))
+        run.add_test_case(_conv("conv_b", success=False))
+
+        assert len(run.conversational_test_cases) == 2

--- a/tests/test_core/test_run/test_test_run_retry_overwrite.py
+++ b/tests/test_core/test_run/test_test_run_retry_overwrite.py
@@ -1,0 +1,166 @@
+"""Tests for the pytest.mark.flaky / pytest-rerunfailures retry-overwrite fix.
+
+When assert_test() is retried, each attempt calls add_test_case(); the
+implementation replaces an existing row with the same name so the
+dashboard shows one row per logical test and evaluation_cost is not
+double-counted across retries.
+
+Covers:
+- LLM: same name twice → one row, latest success wins
+- LLM: two different names → two rows (unchanged)
+- LLM: cost not double-counted on replace
+- LLM: retry with None cost backs out previous cost
+- LLM: first attempt None cost, retry sets cost
+- LLM: three retries → one row, only last cost counted
+- LLM: mixed retried + unique test → correct total cost
+- Conversational: same name twice → one row
+- Conversational: cost not double-counted
+- Conversational: two different names → two rows
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from deepeval.test_run.api import LLMApiTestCase, ConversationalApiTestCase
+from deepeval.test_run.test_run import TestRun
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _llm(
+    name: str, success: bool, cost: Optional[float] = None
+) -> LLMApiTestCase:
+    # LLMApiTestCase uses pydantic Field(alias=...) for several fields.
+    # Without populate_by_name=True in the model config, aliases must be
+    # used at construction time — not the Python attribute names.
+    return LLMApiTestCase(
+        name=name,
+        input="q",
+        success=success,
+        evaluationCost=cost,
+    )
+
+
+def _conv(
+    name: str, success: bool, cost: Optional[float] = None
+) -> ConversationalApiTestCase:
+    # metricsData has no default and must be supplied via its alias.
+    return ConversationalApiTestCase(
+        name=name,
+        success=success,
+        metricsData=[],
+        evaluationCost=cost,
+    )
+
+
+def _fresh_run() -> TestRun:
+    """Return a TestRun with empty lists and no accumulated cost."""
+    # test_file uses alias testFile when populate_by_name is not enabled.
+    return TestRun(testFile="test_file.py")
+
+
+# ---------------------------------------------------------------------------
+# LLM test cases
+# ---------------------------------------------------------------------------
+
+
+class TestLLMRetryOverwrite:
+    def test_retry_produces_single_row(self):
+        """Second call with the same name replaces the first row."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False))
+        run.add_test_case(_llm("test_foo", success=True))
+
+        assert len(run.test_cases) == 1
+        assert run.test_cases[0].success is True
+
+    def test_distinct_names_produce_two_rows(self):
+        """Two different names → two rows (existing behaviour unchanged)."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=True))
+        run.add_test_case(_llm("test_bar", success=False))
+
+        assert len(run.test_cases) == 2
+
+    def test_retry_does_not_double_count_cost(self):
+        """Run-level cost reflects only the *last* attempt's cost."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=0.01))
+        run.add_test_case(_llm("test_foo", success=True, cost=0.02))
+
+        assert run.evaluation_cost == pytest.approx(0.02)
+
+    def test_retry_latest_cost_none_clears_previous(self):
+        """If the retry reports no cost, the previous cost is backed out."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=0.01))
+        run.add_test_case(_llm("test_foo", success=True, cost=None))
+
+        # Previous 0.01 is subtracted; new attempt adds nothing.
+        assert run.evaluation_cost == pytest.approx(0.0)
+
+    def test_first_attempt_cost_none_retry_sets_cost(self):
+        """First attempt has no cost; retry introduces a cost → cost is set."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=None))
+        run.add_test_case(_llm("test_foo", success=True, cost=0.05))
+
+        assert run.evaluation_cost == pytest.approx(0.05)
+
+    def test_multiple_retries_keep_only_last(self):
+        """Three attempts with the same name → one row, last success wins."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_foo", success=False, cost=0.01))
+        run.add_test_case(_llm("test_foo", success=False, cost=0.02))
+        run.add_test_case(_llm("test_foo", success=True, cost=0.03))
+
+        assert len(run.test_cases) == 1
+        assert run.test_cases[0].success is True
+        assert run.evaluation_cost == pytest.approx(0.03)
+
+    def test_cost_accumulates_correctly_for_distinct_tests_with_retry(self):
+        """Mixed scenario: one retried test + one unique test → correct total."""
+        run = _fresh_run()
+        run.add_test_case(_llm("test_a", success=False, cost=0.01))  # attempt 1
+        run.add_test_case(_llm("test_b", success=True, cost=0.05))  # unique
+        run.add_test_case(
+            _llm("test_a", success=True, cost=0.02)
+        )  # attempt 2 (retry)
+
+        assert len(run.test_cases) == 2
+        assert run.evaluation_cost == pytest.approx(0.07)  # 0.02 + 0.05
+
+
+# ---------------------------------------------------------------------------
+# Conversational test cases
+# ---------------------------------------------------------------------------
+
+
+class TestConversationalRetryOverwrite:
+    def test_retry_produces_single_row(self):
+        """Second call with the same name replaces the first row."""
+        run = _fresh_run()
+        run.add_test_case(_conv("conv_test", success=False))
+        run.add_test_case(_conv("conv_test", success=True))
+
+        assert len(run.conversational_test_cases) == 1
+        assert run.conversational_test_cases[0].success is True
+
+    def test_retry_does_not_double_count_cost(self):
+        run = _fresh_run()
+        run.add_test_case(_conv("conv_test", success=False, cost=0.01))
+        run.add_test_case(_conv("conv_test", success=True, cost=0.02))
+
+        assert run.evaluation_cost == pytest.approx(0.02)
+
+    def test_distinct_names_produce_two_rows(self):
+        run = _fresh_run()
+        run.add_test_case(_conv("conv_a", success=True))
+        run.add_test_case(_conv("conv_b", success=False))
+
+        assert len(run.conversational_test_cases) == 2


### PR DESCRIPTION
## Problem

When a test is marked with `pytest.mark.flaky` or `pytest-rerunfailures`,`assert_test()` is called again from scratch on every retry attempt.Each call flows through:

assert_test() → execute_test_cases() → update_test_run() → add_test_case()

`add_test_case()` blindly appended on every call with no duplicate check.
A test that passed on the 3rd attempt would appear on the Confident AI dashboard as **2 failures + 1 pass** instead of just **1 pass**.

The same unconditional append also double-counted `evaluation_cost` — a test costing `0.01` on attempt 1 and `0.02` on attempt 2 accumulated `0.03` on the run total instead of the correct `0.02`.

## Root cause

`TestRun.add_test_case()` in `deepeval/test_run/test_run.py` — no deduplication by test-case name before appending to `self.test_cases` or `self.conversational_test_cases`.

## Fix

One method changed, one file touched: `deepeval/test_run/test_run.py`.

`add_test_case()` now scans the target list for an existing entry with the same `name`. On a match it replaces that slot (latest attempt wins) and backs the replaced attempt's `evaluation_cost` out of the run total before applying the new one. New test cases still append as before via Python's `for/else`.

```python
replaced_cost: Union[float, None] = None
for i, existing in enumerate(target_list):
    if existing.name == api_test_case.name:
        replaced_cost = existing.evaluation_cost
        target_list[i] = api_test_case
        break
else:
    target_list.append(api_test_case)

if replaced_cost is not None and self.evaluation_cost is not None:
    self.evaluation_cost -= replaced_cost
```

## Before / after

```python
run.add_test_case(LLMApiTestCase(name="test_foo", ..., evaluationCost=0.01, success=False))  # attempt 1
run.add_test_case(LLMApiTestCase(name="test_foo", ..., evaluationCost=0.02, success=True))   # retry

# BEFORE
len(run.test_cases)  # 2    ← both attempts appear as separate dashboard rows
run.evaluation_cost  # 0.03 ← cost double-counted

# AFTER
len(run.test_cases)  # 1    ← only the final result reported
run.evaluation_cost  # 0.02 ← correct
```

## Tests

Added `tests/test_core/test_run/test_test_run_retry_overwrite.py` — 10 tests, all passing on Python 3.10 and 3.12:

- LLM: same name twice → one row, latest `success` wins
- LLM: two different names → two rows (existing behaviour unchanged)
- LLM: cost not double-counted on replace
- LLM: retry with `None` cost backs out previous cost correctly
- LLM: first attempt `None` cost, retry sets cost correctly
- LLM: three retries → one row, only last cost counted
- LLM: mixed retried + unique test → correct total cost
- Conversational: same name twice → one row
- Conversational: cost not double-counted
- Conversational: two different names → two rows

## Caveat

Deduplication keys on `name`. If two genuinely distinct test cases share the same display name in one run, the second would silently overwrite the first. Pytest node IDs are unique by default so this shouldn't occur in practice — flagging it in case maintainers prefer a stricter key (e.g. `nodeid`) in future.

## Checklist
- [x] Closes #1992
- [x] Changes limited to `deepeval/test_run/test_run.py` + new test file
- [x] 10/10 tests passing locally (Python 3.10 + 3.12)