### PR TITLE
fix: guard against None input in trimAndLoadJson

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -388,9 +388,15 @@ def check_arena_test_case_params(
 
 
 def trimAndLoadJson(
-    input_string: str,
+    input_string: Optional[str],
     metric: Optional[BaseMetric] = None,
 ) -> Any:
+    if input_string is None:
+        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+        if metric is not None:
+            metric.error = error_str
+        raise ValueError(error_str)
+
     start = input_string.find("{")
     end = input_string.rfind("}") + 1
 


### PR DESCRIPTION
## Problem

When the evaluation LLM returns `None` (instead of a string), `trimAndLoadJson` crashes with:

```
AttributeError: 'NoneType' object has no attribute 'find'
```

This happens because the function calls `input_string.find("{")` without first checking whether `input_string` is `None`.

Related issue: #2554

## Solution

- Changed the type hint of `input_string` from `str` to `Optional[str]`
- Added an explicit `None` guard at the top of the function that:
  - Raises a descriptive `ValueError` with the same message used for other JSON parse errors
  - Sets `metric.error` when a metric is provided (consistent with existing error handling)

## Changes

```diff
 def trimAndLoadJson(
-    input_string: str,
+    input_string: Optional[str],
     metric: Optional[BaseMetric] = None,
 ) -> Any:
+    if input_string is None:
+        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+        if metric is not None:
+            metric.error = error_str
+        raise ValueError(error_str)
+
     start = input_string.find("{")
```

## Testing

The fix is minimal and follows the existing error-handling pattern already present in the function's `except json.JSONDecodeError` block.