### PR TITLE
fix: return 1.0 when no knowledge retention verdicts exist

### DIFF
--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -299,7 +299,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
     def _calculate_score(self) -> float:
         number_of_verdicts = len(self.verdicts)
         if number_of_verdicts == 0:
-            return 0
+            return 1
 
         retention_count = 0
         for verdict in self.verdicts:


### PR DESCRIPTION
## Problem

`KnowledgeRetentionMetric._calculate_score()` returns 0 when `self.verdicts` 
is empty. This happens in short conversations (1-2 turns) where there is no 
accumulated knowledge to forget.

Zero verdicts means "nothing was forgotten" — the reason text confirms this 
("no attritions... all knowledge retained") but the score contradicts it by 
returning 0.

## Fix

Return 1.0 instead of 0 when there are no verdicts. "Nothing to forget" is 
a perfect retention score.

## How to reproduce

```python
from deepeval.metrics import KnowledgeRetentionMetric
from deepeval.test_case import ConversationalTestCase
from deepeval.test_case.conversational_test_case import Turn

test_case = ConversationalTestCase(
    turns=[
        Turn(role="user", content="What is WOVN?"),
        Turn(role="assistant", content="WOVN is a localization platform."),
    ]
)

metric = KnowledgeRetentionMetric()
metric.measure(test_case)
print(metric.score)   # 0.0 — should be 1.0
print(metric.reason)  # "no attritions" — contradicts the score
