### PR TITLE
add ambiguous claims to contradictions when penalized is true

### DIFF
--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -172,6 +172,8 @@ class FaithfulnessMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() == "no":
                 contradictions.append(verdict.reason)
+            if verdict.verdict.strip().lower() == "idk" and self.penalize_ambiguous_claims:
+                contradictions.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self.evaluation_template.generate_reason(
             contradictions=contradictions,
@@ -195,6 +197,8 @@ class FaithfulnessMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() == "no":
                 contradictions.append(verdict.reason)
+            if verdict.verdict.strip().lower() == "idk" and self.penalize_ambiguous_claims:
+                contradictions.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self.evaluation_template.generate_reason(
             contradictions=contradictions,


### PR DESCRIPTION
## Problem

When `penalize_ambiguous_claims=True` in `FaithfulnessMetric`, the reason generated is positive even if when there are penalizations from ambiguous claims.
This happens because the ambiguous claims are not counted as contradictions in `_generate_reason()`.

## Fix

Add all ambiguous claims to the `contradictions` list when `penalize_ambiguous_claims=True`.

```python

from deepeval.metrics import FaithfulnessMetric
from deepeval.test_case import TestCase

example = LLMTestCase(
    intput="What is the refund policy?",
    actual_output="You can return items within 30 days.",
    retrieval_context=["Return policy 20 days for AMER", "Return policy 30 days for EMEA"],
    )

# Current behaviour
metric = FaithfulnessMetric(penalize_ambiguous_claims=True)
metric.measure(example)
>> 0.0
metric.reason
>> Awesome job! There are no contradictions ...

# New behaviour
metric = FaithfulnessMetric(penalize_ambiguous_claims=True)
metric.measure(example)
>> 0.0
metric.reason
>> The score is 0.00 because the actual output incorrectly claims ...
```
