### PR TITLE
fix: MPS device support in BERTScorer

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -166,8 +166,12 @@ class Scorer:
         except ModuleNotFoundError as e:
             print("Please install torch module. Command: pip install torch")
 
-        # FIXME: Fix the case for mps
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif torch.backends.mps.is_available():
+            device = "mps"
+        else:
+            device = "cpu"
         bert_scorer = BERTScorer(
             model_type=model,
             lang=lang,


### PR DESCRIPTION
 ## Summary             
  - Add Apple Silicon MPS backend detection in `Scorer.bert_score()` device selection
  - Previously only CUDA and CPU were considered, causing Mac users with Apple Silicon GPUs to unnecessarily fall back to CPU
  - Fixes the `FIXME` comment at `deepeval/scorer/scorer.py:169`                                                                                                                
                                                                
  ## Changes                                                                                                                                                                    
  - Device selection now checks `torch.backends.mps.is_available()` before falling back to CPU
  - Priority: CUDA → MPS → CPU                                                                                                                                                  
                              
  ## Testing                                                                                                                                                                    
  Verified end-to-end on Apple Silicon Mac:
  Device selected: mps                                                                                                                                                          
  BERTScorer with device="mps" → Precision: 0.8354, Recall: 0.8994, F1: 0.8672
                                                                              
  First time contributor, happy to contribute!                                  