### PR TITLE
fix: correct DeepAcyclicGraph import path in DAG docs

### DIFF
--- a/docs/content/docs/(custom)/metrics-dag.mdx
+++ b/docs/content/docs/(custom)/metrics-dag.mdx
@@ -62,7 +62,7 @@ You'll also need to supply any additional arguments such as `expected_output` an
 The `DAGMetric` can be used to evaluate single-turn LLM interactions based on LLM-as-a-judge decision-trees.
 
 ```python
-from deepeval.dag import DeepAcyclicGraph
+from deepeval.metrics.dag import DeepAcyclicGraph
 from deepeval.metrics import DAGMetric
 
 dag = DeepAcyclicGraph(root_nodes=[...])


### PR DESCRIPTION
## Summary

The Usage section of the DAG metric documentation shows an incorrect import path that raises `ModuleNotFoundError`:

```python
# Shown in docs (broken)
from deepeval.dag import DeepAcyclicGraph
```

The correct import — already used consistently everywhere else in the same file — is:

```python
from deepeval.metrics.dag import DeepAcyclicGraph
```

## Change

- Fixed the import on line 65 of `docs/content/docs/(custom)/metrics-dag.mdx` to match all other examples in the file.

Fixes #2640