### PR TITLE
test: guard test-run tracer provider scope

### DIFF
--- a/tests/test_core/test_dataset_test_run_tracer.py
+++ b/tests/test_core/test_dataset_test_run_tracer.py
@@ -1,0 +1,54 @@
+from opentelemetry import trace
+
+from deepeval.dataset import test_run_tracer
+
+
+class FakeOTLPSpanExporter:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def export(self, spans):
+        return None
+
+    def force_flush(self, timeout_millis=30000):
+        return True
+
+    def shutdown(self):
+        return None
+
+
+def test_test_run_tracer_uses_local_provider_without_replacing_global(
+    monkeypatch,
+):
+    original_provider = trace.get_tracer_provider()
+
+    def fail_if_global_provider_is_replaced(provider):
+        raise AssertionError(
+            "test-run telemetry must not replace the host OpenTelemetry provider"
+        )
+
+    monkeypatch.setattr(
+        trace, "set_tracer_provider", fail_if_global_provider_is_replaced
+    )
+    monkeypatch.setattr(test_run_tracer, "is_opentelemetry_installed", True)
+    monkeypatch.setattr(
+        test_run_tracer,
+        "get_confident_api_key",
+        lambda: "confident_test_key",
+    )
+    monkeypatch.setattr(
+        test_run_tracer,
+        "OTLPSpanExporter",
+        FakeOTLPSpanExporter,
+        raising=False,
+    )
+
+    provider, tracer = test_run_tracer.init_global_test_run_tracer()
+
+    try:
+        assert provider is test_run_tracer.GLOBAL_TEST_RUN_TRACER_PROVIDER
+        assert tracer is test_run_tracer.GLOBAL_TEST_RUN_TRACER
+        assert trace.get_tracer_provider() is original_provider
+    finally:
+        provider.shutdown()


### PR DESCRIPTION
## Summary

Adds a focused regression test for the test-run OpenTelemetry setup:

- verifies `init_global_test_run_tracer()` creates and stores DeepEval's own tracer provider/tracer
- verifies it does not call `opentelemetry.trace.set_tracer_provider()`
- verifies it does not replace the host application's current global tracer provider

## Scope

Issue #2497 reports the risk of library telemetry taking over a host application's global OpenTelemetry provider. Current `main` already appears to use a local provider path for `deepeval.dataset.test_run_tracer`; this PR pins that boundary so future changes do not regress into global provider replacement.

This is intentionally test-only and does not claim to resolve every telemetry/privacy concern listed in the issue.

## Verification

- `python -m pytest tests/test_core/test_dataset_test_run_tracer.py`
- `python -m black --check tests/test_core/test_dataset_test_run_tracer.py`
- `python -m ruff check tests/test_core/test_dataset_test_run_tracer.py`
