### PR TITLE
feat: group contextual precision retrieval units

### DIFF
--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Type, Union
+from typing import Callable, Hashable, Optional, List, Type, Union
 
 from deepeval.utils import (
     get_or_create_event_loop,
@@ -39,6 +39,7 @@ class ContextualPrecisionMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        group_by: Optional[Callable[[str], Hashable]] = None,
         evaluation_template: Type[
             ContextualPrecisionTemplate
         ] = ContextualPrecisionTemplate,
@@ -50,6 +51,7 @@ class ContextualPrecisionMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.group_by = group_by
         self.evaluation_template = evaluation_template
 
     def measure(
@@ -99,6 +101,9 @@ class ContextualPrecisionMetric(BaseMetric):
                         multimodal,
                     )
                 )
+                self._score_verdicts = self._get_score_verdicts(
+                    retrieval_context
+                )
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason(input, multimodal)
                 self.success = self.score >= self.threshold
@@ -147,6 +152,7 @@ class ContextualPrecisionMetric(BaseMetric):
                     input, expected_output, retrieval_context, multimodal
                 )
             )
+            self._score_verdicts = self._get_score_verdicts(retrieval_context)
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason(input, multimodal)
             self.success = self.score >= self.threshold
@@ -165,7 +171,7 @@ class ContextualPrecisionMetric(BaseMetric):
 
         retrieval_contexts_verdicts = [
             {"verdict": verdict.verdict, "reason": verdict.reason}
-            for verdict in self.verdicts
+            for verdict in getattr(self, "_score_verdicts", self.verdicts)
         ]
         prompt = self.evaluation_template.generate_reason(
             input=input,
@@ -188,7 +194,7 @@ class ContextualPrecisionMetric(BaseMetric):
 
         retrieval_contexts_verdicts = [
             {"verdict": verdict.verdict, "reason": verdict.reason}
-            for verdict in self.verdicts
+            for verdict in getattr(self, "_score_verdicts", self.verdicts)
         ]
         prompt = self.evaluation_template.generate_reason(
             input=input,
@@ -255,15 +261,38 @@ class ContextualPrecisionMetric(BaseMetric):
             ],
         )
 
+    def _get_score_verdicts(
+        self, retrieval_context: List[str]
+    ) -> List[cpschema.ContextualPrecisionVerdict]:
+        if self.group_by is None:
+            return self.verdicts
+
+        grouped_verdicts: dict[
+            Hashable, cpschema.ContextualPrecisionVerdict
+        ] = {}
+        for index, verdict in enumerate(self.verdicts):
+            context = retrieval_context[index]
+            key = self.group_by(context)
+            current_verdict = grouped_verdicts.get(key)
+            if current_verdict is None:
+                grouped_verdicts[key] = verdict
+                continue
+
+            if verdict.verdict.strip().lower() == "yes":
+                grouped_verdicts[key] = verdict
+
+        return list(grouped_verdicts.values())
+
     def _calculate_score(self):
-        number_of_verdicts = len(self.verdicts)
+        score_verdicts = getattr(self, "_score_verdicts", self.verdicts)
+        number_of_verdicts = len(score_verdicts)
         if number_of_verdicts == 0:
             return 0
 
         # Convert verdicts to a binary list where 'yes' is 1 and others are 0
         node_verdicts = [
             1 if v.verdict.strip().lower() == "yes" else 0
-            for v in self.verdicts
+            for v in score_verdicts
         ]
 
         sum_weighted_precision_at_k = 0.0

--- a/tests/test_metrics/test_contextual_precision_grouping.py
+++ b/tests/test_metrics/test_contextual_precision_grouping.py
@@ -1,0 +1,64 @@
+import pytest
+
+from deepeval.metrics.contextual_precision.contextual_precision import (
+    ContextualPrecisionMetric,
+)
+from deepeval.metrics.contextual_precision.schema import (
+    ContextualPrecisionVerdict,
+)
+
+
+def make_metric(verdicts, group_by=None):
+    metric = object.__new__(ContextualPrecisionMetric)
+    metric.threshold = 0.5
+    metric.strict_mode = False
+    metric.group_by = group_by
+    metric.verdicts = [
+        ContextualPrecisionVerdict(verdict=verdict, reason="")
+        for verdict in verdicts
+    ]
+    return metric
+
+
+def test_contextual_precision_score_defaults_to_per_chunk_verdicts():
+    metric = make_metric(["yes", "no", "yes"])
+
+    assert metric._calculate_score() == pytest.approx(0.8333333333)
+
+
+def test_contextual_precision_group_by_scores_retrieval_units():
+    retrieval_context = [
+        "doc=10k section=revenue chunk=1",
+        "doc=10k section=revenue chunk=2",
+        "doc=10k section=mda chunk=3",
+    ]
+    metric = make_metric(
+        ["yes", "no", "yes"],
+        group_by=lambda context: context.split(" chunk=")[0],
+    )
+    metric._score_verdicts = metric._get_score_verdicts(retrieval_context)
+
+    assert [verdict.verdict for verdict in metric._score_verdicts] == [
+        "yes",
+        "yes",
+    ]
+    assert metric._calculate_score() == 1.0
+
+
+def test_contextual_precision_group_by_promotes_relevant_overlapping_chunk():
+    retrieval_context = [
+        "doc=10k section=revenue chunk=1",
+        "doc=10k section=revenue chunk=2",
+        "doc=10k section=risk-factors chunk=3",
+    ]
+    metric = make_metric(
+        ["no", "yes", "no"],
+        group_by=lambda context: context.split(" chunk=")[0],
+    )
+    metric._score_verdicts = metric._get_score_verdicts(retrieval_context)
+
+    assert [verdict.verdict for verdict in metric._score_verdicts] == [
+        "yes",
+        "no",
+    ]
+    assert metric._calculate_score() == 1.0


### PR DESCRIPTION
## Summary

Adds an opt-in grouping hook for `ContextualPrecisionMetric` so users can score retrieval units instead of raw chunks when their RAG pipeline uses overlapping windows.

- adds `group_by: Optional[Callable[[str], Hashable]] = None`
- preserves current per-chunk scoring when `group_by` is not set
- groups verdicts in first-seen order when `group_by` is set
- treats a group as relevant if any chunk in that group is relevant

## Why

Issue #2594 describes a common RAG eval failure mode: overlapping chunks from the same answer-supporting section can be penalized as separate retrieval misses. The discussion converged on a backward-compatible `group_by` hook so users can map chunks to a domain-specific retrieval unit, such as a document section.

This keeps the default behavior unchanged while letting users express section/span-level precision when that is the real retrieval unit.

## Scope

This is an opt-in first step. It does not add a metadata schema, automatic section parser, or benchmark claim for financial-document RAG. Users provide the grouping key from their own chunk format.

## Verification

- `python -m pytest tests/test_metrics/test_contextual_precision_grouping.py`
- `python -m pytest tests/test_metrics/test_contextual_precision_metric.py tests/test_metrics/test_contextual_precision_grouping.py`
- `python -m black --check deepeval/metrics/contextual_precision/contextual_precision.py tests/test_metrics/test_contextual_precision_grouping.py`
- `python -m ruff check deepeval/metrics/contextual_precision/contextual_precision.py tests/test_metrics/test_contextual_precision_grouping.py`
