### PR TITLE
feat: add penalize_ambiguous_claims to AnswerRelevancyMetric

### DIFF
--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -38,6 +38,7 @@ class AnswerRelevancyMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        penalize_ambiguous_claims: bool = False,
         evaluation_template: Type[
             AnswerRelevancyTemplate
         ] = AnswerRelevancyTemplate,
@@ -49,6 +50,7 @@ class AnswerRelevancyMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.penalize_ambiguous_claims = penalize_ambiguous_claims
         self.evaluation_template = evaluation_template
 
     def measure(
@@ -164,6 +166,11 @@ class AnswerRelevancyMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() == "no":
                 irrelevant_statements.append(verdict.reason)
+            if (
+                verdict.verdict.strip().lower() == "idk"
+                and self.penalize_ambiguous_claims
+            ):
+                irrelevant_statements.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self.evaluation_template.generate_reason(
             irrelevant_statements=irrelevant_statements,
@@ -188,6 +195,11 @@ class AnswerRelevancyMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() == "no":
                 irrelevant_statements.append(verdict.reason)
+            if (
+                verdict.verdict.strip().lower() == "idk"
+                and self.penalize_ambiguous_claims
+            ):
+                irrelevant_statements.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self.evaluation_template.generate_reason(
             irrelevant_statements=irrelevant_statements,
@@ -291,6 +303,12 @@ class AnswerRelevancyMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() != "no":
                 relevant_count += 1
+
+            if (
+                self.penalize_ambiguous_claims
+                and verdict.verdict.strip().lower() == "idk"
+            ):
+                relevant_count -= 1
 
         score = relevant_count / number_of_verdicts
         return 0 if self.strict_mode and score < self.threshold else score


### PR DESCRIPTION
## Summary

Replaces #2573 (per @penguine-ip's request to open a fresh PR with just the Answer Relevancy changes).

Adds `penalize_ambiguous_claims` to `AnswerRelevancyMetric`, mirroring the existing flag on `FaithfulnessMetric`. When `True`, statements with an `idk` verdict are no longer counted as relevant, and their reasons are surfaced to the LLM rationale prompt as `(Ambiguous) <reason>`. Defaults to `False` to preserve backward compatibility.

Closes #2300.

## Changes

Single file: `deepeval/metrics/answer_relevancy/answer_relevancy.py` (+18, -0).

- Constructor: `penalize_ambiguous_claims: bool = False`
- `_calculate_score`: decrement `relevant_count` for `idk` verdicts when the flag is on (matches `FaithfulnessMetric._calculate_score`)
- `_generate_reason` / `_a_generate_reason`: append `(Ambiguous) <reason>` to `irrelevant_statements` for `idk` verdicts when the flag is on (matches `FaithfulnessMetric._generate_reason` / `_a_generate_reason`)

## Reference: existing FaithfulnessMetric pattern

```python
# deepeval/metrics/faithfulness/faithfulness.py
penalize_ambiguous_claims: bool = False,           # constructor
self.penalize_ambiguous_claims = ...               # assignment
# in _calculate_score:
if self.penalize_ambiguous_claims and verdict.verdict.strip().lower() == "idk":
    faithfulness_count -= 1
# in _generate_reason / _a_generate_reason:
if verdict.verdict.strip().lower() == "idk" and self.penalize_ambiguous_claims:
    contradictions.append(f"(Ambiguous) {verdict.reason}")
```

## Usage

```python
from deepeval.metrics import AnswerRelevancyMetric

# Default - idk verdicts count as relevant (unchanged behavior)
metric = AnswerRelevancyMetric()

# Strict - idk verdicts subtract from the score AND appear in the rationale
metric = AnswerRelevancyMetric(penalize_ambiguous_claims=True)
```

## Test plan

- [x] `_calculate_score`: `flag=False` keeps legacy behavior (yes/idk count as relevant); `flag=True` zeroes out idk contributions
- [x] `_calculate_score`: no-`idk` verdict lists are unaffected by the flag (invariant)
- [x] `_calculate_score`: interacts correctly with `strict_mode` (still returns 0 below threshold)
- [x] `_generate_reason` / `_a_generate_reason`: `flag=True` propagates `(Ambiguous) <reason>` to the LLM prompt; `flag=False` does not
- [x] `include_reason=False` still short-circuits to `None`
- [x] black `--check` and ruff `check` pass on the modified file
