### PR TITLE
feat: add ProcessIntegrityMetric for agent trajectory logical consistency

### DIFF
--- a/deepeval/metrics/__init__.py
+++ b/deepeval/metrics/__init__.py
@@ -31,6 +31,7 @@ from .task_completion.task_completion import TaskCompletionMetric
 from .topic_adherence.topic_adherence import TopicAdherenceMetric
 from .step_efficiency.step_efficiency import StepEfficiencyMetric
 from .plan_adherence.plan_adherence import PlanAdherenceMetric
+from .process_integrity import ProcessIntegrityMetric
 from .plan_quality.plan_quality import PlanQualityMetric
 from .tool_use.tool_use import ToolUseMetric
 from .goal_accuracy.goal_accuracy import GoalAccuracyMetric

--- a/deepeval/metrics/process_integrity/__init__.py
+++ b/deepeval/metrics/process_integrity/__init__.py
@@ -1,0 +1,3 @@
+from .process_integrity import ProcessIntegrityMetric
+
+__all__ = ["ProcessIntegrityMetric"]

--- a/deepeval/metrics/process_integrity/process_integrity.py
+++ b/deepeval/metrics/process_integrity/process_integrity.py
@@ -5,7 +5,10 @@ from typing import List, Optional, Union, Dict
 from deepeval.metrics import BaseMetric
 from deepeval.test_case import LLMTestCase
 from deepeval.models import DeepEvalBaseLLM
-from deepeval.metrics.process_integrity.schema import StepVerdict, ProcessIntegrityResult
+from deepeval.metrics.process_integrity.schema import (
+    StepVerdict,
+    ProcessIntegrityResult,
+)
 from deepeval.metrics.process_integrity.template import ProcessIntegrityTemplate
 
 
@@ -50,7 +53,9 @@ class ProcessIntegrityMetric(BaseMetric):
         self.success = self.score >= self.threshold
         return self.score
 
-    async def a_measure(self, test_case: LLMTestCase, _show_indicator: bool = True) -> float:
+    async def a_measure(
+        self, test_case: LLMTestCase, _show_indicator: bool = True
+    ) -> float:
         steps = self._get_steps(test_case)
         conclusions = await self._a_extract_conclusions(steps)
         verdicts = await self._a_check_integrity(steps, conclusions)
@@ -75,11 +80,13 @@ class ProcessIntegrityMetric(BaseMetric):
             prompt = ProcessIntegrityTemplate.extract_conclusion(step)
             raw = self._call_model(prompt)
             parsed = self._parse_json(raw)
-            results.append({
-                "step_index": i,
-                "conclusion": parsed.get("conclusion", ""),
-                "is_substantive": parsed.get("is_substantive", True),
-            })
+            results.append(
+                {
+                    "step_index": i,
+                    "conclusion": parsed.get("conclusion", ""),
+                    "is_substantive": parsed.get("is_substantive", True),
+                }
+            )
         return results
 
     async def _a_extract_conclusions(self, steps: List[str]) -> List[dict]:
@@ -91,11 +98,13 @@ class ProcessIntegrityMetric(BaseMetric):
         results = []
         for i, raw in enumerate(raw_results):
             parsed = self._parse_json(raw)
-            results.append({
-                "step_index": i,
-                "conclusion": parsed.get("conclusion", ""),
-                "is_substantive": parsed.get("is_substantive", True),
-            })
+            results.append(
+                {
+                    "step_index": i,
+                    "conclusion": parsed.get("conclusion", ""),
+                    "is_substantive": parsed.get("is_substantive", True),
+                }
+            )
         return results
 
     # ── Pass 2: check integrity ──────────────────────────────────────────────
@@ -108,25 +117,31 @@ class ProcessIntegrityMetric(BaseMetric):
 
         for i, (step, conclusion_data) in enumerate(zip(steps, conclusions)):
             if not conclusion_data["is_substantive"]:
-                verdicts.append(StepVerdict(
-                    step_index=i,
-                    verdict="SKIP",
-                    reason="Non-substantive step (tool call or mechanical action).",
-                    conclusion="",
-                ))
+                verdicts.append(
+                    StepVerdict(
+                        step_index=i,
+                        verdict="SKIP",
+                        reason="Non-substantive step (tool call or mechanical action).",
+                        conclusion="",
+                    )
+                )
                 continue
 
             if i == 0 or not prior_substantive:
-                verdicts.append(StepVerdict(
-                    step_index=i,
-                    verdict="PASS",
-                    reason="First substantive step — no prior conclusions to check against.",
-                    conclusion=conclusion_data["conclusion"],
-                ))
-                prior_substantive.append({
-                    "step_index": i,
-                    "conclusion": conclusion_data["conclusion"],
-                })
+                verdicts.append(
+                    StepVerdict(
+                        step_index=i,
+                        verdict="PASS",
+                        reason="First substantive step — no prior conclusions to check against.",
+                        conclusion=conclusion_data["conclusion"],
+                    )
+                )
+                prior_substantive.append(
+                    {
+                        "step_index": i,
+                        "conclusion": conclusion_data["conclusion"],
+                    }
+                )
                 continue
 
             prompt = ProcessIntegrityTemplate.check_integrity(
@@ -137,16 +152,20 @@ class ProcessIntegrityMetric(BaseMetric):
             raw = self._call_model(prompt)
             parsed = self._parse_json(raw)
             verdict_str = parsed.get("verdict", "PASS")
-            verdicts.append(StepVerdict(
-                step_index=i,
-                verdict=verdict_str,
-                reason=parsed.get("reason", ""),
-                conclusion=conclusion_data["conclusion"],
-            ))
-            prior_substantive.append({
-                "step_index": i,
-                "conclusion": conclusion_data["conclusion"],
-            })
+            verdicts.append(
+                StepVerdict(
+                    step_index=i,
+                    verdict=verdict_str,
+                    reason=parsed.get("reason", ""),
+                    conclusion=conclusion_data["conclusion"],
+                )
+            )
+            prior_substantive.append(
+                {
+                    "step_index": i,
+                    "conclusion": conclusion_data["conclusion"],
+                }
+            )
 
         return verdicts
 
@@ -190,9 +209,13 @@ class ProcessIntegrityMetric(BaseMetric):
 
     def _call_model(self, prompt: str) -> str:
         if self.model is None:
-            raise ValueError("No model provided. Pass a model= argument to ProcessIntegrityMetric.")
+            raise ValueError(
+                "No model provided. Pass a model= argument to ProcessIntegrityMetric."
+            )
         if isinstance(self.model, str):
-            raise ValueError("String model names are not supported directly. Pass a DeepEvalBaseLLM instance.")
+            raise ValueError(
+                "String model names are not supported directly. Pass a DeepEvalBaseLLM instance."
+            )
         response, _ = self.model.generate(prompt)
         return response
 
@@ -200,14 +223,22 @@ class ProcessIntegrityMetric(BaseMetric):
         if self.model is None:
             raise ValueError("No model provided.")
         if isinstance(self.model, str):
-            raise ValueError("String model names are not supported directly. Pass a DeepEvalBaseLLM instance.")
+            raise ValueError(
+                "String model names are not supported directly. Pass a DeepEvalBaseLLM instance."
+            )
         response, _ = await self.model.a_generate(prompt)
         return response
 
     @staticmethod
     def _parse_json(raw: str) -> dict:
         try:
-            clean = raw.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+            clean = (
+                raw.strip()
+                .removeprefix("```json")
+                .removeprefix("```")
+                .removesuffix("```")
+                .strip()
+            )
             return json.loads(clean)
         except json.JSONDecodeError:
             return {}

--- a/deepeval/metrics/process_integrity/process_integrity.py
+++ b/deepeval/metrics/process_integrity/process_integrity.py
@@ -1,0 +1,219 @@
+import json
+import asyncio
+from typing import List, Optional, Union, Dict
+
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics.process_integrity.schema import StepVerdict, ProcessIntegrityResult
+from deepeval.metrics.process_integrity.template import ProcessIntegrityTemplate
+
+
+class ProcessIntegrityMetric(BaseMetric):
+    """
+    Evaluates whether an agent's reasoning steps are logically consistent
+    across a trajectory. Detects contradictions, skipped intermediate logic,
+    and irrelevant conclusions inserted mid-trajectory.
+
+    Two-pass LLM pipeline:
+    Pass 1 — extract the logical conclusion from each step (non-substantive
+              steps like raw tool calls receive verdict SKIP).
+    Pass 2 — for each substantive step, check whether its conclusion is
+              consistent with all prior conclusions.
+
+    Score = PASS / (PASS + FAIL). SKIP steps excluded from denominator.
+    self.score_breakdown is populated with per-step verdicts.
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        model: Optional[Union[str, DeepEvalBaseLLM]] = None,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        verbose_mode: bool = False,
+    ):
+        self.threshold = threshold
+        self.model = model
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+        self.verbose_mode = verbose_mode
+        self.score_breakdown: Dict = {}
+
+    def measure(self, test_case: LLMTestCase) -> float:
+        steps = self._get_steps(test_case)
+        conclusions = self._extract_conclusions(steps)
+        verdicts = self._check_integrity(steps, conclusions)
+        self.score = self._compute_score(verdicts)
+        self.score_breakdown = self._build_score_breakdown(verdicts)
+        self.reason = self._build_reason(verdicts)
+        self.success = self.score >= self.threshold
+        return self.score
+
+    async def a_measure(self, test_case: LLMTestCase, _show_indicator: bool = True) -> float:
+        steps = self._get_steps(test_case)
+        conclusions = await self._a_extract_conclusions(steps)
+        verdicts = await self._a_check_integrity(steps, conclusions)
+        self.score = self._compute_score(verdicts)
+        self.score_breakdown = self._build_score_breakdown(verdicts)
+        self.reason = self._build_reason(verdicts)
+        self.success = self.score >= self.threshold
+        return self.score
+
+    def _get_steps(self, test_case: LLMTestCase) -> List[str]:
+        if not hasattr(test_case, "steps") or not test_case.steps:
+            raise ValueError(
+                "ProcessIntegrityMetric requires test_case.steps to be a non-empty list of strings."
+            )
+        return test_case.steps
+
+    # ── Pass 1: extract conclusions ──────────────────────────────────────────
+
+    def _extract_conclusions(self, steps: List[str]) -> List[dict]:
+        results = []
+        for i, step in enumerate(steps):
+            prompt = ProcessIntegrityTemplate.extract_conclusion(step)
+            raw = self._call_model(prompt)
+            parsed = self._parse_json(raw)
+            results.append({
+                "step_index": i,
+                "conclusion": parsed.get("conclusion", ""),
+                "is_substantive": parsed.get("is_substantive", True),
+            })
+        return results
+
+    async def _a_extract_conclusions(self, steps: List[str]) -> List[dict]:
+        tasks = []
+        for i, step in enumerate(steps):
+            prompt = ProcessIntegrityTemplate.extract_conclusion(step)
+            tasks.append(self._a_call_model(prompt, step_index=i))
+        raw_results = await asyncio.gather(*tasks)
+        results = []
+        for i, raw in enumerate(raw_results):
+            parsed = self._parse_json(raw)
+            results.append({
+                "step_index": i,
+                "conclusion": parsed.get("conclusion", ""),
+                "is_substantive": parsed.get("is_substantive", True),
+            })
+        return results
+
+    # ── Pass 2: check integrity ──────────────────────────────────────────────
+
+    def _check_integrity(
+        self, steps: List[str], conclusions: List[dict]
+    ) -> List[StepVerdict]:
+        verdicts = []
+        prior_substantive: List[dict] = []
+
+        for i, (step, conclusion_data) in enumerate(zip(steps, conclusions)):
+            if not conclusion_data["is_substantive"]:
+                verdicts.append(StepVerdict(
+                    step_index=i,
+                    verdict="SKIP",
+                    reason="Non-substantive step (tool call or mechanical action).",
+                    conclusion="",
+                ))
+                continue
+
+            if i == 0 or not prior_substantive:
+                verdicts.append(StepVerdict(
+                    step_index=i,
+                    verdict="PASS",
+                    reason="First substantive step — no prior conclusions to check against.",
+                    conclusion=conclusion_data["conclusion"],
+                ))
+                prior_substantive.append({
+                    "step_index": i,
+                    "conclusion": conclusion_data["conclusion"],
+                })
+                continue
+
+            prompt = ProcessIntegrityTemplate.check_integrity(
+                step=step,
+                conclusion=conclusion_data["conclusion"],
+                prior_conclusions=prior_substantive,
+            )
+            raw = self._call_model(prompt)
+            parsed = self._parse_json(raw)
+            verdict_str = parsed.get("verdict", "PASS")
+            verdicts.append(StepVerdict(
+                step_index=i,
+                verdict=verdict_str,
+                reason=parsed.get("reason", ""),
+                conclusion=conclusion_data["conclusion"],
+            ))
+            prior_substantive.append({
+                "step_index": i,
+                "conclusion": conclusion_data["conclusion"],
+            })
+
+        return verdicts
+
+    async def _a_check_integrity(
+        self, steps: List[str], conclusions: List[dict]
+    ) -> List[StepVerdict]:
+        # Sequential for integrity — each step depends on prior verdicts
+        return self._check_integrity(steps, conclusions)
+
+    # ── Scoring ──────────────────────────────────────────────────────────────
+
+    def _compute_score(self, verdicts: List[StepVerdict]) -> float:
+        pass_count = sum(1 for v in verdicts if v.verdict == "PASS")
+        fail_count = sum(1 for v in verdicts if v.verdict == "FAIL")
+        denominator = pass_count + fail_count
+        if denominator == 0:
+            self.reason = "No substantive steps found — all steps were SKIP."
+            return 0.0
+        return pass_count / denominator
+
+    def _build_score_breakdown(self, verdicts: List[StepVerdict]) -> Dict:
+        return {
+            f"step_{v.step_index}": {
+                "verdict": v.verdict,
+                "reason": v.reason,
+                "conclusion": v.conclusion,
+            }
+            for v in verdicts
+        }
+
+    def _build_reason(self, verdicts: List[StepVerdict]) -> str:
+        fail_verdicts = [v for v in verdicts if v.verdict == "FAIL"]
+        if not fail_verdicts:
+            return "All substantive steps are logically consistent."
+        reasons = "; ".join(
+            f"Step {v.step_index}: {v.reason}" for v in fail_verdicts
+        )
+        return f"{len(fail_verdicts)} integrity failure(s) detected — {reasons}"
+
+    # ── Model call helpers ───────────────────────────────────────────────────
+
+    def _call_model(self, prompt: str) -> str:
+        if self.model is None:
+            raise ValueError("No model provided. Pass a model= argument to ProcessIntegrityMetric.")
+        if isinstance(self.model, str):
+            raise ValueError("String model names are not supported directly. Pass a DeepEvalBaseLLM instance.")
+        response, _ = self.model.generate(prompt)
+        return response
+
+    async def _a_call_model(self, prompt: str, **kwargs) -> str:
+        if self.model is None:
+            raise ValueError("No model provided.")
+        if isinstance(self.model, str):
+            raise ValueError("String model names are not supported directly. Pass a DeepEvalBaseLLM instance.")
+        response, _ = await self.model.a_generate(prompt)
+        return response
+
+    @staticmethod
+    def _parse_json(raw: str) -> dict:
+        try:
+            clean = raw.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+            return json.loads(clean)
+        except json.JSONDecodeError:
+            return {}
+
+    # ── Required BaseMetric properties ───────────────────────────────────────
+
+    @property
+    def __name__(self):
+        return "Process Integrity"

--- a/deepeval/metrics/process_integrity/schema.py
+++ b/deepeval/metrics/process_integrity/schema.py
@@ -1,0 +1,15 @@
+from typing import List, Literal
+from pydantic import BaseModel
+
+
+class StepVerdict(BaseModel):
+    step_index: int
+    verdict: Literal["PASS", "FAIL", "SKIP"]
+    reason: str
+    conclusion: str
+
+
+class ProcessIntegrityResult(BaseModel):
+    verdicts: List[StepVerdict]
+    score: float
+    reason: str

--- a/deepeval/metrics/process_integrity/template.py
+++ b/deepeval/metrics/process_integrity/template.py
@@ -1,0 +1,68 @@
+from typing import List
+
+
+class ProcessIntegrityTemplate:
+
+    @staticmethod
+    def extract_conclusion(step: str) -> str:
+        return f"""You are evaluating a single step from an AI agent's reasoning trajectory.
+
+Your task: extract the logical conclusion this step reaches, and determine whether it is substantive reasoning or a non-substantive action (e.g., a raw tool call, API invocation, or mechanical action with no reasoning).
+
+Step:
+{step}
+
+Respond ONLY with a JSON object. No explanation, no markdown, no preamble.
+
+{{
+  "conclusion": "<the logical conclusion this step reaches, or empty string if none>",
+  "is_substantive": <true if this step contains reasoning or a conclusion, false if it is purely a tool call or mechanical action>
+}}"""
+
+    @staticmethod
+    def check_integrity(
+        step: str,
+        conclusion: str,
+        prior_conclusions: List[dict],
+    ) -> str:
+        prior_block = (
+            "\n".join(
+                f"Step {p['step_index']}: {p['conclusion']}"
+                for p in prior_conclusions
+            )
+            if prior_conclusions
+            else "None — this is the first substantive step."
+        )
+
+        return f"""You are evaluating logical consistency in an AI agent's reasoning trajectory.
+
+Current step:
+{step}
+
+Conclusion reached in this step:
+{conclusion}
+
+Prior conclusions from earlier steps:
+{prior_block}
+
+Rules:
+- If there are no prior conclusions, always return PASS.
+- Return FAIL if this step's conclusion directly contradicts a prior conclusion without acknowledging the change.
+- Return FAIL if this step skips required intermediate logic that should have appeared between the prior conclusion and this one.
+- Return FAIL if this step inserts a conclusion that is irrelevant to the trajectory's reasoning chain.
+- Return PASS otherwise.
+
+Respond ONLY with a JSON object. No explanation, no markdown, no preamble.
+
+If PASS:
+{{
+  "verdict": "PASS",
+  "reason": "<brief explanation>"
+}}
+
+If FAIL:
+{{
+  "verdict": "FAIL",
+  "reason": "<specific explanation of the contradiction, skip, or irrelevance>",
+  "severity": "<low | medium | high>"
+}}"""

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -401,6 +401,7 @@ class LLMTestCase(BaseModel):
             "customColumnKeyValues", "custom_column_key_values"
         ),
     )
+    steps: Optional[List[str]] = Field(default=None)
     _trace_dict: Optional[Dict] = PrivateAttr(default=None)
     _dataset_rank: Optional[int] = PrivateAttr(default=None)
     _dataset_alias: Optional[str] = PrivateAttr(default=None)

--- a/tests/test_process_integrity.py
+++ b/tests/test_process_integrity.py
@@ -24,6 +24,7 @@ def make_metric_with_mock_model(responses: list):
 
 # ── Test 1: clean trajectory — expect score > 0.5 ───────────────────────────
 
+
 def test_clean_trajectory():
     steps = [
         "Searched for flights. Conclusion: cheapest option is United at $320.",
@@ -57,6 +58,7 @@ def test_clean_trajectory():
 
 # ── Test 2: contradicting trajectory — expect score < 0.5 ───────────────────
 
+
 def test_contradicting_trajectory():
     steps = [
         "Analyzed data. Conclusion: Model A outperforms Model B.",
@@ -83,6 +85,7 @@ def test_contradicting_trajectory():
 
 
 # ── Test 3: all tool calls — expect all SKIP, score = 0.0 ───────────────────
+
 
 def test_all_tool_calls():
     steps = [

--- a/tests/test_process_integrity.py
+++ b/tests/test_process_integrity.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from deepeval.metrics.process_integrity import ProcessIntegrityMetric
+from deepeval.test_case import LLMTestCase
+
+
+def make_test_case(steps):
+    tc = LLMTestCase(input="test", actual_output="test")
+    tc.steps = steps
+    return tc
+
+
+def make_metric_with_mock_model(responses: list):
+    """
+    Returns a ProcessIntegrityMetric with a mock model that returns
+    responses in order, one per _call_model invocation.
+    """
+    metric = ProcessIntegrityMetric(threshold=0.5)
+    mock_model = MagicMock()
+    mock_model.generate.side_effect = [(r, None) for r in responses]
+    metric.model = mock_model
+    return metric
+
+
+# ── Test 1: clean trajectory — expect score > 0.5 ───────────────────────────
+
+def test_clean_trajectory():
+    steps = [
+        "Searched for flights. Conclusion: cheapest option is United at $320.",
+        "Checked baggage fees for United. Conclusion: total cost is $370.",
+        "Compared with Delta at $350 all-in. Conclusion: Delta is cheaper overall.",
+        "Recommended Delta to user.",
+    ]
+    # Pass 1 responses (extract_conclusion x4)
+    p1 = [
+        '{"conclusion": "Cheapest option is United at $320.", "is_substantive": true}',
+        '{"conclusion": "Total cost with United is $370.", "is_substantive": true}',
+        '{"conclusion": "Delta is cheaper overall at $350 all-in.", "is_substantive": true}',
+        '{"conclusion": "Delta recommended to user.", "is_substantive": true}',
+    ]
+    # Pass 2 responses (check_integrity x3 — step 0 auto-PASS, steps 1, 2, and 3 checked)
+    p2 = [
+        '{"verdict": "PASS", "reason": "Total cost finding is consistent with cheapest flight baseline."}',
+        '{"verdict": "PASS", "reason": "Consistent with prior cost analysis."}',
+        '{"verdict": "PASS", "reason": "Recommendation follows from cheapest option conclusion."}',
+    ]
+    metric = make_metric_with_mock_model(p1 + p2)
+    tc = make_test_case(steps)
+    score = metric.measure(tc)
+    assert score > 0.5
+    assert metric.success is True
+    assert all(
+        k in metric.score_breakdown
+        for k in ["step_0", "step_1", "step_2", "step_3"]
+    )
+
+
+# ── Test 2: contradicting trajectory — expect score < 0.5 ───────────────────
+
+def test_contradicting_trajectory():
+    steps = [
+        "Analyzed data. Conclusion: Model A outperforms Model B.",
+        "Ran second analysis. Conclusion: Model B outperforms Model A.",
+        "Selected Model A as final recommendation.",
+    ]
+    p1 = [
+        '{"conclusion": "Model A outperforms Model B.", "is_substantive": true}',
+        '{"conclusion": "Model B outperforms Model A.", "is_substantive": true}',
+        '{"conclusion": "Model A selected as final recommendation.", "is_substantive": true}',
+    ]
+    # Step 0 auto-PASS; steps 1 and 2 checked
+    p2 = [
+        '{"verdict": "FAIL", "reason": "Directly contradicts step 0 conclusion that Model A outperforms Model B.", "severity": "high"}',
+        '{"verdict": "FAIL", "reason": "Recommendation contradicts step 1 conclusion without reconciliation.", "severity": "high"}',
+    ]
+    metric = make_metric_with_mock_model(p1 + p2)
+    tc = make_test_case(steps)
+    score = metric.measure(tc)
+    assert score < 0.5
+    assert metric.success is False
+    assert metric.score_breakdown["step_1"]["verdict"] == "FAIL"
+    assert metric.score_breakdown["step_2"]["verdict"] == "FAIL"
+
+
+# ── Test 3: all tool calls — expect all SKIP, score = 0.0 ───────────────────
+
+def test_all_tool_calls():
+    steps = [
+        "Called search_api(query='flights')",
+        "Called get_price(flight_id=123)",
+        "Called book_flight(flight_id=123)",
+    ]
+    p1 = [
+        '{"conclusion": "", "is_substantive": false}',
+        '{"conclusion": "", "is_substantive": false}',
+        '{"conclusion": "", "is_substantive": false}',
+    ]
+    # No Pass 2 calls — all steps SKIP
+    metric = make_metric_with_mock_model(p1)
+    tc = make_test_case(steps)
+    score = metric.measure(tc)
+    assert score == 0.0
+    assert all(
+        metric.score_breakdown[f"step_{i}"]["verdict"] == "SKIP"
+        for i in range(3)
+    )


### PR DESCRIPTION
## What gap this fills
DeepEval has strong coverage of agent outcome quality (TaskCompletion,
GoalAccuracy), planning adherence (PlanAdherence), and step cost
(StepEfficiency), but no metric evaluates whether an agent's reasoning
steps are logically consistent across a trajectory. An agent can complete
a task, follow a declared plan, and use minimal steps — while silently
contradicting its own prior conclusions mid-trajectory. This PR adds
ProcessIntegrityMetric to detect exactly that.

## How it works
Two-pass LLM pipeline per trajectory:
Pass 1 — extract the logical conclusion from each step (non-substantive
steps like raw tool calls receive verdict SKIP).
Pass 2 — for each substantive step, check whether its conclusion is
consistent with all prior conclusions. Produces List[StepVerdict] with
per-step verdict (PASS/FAIL/SKIP) and reason.
Score = PASS / (PASS + FAIL), SKIP steps excluded from denominator.
self.score_breakdown is populated with per-step verdicts — the first
metric in DeepEval to use this BaseMetric field.

## What's in this PR
- deepeval/metrics/process_integrity/ (4 files)
- deepeval/test_case/llm_test_case.py — added steps field (required by metric)
- tests/test_process_integrity.py (3 test cases)
- Export added to deepeval/metrics/__init__.py
Deferred to follow-up: async batch evaluation, multimodal step support,
upload() integration with Confident AI platform.