### PR TITLE
docs: fix broken examples in custom LLMs guide (refs #1420)

### DIFF
--- a/docs/content/guides/guides-using-custom-llms.mdx
+++ b/docs/content/guides/guides-using-custom-llms.mdx
@@ -69,7 +69,7 @@ class CustomLlama3_8B(DeepEvalBaseLLM):
             pad_token_id=self.tokenizer.eos_token_id,
         )
 
-        return pipeline(prompt)
+        return pipeline(prompt)[0]["generated_text"]
 
     async def a_generate(self, prompt: str) -> str:
         return self.generate(prompt)
@@ -548,6 +548,7 @@ Here's a full example of a JSON confined custom Mistral 7B model implemented thr
 
 ```python
 import json
+import transformers
 
 from pydantic import BaseModel
 import torch
@@ -588,7 +589,7 @@ class CustomMistral7B(DeepEvalBaseLLM):
 
     def generate(self, prompt: str, schema: BaseModel) -> BaseModel:
         model = self.load_model()
-        pipeline = pipeline(
+        pipeline = transformers.pipeline(
             "text-generation",
             model=model,
             tokenizer=self.tokenizer,

--- a/docs/content/guides/guides-using-custom-llms.mdx
+++ b/docs/content/guides/guides-using-custom-llms.mdx
@@ -83,12 +83,12 @@ There are **SIX** rules to follow when creating a custom LLM evaluation model:
 1. Inherit `DeepEvalBaseLLM`.
 2. Implement the `get_model_name()` method, which simply returns a string representing your custom model name.
 3. Implement the `load_model()` method, which will be responsible for returning a model object.
-4. Implement the `generate()` method with **one and only one** parameter of type string that acts as the prompt to your custom LLM.
-5. The `generate()` method should return the generated string output from your custom LLM. Note that we called `pipeline(prompt)` to access the model generations in this particular example, but this could be different depending on the implementation of your custom model object.
-6. Implement the `a_generate()` method, with the same function signature as `generate()`. **Note that this is an async method**. In this example, we called `self.generate(prompt)`, which simply reuses the synchronous `generate()` method. However, although optional, you should implement an asynchronous version (if possible) to speed up evaluation.
+4. Implement the `generate()` method whose first parameter is the prompt string. For full compatibility with all of `deepeval`'s metrics, accept an additional `schema: BaseModel | None = None` parameter — when `schema` is supplied, the method must return an instance of that Pydantic schema (see [JSON Confinement for Custom LLMs](#json-confinement-for-custom-llms) below).
+5. When called without a `schema`, `generate()` should return the model's raw output as a string. Note that we called `pipeline(prompt)[0]["generated_text"]` to access the model generation in this particular example, but this could be different depending on the implementation of your custom model object.
+6. Implement the `a_generate()` method, with the same signature as `generate()`. **Note that this is an async method**. In this example, we called `self.generate(prompt)`, which simply reuses the synchronous `generate()` method. However, although optional, you should implement an asynchronous version (if possible) to speed up evaluation.
 
 :::caution
-In later sections, you'll find an exception to rules 4. and 5., as the `generate()` and `a_generate()` method can actually be rewritten to optimize custom LLM outputs that are essential for evaluation.
+If you skip the `schema` parameter, metrics that require structured output (e.g. `SummarizationMetric`, `FaithfulnessMetric`) will fail with a confusing `AttributeError` because they cannot extract the fields they need from a raw string. Add schema-aware output as shown in [JSON Confinement for Custom LLMs](#json-confinement-for-custom-llms) below to avoid this.
 :::
 
 Then, instantiate the `CustomLlama3_8B` class and test the `generate()` (or `a_generate()`) method out:
@@ -160,9 +160,9 @@ When creating a custom LLM evaluation model you should **ALWAYS**:
 - inherit `DeepEvalBaseLLM`.
 - implement the `get_model_name()` method, which simply returns a string representing your custom model name.
 - implement the `load_model()` method, which will be responsible for returning a model object.
-- implement the `generate()` method with **one and only one** parameter of type string that acts as the prompt to your custom LLM.
-- the `generate()` method should return the final output string of your custom LLM. Note that we called `chat_model.invoke(prompt).content` to access the model generations in this particular example, but this could be different depending on the implementation of your custom model object.
-- implement the `a_generate()` method, with the same function signature as `generate()`. **Note that this is an async method**. In this example, we called `await chat_model.ainvoke(prompt)`, which is an asynchronous wrapper provided by LangChain's chat models.
+- implement the `generate()` method whose first parameter is the prompt string. For full compatibility with all of `deepeval`'s metrics, accept an additional `schema: BaseModel | None = None` parameter and, when `schema` is supplied, return an instance of that Pydantic schema (see [JSON Confinement for Custom LLMs](#json-confinement-for-custom-llms) below).
+- without a `schema`, return the final output string of your custom LLM. Note that we called `chat_model.invoke(prompt).content` to access the model generations in this particular example, but this could be different depending on the implementation of your custom model object.
+- implement the `a_generate()` method, with the same signature as `generate()`. **Note that this is an async method**. In this example, we called `await chat_model.ainvoke(prompt)`, which is an asynchronous wrapper provided by LangChain's chat models.
 
 :::tip
 The `a_generate()` method is what `deepeval` uses to generate LLM outputs when you execute metrics / run evaluations asynchronously.
@@ -186,6 +186,10 @@ While the Azure OpenAI command configures `deepeval` to use Azure OpenAI globall
 ### Mistral 7B Example
 
 Here is an example of creating a custom [Mistral 7B model](https://huggingface.co/docs/transformers/model_doc/mistral) through Hugging Face's `transformers` library for evaluation:
+
+:::caution
+This minimal `Mistral7B` implementation returns a raw string and does not accept a `schema` parameter, so it will fail with metrics that require structured output (e.g. `SummarizationMetric`, `FaithfulnessMetric`) — see the schema contract in the [rules above](#creating-a-custom-llm) and the schema-aware `CustomMistral7B` example in [JSON Confinement for Custom LLMs](#json-confinement-for-custom-llms) below before using it with these metrics.
+:::
 
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer


### PR DESCRIPTION
## Summary

`docs/content/guides/guides-using-custom-llms.mdx` is the canonical guide users land on when adopting deepeval with non-OpenAI providers. Today it contains a code example that crashes for the user, plus a "rules" block that doesn't match the real `DeepEvalBaseLLM` contract.

Issue #1420 reports the exact failure mode — copying the basic Mistral 7B example from this guide and getting `'str' object has no attribute 'truths'` from `SummarizationMetric`. Maintainer @penguine-ip acknowledged the report on 2025-03-07 but the doc still ships the broken example. This PR fixes it.

## Changes (2 commits)

1. **Fix two broken Python snippets** (`5c0f8e6a9`)
   - `CustomLlama3_8B.generate()` is annotated `-> str` but returns `pipeline(prompt)` (a `list[dict]`). Now returns `pipeline(prompt)[0]["generated_text"]`.
   - The JSON-confined `CustomMistral7B.generate()` has `pipeline = pipeline(...)` — `pipeline` is never imported and Python promotes it to a local, so this line raises `UnboundLocalError` before any model call. Now imports `transformers` and calls `transformers.pipeline(...)`, matching the working `CustomLlama3_8B` variant above.

2. **Align rules with the real contract** (`e7fc09d0e`)
   - Both rules blocks ("SIX rules" and "ALWAYS") said `generate()` must take "one and only one parameter of type string." The real contract — used by every built-in provider in `deepeval/models/llms/` — is `generate(prompt: str, schema: Optional[BaseModel] = None)`. Most metrics pass `schema=...`, and the `generate_with_schema()` `TypeError` fallback at `deepeval/models/base_model.py:125` doesn't help structured-output metrics, which is why #1420 surfaces as `AttributeError`.
   - The misleading "exception to rules 4. and 5." note is replaced with an actionable caution that names the failure mode and the specific metrics it affects.
   - Adds a caution above the basic Mistral 7B example (the verbatim code from #1420) routing users to the schema-aware variant.

## What I deliberately did not change

- No code changes to `deepeval/models/base_model.py` — formalizing the signature is a contract change and warrants its own discussion.
- Did not rewrite the Azure / Vertex / Bedrock examples to add `schema`. They use LangChain wrappers whose `.invoke(...)` returns strings — they hit the same `AttributeError` failure mode on structured metrics, but the new caution block in the rules section covers the general case. Touching every example would balloon the diff; happy to do it as a follow-up if maintainers want.

## Verification

- All 19 Python code blocks in the modified file `ast.parse` cleanly (excluding one pre-existing block of templated `<placeholders>` in the Bedrock example, which is unrelated).
- Total diff: +14 / −9 lines, one file.

## Test plan

- [ ] Build the Docusaurus site locally and confirm the two cautions and the cross-section anchor links render.
- [ ] Re-test the failing case from #1420: instantiate the basic `Mistral7B` example and run it through `SummarizationMetric`. With the new caution in place, users are routed to the schema-aware path before hitting the crash.

Refs #1420