### PR TITLE
docs: correctly attribute telemetry to PostHog, not Sentry

### DIFF
--- a/docs/content/docs/data-privacy.mdx
+++ b/docs/content/docs/data-privacy.mdx
@@ -13,14 +13,22 @@ If at any point you think you might have accidentally sent us sensitive data, **
 
 ## Your Privacy Using `deepeval`
 
-By default, `deepeval` uses `Sentry` to track only very basic telemetry data (number of evaluations run and which metric is used). Personally identifiable information is explicitly excluded. We also provide the option of opting out of the telemetry data collection through an environment variable:
+By default, `deepeval` uses **PostHog** to track only very basic telemetry data. Specifically, the following is collected:
+
+- Event names (e.g. evaluation started/completed)
+- Metric names used
+- Whether the evaluation is running in a Jupyter notebook
+- A randomly generated anonymous UUID (no user or company identity)
+- Public IP address (used only for coarse regional analytics)
+
+Personally identifiable information is explicitly excluded. You can opt out of all telemetry at any time:
 
 ```bash
 export DEEPEVAL_TELEMETRY_OPT_OUT=1
 
 ```
 
-`deepeval` also only tracks errors and exceptions raised within the package **only if you have explicitly opted in**, and **does not collect any user or company data in any way**. To help us catch bugs for future releases, set the `ERROR_REPORTING` environment variable to 1.
+`deepeval` also uses **Sentry** to capture errors and exceptions raised within the package, **only if you have explicitly opted in**. No user or company data is collected through Sentry. To help us catch bugs for future releases, set the `ERROR_REPORTING` environment variable to 1:
 
 ```bash
 export ERROR_REPORTING=1


### PR DESCRIPTION
## Summary

The `data-privacy.mdx` page incorrectly stated that `deepeval` uses **Sentry** for telemetry. In reality:

- **PostHog** handles telemetry (always-on by default, opt-out via `DEEPEVAL_TELEMETRY_OPT_OUT=1`)
- **Sentry** handles error/exception capture (strictly opt-in via `ERROR_REPORTING=1`)

A contributor ([@trevor-cai](https://github.com/trevor-cai)) identified this in issue #2092 and documented exactly what PostHog collects by reading the source in `deepeval/telemetry.py`. A PR was previously filed (#2535) but closed without merging.

## Changes

- Corrected the telemetry provider from Sentry → PostHog
- Added a bullet list of exactly what PostHog collects so users can make an informed opt-out decision
- Clarified that Sentry is a separate, opt-in system (wording already implied this, now explicit)

No code changes. Documentation only.

Fixes #2092