### PR TITLE
fix(TurnContextualRecallMetric): pass expected_outcome in a_measure, not multimodal

### DIFF
--- a/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
+++ b/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
@@ -161,7 +161,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
             async def get_individual_scores(window):
                 scores.extend(
                     await self._a_get_contextual_recall_scores(
-                        window, test_case.multimodal, multimodal
+                        window, test_case.expected_outcome, multimodal
                     )
                 )
 

--- a/tests/test_metrics/test_turn_contextual_recall_metric.py
+++ b/tests/test_metrics/test_turn_contextual_recall_metric.py
@@ -1,5 +1,7 @@
+import asyncio
 import os
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 from deepeval.metrics import TurnContextualRecallMetric
 from deepeval.test_case import (
     ConversationalTestCase,
@@ -178,3 +180,62 @@ class TestTurnContextualRecallMetric:
         results = evaluate([convo_test_case], [metric])
 
         assert results is not None
+
+
+class TestTurnContextualRecallMetricUnit:
+    """Unit tests that don't require an API key."""
+
+    def test_async_expected_outcome_forwarded_not_multimodal(self):
+        """Regression: a_measure must pass expected_outcome (str) to
+        _a_get_contextual_recall_scores, not multimodal (bool).
+
+        Before the fix, test_case.multimodal (always False) was passed as
+        the expected_outcome arg, causing _a_generate_verdicts to receive an
+        empty string and score every turn as 0.
+        """
+        from deepeval.metrics.turn_contextual_recall.schema import (
+            InteractionContextualRecallScore,
+        )
+
+        convo_test_case = ConversationalTestCase(
+            turns=[
+                Turn(role="user", content="What if these shoes don't fit?"),
+                Turn(
+                    role="assistant",
+                    content="We offer a 30-day full refund at no extra cost.",
+                    retrieval_context=[
+                        "All customers are eligible for a 30 day full refund at no extra cost."
+                    ],
+                ),
+            ],
+            expected_outcome="The chatbot must explain the store policies like refunds, discounts, ..etc.",
+            chatbot_role="A helpful assistant",
+        )
+
+        captured = {}
+
+        async def spy_get_scores(window, expected_outcome, multimodal):
+            captured["expected_outcome"] = expected_outcome
+            captured["multimodal"] = multimodal
+            return [InteractionContextualRecallScore(score=1.0, reason="ok", verdicts=[])]
+
+        mock_model = MagicMock()
+        mock_model.get_model_name.return_value = "mock-model"
+
+        base = "deepeval.metrics.turn_contextual_recall.turn_contextual_recall"
+        with (
+            patch(f"{base}.initialize_model", return_value=(mock_model, True)),
+            patch(f"{base}.check_conversational_test_case_params"),
+        ):
+            metric = TurnContextualRecallMetric()
+            with (
+                patch.object(metric, "_a_get_contextual_recall_scores", side_effect=spy_get_scores),
+                patch.object(metric, "_a_generate_reason", new=AsyncMock(return_value="ok")),
+            ):
+                asyncio.run(metric.a_measure(convo_test_case, _show_indicator=False))
+
+        assert captured["expected_outcome"] == convo_test_case.expected_outcome, (
+            f"expected_outcome should be '{convo_test_case.expected_outcome}', "
+            f"got {captured['expected_outcome']!r}"
+        )
+        assert captured["multimodal"] == convo_test_case.multimodal


### PR DESCRIPTION
## Root Cause

In `a_measure`, the inner coroutine `get_individual_scores` was calling:

```python
await self._a_get_contextual_recall_scores(window, test_case.multimodal, multimodal)
```

`test_case.multimodal` is a `bool` (defaults to `False`). The second positional arg of `_a_get_contextual_recall_scores` is `expected_outcome: str`. Passing `False` means every call to `_a_generate_verdicts` receives an empty expected outcome — the LLM has nothing to evaluate against — so all verdicts come back unsupported and the score is always 0.

The sync path in `_get_contextual_recall_scores` already used `test_case.expected_outcome` correctly. This PR fixes the async path to match.

## Fix

One-line change in `a_measure`:

```python
# before
window, test_case.multimodal, multimodal

# after
window, test_case.expected_outcome, multimodal
```

## Test

Added `TestTurnContextualRecallMetricUnit.test_async_expected_outcome_forwarded_not_multimodal` — a no-API-key unit test that mocks the LLM layer, spies on what `_a_get_contextual_recall_scores` receives, and asserts it is the `expected_outcome` string, not the `multimodal` bool. Runs without `OPENAI_API_KEY`.

Closes #2679