### PR TITLE
docs(rag): remove actual_output from Required Arguments for contextual {precision,recall,relevancy}

### DIFF
--- a/docs/content/docs/(rag)/metrics-contextual-precision.mdx
+++ b/docs/content/docs/(rag)/metrics-contextual-precision.mdx
@@ -18,9 +18,10 @@ The `ContextualPrecisionMetric` focuses on evaluating the re-ranker of your RAG 
 To use the `ContextualPrecisionMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
 
 - `input`
-- `actual_output`
 - `expected_output`
 - `retrieval_context`
+
+Note that `actual_output` is not consumed by this metric: as the [How Is It Calculated](#how-is-it-calculated) section shows, the score is computed from the `input`, `expected_output`, and the ordering of `retrieval_context` chunks alone. You may still pass `actual_output` on the `LLMTestCase` (for example, to share the same test case with other metrics), but it has no effect on the contextual precision score.
 
 Read the [How Is It Calculated](#how-is-it-calculated) section below to learn how test case parameters are used for metric calculation.
 

--- a/docs/content/docs/(rag)/metrics-contextual-recall.mdx
+++ b/docs/content/docs/(rag)/metrics-contextual-recall.mdx
@@ -21,9 +21,10 @@ deepeval recommend metrics
 To use the `ContextualRecallMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
 
 - `input`
-- `actual_output`
 - `expected_output`
 - `retrieval_context`
+
+Note that `actual_output` is not consumed by this metric: the score is computed from the `expected_output` and the `retrieval_context` alone (see [How Is It Calculated](#how-is-it-calculated)). You may still pass `actual_output` on the `LLMTestCase` to share it with other metrics, but it has no effect on the contextual recall score.
 
 Read the [How Is It Calculated](#how-is-it-calculated) section below to learn how test case parameters are used for metric calculation.
 

--- a/docs/content/docs/(rag)/metrics-contextual-relevancy.mdx
+++ b/docs/content/docs/(rag)/metrics-contextual-relevancy.mdx
@@ -21,8 +21,9 @@ deepeval recommend metrics
 To use the `ContextualRelevancyMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
 
 - `input`
-- `actual_output`
 - `retrieval_context`
+
+Note that `actual_output` is not consumed by this metric: the score is computed from the `input` and the `retrieval_context` alone (see [How Is It Calculated](#how-is-it-calculated)). You may still pass `actual_output` on the `LLMTestCase` to share it with other metrics, but it has no effect on the contextual relevancy score.
 
 :::note
 Similar to `ContextualPrecisionMetric`, the `ContextualRelevancyMetric` uses `retrieval_context` from your RAG pipeline for evaluation.


### PR DESCRIPTION
## Summary

Three RAG metrics — `ContextualPrecisionMetric`, `ContextualRecallMetric`, and `ContextualRelevancyMetric` — declare `_required_params` in code without `SingleTurnParams.ACTUAL_OUTPUT`, and none of them references `actual_output` anywhere in their implementation or evaluation templates. The official docs at `docs.confident-ai.com` (sourced from `docs/content/docs/(rag)/metrics-contextual-*.mdx`) still listed `actual_output` under **Required Arguments**, which is what #1212 reported about `ContextualPrecisionMetric`.

This PR aligns the docs with the code for all three sibling metrics and adds a short note clarifying that `actual_output` may still be present on the `LLMTestCase` for sharing with other metrics but does not affect the contextual score.

Fixes #1212.

## Files changed

- `docs/content/docs/(rag)/metrics-contextual-precision.mdx`
- `docs/content/docs/(rag)/metrics-contextual-recall.mdx`
- `docs/content/docs/(rag)/metrics-contextual-relevancy.mdx`

## Evidence (current `main` at `ec8ea66`)

`ContextualPrecisionMetric` — `deepeval/metrics/contextual_precision/contextual_precision.py`:

```python
class ContextualPrecisionMetric(BaseMetric):
    _required_params: List[SingleTurnParams] = [
        SingleTurnParams.INPUT,
        SingleTurnParams.RETRIEVAL_CONTEXT,
        SingleTurnParams.EXPECTED_OUTPUT,
    ]
```

`ContextualRecallMetric` — `deepeval/metrics/contextual_recall/contextual_recall.py`:

```python
    _required_params: List[SingleTurnParams] = [
        SingleTurnParams.INPUT,
        SingleTurnParams.RETRIEVAL_CONTEXT,
        SingleTurnParams.EXPECTED_OUTPUT,
    ]
```

`ContextualRelevancyMetric` — `deepeval/metrics/contextual_relevancy/contextual_relevancy.py`:

```python
    _required_params: List[SingleTurnParams] = [
        SingleTurnParams.INPUT,
        SingleTurnParams.RETRIEVAL_CONTEXT,
    ]
```

`grep -n actual_output` in each metric's module and template returns no hits.

The enforcement path in `deepeval/metrics/utils.py::check_llm_test_case_params` only iterates `_required_params`, so any missing `actual_output` does not raise `MissingTestCaseParamsError` for these three metrics.

## Reproduce BEFORE/AFTER yourself (copy-paste)

The behavior described in the bug report is purely on the docs side — the metric code already handles missing `actual_output` correctly. To verify the code claim with a real metric run (no LLM call needed, just the parameter check):

```bash
# Pick a Python with deepeval extras installed (poetry env or a fresh uv venv).
# BEFORE: clone main, the *docs* claim actual_output is required.
git clone https://github.com/confident-ai/deepeval /tmp/deepeval-before
cd /tmp/deepeval-before && git checkout main
grep -A2 "Required Arguments" "docs/content/docs/(rag)/metrics-contextual-precision.mdx" | head -10
# Expected (BEFORE): "actual_output" is listed under Required Arguments — confusing per #1212.

# AFTER: this branch.
git clone -b docs/1212-contextual-required-args https://github.com/jbbqqf/deepeval /tmp/deepeval-after
cd /tmp/deepeval-after
grep -A2 "Required Arguments" "docs/content/docs/(rag)/metrics-contextual-precision.mdx" | head -10
# Expected (AFTER): "actual_output" no longer listed; a clarifying note is added below.

# Cross-check against the actual code requirement (same in BEFORE and AFTER):
python3 -c "
from deepeval.metrics.contextual_precision.contextual_precision import ContextualPrecisionMetric
from deepeval.metrics.contextual_recall.contextual_recall import ContextualRecallMetric
from deepeval.metrics.contextual_relevancy.contextual_relevancy import ContextualRelevancyMetric
for cls in (ContextualPrecisionMetric, ContextualRecallMetric, ContextualRelevancyMetric):
    print(cls.__name__, [p.value for p in cls._required_params])
"
# Expected (both BEFORE and AFTER):
#   ContextualPrecisionMetric ['input', 'retrieval_context', 'expected_output']
#   ContextualRecallMetric ['input', 'retrieval_context', 'expected_output']
#   ContextualRelevancyMetric ['input', 'retrieval_context']
# i.e. actual_output is never in any of the three _required_params lists, on either ref.
```

## What I ran locally

- `grep -rn "actual_output" deepeval/metrics/contextual_precision/ deepeval/metrics/contextual_recall/ deepeval/metrics/contextual_relevancy/` — zero hits in implementation and templates.
- `grep -rn "_required_params" deepeval/metrics/contextual_precision/contextual_precision.py deepeval/metrics/contextual_recall/contextual_recall.py deepeval/metrics/contextual_relevancy/contextual_relevancy.py` — confirmed the three lists shown above.
- This is a docs-only change; no tests or runtime were impacted.

## Edge cases

| Case | Behavior |
|---|---|
| User passes `actual_output` on `LLMTestCase` alongside one of these three metrics | Unchanged — `actual_output` is accepted on the test case but ignored by the metric. The new note documents this explicitly. |
| User omits `actual_output` entirely | Unchanged — `check_llm_test_case_params` only iterates `_required_params`, which never contains `ACTUAL_OUTPUT` for these metrics, so no `MissingTestCaseParamsError` is raised. |
| Multi-turn variants (`TurnContextualPrecisionMetric`, etc.) | Out of scope; `docs/content/docs/(multi-turn)/metrics-turn-contextual-*.mdx` already does not list `actual_output` under Required Arguments. |
| Other RAG metrics that *do* use `actual_output` (e.g. `FaithfulnessMetric`, `AnswerRelevancyMetric`) | Out of scope; their `_required_params` do include `ACTUAL_OUTPUT` and their docs are correct. |

---

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against deepeval's source. The reproducer block above is the one I used during development; reviewers can paste it verbatim.*
