### PR TITLE
docs: fix typos in tutorials and docs

### DIFF
--- a/.scripts/changelog/generate.py
+++ b/.scripts/changelog/generate.py
@@ -841,7 +841,7 @@ def prune_ignored(idx: ChangelogIndex, ignore_prs: set[int]) -> int:
     """
     Remove any PR entries whose number is in `ignore_prs`.
 
-    This is what makes deletions persist accross updates: add the PR number to the ignore block, re-run
+    This is what makes deletions persist across updates: add the PR number to the ignore block, re-run
     the generator, and the entry will be removed and it won't be re-added by future generator updates.
     """
     removed = 0

--- a/docs/content/docs/metrics-introduction.mdx
+++ b/docs/content/docs/metrics-introduction.mdx
@@ -86,7 +86,7 @@ For those looking for a full-blown LLM red teaming orchestration frameowork, che
 </Tab>
 <Tab value="Image">
 
-Metrics in `deepeval` are multi-modal by default, metrics targetting images are metrics that definitely expects an image in the test case. They include:
+Metrics in `deepeval` are multi-modal by default, metrics targeting images are metrics that definitely expects an image in the test case. They include:
 
 - Image Coherence
 - Image Helpfulness

--- a/docs/content/tutorials/medical-chatbot/development.mdx
+++ b/docs/content/tutorials/medical-chatbot/development.mdx
@@ -162,7 +162,7 @@ Great! Now that we have the essentials for making a diagnosis, time to move on t
 
 Since we need a way for our chatbot to book appointments based on the diagnosis at hand, this section will focus on creating the tools required to do so. There's only one tool for booking appointments for the sake of simplicity:
 
-- `create_appointment`: Creates a new appointment **in memory** (you can also use something like SQLite for persistance storage)
+- `create_appointment`: Creates a new appointment **in memory** (you can also use something like SQLite for persistent storage)
 
 First, let's create a simple data model for appointments:
 

--- a/docs/content/tutorials/summarization-agent/evaluation.mdx
+++ b/docs/content/tutorials/summarization-agent/evaluation.mdx
@@ -27,7 +27,7 @@ test_case = LLMTestCase(
 ```
 
 :::tip
-In our case, the summarization agent creates two seperate LLM calls. 
+In our case, the summarization agent creates two separate LLM calls. 
 
 1. To generate summary
 2. To generate action items
@@ -107,7 +107,7 @@ dataset.push(alias="MeetingSummarizer Dataset")
 
 ### Creating Test Cases 
 
-We will now call our summarization agent on the dataset `input`s and create our `LLMTestCase`s that we can use to evaluate our agent. Since our summarization agent returns summary and action items seperately, we will create 2 test cases for 1 `summarize()` call.
+We will now call our summarization agent on the dataset `input`s and create our `LLMTestCase`s that we can use to evaluate our agent. Since our summarization agent returns summary and action items separately, we will create 2 test cases for 1 `summarize()` call.
 
 Here's how we can pull our dataset and create test cases:
 
@@ -194,7 +194,7 @@ We can now use the test cases and metrics we created to run our evaluations. Her
 
 ### Summary Eval
 
-Since we created seperate metrics and seperate test cases for our summarizer, we'll first evaluate the summary concision:
+Since we created separate metrics and separate test cases for our summarizer, we'll first evaluate the summary concision:
 
 ```python
 from deepeval import evaluate
@@ -207,7 +207,7 @@ evaluate(
 
 ### Action Item Eval
 
-We can run a seperate evaluation for action items generated as shown below:
+We can run a separate evaluation for action items generated as shown below:
 
 ```python
 from deepeval import evaluate


### PR DESCRIPTION
Spotted a few typos while reading through the docs and a changelog helper script.

- `targetting` → `targeting` in metrics-introduction
- `persistance` → `persistent` in medical-chatbot tutorial
- `seperate`/`seperately` → `separate`/`separately` (4 occurrences) in summarization-agent tutorial
- `accross` → `across` in changelog generator docstring

Docs-only, no behavior change.