### PR TITLE
feat(tracing): classify OTel GenAI plan spans as agents

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -18,3 +18,4 @@ jobs:
           options: "--check --verbose"
           src: "."
           jupyter: true
+          version: "25.12.0"

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -85,7 +85,8 @@ jobs:
           poetry run pytest -vv -rA --maxfail=1 --capture=tee-sys tests/test_core/  \
           --ignore=tests/test_core/test_synthesizer/                                \
           --ignore=tests/test_core/test_datasets/                                   \
-          --ignore=tests/test_core/test_tracing/test_dataset_iterator.py            \
+          --ignore=tests/test_core/test_simulator/                                  \
+          --ignore=tests/test_core/test_tracing/test_integration/test_dataset_iterator.py \
           --ignore=tests/test_core/test_evaluation/test_end_to_end/test_configs.py
 
       # Dev tests (with secrets)
@@ -100,7 +101,7 @@ jobs:
         if: ${{ env.OPENAI_API_KEY == '' }}
         run: |
           poetry run pytest -vv -rA --maxfail=1 --capture=tee-sys tests/test_core/test_synthesizer/ tests/test_core/test_datasets/ tests/test_core/test_simulator/ \
-          --ignore=tests/test_core/test_tracing/test_dataset_iterator.py            \
+          --ignore=tests/test_core/test_tracing/test_integration/test_dataset_iterator.py \
           --ignore=tests/test_core/test_synthesizer/test_context_generator.py       \
           --ignore=tests/test_core/test_simulator/test_conversation_simulator.py    \
           --ignore=tests/test_core/test_synthesizer/test_generate_from_goldens.py   \

--- a/deepeval/integrations/agentcore/instrumentator.py
+++ b/deepeval/integrations/agentcore/instrumentator.py
@@ -105,7 +105,7 @@ init_clock_bridge()
 # Span classification: ``gen_ai.*`` (OTel GenAI semconv), Traceloop attrs,
 # and span-name heuristics. Settings-independent; inspects raw OTel span only.
 
-_AGENT_OP_NAMES = {"invoke_agent", "create_agent"}
+_AGENT_OP_NAMES = {"invoke_agent", "create_agent", "plan"}
 _LLM_OP_NAMES = {
     "chat",
     "generate_content",

--- a/deepeval/integrations/pydantic_ai/instrumentator.py
+++ b/deepeval/integrations/pydantic_ai/instrumentator.py
@@ -48,11 +48,11 @@ try:
         TracerProvider,
     )
     from opentelemetry.sdk.trace.export import (
-        BatchSpanProcessor,
-        SimpleSpanProcessor,
+        BatchSpanProcessor,  # noqa: F401 - imported to verify dependency availability
+        SimpleSpanProcessor,  # noqa: F401 - imported to verify dependency availability
     )
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-        OTLPSpanExporter,
+        OTLPSpanExporter,  # noqa: F401 - imported to verify dependency availability
     )
     from opentelemetry.trace import set_tracer_provider
     from pydantic_ai.models.instrumented import (
@@ -341,8 +341,11 @@ class SpanInterceptor(SpanProcessor):
             or span.attributes.get("agent_name")
         )
 
-        if agent_name and self._is_agent_span(operation_name):
-            self._add_agent_span(span, agent_name)
+        if self._is_agent_span(operation_name):
+            self._add_agent_span(
+                span,
+                self._resolve_agent_span_name(span, agent_name, operation_name),
+            )
 
         if operation_name in self.LLM_OPERATION_NAMES:
             # Explicitly classify model request spans as LLM spans so
@@ -424,8 +427,13 @@ class SpanInterceptor(SpanProcessor):
                 or span.attributes.get("pydantic_ai.agent.name")
                 or span.attributes.get("agent_name")
             )
-            if agent_name and self._is_agent_span(operation_name):
-                self._add_agent_span(span, agent_name)
+            if self._is_agent_span(operation_name):
+                self._add_agent_span(
+                    span,
+                    self._resolve_agent_span_name(
+                        span, agent_name, operation_name
+                    ),
+                )
 
         attrs = span.attributes or {}
         if not attrs.get("confident.span.integration"):
@@ -814,4 +822,14 @@ class SpanInterceptor(SpanProcessor):
         self._set_attr_post_end(span, "confident.span.name", name)
 
     def _is_agent_span(self, operation_name: Optional[str]) -> bool:
-        return operation_name == "invoke_agent"
+        return operation_name in {"invoke_agent", "plan"}
+
+    def _resolve_agent_span_name(
+        self, span, agent_name: Optional[str], operation_name: Optional[str]
+    ) -> str:
+        if agent_name:
+            return agent_name
+        span_name = getattr(span, "name", None)
+        if isinstance(span_name, str) and span_name:
+            return span_name
+        return operation_name or "agent"

--- a/deepeval/integrations/strands/instrumentator.py
+++ b/deepeval/integrations/strands/instrumentator.py
@@ -114,7 +114,7 @@ init_clock_bridge()
 # Strands), Traceloop attrs (kept inert for parity), and span-name
 # heuristics. Settings-independent; inspects raw OTel span only.
 
-_AGENT_OP_NAMES = {"invoke_agent", "create_agent"}
+_AGENT_OP_NAMES = {"invoke_agent", "create_agent", "plan"}
 _LLM_OP_NAMES = {
     "chat",
     "generate_content",

--- a/deepeval/tracing/otel/exporter.py
+++ b/deepeval/tracing/otel/exporter.py
@@ -29,6 +29,7 @@ from deepeval.tracing.otel.utils import (
     check_pydantic_ai_trace_input_output,
     check_tool_input_parameters_from_gen_ai_attributes,
     check_span_type_from_gen_ai_attributes,
+    check_agent_name_from_gen_ai_attributes,
     check_model_from_gen_ai_attributes,
     check_llm_input_from_gen_ai_attributes,
     check_tool_name_from_gen_ai_attributes,
@@ -684,6 +685,13 @@ class ConfidentSpanExporter(SpanExporter):
 
         elif span_type == "agent":
             name = span.attributes.get("confident.agent.name")
+            if not name:
+                name = check_agent_name_from_gen_ai_attributes(span)
+            if not name:
+                name = span.attributes.get("confident.span.name")
+            if not name:
+                span_name = getattr(span, "name", None)
+                name = span_name if isinstance(span_name, str) else None
             available_tools_attr = span.attributes.get(
                 "confident.agent.available_tools"
             )

--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -12,6 +12,7 @@ from deepeval.tracing import trace_manager, BaseSpan
 from deepeval.tracing.utils import make_json_serializable
 
 GEN_AI_OPERATION_NAMES = ["chat", "generate_content", "text_completion"]
+GEN_AI_AGENT_OPERATION_NAMES = ["plan"]
 
 # Pending-metrics overlay: in-process side-channel for ``List[BaseMetric]``,
 # which can't fit in OTel attrs (primitives only). Writer is
@@ -285,12 +286,29 @@ def check_span_type_from_gen_ai_attributes(span: ReadableSpan):
         ):
             return "llm"
 
+        elif (
+            gen_ai_operation_name
+            and gen_ai_operation_name in GEN_AI_AGENT_OPERATION_NAMES
+        ):
+            return "agent"
+
         elif gen_ai_tool_name:
             return "tool"
     except Exception:
         pass
 
     return "base"
+
+
+def check_agent_name_from_gen_ai_attributes(span: ReadableSpan):
+    try:
+        gen_ai_agent_name = span.attributes.get("gen_ai.agent.name")
+        if gen_ai_agent_name:
+            return gen_ai_agent_name
+    except Exception:
+        pass
+
+    return None
 
 
 def check_model_from_gen_ai_attributes(span: ReadableSpan):

--- a/tests/test_core/test_tracing/test_otel_genai_plan.py
+++ b/tests/test_core/test_tracing/test_otel_genai_plan.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from opentelemetry.trace.status import Status, StatusCode
+
+from deepeval.tracing.otel.exporter import ConfidentSpanExporter
+from deepeval.tracing.otel.utils import check_span_type_from_gen_ai_attributes
+from deepeval.tracing.perf_epoch_bridge import init_clock_bridge
+from deepeval.tracing.types import AgentSpan
+
+init_clock_bridge()
+
+
+class _Span:
+    def __init__(self, attributes):
+        self.attributes = attributes
+
+
+class _ReadableSpan:
+    attributes = {
+        "gen_ai.operation.name": "plan",
+        "gen_ai.agent.name": "planner",
+    }
+    context = SimpleNamespace(trace_id=1, span_id=2)
+    parent = None
+    status = Status(StatusCode.UNSET)
+    start_time = 1_000_000_000
+    end_time = 2_000_000_000
+    name = "plan planner"
+
+
+class _ReadablePlanSpanWithoutAgentName:
+    attributes = {"gen_ai.operation.name": "plan"}
+    context = SimpleNamespace(trace_id=1, span_id=3)
+    parent = None
+    status = Status(StatusCode.UNSET)
+    start_time = 1_000_000_000
+    end_time = 2_000_000_000
+    name = "plan"
+
+
+def test_gen_ai_plan_operation_classifies_as_agent():
+    span = _Span({"gen_ai.operation.name": "plan"})
+
+    assert check_span_type_from_gen_ai_attributes(span) == "agent"
+
+
+def test_gen_ai_plan_agent_name_is_preserved_in_boilerplate_span():
+    span = ConfidentSpanExporter.prepare_boilerplate_base_span(_ReadableSpan())
+
+    assert isinstance(span, AgentSpan)
+    assert span.name == "planner"
+
+
+def test_gen_ai_plan_uses_span_name_when_agent_name_is_unavailable():
+    span = ConfidentSpanExporter.prepare_boilerplate_base_span(
+        _ReadablePlanSpanWithoutAgentName()
+    )
+
+    assert isinstance(span, AgentSpan)
+    assert span.name == "plan"

--- a/tests/test_integrations/test_agentcore/test_span_interceptor.py
+++ b/tests/test_integrations/test_agentcore/test_span_interceptor.py
@@ -41,13 +41,11 @@ from deepeval.tracing.context import (
     current_span_context,
     current_trace_context,
     next_agent_span,
-    next_llm_span,
     next_tool_span,
     update_current_span,
     update_current_trace,
 )
 from deepeval.tracing.trace_context import trace
-
 
 _span_id_counter = count(start=1)
 _trace_id_counter = count(start=1)
@@ -493,6 +491,17 @@ class TestParentBridge:
 
 
 class TestNextSpanInterceptorIntegration:
+    def test_plan_operation_is_classified_as_agent_span(self):
+        settings = _make_settings()
+        interceptor = AgentCoreSpanInterceptor(settings)
+        span = _make_mock_span(operation_name="plan", agent_name="planner")
+
+        interceptor.on_start(span, None)
+        interceptor.on_end(span)
+
+        assert span.attributes.get("confident.span.type") == "agent"
+        assert span.attributes.get("confident.span.name") == "planner"
+
     def test_next_agent_span_metric_collection_lands_on_otel_attrs(self):
         settings = _make_settings()
         interceptor = AgentCoreSpanInterceptor(settings)

--- a/tests/test_integrations/test_pydanticai/test_span_interceptor.py
+++ b/tests/test_integrations/test_pydanticai/test_span_interceptor.py
@@ -44,12 +44,13 @@ from deepeval.tracing.otel.context_aware_processor import (
 )
 from deepeval.tracing.trace_context import trace
 
-
 _span_id_counter = count(start=1)
 _trace_id_counter = count(start=1)
 
 
-def _make_mock_span(operation_name=None, agent_name=None, tool_name=None):
+def _make_mock_span(
+    operation_name=None, agent_name=None, tool_name=None, span_name=""
+):
     """Mock OTel span that records ``set_attribute`` calls.
 
     Mirrors the real OTel SDK's invariant that ``Span.attributes`` is a view
@@ -73,6 +74,7 @@ def _make_mock_span(operation_name=None, agent_name=None, tool_name=None):
         trace_id=next(_trace_id_counter),
         span_id=next(_span_id_counter),
     )
+    span.name = span_name
     span.parent = None
     span.start_time = None  # forces _push_span_context to use perf_counter()
     return span
@@ -1160,6 +1162,28 @@ def _make_agent_span_mock(agent_name="agent_x"):
 
 
 class TestNextSpanInterceptorIntegration:
+    def test_plan_operation_is_classified_as_agent_span(self):
+        settings = _make_settings()
+        interceptor = SpanInterceptor(settings)
+        span = _make_mock_span(operation_name="plan", agent_name="planner")
+
+        interceptor.on_start(span, None)
+        interceptor.on_end(span)
+
+        assert span.attributes.get("confident.span.type") == "agent"
+        assert span.attributes.get("confident.span.name") == "planner"
+
+    def test_plan_operation_without_agent_name_uses_span_name(self):
+        settings = _make_settings()
+        interceptor = SpanInterceptor(settings)
+        span = _make_mock_span(operation_name="plan", span_name="plan")
+
+        interceptor.on_start(span, None)
+        interceptor.on_end(span)
+
+        assert span.attributes.get("confident.span.type") == "agent"
+        assert span.attributes.get("confident.span.name") == "plan"
+
     def test_next_agent_span_metric_collection_lands_on_otel_attrs(self):
         """``with next_agent_span(metric_collection=...)`` is consumed by
         the interceptor's ``_push_span_context`` for the agent span and

--- a/tests/test_integrations/test_strands/test_span_interceptor.py
+++ b/tests/test_integrations/test_strands/test_span_interceptor.py
@@ -41,13 +41,11 @@ from deepeval.tracing.context import (
     current_span_context,
     current_trace_context,
     next_agent_span,
-    next_llm_span,
     next_tool_span,
     update_current_span,
     update_current_trace,
 )
 from deepeval.tracing.trace_context import trace
-
 
 _span_id_counter = count(start=1)
 _trace_id_counter = count(start=1)
@@ -535,6 +533,17 @@ class TestParentBridge:
 
 
 class TestNextSpanInterceptorIntegration:
+    def test_plan_operation_is_classified_as_agent_span(self):
+        settings = _make_settings()
+        interceptor = StrandsSpanInterceptor(settings)
+        span = _make_mock_span(operation_name="plan", agent_name="planner")
+
+        interceptor.on_start(span, None)
+        interceptor.on_end(span)
+
+        assert span.attributes.get("confident.span.type") == "agent"
+        assert span.attributes.get("confident.span.name") == "planner"
+
     def test_next_agent_span_metric_collection_lands_on_otel_attrs(self):
         settings = _make_settings()
         interceptor = StrandsSpanInterceptor(settings)


### PR DESCRIPTION
## Summary

- Classify explicit OTel GenAI `gen_ai.operation.name = "plan"` spans as DeepEval agent spans.
- Cover the generic OTel exporter plus Strands, AgentCore, and Pydantic AI interceptors.
- Preserve `gen_ai.agent.name` where present and fall back to the OTel span name when it is absent.

## Reference

OTel GenAI plan-span semantics define `gen_ai.operation.name` as `plan` for agent planning/task decomposition phases: https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md#plan-span

## Tests

- Targeted plan/no-agent test set passed: 7 passed, 1 warning.
- Full affected test files passed: 143 passed, 1 warning.
- Ruff check passed on changed files.
- Black check passed on changed files.
