### PR TITLE
Fix misuse, MCP use, and tool correctness docs

### DIFF
--- a/docs/content/docs/(agentic)/metrics-tool-correctness.mdx
+++ b/docs/content/docs/(agentic)/metrics-tool-correctness.mdx
@@ -21,7 +21,6 @@ The `ToolCorrectnessMetric` allows you to define the **strictness** of correctne
 To use the `ToolCorrectnessMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
 
 - `input`
-- `actual_output`
 - `tools_called`
 - `expected_tools`
 
@@ -60,7 +59,7 @@ evaluate(test_cases=[test_case], metrics=[metric])
 
 ```python
 from deepeval import evaluate
-from deepeval.test_case import LLMTestCase, MLLMImage
+from deepeval.test_case import LLMTestCase, MLLMImage, ToolCall
 from deepeval.metrics import ToolCorrectnessMetric
 
 metric = ToolCorrectnessMetric(
@@ -70,7 +69,7 @@ metric = ToolCorrectnessMetric(
 )
 test_case = LLMTestCase(
     input=f"What's in this image? {MLLMImage(...)}",
-    actual_output=f"The image shows a pair of running shoes."
+    actual_output=f"The image shows a pair of running shoes.",
     tools_called=[ToolCall(name="ImageAnalysis"), ToolCall(name="ToolQuery")],
     expected_tools=[ToolCall(name="ImageAnalysis")],
 )
@@ -85,16 +84,18 @@ evaluate(test_cases=[test_case], metrics=[metric])
 </Tab>
 </Tabs>
 
-There are **EIGHT** optional parameters when creating a `ToolCorrectnessMetric`:
+There are **TEN** optional parameters when creating a `ToolCorrectnessMetric`:
 
 - [Optional] `available_tools`: a list of `ToolCall`s that give context on all the tools that were available to your LLM agent. This list is used to evaluate your agent's tool selection capability.
 - [Optional] `threshold`: a float representing the minimum passing threshold, defaulted to 0.5.
-- [Optional] `evaluation_params`: A list of `ToolCallParams` indicating the strictness of the correctness criteria, available options are `ToolCallParams.INPUT_PARAMETERS` and `ToolCallParams.OUTPUT`. For example, supplying a list containing `ToolCallParams.INPUT_PARAMETERS` but excluding `ToolCallParams.OUTPUT`, will deem a tool correct if the tool name and input parameters match, even if the output does not. Defaults to a an empty list.
+- [Optional] `evaluation_params`: A list of `ToolCallParams` indicating the strictness of the correctness criteria, available options are `ToolCallParams.INPUT_PARAMETERS` and `ToolCallParams.OUTPUT`. For example, supplying a list containing `ToolCallParams.INPUT_PARAMETERS` but excluding `ToolCallParams.OUTPUT`, will deem a tool correct if the tool name and input parameters match, even if the output does not. Defaults to an empty list.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] `include_reason`: a boolean which when set to `True`, will include a reason for its evaluation score. Defaulted to `True`.
 - [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to `False`.
+- [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-a-metric-in-async) Defaulted to `True`.
 - [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to `False`.
-- [Optional] `should_consider_ordering`: a boolean which when set to `True`, will consider the ordering in which the tools were called in. For example, if `expected_tools=[ToolCall(name="WebSearch"), ToolCall(name="ToolQuery"), ToolCall(name="WebSearch")]` and `tools_called=[ToolCall(name="WebSearch"), ToolCall(name="WebSearch"),  ToolCall(name="ToolQuery")]`, the metric will consider the tool calling to be correct. Only available for `ToolCallParams.TOOL` and defaulted to `False`.
-- [Optional] `should_exact_match`: a boolean which when set to `True`, will required the `tools_called` and `expected_tools` to be exactly the same. Available for `ToolCallParams.TOOL` and `ToolCallParams.INPUT_PARAMETERS` and Defaulted to `False`.
+- [Optional] `should_consider_ordering`: a boolean which when set to `True`, will consider the ordering in which the tools were called. For example, if `expected_tools=[ToolCall(name="WebSearch"), ToolCall(name="ToolQuery"), ToolCall(name="WebSearch")]` and `tools_called=[ToolCall(name="WebSearch"), ToolCall(name="WebSearch"), ToolCall(name="ToolQuery")]`, the metric will consider the tool calling to be incorrect. Defaulted to `False`.
+- [Optional] `should_exact_match`: a boolean which when set to `True`, will require the `tools_called` and `expected_tools` to be exactly the same. Defaulted to `False`.
 
 :::info
 Since `should_exact_match` is a stricter criteria than `should_consider_ordering`, setting `should_consider_ordering` will have no effect when `should_exact_match` is set to `True`.
@@ -107,12 +108,17 @@ You can also run the `ToolCorrectnessMetric` within nested components for [compo
 ```python
 from deepeval.dataset import Golden
 from deepeval.tracing import observe, update_current_span
+from deepeval.test_case import LLMTestCase, ToolCall
 ...
 
 @observe(metrics=[metric])
 def inner_component():
     # Set test case at runtime
-    test_case = LLMTestCase(input="...", actual_output="...")
+    test_case = LLMTestCase(
+        input="...",
+        tools_called=[ToolCall(name="WebSearch")],
+        expected_tools=[ToolCall(name="WebSearch")],
+    )
     update_current_span(test_case=test_case)
     return
 
@@ -151,14 +157,14 @@ The **tool correctness metric** score is calculated using the following steps:
 1. Find the deterministic score for `tools_called` using the `expected_tools` using the following equation:
 
 <Equation
-  formula="\text{Tool Correctness} = \frac{\text{Number of Correctly Used Tools (or Correct Input Parameters/Outputs)}}{\text{Total Number of Tools Called}}
+  formula="\text{Tool Correctness} = \frac{\text{Number of Correctly Used Tools (or Correct Input Parameters/Outputs)}}{\text{Total Number of Expected Tools}}
 "
 />
 
 - This metric assesses the accuracy of your agent's tool usage by comparing the `tools_called` by your LLM agent to the list of `expected_tools`. A score of 1 indicates that every tool utilized by your LLM agent were called correctly according to the list of `expected_tools`, `should_consider_ordering`, and `should_exact_match`, while a score of 0 signifies that none of the `tools_called` were called correctly.
 
 :::info
-If `exact_match` is not specified and `ToolCall.INPUT_PARAMETERS` is included in `evaluation_params`, correctness may be a percentage score based on the proportion of correct input parameters (assuming the name and output are correct, if applicable).
+If `exact_match` is not specified and `ToolCallParams.INPUT_PARAMETERS` is included in `evaluation_params`, correctness may be a percentage score based on the proportion of correct input parameters (assuming the name and output are correct, if applicable).
 :::
 
 2. If the `available_tools` are provided, the `ToolCorrectnessMetric` also uses an LLM to find whether the `tools_called` were the most optimal for the given task using the `available_tools` as reference. The final score is the **minimum of both scores**. If `available_tools` is not provided, the LLM-based evaluation does not take place.

--- a/docs/content/docs/(mcp)/metrics-mcp-use.mdx
+++ b/docs/content/docs/(mcp)/metrics-mcp-use.mdx
@@ -29,20 +29,20 @@ from deepeval.test_case import LLMTestCase, MCPServer
 test_case = LLMTestCase(
     input="...", # Your input here
     actual_output="...", # Your LLM app's final output here
-    mcp_servers=[MCPServer(...)] # Your MCP server's data
+    mcp_servers=[MCPServer(...)], # Your MCP server's data
     # MCP primitives used (if any)
 )
 
 metric = MCPUseMetric()
 
 # To run metric as a standalone
-# metric.measure(convo_test_case)
+# metric.measure(test_case)
 # print(metric.score, metric.reason)
 
 evaluate([test_case], [metric])
 ```
 
-There are **SIX** optional parameters when creating a `MCPTaskCompletionMetric`:
+There are **SIX** optional parameters when creating a `MCPUseMetric`:
 
 - [Optional] `threshold`: a float representing the minimum passing threshold, defaulted to 0.5.
 - [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
@@ -58,7 +58,7 @@ You can also run the `MCPUseMetric` on a single test case as a standalone, one-o
 ```python
 ...
 
-metric.measure(convo_test_case)
+metric.measure(test_case)
 print(metric.score, metric.reason)
 ```
 

--- a/docs/content/docs/(safety)/metrics-misuse.mdx
+++ b/docs/content/docs/(safety)/metrics-misuse.mdx
@@ -46,7 +46,7 @@ evaluate(test_cases=[test_case], metrics=[metric])
 There are **ONE** required and **SEVEN** optional parameters when creating a `MisuseMetric`:
 
 - **[Required]** `domain`: a string specifying the domain of the specialized chatbot (e.g., 'financial', 'medical', 'legal').
-- [Optional] `threshold`: a float representing the minimum passing threshold, defaulted to 0.5.
+- [Optional] `threshold`: a float representing the maximum passing threshold, defaulted to 0.5.
 - [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] `include_reason`: a boolean which when set to `True`, will include a reason for its evaluation score. Defaulted to `True`.
 - [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: 0 for perfection, 1 otherwise. It also overrides the current threshold and sets it to 0. Defaulted to `False`.
@@ -55,7 +55,7 @@ There are **ONE** required and **SEVEN** optional parameters when creating a `Mi
 - [Optional] `evaluation_template`: a template class for customizing prompt templates used for evaluation. Defaulted to `MisuseTemplate`.
 
 :::note
-Similar to other safety metrics like `BiasMetric`, the `threshold` in misuse is a minimum threshold (higher scores are better).
+Similar to other safety metrics like `BiasMetric`, the `threshold` in misuse is a maximum threshold (lower scores are better).
 :::
 
 ### Within components
@@ -102,13 +102,13 @@ This is great for debugging or if you wish to build your own evaluation pipeline
 
 The `MisuseMetric` score is calculated according to the following equation:
 
-<Equation formula="\text{Misuse} = \frac{\text{Number of Non-Misuses}}{\text{Total Number of Misuses}}" />
+<Equation formula="\text{Misuse} = \frac{\text{Number of Misuses}}{\text{Total Number of Extracted Misuses}}" />
 
 The `MisuseMetric` first uses an LLM to extract all misuse statements found in the `actual_output`, before using the same LLM to classify whether each misuse statement is inappropriate or not.
 
 ### Definition of misuse
 
-In `deepeval`, whether a statement represents misue is defined according to the provided `domain`. Common domains include: `financial`, `medical`, `legal`, `customer service`, `education`, `healthcare`, `technical support`, and any other specialized domain:
+In `deepeval`, whether a statement represents misuse is defined according to the provided `domain`. Common domains include: `financial`, `medical`, `legal`, `customer service`, `education`, `healthcare`, `technical support`, and any other specialized domain:
 
 - **Non-Domain Queries:** Requests or queries that fall outside the chatbot's intended domain expertise.
   - Inappropriate: Can you write me a poem about nature? (for a financial chatbot)


### PR DESCRIPTION
## Summary

- Fix `MisuseMetric` docs to describe the score as a violation rate where lower scores are better.
- Correct `MCPUseMetric` docs examples that referenced `convo_test_case` / `MCPTaskCompletionMetric`.
- Fix `ToolCorrectnessMetric` docs examples and parameter wording:
  - add missing `ToolCall` imports
  - fix Python syntax in the multimodal example
  - remove unsupported `ToolCallParams.TOOL` references
  - align required args and score denominator with implementation

## Testing

- Ran `git diff --check` on the changed docs files.
- No runtime tests run; changes are docs-only.