### PR TITLE
Fix async turn contextual recall expected outcome

### DIFF
--- a/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
+++ b/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
@@ -161,7 +161,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
             async def get_individual_scores(window):
                 scores.extend(
                     await self._a_get_contextual_recall_scores(
-                        window, test_case.multimodal, multimodal
+                        window, test_case.expected_outcome, multimodal
                     )
                 )
 

--- a/tests/test_metrics/test_turn_contextual_recall_no_api.py
+++ b/tests/test_metrics/test_turn_contextual_recall_no_api.py
@@ -1,0 +1,68 @@
+from deepeval.metrics import TurnContextualRecallMetric
+from deepeval.metrics.turn_contextual_recall.schema import (
+    ContextualRecallScoreReason,
+    ContextualRecallVerdict,
+    Verdicts,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import ConversationalTestCase, Turn
+
+
+EXPECTED_OUTCOME = "The assistant must mention the refund policy."
+
+
+class FakeTurnRecallModel(DeepEvalBaseLLM):
+    def load_model(self):
+        return self
+
+    def get_model_name(self):
+        return "fake-turn-recall-model"
+
+    def generate(self, prompt, schema=None):
+        return self._generate_response(prompt, schema)
+
+    async def a_generate(self, prompt, schema=None):
+        return self._generate_response(prompt, schema)
+
+    def _generate_response(self, prompt, schema):
+        if schema is Verdicts:
+            verdict = "yes" if EXPECTED_OUTCOME in prompt else "no"
+            return Verdicts(
+                verdicts=[
+                    ContextualRecallVerdict(
+                        verdict=verdict,
+                        reason="Expected outcome was passed into the prompt.",
+                    )
+                ]
+            )
+        if schema is ContextualRecallScoreReason:
+            return ContextualRecallScoreReason(
+                reason="The retrieved context supports the expected outcome."
+            )
+        raise AssertionError(f"Unexpected schema: {schema}")
+
+
+def build_test_case():
+    return ConversationalTestCase(
+        turns=[
+            Turn(role="user", content="What if these shoes do not fit?"),
+            Turn(
+                role="assistant",
+                content="You can return them within 30 days.",
+                retrieval_context=[
+                    "Customers can return shoes for a refund within 30 days."
+                ],
+            ),
+        ],
+        expected_outcome=EXPECTED_OUTCOME,
+        chatbot_role="A helpful assistant",
+    )
+
+
+def test_turn_contextual_recall_async_uses_expected_outcome():
+    metric = TurnContextualRecallMetric(model=FakeTurnRecallModel())
+    score = metric.measure(build_test_case())
+
+    assert score == 1
+    assert metric.score == 1
+    assert metric.success is True


### PR DESCRIPTION
## Summary
- Fix the async TurnContextualRecallMetric path to pass test_case.expected_outcome into _a_get_contextual_recall_scores
- Add an API-free regression test with a fake DeepEvalBaseLLM so the bug is caught without external model calls

## Why
The sync path already evaluates retrieval context against expected_outcome. The async path was passing test_case.multimodal as the expected_outcome argument, which meant the prompt could receive a boolean instead of the expected behavior being evaluated. That can make otherwise valid conversational retrieval score as no/0.

## Verification
- /tmp/deepeval-venv/bin/python -m pytest tests/test_metrics/test_turn_contextual_recall_no_api.py -q
- /tmp/deepeval-venv/bin/python -m compileall deepeval/metrics/turn_contextual_recall tests/test_metrics/test_turn_contextual_recall_no_api.py
- /tmp/deepeval-venv/bin/python -m black --check deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py tests/test_metrics/test_turn_contextual_recall_no_api.py
- git diff --check