### PR TITLE
fix(cli): allow `deepeval test run <file>` for any filename

### DIFF
--- a/deepeval/cli/test/command.py
+++ b/deepeval/cli/test/command.py
@@ -30,19 +30,12 @@ app = typer.Typer(name="test")
 
 def check_if_valid_file(test_file_or_directory: str):
     if "::" in test_file_or_directory:
-        test_file_or_directory, test_case = test_file_or_directory.split("::")
-    if os.path.isfile(test_file_or_directory):
-        if test_file_or_directory.endswith(".py"):
-            if not os.path.basename(test_file_or_directory).startswith("test_"):
-                raise ValueError(
-                    "Test will not run. Please ensure the file starts with `test_` prefix."
-                )
-    elif os.path.isdir(test_file_or_directory):
+        test_file_or_directory = test_file_or_directory.split("::", 1)[0]
+    if os.path.isfile(test_file_or_directory) or os.path.isdir(
+        test_file_or_directory
+    ):
         return
-    else:
-        raise ValueError(
-            "Provided path is neither a valid file nor a directory."
-        )
+    raise ValueError("Provided path is neither a valid file nor a directory.")
 
 
 # Allow extra args and ignore unknown options allow extra args to be passed to pytest

--- a/tests/test_core/test_cli/test_check_if_valid_file.py
+++ b/tests/test_core/test_cli/test_check_if_valid_file.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from deepeval.cli.test.command import check_if_valid_file
+
+
+def test_accepts_file_without_test_prefix(tmp_path):
+    eval_file = tmp_path / "judgment_eval.py"
+    eval_file.write_text("def test_something():\n    assert True\n")
+
+    check_if_valid_file(str(eval_file))
+
+
+def test_rejects_nonexistent_path(tmp_path):
+    missing = tmp_path / "does_not_exist.py"
+
+    with pytest.raises(
+        ValueError, match="neither a valid file nor a directory"
+    ):
+        check_if_valid_file(str(missing))


### PR DESCRIPTION
## Summary

`deepeval test run <path>` rejects any explicitly-named `.py` file whose basename does not start with `test_`:

```
$ deepeval test run evals/judgment_eval.py
ValueError: Test will not run. Please ensure the file starts with `test_` prefix.
```

This forces users to rename evaluation files (e.g. `judgment_eval.py`) just to run them, even though pytest itself has no such requirement.

## Why this restriction doesn't hold up

- **Stricter than pytest.** When you pass an explicitly-named file, pytest collects it regardless of the `python_files` patterns (initial paths bypass the pattern filter). pytest also accepts `*_test.py`. The CLI gate is the *only* thing blocking a file like `judgment_eval.py`.
- **Inconsistent with its own directory branch.** `check_if_valid_file` already defers entirely to pytest for directory arguments — it only enforced the prefix for file arguments.

## Changes

- `check_if_valid_file` now defers collection to pytest for both files and directories, keeping only the existence check (a path that is neither a file nor a directory still raises).
- Strip the full pytest node id before validating, via `split("::", 1)`. The previous `split("::")` crashed with `ValueError: too many values to unpack` on nested ids such as `file.py::Class::method`.

```python
def check_if_valid_file(test_file_or_directory: str):
    if "::" in test_file_or_directory:
        test_file_or_directory = test_file_or_directory.split("::", 1)[0]
    if os.path.isfile(test_file_or_directory) or os.path.isdir(
        test_file_or_directory
    ):
        return
    raise ValueError("Provided path is neither a valid file nor a directory.")
```

## Behaviour after the change

- `deepeval test run evals/judgment_eval.py` runs (collection deferred to pytest, as with a bare `pytest evals/judgment_eval.py`).
- Note: naming conventions for *directory* discovery (`python_files`) and non-`test_` *functions* (`python_functions`) remain pytest config concerns and are unchanged here.

## Testing

- Added `tests/test_core/test_cli/test_check_if_valid_file.py` (non-`test_` file accepted; nonexistent path raises).
- `tests/test_core/test_cli/` suite passes; verified end-to-end that `deepeval test run <dir>/judgment_eval.py` collects and runs.