### PR TITLE
Fix trimAndLoadJson corrupting valid JSON string values

### DIFF
--- a/deepeval/dataset/utils.py
+++ b/deepeval/dataset/utils.py
@@ -109,11 +109,17 @@ def convert_convo_goldens_to_convo_test_cases(
 
 
 def trimAndLoadJson(input_string: str) -> Any:
+    stripped = input_string.strip()
     try:
-        cleaned_string = re.sub(r",\s*([\]}])", r"\1", input_string.strip())
-        return json.loads(cleaned_string)
-    except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid JSON: {input_string}. Error: {str(e)}")
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        # Strip a trailing comma before a closing ] or } and retry, but only
+        # after a direct parse fails, so valid JSON string values containing
+        # ", ]" or ", }" are never corrupted.
+        try:
+            return json.loads(re.sub(r",\s*([\]}])", r"\1", stripped))
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {input_string}. Error: {str(e)}")
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
 

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -431,16 +431,20 @@ def trimAndLoadJson(
         end = len(input_string)
 
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
-    # Remove trailing comma if one is present
-    jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
 
     try:
         return json.loads(jsonStr)
     except json.JSONDecodeError:
-        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
-        if metric is not None:
-            metric.error = error_str
-        raise ValueError(error_str)
+        # Some models emit a trailing comma before a closing ] or }. Strip it
+        # and retry, but only after a direct parse fails, so valid JSON string
+        # values containing ", ]" or ", }" are never corrupted.
+        try:
+            return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
+        except json.JSONDecodeError:
+            error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+            if metric is not None:
+                metric.error = error_str
+            raise ValueError(error_str)
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
 

--- a/tests/test_core/test_trim_and_load_json.py
+++ b/tests/test_core/test_trim_and_load_json.py
@@ -1,0 +1,39 @@
+"""Regression tests for trimAndLoadJson trailing-comma handling.
+
+Both the metrics and dataset copies stripped ``,\\s*`` before a closing ``]``/``}``
+unconditionally, which corrupted valid JSON whose string values happened to
+contain ``", ]"`` or ``", }"``. The cleanup must only run as a fallback when a
+direct parse fails.
+"""
+
+import json
+
+import pytest
+
+from deepeval.dataset.utils import trimAndLoadJson as trim_dataset
+from deepeval.metrics.utils import trimAndLoadJson as trim_metrics
+
+TRIM_FNS = [trim_metrics, trim_dataset]
+
+
+@pytest.mark.parametrize("trim", TRIM_FNS)
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"reason": "found items A, B, ] then stopped"}',
+        '{"note": "the set is {x, y, } here"}',
+    ],
+)
+def test_valid_json_string_values_are_preserved(trim, raw):
+    assert trim(raw) == json.loads(raw)
+
+
+@pytest.mark.parametrize("trim", TRIM_FNS)
+def test_trailing_comma_is_still_stripped(trim):
+    assert trim('{"a": [1, 2, ]}') == {"a": [1, 2]}
+
+
+@pytest.mark.parametrize("trim", TRIM_FNS)
+def test_invalid_json_still_raises(trim):
+    with pytest.raises(ValueError):
+        trim("not json at all {[")


### PR DESCRIPTION
## Summary

`trimAndLoadJson` strips a comma + optional whitespace before a closing `]`/`}` to drop trailing commas from model output:

```python
re.sub(r",\s*([\]}])", r"\1", jsonStr)
```

It runs this regex unconditionally over the whole string before `json.loads`. Because the regex is not string-literal aware, it also rewrites `", ]"` / `", }"` sequences **inside string values**, silently corrupting otherwise-valid JSON:

```python
trimAndLoadJson('{"reason": "found items A, B, ] then stopped"}')
# -> {'reason': 'found items A, B] then stopped'}   # ", ]" collapsed to "]"
```

This affects two copies of the helper:
- `deepeval/metrics/utils.py` — parses LLM judge output (a `reason`/explanation field can easily contain such text).
- `deepeval/dataset/utils.py` — parses tool calls when loading datasets from CSV/JSONL.

## Fix

Parse the input directly first, and only apply the trailing-comma cleanup as a **fallback** when the direct parse fails. Valid JSON is then never altered, while malformed output with a genuine trailing comma (e.g. `{"a": [1, 2, ]}`) is still recovered.

## Test plan

- Added `tests/test_core/test_trim_and_load_json.py` (parametrized over both copies):
  - valid JSON whose string values contain `", ]"` / `", }"` round-trips unchanged — **fails on `main`**, passes here;
  - a real trailing comma is still stripped;
  - genuinely-invalid JSON still raises `ValueError`.
- `pytest tests/test_core/test_trim_and_load_json.py` → 8 passed. `black` clean.

## Note

Not a duplicate of #2410 — that PR strips `<think>` tags before parsing (a different failure mode) and only touches the metrics copy; this PR fixes the trailing-comma string corruption in both copies. The changes are complementary.