### PR TITLE
docs: fix m_test_case variable name mismatch in metrics-introduction

### DIFF
--- a/docs/content/docs/metrics-introduction.mdx
+++ b/docs/content/docs/metrics-introduction.mdx
@@ -291,7 +291,7 @@ from deepeval.metrics import ImageCoherenceMetric
 test_case = LLMTestCase(input=f"What does thsi image say? {MLLMImage(...)}", actual_output="No idea!")
 image_coherence = ImageCoherenceMetric(threshold=0.5)
 
-image_coherence.measure(m_test_case)
+image_coherence.measure(test_case)
 print(image_coherence.score, image_coherence.reason)
 ```
 


### PR DESCRIPTION
## Summary

Fixes a variable name mismatch in the Images tab code example in `docs/content/docs/metrics-introduction.mdx`. The test case is defined as `test_case` but then passed to `image_coherence.measure()` as `m_test_case`, causing a `NameError` if a user copies the snippet.

## Changes

- `docs/content/docs/metrics-introduction.mdx` — changed `m_test_case` to `test_case` on line 294 to match the variable defined on line 291

## Test plan

- [ ] `python -m black --check` — no Python files changed
- [ ] `python -m ruff check` — no Python files changed

## Fixes / Closes

Closes #2696