### PR TITLE
fix: restore deepeval.evaluate subpackage binding shadowed by _expose_public_api

### DIFF
--- a/deepeval/__init__.py
+++ b/deepeval/__init__.py
@@ -15,15 +15,12 @@ autoload_dotenv()
 def _expose_public_api() -> None:
     # All other imports must happen after env is loaded
     # Do not do this at module level or ruff will complain with E402
-    global __version__, evaluate, assert_test, compare
+    global __version__, assert_test, compare
     global on_test_run_end, log_hyperparameters, login, telemetry
     global instrument
 
     from ._version import __version__ as _version
-    from deepeval.evaluate import (
-        evaluate as _evaluate,
-        assert_test as _assert_test,
-    )
+    from deepeval.evaluate import assert_test as _assert_test
     from deepeval.evaluate.compare import compare as _compare
     from deepeval.test_run import (
         on_test_run_end as _on_end,
@@ -33,7 +30,6 @@ def _expose_public_api() -> None:
     import deepeval.telemetry as _telemetry
 
     __version__ = _version
-    evaluate = _evaluate
     assert_test = _assert_test
     compare = _compare
     on_test_run_end = _on_end

--- a/deepeval/evaluate/__init__.py
+++ b/deepeval/evaluate/__init__.py
@@ -1,3 +1,8 @@
+import sys
+import importlib
+
+_stdlib_types = importlib.import_module("types")
+
 from .evaluate import evaluate, assert_test
 from .compare import compare
 from .configs import AsyncConfig, DisplayConfig, CacheConfig, ErrorConfig
@@ -11,3 +16,20 @@ __all__ = [
     "CacheConfig",
     "ErrorConfig",
 ]
+
+
+class _CallableEvaluateModule(_stdlib_types.ModuleType):
+    """Module subclass that lets ``deepeval.evaluate(...)`` be called directly.
+
+    Without this, ``deepeval/__init__.py`` had to shadow the subpackage with the
+    bare function, which broke dotted submodule access such as
+    ``import deepeval.evaluate.configs; deepeval.evaluate.configs.AsyncConfig()``.
+    """
+
+    def __call__(self, *args, **kwargs):
+        from .evaluate import evaluate as _fn
+
+        return _fn(*args, **kwargs)
+
+
+sys.modules[__name__].__class__ = _CallableEvaluateModule

--- a/tests/test_core/test_imports.py
+++ b/tests/test_core/test_imports.py
@@ -250,6 +250,25 @@ def test_evaluate_imports():
     assert ErrorConfig is not None
 
 
+def test_evaluate_submodule_attribute_access():
+    """Regression test for issue #2216.
+
+    ``deepeval/__init__.py`` used to shadow the ``deepeval.evaluate`` subpackage
+    with the bare function, so dotted attribute access like
+    ``deepeval.evaluate.configs.AsyncConfig()`` raised
+    ``AttributeError: 'function' object has no attribute 'configs'``.
+    """
+    import deepeval
+    import deepeval.evaluate.configs
+
+    # Dotted submodule access must resolve to the module, not a bare function.
+    config = deepeval.evaluate.configs.AsyncConfig()
+    assert config is not None
+
+    # deepeval.evaluate must remain callable (so deepeval.evaluate(...) still works).
+    assert callable(deepeval.evaluate)
+
+
 def test_dataset_imports():
     """Test that dataset classes can be imported."""
     from deepeval.dataset import (


### PR DESCRIPTION
## Summary

`deepeval/__init__.py`'s `_expose_public_api()` imported the `evaluate` function from the subpackage (which caused Python's import machinery to bind `deepeval.evaluate → <subpackage>`), then immediately overwrote that binding with `evaluate = _evaluate` (the bare function).

When users later did `import deepeval.evaluate.configs`, Python found `deepeval.evaluate` already in `sys.modules` and skipped resetting the parent binding, so `deepeval.evaluate` stayed as the function and:

```python
import deepeval.evaluate.configs
deepeval.evaluate.configs.AsyncConfig()
# AttributeError: 'function' object has no attribute 'configs'
```

## Changes

- `deepeval/evaluate/__init__.py` — adds `_CallableEvaluateModule(types.ModuleType)` with `__call__` and switches the module's class to it. This preserves `deepeval.evaluate(...)` call semantics (via `__call__`) without needing to shadow the subpackage with the bare function. Uses `importlib.import_module("types")` to avoid collision with the local `deepeval/evaluate/types.py`.
- `deepeval/__init__.py` — removes the `evaluate = _evaluate` overwrite and its `global` declaration. Python's import machinery now keeps `deepeval.evaluate` pointing to the callable subpackage.
- `tests/test_core/test_imports.py` — adds `test_evaluate_submodule_attribute_access` regression test.

## Test plan

- [x] `python -m pytest tests/test_core/test_imports.py -v` — 12/12 pass
- [x] `python -m black --check deepeval/__init__.py deepeval/evaluate/__init__.py tests/test_core/test_imports.py`
- [x] Manually verified: `import deepeval.evaluate.configs; deepeval.evaluate.configs.AsyncConfig()` works
- [x] Manually verified: `callable(deepeval.evaluate)` is `True` (call semantics preserved)

## Fixes

Closes #2216