### PR TITLE
docs(guides-rag-evaluation): fix word order in retrieval hyperparameter note (#2707)

### DIFF
--- a/docs/content/guides/guides-rag-evaluation.mdx
+++ b/docs/content/guides/guides-rag-evaluation.mdx
@@ -46,7 +46,7 @@ A "vector store" can either be a dedicated vector database (eg. Pinecone) or a v
 
 As you've noticed, there are quite a few hyperparameters such as the choice of embedding model, top-K, etc. that needs tuning. Here are some questions RAG evaluation aims to solve in the retrieval step:
 
-- **Does the embedding model you're using capture domain-specific nuances?** (If you're working on a medical use case, a generic embedding model offered by OpenAI might not provide expected the vector search results.)
+- **Does the embedding model you're using capture domain-specific nuances?** (If you're working on a medical use case, a generic embedding model offered by OpenAI might not provide the expected vector search results.)
 - **Does your reranker model ranks the retrieved nodes in the "correct" order?**
 - **Are you retrieving the right amount of information?** This is influenced by hyperparameters text chunk size, top-K number.
 


### PR DESCRIPTION
Fixes #2707.

## Change

`docs/content/guides/guides-rag-evaluation.mdx` (the RAG Evaluation guide) had a transposed adjective + article in the retrieval hyperparameter note:

> ... a generic embedding model offered by OpenAI might not provide **expected the** vector search results.

Reordered to the natural English phrasing:

> ... a generic embedding model offered by OpenAI might not provide **the expected** vector search results.

This is exactly the spot the issue reporter highlighted in the screenshot.

## Scope

- 1 file, 1 line changed
- Documentation only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)