### PR TITLE
fix: use correct confinement instructions for ARC questions with numeric labels

### DIFF
--- a/deepeval/benchmarks/arc/arc.py
+++ b/deepeval/benchmarks/arc/arc.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Optional, Dict
 from tqdm import tqdm
 
@@ -44,6 +45,7 @@ class ARC(DeepEvalBaseBenchmark):
         self.predictions: Optional[pd.DataFrame] = None
         self.overall_score: Optional[float] = None
         self.verbose_mode = verbose_mode
+        self._custom_confinement = confinement_instructions is not None
         if not confinement_instructions:
             self.confinement_instructions = (
                 "Output 'A', 'B', 'C', or 'D'. Full answer not needed."
@@ -99,6 +101,13 @@ class ARC(DeepEvalBaseBenchmark):
                 overall_accuracy=overall_accuracy
             )
 
+    def _confinement_for(self, input: str) -> str:
+        if self._custom_confinement:
+            return self.confinement_instructions
+        if re.search(r"\n1\.", input):
+            return "Output '1', '2', '3', or '4'. Full answer not needed."
+        return self.confinement_instructions
+
     def predict(self, model: DeepEvalBaseLLM, golden: Golden) -> Dict:
         # Define prompt template
         prompt: dict = ARCTemplate.generate_output(
@@ -113,7 +122,7 @@ class ARC(DeepEvalBaseBenchmark):
             )
             prediction = res.answer
         except TypeError:
-            prompt += f"\n\n{self.confinement_instructions}"
+            prompt += f"\n\n{self._confinement_for(golden.input)}"
             prediction = model.generate(prompt)
 
         # For native models, shouldn't happen but just in case


### PR DESCRIPTION
Some ARC questions use labels `"1","2","3","4"` instead of `"A","B","C","D"` (e.g. questions from the NYSEDREGENTS set). The `confinement_instructions` field was hardcoded to `"Output 'A', 'B', 'C', or 'D'. Full answer not needed."` for all questions, so models using the text-generation fallback path would receive incorrect instructions and produce wrong answers for numeric-label questions.

**Changes:**
- `deepeval/benchmarks/arc/arc.py`: Added `_custom_confinement` flag in `__init__` and a `_confinement_for(input)` helper that detects numeric labels (`\n1.` pattern) and returns the appropriate instruction string. The fallback path in `predict()` now calls `_confinement_for(golden.input)` instead of using `self.confinement_instructions` directly. Custom `confinement_instructions` passed by the caller are always respected as before.

**Repro:**
```python
arc = ARC(n_shots=0, n_problems=1)
# question with labels 1/2/3/4 would get "Output 'A','B','C','D'" — wrong
# after fix: gets "Output '1','2','3','4'" for those questions
```

Fixes #2352