### PR TITLE
fix: loosen opentelemetry version constraint to allow 1.x and 2.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -11242,4 +11242,4 @@ inspect = ["pyperclip", "textual"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9, <4.0"
-content-hash = "1c8a2d716d795a792069526c406df879b4f1f783ab4833e09093139e439ba07d"
+content-hash = "6d371376338552bbdf39d0292c1dc72e17fc347a23dceb4ecbf48ed22d1f3d6f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ setuptools = "*"
 wheel = "*"
 nest_asyncio = "*"
 tenacity = ">=8.0.0,<=10.0.0"
-opentelemetry-api = "^1.24.0"
-opentelemetry-sdk = "^1.24.0"
+opentelemetry-api = ">=1.24.0,<3.0.0"
+opentelemetry-sdk = ">=1.24.0,<3.0.0"
 grpcio = "^1.67.1"
 
 posthog = [


### PR DESCRIPTION
`opentelemetry-api = "^1.24.0"` and `opentelemetry-sdk = "^1.24.0"` use Poetry's caret operator, which resolves to `>=1.24.0, <2.0.0`. This blocks users whose projects need opentelemetry 2.x or transitively require a version of other packages that depends on it.

**Change:**
- `pyproject.toml`: Changed both constraints from `^1.24.0` to `>=1.24.0,<3.0.0`, allowing both the current 1.x series and future 2.x releases. The lower bound is preserved so all existing functionality continues to work.

Fixes #1968