### PR TITLE
docs: document how to enable GEval weighted summation for custom models

### DIFF
--- a/docs/content/docs/(custom)/metrics-llm-evals.mdx
+++ b/docs/content/docs/(custom)/metrics-llm-evals.mdx
@@ -233,6 +233,26 @@ When you provide `evaluation_steps`, the `GEval` metric skips the first step and
 In the original G-Eval paper, the authors used the probabilities of the LLM output tokens to normalize the score by calculating a weighted summation.
 
 This step was introduced in the paper because it minimizes bias in LLM scoring. **This normalization step is automatically handled by `deepeval` by default** (unless you're using a custom model).
+
+To enable weighted summation for a custom model, implement `a_generate_raw_response` (and optionally `generate_raw_response`) on your `DeepEvalBaseLLM` subclass. The method must return a tuple of `(ChatCompletion, cost)` where the `ChatCompletion` object contains `logprobs` in its response:
+
+```python
+from openai.types.chat import ChatCompletion
+
+class MyCustomModel(DeepEvalBaseLLM):
+    async def a_generate_raw_response(self, prompt: str, **kwargs) -> tuple:
+        # Call your LLM with logprobs enabled (top_logprobs is passed via kwargs)
+        response: ChatCompletion = await self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[{"role": "user", "content": prompt}],
+            logprobs=True,
+            top_logprobs=kwargs.get("top_logprobs", 5),
+        )
+        cost = 0  # replace with actual cost if available
+        return response, cost
+```
+
+`deepeval` will automatically use the `logprobs` in the returned `ChatCompletion` to compute the weighted summation score. If `a_generate_raw_response` is not implemented, `deepeval` falls back to the raw integer score from `a_generate`.
 :::
 
 ## Examples


### PR DESCRIPTION
The GEval docs note that the weighted summation step from the G-Eval paper is "automatically handled by deepeval by default (unless you're using a custom model)" but give no guidance on how custom-model users can opt in.

Custom `DeepEvalBaseLLM` subclasses can enable weighted summation by implementing `a_generate_raw_response` to return a `(ChatCompletion, cost)` tuple with `logprobs` populated. `deepeval` already handles the rest internally via `calculate_weighted_summed_score`, but this path was completely undocumented.

**Changes:**
- `docs/content/docs/(custom)/metrics-llm-evals.mdx`: Expanded the existing tip block to include a short explanation and a minimal code example showing how to implement `a_generate_raw_response` on a custom model class.

Fixes #1831