### PR TITLE
docs: fix remaining typos in README and metrics-introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ DeepEval plugs into any LLM framework — OpenAI Agents, LangChain, CrewAI, and 
 [Confident AI](https://www.confident-ai.com?utm_source=deepeval&utm_medium=github&utm_content=platform_section) is an all-in-one platform that integrates natively with DeepEval.
 
 - Manage datasets, trace LLM applications, run evaluations, and monitor responses in production — all from one platform.
-- Don't need a UI? Confident AI can also be your data persistant layer - run evals, pull datasets, and inspect traces straight from claude code, cursor, via Confident AI's [MCP server](https://github.com/confident-ai/confident-mcp-server).
+- Don't need a UI? Confident AI can also be your data persistent layer - run evals, pull datasets, and inspect traces straight from claude code, cursor, via Confident AI's [MCP server](https://github.com/confident-ai/confident-mcp-server).
 
 <p align="center">
   <img src="assets/confident-mcp-architecture.png" alt="Confident AI MCP Architecture" width="500">
@@ -265,12 +265,12 @@ And finally, run `test_chatbot.py` in the CLI:
 deepeval test run test_chatbot.py
 ```
 
-**Congratulations! Your test case should have passed ✅** Let's breakdown what happened.
+**Congratulations! Your test case should have passed ✅** Let's break down what happened.
 
 - The variable `input` mimics a user input, and `actual_output` is a placeholder for what your application's supposed to output based on this input.
-- The variable `expected_output` represents the ideal answer for a given `input`, and [`GEval`](https://deepeval.com/docs/metrics-llm-evals) is a research-backed metric provided by `deepeval` for you to evaluate your LLM output's on any custom with human-like accuracy.
+- The variable `expected_output` represents the ideal answer for a given `input`, and [`GEval`](https://deepeval.com/docs/metrics-llm-evals) is a research-backed metric provided by `deepeval` for you to evaluate your LLM outputs on any custom with human-like accuracy.
 - In this example, the metric `criteria` is correctness of the `actual_output` based on the provided `expected_output`.
-- All metric scores range from 0 - 1, which the `threshold=0.5` threshold ultimately determines if your test have passed or not.
+- All metric scores range from 0 - 1, which the `threshold=0.5` threshold ultimately determines if your test has passed or not.
 
 [Read our documentation](https://deepeval.com/docs/getting-started?utm_source=GitHub) for more information!
 

--- a/docs/content/docs/metrics-introduction.mdx
+++ b/docs/content/docs/metrics-introduction.mdx
@@ -263,7 +263,7 @@ evaluate(observed_callback=trip_planner_agent, goldens=[Golden(input="Paris, 2")
 
 Chatbots require "conversational" (or multi-turn) metrics and they include:
 
-- **Conversation Completeness:** Evaluates if conversation satisify user needs.
+- **Conversation Completeness:** Evaluates if conversation satisfy user needs.
 - **Conversation Relevancy:** Measures if the generated outputs are relevant to user inputs.
 - **Role Adherence:** Assesses if the chatbot stays in character throughout a conversation.
 - **Knowledge Retention:** Evaluates if the chatbot is able to retain knowledge learnt throughout a conversation.
@@ -288,7 +288,7 @@ print(role_adherence.score, role_adherence.reason)
 from deepeval.test_case import LLMTestCase, MLLMImage
 from deepeval.metrics import ImageCoherenceMetric
 
-test_case = LLMTestCase(input=f"What does thsi image say? {MLLMImage(...)}", actual_output="No idea!")
+test_case = LLMTestCase(input=f"What does this image say? {MLLMImage(...)}", actual_output="No idea!")
 image_coherence = ImageCoherenceMetric(threshold=0.5)
 
 image_coherence.measure(test_case)


### PR DESCRIPTION
## Summary

Follow-up to issue #2696. PR #2703 only handled the m_test_case variable name mismatch from that issue. This PR addresses the remaining typos.

## Changes

**README.md**
- `persistant layer` → `persistent layer`
- `Let's breakdown what happened` → `Let's break down what happened`
- `if your test have passed` → `if your test has passed`
- `LLM output's on any custom` → `LLM outputs on any custom`

**docs/content/docs/metrics-introduction.mdx**
- `satisify` → `satisfy`
- `thsi image` → `this image`

No code logic changes. Documentation only.