### PR TITLE
Add optional juryeval integration for LLM-as-Judge metrics

### DIFF
--- a/deepeval/metrics/__init__.py
+++ b/deepeval/metrics/__init__.py
@@ -66,6 +66,11 @@ from .multimodal_metrics import (
     ImageReferenceMetric,
 )
 
+try:
+    from .juryeval import JuryEvalMetric, PairwiseJudgeMetric, PointwiseJudgeMetric
+except ImportError:
+    pass
+
 __all__ = [
     # Base classes
     "BaseMetric",
@@ -129,4 +134,8 @@ __all__ = [
     "ImageCoherenceMetric",
     "ImageHelpfulnessMetric",
     "ImageReferenceMetric",
+    # JuryEval metrics (optional)
+    "JuryEvalMetric",
+    "PairwiseJudgeMetric",
+    "PointwiseJudgeMetric",
 ]

--- a/deepeval/metrics/juryeval/__init__.py
+++ b/deepeval/metrics/juryeval/__init__.py
@@ -1,0 +1,3 @@
+from deepeval.metrics.juryeval.juryeval_metric import JuryEvalMetric, PairwiseJudgeMetric, PointwiseJudgeMetric
+
+__all__ = ["JuryEvalMetric", "PairwiseJudgeMetric", "PointwiseJudgeMetric"]

--- a/deepeval/metrics/juryeval/juryeval_metric.py
+++ b/deepeval/metrics/juryeval/juryeval_metric.py
@@ -1,0 +1,168 @@
+from typing import List, Optional, Dict, Any
+
+from deepeval.metrics import BaseMetric
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.utils import (
+    check_llm_test_case_params,
+    construct_verbose_logs,
+)
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+
+class JuryEvalMetric(BaseMetric):
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        metric_fn=None,
+        metric_name: str = "JuryEval",
+        threshold: float = 0.5,
+        verbose_mode: bool = False,
+        **kwargs,
+    ):
+        try:
+            import juryeval  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "juryeval is required for JuryEvalMetric. "
+                "Install it with: pip install juryeval"
+            )
+        self.metric_fn = metric_fn
+        self._name = metric_name
+        self.threshold = threshold
+        self.verbose_mode = verbose_mode
+        self.kwargs = kwargs
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        from juryeval import PairwiseJudge, PointwiseJudge
+
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            None,
+            test_case.multimodal,
+        )
+
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            if isinstance(self.metric_fn, PairwiseJudge):
+                self.score = self._run_pairwise(test_case)
+            elif isinstance(self.metric_fn, PointwiseJudge):
+                self.score = self._run_pointwise(test_case)
+            elif callable(self.metric_fn):
+                result = self.metric_fn(
+                    predictions=[test_case.actual_output],
+                    references=[test_case.expected_output] if test_case.expected_output else None,
+                    **self.kwargs,
+                )
+                if isinstance(result, dict):
+                    self.score = float(list(result.values())[0])
+                else:
+                    self.score = float(result)
+            else:
+                raise ValueError(
+                    "metric_fn must be a callable, PairwiseJudge, or PointwiseJudge instance"
+                )
+
+            self.reason = f"{self._name} score: {self.score:.4f}"
+            self.success = self.score >= self.threshold
+
+            if self.verbose_mode:
+                self.verbose_logs = construct_verbose_logs(
+                    self,
+                    steps=[f"Score: {self.score:.4f}", f"Reason: {self.reason}"],
+                )
+
+            return self.score
+
+    def _run_pairwise(self, test_case: LLMTestCase) -> float:
+        result = self.metric_fn.compare(
+            answer_a=test_case.actual_output,
+            answer_b=test_case.expected_output or "",
+            question=test_case.input,
+        )
+        return result.get("score", 0.0)
+
+    def _run_pointwise(self, test_case: LLMTestCase) -> float:
+        result = self.metric_fn.score(
+            output=test_case.actual_output,
+            question=test_case.input,
+            reference=test_case.expected_output,
+        )
+        return result.get("score", 0.0)
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        return self.measure(
+            test_case,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        )
+
+    def is_successful(self) -> bool:
+        if self.error is not None:
+            self.success = False
+        else:
+            try:
+                self.success = self.score >= self.threshold
+            except Exception:
+                self.success = False
+        return self.success
+
+    @property
+    def __name__(self):
+        return self._name
+
+
+class PairwiseJudgeMetric(JuryEvalMetric):
+    def __init__(
+        self,
+        model: str = "gpt-4",
+        threshold: float = 0.5,
+        verbose_mode: bool = False,
+        **judge_kwargs,
+    ):
+        from juryeval import PairwiseJudge
+
+        judge = PairwiseJudge(model=model, **judge_kwargs)
+        super().__init__(
+            metric_fn=judge,
+            metric_name="Pairwise Judge",
+            threshold=threshold,
+            verbose_mode=verbose_mode,
+        )
+
+
+class PointwiseJudgeMetric(JuryEvalMetric):
+    def __init__(
+        self,
+        model: str = "gpt-4",
+        threshold: float = 0.5,
+        verbose_mode: bool = False,
+        **judge_kwargs,
+    ):
+        from juryeval import PointwiseJudge
+
+        judge = PointwiseJudge(model=model, **judge_kwargs)
+        super().__init__(
+            metric_fn=judge,
+            metric_name="Pointwise Judge",
+            threshold=threshold,
+            verbose_mode=verbose_mode,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,11 @@ jinja2 = "*"
 
 textual = { version = ">=0.80,<2.0", optional = true }
 pyperclip = { version = "^1.8", optional = true }
+juryeval = { version = ">=0.4.0", optional = true }
 
 [tool.poetry.extras]
 inspect = ["textual", "pyperclip"]
+juryeval = ["juryeval"]
 
 [tool.poetry.group.dev.dependencies]
 twine = "5.1.1"

--- a/tests/test_metrics/test_juryeval_metric.py
+++ b/tests/test_metrics/test_juryeval_metric.py
@@ -1,0 +1,79 @@
+import pytest
+
+from deepeval.test_case import LLMTestCase
+
+
+class TestJuryEvalMetric:
+    def test_juryeval_not_installed_raises(self):
+        try:
+            import juryeval  # noqa: F401
+            pytest.skip("juryeval is installed")
+        except ImportError:
+            pass
+        with pytest.raises(ImportError, match="juryeval is required"):
+            from deepeval.metrics.juryeval import JuryEvalMetric
+
+            JuryEvalMetric(metric_fn=lambda preds, refs: 0.5)
+
+    def test_custom_metric_fn(self):
+        from deepeval.metrics.juryeval import JuryEvalMetric
+
+        def dummy_fn(predictions, references=None, **kwargs):
+            return 0.75
+
+        metric = JuryEvalMetric(metric_fn=dummy_fn, metric_name="Custom", threshold=0.5)
+        test_case = LLMTestCase(
+            input="test input",
+            actual_output="test output",
+        )
+        score = metric.measure(test_case)
+        assert score == 0.75
+        assert metric.score == 0.75
+        assert metric.is_successful() is True
+        assert "Custom" in metric.__name__
+
+    def test_custom_metric_fn_below_threshold(self):
+        from deepeval.metrics.juryeval import JuryEvalMetric
+
+        def dummy_fn(predictions, references=None, **kwargs):
+            return 0.3
+
+        metric = JuryEvalMetric(metric_fn=dummy_fn, metric_name="Custom", threshold=0.5)
+        test_case = LLMTestCase(
+            input="test input",
+            actual_output="test output",
+        )
+        metric.measure(test_case)
+        assert metric.is_successful() is False
+
+    def test_async_measure(self):
+        from deepeval.metrics.juryeval import JuryEvalMetric
+
+        def dummy_fn(predictions, references=None, **kwargs):
+            return 0.8
+
+        metric = JuryEvalMetric(metric_fn=dummy_fn, metric_name="Custom")
+        test_case = LLMTestCase(
+            input="test input",
+            actual_output="test output",
+        )
+        import asyncio
+
+        score = asyncio.run(metric.a_measure(test_case))
+        assert score == 0.8
+
+    def test_with_expected_output(self):
+        from deepeval.metrics.juryeval import JuryEvalMetric
+
+        def dummy_fn(predictions, references=None, **kwargs):
+            assert references is not None
+            return 1.0
+
+        metric = JuryEvalMetric(metric_fn=dummy_fn, metric_name="Custom")
+        test_case = LLMTestCase(
+            input="test input",
+            actual_output="test output",
+            expected_output="expected output",
+        )
+        score = metric.measure(test_case)
+        assert score == 1.0


### PR DESCRIPTION
## Summary

Adds optional integration with [juryeval](https://github.com/liodon-ai/juryeval) — an open-source NLP/LLM evaluation toolkit that provides LLM-as-Judge infrastructure, statistical significance testing, and prompt robustness analysis.

When `juryeval` is installed (via `pip install deepeval[juryeval]`), three new metric classes become available:

- **`JuryEvalMetric`** — generic wrapper accepting any callable or juryeval judge instance
- **`PairwiseJudgeMetric`** — compares `actual_output` vs `expected_output` via `PairwiseJudge`
- **`PointwiseJudgeMetric`** — scores `actual_output` via `PointwiseJudge`

### Changes

- **`deepeval/metrics/juryeval/`** — new package with `JuryEvalMetric(BaseMetric)`, `PairwiseJudgeMetric`, `PointwiseJudgeMetric`
- **`deepeval/metrics/__init__.py`** — guarded import of juryeval metrics
- **`pyproject.toml`** — adds `juryeval>=0.4.0` as an optional dependency with `[juryeval]` extra
- **`tests/test_metrics/test_juryeval_metric.py`** — 5 tests (4 pass, 1 skipped when juryeval is installed)

### Usage

```python
from deepeval import evaluate
from deepeval.test_case import LLMTestCase
from deepeval.metrics import PairwiseJudgeMetric

metric = PairwiseJudgeMetric(model="gpt-4", threshold=0.5)
test_case = LLMTestCase(
    input="What is the capital of France?",
    actual_output="Paris",
    expected_output="Paris is the capital of France.",
)
metric.measure(test_case)
print(metric.score, metric.reason, metric.is_successful())
```

### Notes

- Guarded with try/except ImportError — no impact when juryeval is not installed
- Follows the `BaseMetric` ABC pattern (same as `ExactMatchMetric`, `GEval`, etc.)
- Async support via `a_measure()`
- Custom callables can be passed to `JuryEvalMetric(metric_fn=...)` for any juryeval metric function