### PR TITLE
Fix TurnFaithfulnessMetric crash on assistant turns with no claims

### DIFF
--- a/deepeval/metrics/turn_faithfulness/turn_faithfulness.py
+++ b/deepeval/metrics/turn_faithfulness/turn_faithfulness.py
@@ -379,7 +379,8 @@ class TurnFaithfulnessMetric(BaseConversationalMetric):
     ) -> Tuple[float, str]:
         number_of_verdicts = len(verdicts)
         if number_of_verdicts == 0:
-            return 1
+            reason = "<no claims to verify>" if self.include_reason else None
+            return 1.0, reason
 
         faithfulness_count = 0
         for verdict in verdicts:
@@ -405,7 +406,8 @@ class TurnFaithfulnessMetric(BaseConversationalMetric):
     ) -> Tuple[float, str]:
         number_of_verdicts = len(verdicts)
         if number_of_verdicts == 0:
-            return 1
+            reason = "<no claims to verify>" if self.include_reason else None
+            return 1.0, reason
 
         faithfulness_count = 0
         for verdict in verdicts:

--- a/tests/test_metrics/test_turn_faithfulness_metric_empty_verdicts.py
+++ b/tests/test_metrics/test_turn_faithfulness_metric_empty_verdicts.py
@@ -1,0 +1,74 @@
+"""Regression tests for TurnFaithfulnessMetric's empty-verdicts code path.
+
+The score-and-reason helpers must always return a (float, str) tuple so that
+callers can unpack the result with `score, reason = ...`. Returning a bare int
+on the empty-verdicts branch crashed any conversation containing an assistant
+turn with no extractable factual claims (e.g. "Sure, happy to help!").
+
+These tests exercise the helpers directly with a stub model, so they run
+without an LLM provider API key.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics import TurnFaithfulnessMetric
+from deepeval.models.base_model import DeepEvalBaseLLM
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM that never calls out to a provider."""
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        raise AssertionError("generate should not be called in this test")
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        raise AssertionError("a_generate should not be called in this test")
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+@pytest.fixture
+def metric() -> TurnFaithfulnessMetric:
+    return TurnFaithfulnessMetric(model=_StubLLM())
+
+
+def test_sync_empty_verdicts_returns_tuple(metric: TurnFaithfulnessMetric):
+    result = metric._get_interaction_score_and_reason([], multimodal=False)
+
+    score, reason = result  # must be unpackable
+    assert score == 1.0
+    assert isinstance(score, float)
+    assert isinstance(reason, str) and reason
+
+
+def test_async_empty_verdicts_returns_tuple(metric: TurnFaithfulnessMetric):
+    result = asyncio.run(
+        metric._a_get_interaction_score_and_reason([], multimodal=False)
+    )
+
+    score, reason = result
+    assert score == 1.0
+    assert isinstance(score, float)
+    assert isinstance(reason, str) and reason
+
+
+def test_sync_empty_verdicts_respects_include_reason_false():
+    m = TurnFaithfulnessMetric(model=_StubLLM(), include_reason=False)
+    score, reason = m._get_interaction_score_and_reason([], multimodal=False)
+    assert score == 1.0
+    assert reason is None
+
+
+def test_async_empty_verdicts_respects_include_reason_false():
+    m = TurnFaithfulnessMetric(model=_StubLLM(), include_reason=False)
+    score, reason = asyncio.run(
+        m._a_get_interaction_score_and_reason([], multimodal=False)
+    )
+    assert score == 1.0
+    assert reason is None


### PR DESCRIPTION
While poking at TurnFaithfulnessMetric I noticed it crashes on a really common code path: any conversation containing an assistant turn with no factual claims to extract (things like "Sure!", "Happy to help!", "Let me think about that…").

### What's wrong

In deepeval/metrics/turn_faithfulness/turn_faithfulness.py, the helper is declared as:

def _get_interaction_score_and_reason(self, verdicts, multimodal) -> Tuple[float, str]:

…and the caller relies on that shape:

score, reason = self._get_interaction_score_and_reason(...)

But on the "no verdicts to evaluate" branch it returns a bare `1` instead of a tuple, so Python blows up unpacking it:
TypeError: cannot unpack non-iterable int object

Both the sync and async variants have the same bug (lines 382 and 408 before the patch), so toggling `async_mode` doesn't help. And the path is hit very often, because `_generate_verdicts` short-circuits to `[]` whenever the claim extractor returns no claims, which is the normal outcome for chit-chat assistant turns.

### The fix

Return a proper tuple on that branch:

 return 1.0, "<no claims to verify>"

Score of 1.0 because zero claims means nothing was unfaithful (vacuously perfect, same convention the single-turn FaithfulnessMetric uses). The reason string honors `include_reason` the same way the surrounding `_get_interaction_reason` does — it's `None` when `include_reason=False`.

### Tests

Added tests/test_metrics/test_turn_faithfulness_metric_empty_verdicts.py with four small unit tests for the empty-verdicts branch: sync, async, and both with `include_reason=False`. They use a stub `DeepEvalBaseLLM` so they run without `OPENAI_API_KEY`. All four fail against `main` with the TypeError and pass with this change. The existing test_turn_faithfulness_metric.py still collects/skips cleanly.
