### PR TITLE
fix(dataset): serialize RetrievedContextData in save_as instead of crashing

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -24,6 +24,9 @@ from deepeval.dataset.utils import (
     format_turns,
     check_tracer,
     parse_turns,
+    serialize_retrieval_context,
+    join_retrieval_context,
+    reconstruct_retrieval_context,
     trimAndLoadJson,
 )
 from deepeval.dataset.api import (
@@ -42,7 +45,6 @@ from deepeval.test_case import (
     LLMTestCase,
     ConversationalTestCase,
     ToolCall,
-    RetrievedContextData,
 )
 from deepeval.test_run.hyperparameters import process_hyperparameters
 from deepeval.test_run.test_run import TEMP_FILE_PATH
@@ -318,7 +320,9 @@ class EvaluationDataset:
         ]
         retrieval_contexts = [
             (
-                retrieval_context.split(retrieval_context_col_delimiter)
+                reconstruct_retrieval_context(
+                    retrieval_context.split(retrieval_context_col_delimiter)
+                )
                 if retrieval_context
                 else []
             )
@@ -454,7 +458,9 @@ class EvaluationDataset:
             actual_output = json_obj[actual_output_key_name]
             expected_output = json_obj.get(expected_output_key_name)
             context = json_obj.get(context_key_name)
-            retrieval_context = json_obj.get(retrieval_context_key_name)
+            retrieval_context = reconstruct_retrieval_context(
+                json_obj.get(retrieval_context_key_name)
+            )
             tools_called_data = json_obj.get(tools_called_key_name, [])
             tools_called = [ToolCall(**tool) for tool in tools_called_data]
             expected_tools_data = json_obj.get(expected_tools_key_name, [])
@@ -530,7 +536,9 @@ class EvaluationDataset:
         ]
         retrieval_contexts = [
             (
-                retrieval_context.split(retrieval_context_col_delimiter)
+                reconstruct_retrieval_context(
+                    retrieval_context.split(retrieval_context_col_delimiter)
+                )
                 if retrieval_context
                 else []
             )
@@ -714,7 +722,9 @@ class EvaluationDataset:
                 actual_output = json_obj.get(actual_output_key_name)
                 expected_output = json_obj.get(expected_output_key_name)
                 context = json_obj.get(context_key_name)
-                retrieval_context = json_obj.get(retrieval_context_key_name)
+                retrieval_context = reconstruct_retrieval_context(
+                    json_obj.get(retrieval_context_key_name)
+                )
                 tools_called = json_obj.get(tools_called_key_name)
                 expected_tools = json_obj.get(expected_tools_key_name)
                 comments = json_obj.get(comments_key_name)
@@ -835,9 +845,11 @@ class EvaluationDataset:
                 context = parse_context(
                     json_obj.get(context_key_name), context_col_delimiter
                 )
-                retrieval_context = parse_context(
-                    json_obj.get(retrieval_context_key_name),
-                    retrieval_context_col_delimiter,
+                retrieval_context = reconstruct_retrieval_context(
+                    parse_context(
+                        json_obj.get(retrieval_context_key_name),
+                        retrieval_context_col_delimiter,
+                    )
                 )
                 tools_called = parse_tools(json_obj.get(tools_called_key_name))
                 expected_tools = parse_tools(
@@ -1217,33 +1229,6 @@ class EvaluationDataset:
 
         full_file_path = os.path.join(directory, new_filename)
 
-        def _serialize_retrieval_context(retrieval_context):
-            # retrieval_context items may be RetrievedContextData, which
-            # declares its own @model_serializer ("source: context"). Honor
-            # it so structured items are not handed raw to json.dump or
-            # "|".join, both of which raise TypeError on a non-str/dict.
-            if retrieval_context is None:
-                return None
-            return [
-                (
-                    item.model_dump()
-                    if isinstance(item, RetrievedContextData)
-                    else item
-                )
-                for item in retrieval_context
-            ]
-
-        def _join_retrieval_context(retrieval_context):
-            # Flat join for csv/jsonl. The serialized items are strings today
-            # (RetrievedContextData serializes to "source: context"); coerce
-            # defensively so the join never breaks if that ever changes.
-            if retrieval_context is None:
-                return None
-            return "|".join(
-                str(item)
-                for item in _serialize_retrieval_context(retrieval_context)
-            )
-
         if file_type == "json":
             with open(full_file_path, "w", encoding="utf-8") as file:
                 if self._multi_turn:
@@ -1294,7 +1279,7 @@ class EvaluationDataset:
                                 "input": golden.input,
                                 "actual_output": golden.actual_output,
                                 "expected_output": golden.expected_output,
-                                "retrieval_context": _serialize_retrieval_context(
+                                "retrieval_context": serialize_retrieval_context(
                                     golden.retrieval_context
                                 ),
                                 "context": golden.context,
@@ -1388,7 +1373,7 @@ class EvaluationDataset:
                         ]
                     )
                     for golden in goldens:
-                        retrieval_context = _join_retrieval_context(
+                        retrieval_context = join_retrieval_context(
                             golden.retrieval_context
                         )
                         context = (
@@ -1469,7 +1454,7 @@ class EvaluationDataset:
                             "custom_column_key_values": golden.custom_column_key_values,
                         }
                     else:
-                        retrieval_context = _join_retrieval_context(
+                        retrieval_context = join_retrieval_context(
                             golden.retrieval_context
                         )
                         context = (

--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -42,6 +42,7 @@ from deepeval.test_case import (
     LLMTestCase,
     ConversationalTestCase,
     ToolCall,
+    RetrievedContextData,
 )
 from deepeval.test_run.hyperparameters import process_hyperparameters
 from deepeval.test_run.test_run import TEMP_FILE_PATH
@@ -1216,6 +1217,33 @@ class EvaluationDataset:
 
         full_file_path = os.path.join(directory, new_filename)
 
+        def _serialize_retrieval_context(retrieval_context):
+            # retrieval_context items may be RetrievedContextData, which
+            # declares its own @model_serializer ("source: context"). Honor
+            # it so structured items are not handed raw to json.dump or
+            # "|".join, both of which raise TypeError on a non-str/dict.
+            if retrieval_context is None:
+                return None
+            return [
+                (
+                    item.model_dump()
+                    if isinstance(item, RetrievedContextData)
+                    else item
+                )
+                for item in retrieval_context
+            ]
+
+        def _join_retrieval_context(retrieval_context):
+            # Flat join for csv/jsonl. The serialized items are strings today
+            # (RetrievedContextData serializes to "source: context"); coerce
+            # defensively so the join never breaks if that ever changes.
+            if retrieval_context is None:
+                return None
+            return "|".join(
+                str(item)
+                for item in _serialize_retrieval_context(retrieval_context)
+            )
+
         if file_type == "json":
             with open(full_file_path, "w", encoding="utf-8") as file:
                 if self._multi_turn:
@@ -1266,7 +1294,9 @@ class EvaluationDataset:
                                 "input": golden.input,
                                 "actual_output": golden.actual_output,
                                 "expected_output": golden.expected_output,
-                                "retrieval_context": golden.retrieval_context,
+                                "retrieval_context": _serialize_retrieval_context(
+                                    golden.retrieval_context
+                                ),
                                 "context": golden.context,
                                 "name": golden.name,
                                 "comments": golden.comments,
@@ -1358,10 +1388,8 @@ class EvaluationDataset:
                         ]
                     )
                     for golden in goldens:
-                        retrieval_context = (
-                            "|".join(golden.retrieval_context)
-                            if golden.retrieval_context is not None
-                            else None
+                        retrieval_context = _join_retrieval_context(
+                            golden.retrieval_context
                         )
                         context = (
                             "|".join(golden.context)
@@ -1441,10 +1469,8 @@ class EvaluationDataset:
                             "custom_column_key_values": golden.custom_column_key_values,
                         }
                     else:
-                        retrieval_context = (
-                            "|".join(golden.retrieval_context)
-                            if golden.retrieval_context is not None
-                            else None
+                        retrieval_context = _join_retrieval_context(
+                            golden.retrieval_context
                         )
                         context = (
                             "|".join(golden.context)

--- a/deepeval/dataset/utils.py
+++ b/deepeval/dataset/utils.py
@@ -8,7 +8,63 @@ from opentelemetry.trace import Tracer
 
 from deepeval.dataset.api import Golden
 from deepeval.dataset.golden import ConversationalGolden
-from deepeval.test_case import LLMTestCase, ConversationalTestCase, Turn
+from deepeval.test_case import (
+    LLMTestCase,
+    ConversationalTestCase,
+    Turn,
+    RetrievedContextData,
+)
+
+# RetrievedContextData declares an @model_serializer, so a plain model_dump
+# flattens it and a save/load round-trip loses the source. Serialize each item
+# to a namespaced, parseable marker instead, and reconstruct it on load.
+_RETRIEVED_CONTEXT_MARKER = re.compile(
+    r"^deepeval_source=(?P<source>.*?),deepeval_context=(?P<context>.*)$"
+)
+
+
+def serialize_retrieval_context(retrieval_context):
+    """Serialize retrieval_context items for file output, preserving the
+    source/context of any RetrievedContextData via a reconstructable marker."""
+    if retrieval_context is None:
+        return None
+    return [
+        (
+            f"deepeval_source={item.source},deepeval_context={item.context}"
+            if isinstance(item, RetrievedContextData)
+            else item
+        )
+        for item in retrieval_context
+    ]
+
+
+def join_retrieval_context(retrieval_context, delimiter="|"):
+    """Flat join of serialized retrieval_context for csv/jsonl cells."""
+    serialized = serialize_retrieval_context(retrieval_context)
+    if serialized is None:
+        return None
+    return delimiter.join(str(item) for item in serialized)
+
+
+def reconstruct_retrieval_context(retrieval_context):
+    """Inverse of serialize_retrieval_context: rebuild RetrievedContextData
+    from any marker strings, leaving plain strings untouched."""
+    if retrieval_context is None:
+        return None
+    reconstructed = []
+    for item in retrieval_context:
+        if isinstance(item, str):
+            match = _RETRIEVED_CONTEXT_MARKER.match(item)
+            if match:
+                reconstructed.append(
+                    RetrievedContextData(
+                        source=match.group("source"),
+                        context=match.group("context"),
+                    )
+                )
+                continue
+        reconstructed.append(item)
+    return reconstructed
 
 
 def convert_test_cases_to_goldens(
@@ -21,14 +77,10 @@ def convert_test_cases_to_goldens(
             "actual_output": test_case.actual_output,
             "expected_output": test_case.expected_output,
             "context": test_case.context,
-            "retrieval_context": (
-                [
-                    rc.context if hasattr(rc, "context") else rc
-                    for rc in test_case.retrieval_context
-                ]
-                if test_case.retrieval_context
-                else None
-            ),
+            # Pass retrieval_context through unchanged so save_as serializes
+            # any RetrievedContextData via the shared marker (and reloads it),
+            # rather than flattening to .context and dropping the source here.
+            "retrieval_context": test_case.retrieval_context,
             "tools_called": test_case.tools_called,
             "expected_tools": test_case.expected_tools,
             "additional_metadata": test_case.metadata,
@@ -147,13 +199,8 @@ def format_turns(turns: List[Turn]) -> str:
             "role": turn.role,
             "content": turn.content,
             "user_id": turn.user_id if turn.user_id is not None else None,
-            "retrieval_context": (
-                [
-                    rc.context if hasattr(rc, "context") else rc
-                    for rc in turn.retrieval_context
-                ]
-                if turn.retrieval_context
-                else None
+            "retrieval_context": serialize_retrieval_context(
+                turn.retrieval_context
             ),
             "tools_called": _dump_list(turn.tools_called),
             "mcp_tools_called": _dump_list(turn.mcp_tools_called),
@@ -193,6 +240,11 @@ def parse_turns(turns_str: Any) -> List[Turn]:
             raise ValueError(f"Turn at index {i} is missing a valid 'role'.")
         if "content" not in turn or not isinstance(turn["content"], str):
             raise ValueError(f"Turn at index {i} is missing a valid 'content'.")
+
+        if "retrieval_context" in turn:
+            turn["retrieval_context"] = reconstruct_retrieval_context(
+                turn["retrieval_context"]
+            )
 
         try:
             # Pydantic v2

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -240,12 +240,12 @@ class TestSaveAndLoad:
                     custom_obj = json.loads(vals[custom_idx])
                     assert custom_obj["col"] == "val"
 
-    def test_save_as_serializes_retrieval_context_data(self):
-        """save_as must not crash when retrieval_context holds RetrievedContextData
-        (a type-allowed member of Golden.retrieval_context). Items are serialized
-        through the model's own @model_serializer ('source: context'), so a
-        reloaded golden carries retrieval_context as strings; structured
-        round-trip is intentionally out of scope."""
+    def test_save_as_round_trips_retrieval_context_data(self):
+        """save_as serializes a RetrievedContextData (a type-allowed member of
+        Golden.retrieval_context that used to crash the save) as a namespaced,
+        reconstructable marker, and the matching loaders rebuild it. So
+        retrieval_context survives a save/load round-trip losslessly (source
+        preserved) in all three formats. Plain strings and None pass through."""
         goldens = [
             Golden(
                 input="q",
@@ -255,51 +255,66 @@ class TestSaveAndLoad:
                     "plain",
                 ],
             ),
-            Golden(
-                input="q2",
-                actual_output="a2",
-                retrieval_context=[
-                    RetrievedContextData(context="c2", source="s2"),
-                ],
-            ),
             Golden(input="q3", actual_output="a3", retrieval_context=None),
         ]
-        dataset = EvaluationDataset(goldens)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # JSON: list of flat strings, no crash
-            json_path = dataset.save_as(
+            # On disk, a RetrievedContextData is a marker, not a raw model
+            json_path = EvaluationDataset(goldens).save_as(
                 "json", directory=tmpdir, file_name="rc_json"
             )
             with open(json_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            assert data[0]["retrieval_context"] == ["s: c", "plain"]
-            assert data[1]["retrieval_context"] == ["s2: c2"]  # all-RCD list
-            assert data[2]["retrieval_context"] is None  # None passes through
+            assert data[0]["retrieval_context"] == [
+                "deepeval_source=s,deepeval_context=c",
+                "plain",
+            ]
+            assert data[1]["retrieval_context"] is None
 
-            # JSONL: "|"-joined flat strings
-            jsonl_path = dataset.save_as(
-                "jsonl", directory=tmpdir, file_name="rc_jsonl"
+            # Each loader rebuilds RetrievedContextData losslessly
+            for fmt, loader in (
+                ("json", "add_goldens_from_json_file"),
+                ("csv", "add_goldens_from_csv_file"),
+                ("jsonl", "add_goldens_from_jsonl_file"),
+            ):
+                path = EvaluationDataset(goldens).save_as(
+                    fmt, directory=tmpdir, file_name=f"rc_{fmt}"
+                )
+                reloaded = EvaluationDataset()
+                getattr(reloaded, loader)(path)
+                rc = reloaded.goldens[0].retrieval_context
+                assert len(rc) == 2
+                assert isinstance(rc[0], RetrievedContextData)
+                assert rc[0].source == "s" and rc[0].context == "c"
+                assert rc[1] == "plain"
+
+    def test_save_as_round_trips_turn_retrieval_context_data(self):
+        """Multi-turn goldens serialize through format_turns, which previously
+        dropped the source of a Turn's RetrievedContextData. It now round-trips
+        losslessly as well."""
+        golden = ConversationalGolden(
+            scenario="sc",
+            expected_outcome="o",
+            turns=[
+                Turn(
+                    role="user",
+                    content="hi",
+                    retrieval_context=[
+                        RetrievedContextData(context="c", source="s"),
+                    ],
+                )
+            ],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = EvaluationDataset([golden]).save_as(
+                "json", directory=tmpdir, file_name="convo"
             )
-            with open(jsonl_path, "r", encoding="utf-8") as f:
-                row = json.loads(f.readline())
-            assert row["retrieval_context"] == "s: c|plain"
-
-            # CSV: "|"-joined flat strings in the retrieval_context column
-            csv_path = dataset.save_as(
-                "csv", directory=tmpdir, file_name="rc_csv"
-            )
-            with open(csv_path, "r", encoding="utf-8") as f:
-                rows = list(csv.reader(f))
-            idx = rows[0].index("retrieval_context")
-            assert rows[1][idx] == "s: c|plain"
-
-            # Round-trip: reloading the JSON rebuilds a golden whose
-            # retrieval_context is the flattened strings (documents that the
-            # structured form is not preserved, by the model's own design).
             reloaded = EvaluationDataset()
-            reloaded.add_goldens_from_json_file(json_path)
-            assert reloaded.goldens[0].retrieval_context == ["s: c", "plain"]
+            reloaded.add_goldens_from_json_file(path)
+            rc = reloaded.goldens[0].turns[0].retrieval_context
+            assert len(rc) == 1
+            assert isinstance(rc[0], RetrievedContextData)
+            assert rc[0].source == "s" and rc[0].context == "c"
 
     def test_save_as_includes_turn_fields_in_multi_turn_json_and_jsonl(self):
         """Multi-turn JSON/JSONL include full turn fields (user_id, tools)."""
@@ -500,6 +515,31 @@ class TestSaveAndLoad:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
                 assert any(item["input"] == "input case" for item in data)
+
+    def test_save_as_includes_test_cases_round_trips_retrieval_context_data(
+        self,
+    ):
+        """A RetrievedContextData on an included test case survives the
+        include_test_cases save/load round-trip losslessly too (the
+        test-case -> golden conversion no longer flattens it)."""
+        test_case = LLMTestCase(
+            input="input case",
+            actual_output="actual",
+            retrieval_context=[RetrievedContextData(context="c", source="s")],
+        )
+        dataset = EvaluationDataset()
+        dataset.add_test_case(test_case)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = dataset.save_as(
+                "json", directory=tmpdir, include_test_cases=True
+            )
+            reloaded = EvaluationDataset()
+            reloaded.add_goldens_from_json_file(path)
+            rc = reloaded.goldens[0].retrieval_context
+            assert len(rc) == 1
+            assert isinstance(rc[0], RetrievedContextData)
+            assert rc[0].source == "s" and rc[0].context == "c"
 
     def test_save_as_includes_convo_test_cases(self):
         """Check that convo test cases get included when include_test_cases=True."""

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -10,6 +10,7 @@ from deepeval.test_case import (
     LLMTestCase,
     ConversationalTestCase,
     ToolCall,
+    RetrievedContextData,
 )
 
 
@@ -238,6 +239,67 @@ class TestSaveAndLoad:
                 if vals[custom_idx]:
                     custom_obj = json.loads(vals[custom_idx])
                     assert custom_obj["col"] == "val"
+
+    def test_save_as_serializes_retrieval_context_data(self):
+        """save_as must not crash when retrieval_context holds RetrievedContextData
+        (a type-allowed member of Golden.retrieval_context). Items are serialized
+        through the model's own @model_serializer ('source: context'), so a
+        reloaded golden carries retrieval_context as strings; structured
+        round-trip is intentionally out of scope."""
+        goldens = [
+            Golden(
+                input="q",
+                actual_output="a",
+                retrieval_context=[
+                    RetrievedContextData(context="c", source="s"),
+                    "plain",
+                ],
+            ),
+            Golden(
+                input="q2",
+                actual_output="a2",
+                retrieval_context=[
+                    RetrievedContextData(context="c2", source="s2"),
+                ],
+            ),
+            Golden(input="q3", actual_output="a3", retrieval_context=None),
+        ]
+        dataset = EvaluationDataset(goldens)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # JSON: list of flat strings, no crash
+            json_path = dataset.save_as(
+                "json", directory=tmpdir, file_name="rc_json"
+            )
+            with open(json_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            assert data[0]["retrieval_context"] == ["s: c", "plain"]
+            assert data[1]["retrieval_context"] == ["s2: c2"]  # all-RCD list
+            assert data[2]["retrieval_context"] is None  # None passes through
+
+            # JSONL: "|"-joined flat strings
+            jsonl_path = dataset.save_as(
+                "jsonl", directory=tmpdir, file_name="rc_jsonl"
+            )
+            with open(jsonl_path, "r", encoding="utf-8") as f:
+                row = json.loads(f.readline())
+            assert row["retrieval_context"] == "s: c|plain"
+
+            # CSV: "|"-joined flat strings in the retrieval_context column
+            csv_path = dataset.save_as(
+                "csv", directory=tmpdir, file_name="rc_csv"
+            )
+            with open(csv_path, "r", encoding="utf-8") as f:
+                rows = list(csv.reader(f))
+            idx = rows[0].index("retrieval_context")
+            assert rows[1][idx] == "s: c|plain"
+
+            # Round-trip: reloading the JSON rebuilds a golden whose
+            # retrieval_context is the flattened strings (documents that the
+            # structured form is not preserved, by the model's own design).
+            reloaded = EvaluationDataset()
+            reloaded.add_goldens_from_json_file(json_path)
+            assert reloaded.goldens[0].retrieval_context == ["s: c", "plain"]
 
     def test_save_as_includes_turn_fields_in_multi_turn_json_and_jsonl(self):
         """Multi-turn JSON/JSONL include full turn fields (user_id, tools)."""


### PR DESCRIPTION
## What

`EvaluationDataset.save_as()` crashes with `TypeError` in **all three** output formats when a `Golden`'s `retrieval_context` contains a `RetrievedContextData` object, which is a *type-allowed* member of the field:

```python
retrieval_context: Optional[List[Union[str, RetrievedContextData]]]
```

```python
from deepeval.dataset import Golden, EvaluationDataset
from deepeval.test_case import RetrievedContextData

g = Golden(input="q", retrieval_context=[RetrievedContextData(context="c", source="s")])
ds = EvaluationDataset(goldens=[g])
ds.save_as("json", ".")   # TypeError: Object of type RetrievedContextData is not JSON serializable
ds.save_as("csv", ".")    # TypeError: sequence item 0: expected str instance, RetrievedContextData found
ds.save_as("jsonl", ".")  # same as csv
```

## Why

`save_as` builds its output by hand and bypasses pydantic for `retrieval_context`: the json branch passes the raw list straight to `json.dump`, and the csv/jsonl branches do `"|".join(...)` over it. Neither tolerates a `RetrievedContextData`.

The key point: `RetrievedContextData` declares its own `@model_serializer` that returns `"source: context"`, and the model's canonical dump already uses it.

```python
golden.model_dump()["retrieval_context"]   # -> ['s: c']
```

So `save_as` was the only serialization path that did **not** go through the model's own serializer. Every other dump already emits that flat string; `save_as` uniquely bypassed it and crashed instead.

## Fix

Route `retrieval_context` items through `model_dump()` (the model's declared serialization) before `json.dump` / the join. The csv/jsonl join additionally coerces each item to `str`, so it cannot regress if that serializer ever changes shape.

A saved-then-reloaded golden therefore carries `retrieval_context` as strings. Preserving the structured `{context, source}` form is intentionally out of scope: that would make `save_as` deviate from the model's own `model_dump()`. (`tools_called` / `expected_tools` already coerce via `model_dump`, and the multi-turn path serializes turns through pydantic, so neither is affected.)

## Tests

Adds a regression test covering all three formats, a mixed `str` / `RetrievedContextData` list, an all-`RetrievedContextData` list, a `None` retrieval_context, and a JSON reload round-trip. The full `tests/test_core/test_datasets/` suite passes.
