### PR TITLE
Fix GeminiModel always reporting $0 evaluation cost

### DIFF
--- a/deepeval/models/llms/gemini_model.py
+++ b/deepeval/models/llms/gemini_model.py
@@ -314,12 +314,27 @@ class GeminiModel(DeepEvalBaseLLM):
     # Utilities
     ###############################################
 
-    @staticmethod
-    def _token_cost(response) -> EvaluationCost:
+    def calculate_cost(
+        self, input_tokens: int, output_tokens: int
+    ) -> Optional[EvaluationCost]:
+        if self.model_data.input_price and self.model_data.output_price:
+            input_cost = input_tokens * self.model_data.input_price
+            output_cost = output_tokens * self.model_data.output_price
+            return EvaluationCost(
+                input_cost + output_cost, input_tokens, output_tokens
+            )
+
+    def _token_cost(self, response) -> EvaluationCost:
         usage = getattr(response, "usage_metadata", None)
         input_tokens = getattr(usage, "prompt_token_count", None)
         output_tokens = getattr(usage, "candidates_token_count", None)
-        return EvaluationCost(0, input_tokens, output_tokens)
+        if input_tokens is not None and output_tokens is not None:
+            cost = self.calculate_cost(input_tokens, output_tokens)
+            if cost is not None:
+                return cost
+        # Fall back to a zero-cost EvaluationCost that still carries whatever
+        # token info we have, so callers can distinguish "unknown" from "zero".
+        return EvaluationCost(0.0, input_tokens, output_tokens)
 
     #########################
     # Capabilities          #

--- a/tests/test_core/test_models/test_gemini_model.py
+++ b/tests/test_core/test_models/test_gemini_model.py
@@ -1,8 +1,11 @@
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from pydantic import SecretStr
 
+from deepeval.models.llms.constants import GEMINI_MODELS_DATA
 from deepeval.models.llms.gemini_model import GeminiModel
+from deepeval.models.utils import EvaluationCost
 from tests.test_core.stubs import _make_fake_genai_module
 
 ##########################
@@ -179,22 +182,20 @@ def test_gemini_model_use_vertexai_param_overrides_settings(
     assert client.kwargs.get("credentials") is None
 
 
-########################################
-# Cost behavior: Gemini always returns 0
-########################################
+#################################
+# Cost behavior: token × price  #
+#################################
 
 
-@patch("deepeval.models.llms.gemini_model.require_dependency")
-def test_gemini_generate_returns_zero_cost(mock_require_dep, settings):
-    from unittest.mock import MagicMock
-
+def _build_gemini_model_with_fake_client(
+    mock_require_dep, settings, fake_response, model_name="gemini-1.5-pro"
+):
+    """Wire a GeminiModel whose underlying client returns ``fake_response``."""
     fake_genai = _make_fake_genai_module()
     fake_genai.types.GenerateContentConfig = lambda **kwargs: kwargs
 
     fake_client = MagicMock()
-    fake_client.models.generate_content.return_value = MagicMock(
-        text="Hello world"
-    )
+    fake_client.models.generate_content.return_value = fake_response
 
     def _fake_require_dependency(name, *args, **kwargs):
         if name == "google.genai":
@@ -206,9 +207,124 @@ def test_gemini_generate_returns_zero_cost(mock_require_dep, settings):
     with settings.edit(persist=False):
         settings.GOOGLE_API_KEY = "test-key"
 
-    model = GeminiModel(model="gemini-1.5-pro")
+    model = GeminiModel(model=model_name)
     model.load_model = lambda *a, **kw: fake_client
+    return model
+
+
+@patch("deepeval.models.llms.gemini_model.require_dependency")
+def test_gemini_generate_computes_cost_from_tokens_and_registry_prices(
+    mock_require_dep, settings
+):
+    """
+    With populated ``usage_metadata`` and a model present in the registry,
+    ``generate`` must return an ``EvaluationCost`` whose float value equals
+    ``input_tokens × input_price + output_tokens × output_price`` and whose
+    ``input_tokens`` / ``output_tokens`` attrs reflect what the SDK reported.
+    """
+    fake_response = SimpleNamespace(
+        text="Hello world",
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=1000,
+            candidates_token_count=500,
+        ),
+    )
+
+    model = _build_gemini_model_with_fake_client(
+        mock_require_dep, settings, fake_response, model_name="gemini-1.5-pro"
+    )
 
     output, cost = model.generate("test prompt")
-    assert cost == 0
+
+    registry = GEMINI_MODELS_DATA.get("gemini-1.5-pro")
+    expected = 1000 * registry.input_price + 500 * registry.output_price
+
     assert output == "Hello world"
+    assert isinstance(cost, EvaluationCost)
+    assert cost == expected
+    assert cost > 0  # guard against regressing back to the literal-zero bug
+    assert cost.input_tokens == 1000
+    assert cost.output_tokens == 500
+
+
+@patch("deepeval.models.llms.gemini_model.require_dependency")
+def test_gemini_generate_returns_zero_cost_when_usage_metadata_missing(
+    mock_require_dep, settings
+):
+    """
+    When the SDK response omits ``usage_metadata``, cost falls back to 0 and
+    the token attributes are ``None`` (we cannot invent a price-bearing count).
+    """
+    fake_response = MagicMock(spec=["text"])
+    fake_response.text = "Hello world"
+
+    model = _build_gemini_model_with_fake_client(
+        mock_require_dep, settings, fake_response
+    )
+
+    output, cost = model.generate("test prompt")
+
+    assert output == "Hello world"
+    assert isinstance(cost, EvaluationCost)
+    assert cost == 0
+    assert cost.input_tokens is None
+    assert cost.output_tokens is None
+
+
+@patch("deepeval.models.llms.gemini_model.require_dependency")
+def test_gemini_generate_returns_zero_cost_for_unregistered_model(
+    mock_require_dep, settings
+):
+    """
+    Unknown/custom model names resolve to a default ``DeepEvalModelData`` with
+    ``input_price=None`` / ``output_price=None``. Cost must be 0 and must not
+    raise, but token counts should still ride along on the EvaluationCost.
+    """
+    fake_response = SimpleNamespace(
+        text="Hello world",
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=42,
+            candidates_token_count=7,
+        ),
+    )
+
+    model = _build_gemini_model_with_fake_client(
+        mock_require_dep,
+        settings,
+        fake_response,
+        model_name="gemini-unregistered-experimental",
+    )
+    # Sanity: the registry really did fall back to a no-price default.
+    assert model.model_data.input_price is None
+    assert model.model_data.output_price is None
+
+    output, cost = model.generate("test prompt")
+
+    assert output == "Hello world"
+    assert isinstance(cost, EvaluationCost)
+    assert cost == 0
+    assert cost.input_tokens == 42
+    assert cost.output_tokens == 7
+
+
+@patch("deepeval.models.llms.gemini_model.require_dependency")
+def test_gemini_calculate_cost_unit(mock_require_dep, settings):
+    """Direct unit test for ``calculate_cost`` — registry hit and miss."""
+    mock_require_dep.return_value = _make_fake_genai_module()
+
+    with settings.edit(persist=False):
+        settings.GOOGLE_API_KEY = "test-key"
+
+    model = GeminiModel(model="gemini-2.5-flash")
+    registry = GEMINI_MODELS_DATA.get("gemini-2.5-flash")
+    expected = 10_000 * registry.input_price + 2_500 * registry.output_price
+
+    result = model.calculate_cost(10_000, 2_500)
+    assert isinstance(result, EvaluationCost)
+    assert result == expected
+    assert result.input_tokens == 10_000
+    assert result.output_tokens == 2_500
+
+    # Pricing missing -> contract is to return None (matches OpenAI/Anthropic).
+    model.model_data.input_price = None
+    assert model.calculate_cost(10_000, 2_500) is None


### PR DESCRIPTION
## What

`GeminiModel` was silently reporting `evaluation_cost = $0.00` for every run. The culprit was `_token_cost` being a `@staticmethod`, it couldn't reach `self.model_data.input_price` / `output_price`, so it just hard-coded `0` and returned.
Token counts were extracted correctly, but never multiplied by anything.

## Why it matters

Every Gemini evaluation reported `$0` to the console, to `EvaluationCost`, and to Confident AI dashboards. Cost comparisons across providers were quietly wrong, Gemini always looked free.

## The fix

`deepeval/models/llms/gemini_model.py`
- Added `calculate_cost(input_tokens, output_tokens)` matching the contract every other provider already uses (OpenAI, Anthropic, Grok, Kimi, Azure, Bedrock).
- Made `_token_cost` an instance method that delegates to it, falling back to a zero-cost `EvaluationCost` when token counts or prices are missing, token attrs still ride along so callers can tell "unknown" from "zero".

## Tests

`tests/test_core/test_models/test_gemini_model.py`
- Replaced the stale `test_gemini_generate_returns_zero_cost` test (which was locking in the bug as a contract).
- Added four scenarios: registry hit with real cost math, missing `usage_metadata`, unregistered model with no pricing, and a direct unit test on `calculate_cost`.
- Includes an `assert cost > 0` guard so this can't silently regress back to literal zero.