### PR TITLE
Fix LiteLLM cost calculation (was 666× over for common models)

### DIFF
--- a/deepeval/models/llms/litellm_model.py
+++ b/deepeval/models/llms/litellm_model.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import Optional, Tuple, Union, Dict, List, Any
 from pydantic import BaseModel, SecretStr
 from tenacity import (
@@ -38,6 +39,23 @@ retryable_exceptions = (
 _ALIAS_MAP = {
     "base_url": ["api_base"],
 }
+
+
+def _coerce_cost(value: Any) -> Optional[float]:
+    """Return ``value`` as a non-negative finite float, or ``None`` if it
+    can't be trusted as a USD amount. Rejects bool (subclass of int — would
+    silently bill $1.00 for True), strings that don't parse, NaN, infinity,
+    and negatives — any of these would otherwise corrupt the accumulator
+    (NaN poisons every subsequent total; negative cost subtracts)."""
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(result) or result < 0.0:
+        return None
+    return result
 
 
 class LiteLLMModel(DeepEvalBaseLLM):
@@ -294,11 +312,11 @@ class LiteLLMModel(DeepEvalBaseLLM):
 
             response = completion(**completion_params)
             cost = self.calculate_cost(response)
-            return response, float(cost)  # Ensure cost is always a float
+            return response, cost
 
         except Exception as e:
             logging.error(f"Error in LiteLLM generate_raw_response: {e}")
-            return None, 0.0  # Return 0.0 cost on error
+            return None, 0.0
 
     @retry(
         wait=wait_exponential_jitter(
@@ -341,11 +359,11 @@ class LiteLLMModel(DeepEvalBaseLLM):
 
             response = await acompletion(**completion_params)
             cost = self.calculate_cost(response)
-            return response, float(cost)  # Ensure cost is always a float
+            return response, cost
 
         except Exception as e:
             logging.error(f"Error in LiteLLM a_generate_raw_response: {e}")
-            return None, 0.0  # Return 0.0 cost on error
+            return None, 0.0
 
     @retry(
         wait=wait_exponential_jitter(
@@ -414,31 +432,71 @@ class LiteLLMModel(DeepEvalBaseLLM):
                     )
         return content
 
-    def calculate_cost(self, response: Any) -> float:
-        """Calculate the cost of the response based on token usage."""
+    def calculate_cost(self, response: Any) -> EvaluationCost:
+        """USD cost for a completion. Prefers explicit cost on the response
+        or its usage block; else asks ``litellm.completion_cost``. Invalid or
+        unknown pricing yields 0.0 with tokens preserved — never a fabricated
+        per-token rate, and never an unvalidated NaN/negative that would
+        poison the accumulator."""
+        input_tokens: Optional[int] = None
+        output_tokens: Optional[int] = None
         try:
-            # Get token usage from response
-            input_tokens = getattr(response.usage, "prompt_tokens", 0)
-            output_tokens = getattr(response.usage, "completion_tokens", 0)
-
-            # Try to get cost from response if available
-            if hasattr(response, "cost") and response.cost is not None:
-                cost = float(response.cost)
+            usage = getattr(response, "usage", None)
+            if isinstance(usage, dict):
+                input_tokens = usage.get("prompt_tokens")
+                output_tokens = usage.get("completion_tokens")
+                usage_cost = usage.get("cost")
             else:
-                # Fallback to token-based calculation
-                # Default cost per token (can be adjusted based on provider)
-                input_cost_per_token = 0.0001
-                output_cost_per_token = 0.0002
-                cost = (input_tokens * input_cost_per_token) + (
-                    output_tokens * output_cost_per_token
+                input_tokens = getattr(usage, "prompt_tokens", None)
+                output_tokens = getattr(usage, "completion_tokens", None)
+                usage_cost = getattr(usage, "cost", None)
+
+            cost: Optional[float] = None
+            for raw, source in (
+                (getattr(response, "cost", None), "response.cost"),
+                (usage_cost, "response.usage.cost"),
+            ):
+                if raw is None:
+                    continue
+                cost = _coerce_cost(raw)
+                if cost is not None:
+                    break
+                logging.warning(
+                    f"LiteLLMModel: ignoring invalid {source}={raw!r} "
+                    f"for model '{self.name}'."
                 )
 
-            # Update total evaluation cost
-            self.evaluation_cost += float(cost)
-            return EvaluationCost(float(cost), input_tokens, output_tokens)
+            if cost is None:
+                try:
+                    from litellm import completion_cost as _completion_cost
+
+                    computed = _completion_cost(completion_response=response)
+                    if computed is not None:
+                        cost = _coerce_cost(computed)
+                        if cost is None:
+                            logging.warning(
+                                f"litellm.completion_cost returned invalid "
+                                f"value {computed!r} for model "
+                                f"'{self.name}'; reporting 0.0."
+                            )
+                except ImportError as e:
+                    logging.warning(
+                        f"litellm.completion_cost unavailable ({e}); "
+                        f"reporting 0.0 cost for model '{self.name}'. "
+                        "Upgrade litellm to enable per-model pricing."
+                    )
+                except Exception as e:
+                    logging.warning(
+                        f"LiteLLM cost lookup failed for model '{self.name}': "
+                        f"{e}. Reporting 0.0 cost for this call."
+                    )
+
+            resolved_cost = cost if cost is not None else 0.0
+            self.evaluation_cost += resolved_cost
+            return EvaluationCost(resolved_cost, input_tokens, output_tokens)
         except Exception as e:
             logging.warning(f"Error calculating cost: {e}")
-            return EvaluationCost(0.0, None, None)
+            return EvaluationCost(0.0, input_tokens, output_tokens)
 
     def get_evaluation_cost(self) -> float:
         """Get the total evaluation cost."""

--- a/tests/test_core/test_models/test_litellm_model.py
+++ b/tests/test_core/test_models/test_litellm_model.py
@@ -1,3 +1,4 @@
+import math
 import sys
 import types
 import pytest
@@ -5,21 +6,24 @@ from types import SimpleNamespace
 from pydantic import SecretStr
 
 from deepeval.errors import DeepEvalError
-from deepeval.models.llms.litellm_model import LiteLLMModel  # noqa: E402
+from deepeval.models.utils import EvaluationCost
 
-############################################################################
-# Stub a fake `litellm` module so LiteLLMModel can import it even when the #
-# real dependency is not installed.                                        #
-############################################################################
-
-
+# Stub `litellm` so LiteLLMModel imports cleanly without the real package.
 if "litellm" not in sys.modules:
-    fake_litellm = types.SimpleNamespace(
+    sys.modules["litellm"] = types.SimpleNamespace(
         completion=lambda *a, **k: None,
         acompletion=lambda *a, **k: None,
         get_llm_provider=lambda model: "stub-provider",
+        completion_cost=lambda **k: None,
     )
-    sys.modules["litellm"] = fake_litellm
+elif (
+    isinstance(sys.modules["litellm"], types.SimpleNamespace)
+    and not hasattr(sys.modules["litellm"], "completion_cost")
+):
+    # Only ever patch our own test stub — never the real litellm module.
+    sys.modules["litellm"].completion_cost = lambda **k: None
+
+from deepeval.models.llms.litellm_model import LiteLLMModel  # noqa: E402
 
 
 def test_litellm_explicit_overrides_settings_and_env(monkeypatch, settings):
@@ -124,9 +128,9 @@ def test_litellm_model_accepts_legacy_api_base_keyword_and_maps_to_base_url(
 ##############################
 
 
-def _mk_litellm_model(settings):
+def _mk_litellm_model(settings, model_name="test-model"):
     with settings.edit(persist=False):
-        settings.LITELLM_MODEL_NAME = "test-model"
+        settings.LITELLM_MODEL_NAME = model_name
         settings.LITELLM_API_KEY = "test-key"
     return LiteLLMModel()
 
@@ -142,54 +146,354 @@ def _mk_response(prompt_tokens=100, completion_tokens=50, cost=None):
     return resp
 
 
-def test_litellm_calculate_cost_prefers_response_cost(settings):
+@pytest.fixture
+def patch_completion_cost(monkeypatch):
+    """Swap ``litellm.completion_cost`` for the duration of one test."""
+
+    def _set(fn):
+        monkeypatch.setattr(sys.modules["litellm"], "completion_cost", fn)
+
+    yield _set
+
+
+def test_litellm_calculate_cost_prefers_explicit_response_cost(
+    settings, patch_completion_cost
+):
+    """An explicit ``response.cost`` wins; the registry isn't even consulted."""
+    called = {"hit": False}
+
+    def boom(**_):
+        called["hit"] = True
+        return 999.0
+
+    patch_completion_cost(boom)
+
     model = _mk_litellm_model(settings)
     response = _mk_response(prompt_tokens=100, completion_tokens=50, cost=0.042)
     cost = model.calculate_cost(response)
+
+    assert isinstance(cost, EvaluationCost)
     assert cost == 0.042
+    assert cost.input_tokens == 100
+    assert cost.output_tokens == 50
+    assert called["hit"] is False
 
 
-def test_litellm_calculate_cost_falls_back_to_hardcoded_rates(settings):
+def test_litellm_calculate_cost_uses_litellm_completion_cost(
+    settings, patch_completion_cost
+):
+    """Without an explicit cost, fall through to LiteLLM's pricing API."""
+    patch_completion_cost(lambda **_: 0.000275)
+
     model = _mk_litellm_model(settings)
+    response = _mk_response(prompt_tokens=1000, completion_tokens=500)
+    cost = model.calculate_cost(response)
+
+    assert isinstance(cost, EvaluationCost)
+    assert cost == pytest.approx(0.000275)
+    assert cost.input_tokens == 1000
+    assert cost.output_tokens == 500
+
+
+def test_litellm_calculate_cost_does_not_fabricate_per_token_rates(
+    settings, patch_completion_cost
+):
+    """Regression guard: the old fallback charged $0.0001/$0.0002 per token —
+    7–666× over real prices. Unknown pricing must report 0.0, not invent one."""
+    patch_completion_cost(lambda **_: None)
+
+    model = _mk_litellm_model(settings, model_name="some-unregistered-model")
     response = _mk_response(prompt_tokens=100, completion_tokens=50)
     cost = model.calculate_cost(response)
-    expected = (100 * 0.0001) + (50 * 0.0002)
-    assert cost == expected
+
+    fabricated = (100 * 0.0001) + (50 * 0.0002)
+    assert cost != fabricated
+    assert cost == 0.0
+    assert cost.input_tokens == 100
+    assert cost.output_tokens == 50
 
 
-def test_litellm_calculate_cost_response_cost_none_uses_fallback(settings):
-    model = _mk_litellm_model(settings)
-    response = _mk_response(prompt_tokens=200, completion_tokens=100, cost=None)
-    cost = model.calculate_cost(response)
-    expected = (200 * 0.0001) + (100 * 0.0002)
-    assert cost == expected
+def test_litellm_calculate_cost_returns_zero_when_completion_cost_raises(
+    settings, patch_completion_cost, caplog
+):
+    """If LiteLLM raises (unknown model), report 0.0 + log — never crash."""
+
+    def raises(**_):
+        raise Exception("Model not in pricing registry: foo/bar")
+
+    patch_completion_cost(raises)
+
+    model = _mk_litellm_model(settings, model_name="foo/bar")
+    response = _mk_response(prompt_tokens=200, completion_tokens=100)
+
+    with caplog.at_level("WARNING"):
+        cost = model.calculate_cost(response)
+
+    assert cost == 0.0
+    assert cost.input_tokens == 200
+    assert cost.output_tokens == 100
+    assert any(
+        "LiteLLM cost lookup failed" in rec.message for rec in caplog.records
+    )
 
 
-def test_litellm_calculate_cost_accumulates_evaluation_cost(settings):
+def test_litellm_calculate_cost_accumulates_evaluation_cost(
+    settings, patch_completion_cost
+):
+    """Per-call costs add up cleanly into ``evaluation_cost``."""
+    patch_completion_cost(lambda **_: None)
+
     model = _mk_litellm_model(settings)
     assert model.evaluation_cost == 0.0
 
-    resp1 = _mk_response(cost=0.01)
-    resp2 = _mk_response(cost=0.02)
-    resp3 = _mk_response(cost=0.03)
-
-    model.calculate_cost(resp1)
-    model.calculate_cost(resp2)
-    model.calculate_cost(resp3)
+    model.calculate_cost(_mk_response(cost=0.01))
+    model.calculate_cost(_mk_response(cost=0.02))
+    model.calculate_cost(_mk_response(cost=0.03))
 
     assert model.evaluation_cost == pytest.approx(0.06)
     assert model.get_evaluation_cost() == pytest.approx(0.06)
 
 
-def test_litellm_calculate_cost_with_zero_tokens_no_response_cost(settings):
+def test_litellm_calculate_cost_accumulator_unaffected_by_unknown_price(
+    settings, patch_completion_cost
+):
+    """Unknown-price calls add 0 — totals stay honest across mixed runs."""
+    patch_completion_cost(lambda **_: None)
+
+    model = _mk_litellm_model(settings)
+    model.calculate_cost(_mk_response(cost=0.10))
+    model.calculate_cost(_mk_response(prompt_tokens=500, completion_tokens=500))
+    model.calculate_cost(_mk_response(cost=0.05))
+
+    assert model.evaluation_cost == pytest.approx(0.15)
+
+
+def test_litellm_calculate_cost_with_zero_tokens_no_response_cost(
+    settings, patch_completion_cost
+):
+    """Zero tokens, no price → zero cost, accumulator untouched."""
+    patch_completion_cost(lambda **_: None)
+
     model = _mk_litellm_model(settings)
     response = _mk_response(prompt_tokens=0, completion_tokens=0)
     cost = model.calculate_cost(response)
+
     assert cost == 0.0
+    assert model.evaluation_cost == 0.0
 
 
-def test_litellm_calculate_cost_handles_exception_gracefully(settings):
+def test_litellm_calculate_cost_handles_malformed_response_gracefully(
+    settings, patch_completion_cost
+):
+    """A response missing ``.usage`` must not crash the metric run."""
+    patch_completion_cost(lambda **_: None)
     model = _mk_litellm_model(settings)
     bad_response = SimpleNamespace()
     cost = model.calculate_cost(bad_response)
     assert cost == 0.0
+    assert cost.input_tokens is None
+    assert cost.output_tokens is None
+
+
+def test_litellm_calculate_cost_handles_non_numeric_explicit_cost(
+    settings, patch_completion_cost, caplog
+):
+    """A junk ``response.cost`` (bad proxy payload) falls through to
+    completion_cost AND emits a warning so operators see the broken proxy."""
+    patch_completion_cost(lambda **_: 0.007)
+
+    model = _mk_litellm_model(settings)
+    response = _mk_response(prompt_tokens=10, completion_tokens=5)
+    response.cost = "not-a-number"
+
+    with caplog.at_level("WARNING"):
+        cost = model.calculate_cost(response)
+
+    assert cost == pytest.approx(0.007)
+    assert cost.input_tokens == 10
+    assert cost.output_tokens == 5
+    assert any(
+        "ignoring invalid response.cost" in rec.message
+        for rec in caplog.records
+    )
+
+
+###################################################
+# Hardening: NaN / Inf / negative / bool / dict   #
+###################################################
+
+
+def test_litellm_calculate_cost_rejects_nan(settings, patch_completion_cost):
+    """NaN in response.cost would poison the accumulator forever (NaN + x
+    == NaN). Must be treated as invalid and report 0.0."""
+    patch_completion_cost(lambda **_: None)
+    model = _mk_litellm_model(settings)
+    response = _mk_response(prompt_tokens=10, completion_tokens=5, cost=float("nan"))
+    cost = model.calculate_cost(response)
+
+    assert cost == 0.0
+    assert model.evaluation_cost == 0.0
+    assert not math.isnan(model.evaluation_cost)
+    assert cost.input_tokens == 10
+    assert cost.output_tokens == 5
+
+
+def test_litellm_calculate_cost_rejects_infinity(
+    settings, patch_completion_cost
+):
+    """+inf would also poison the accumulator."""
+    patch_completion_cost(lambda **_: None)
+    model = _mk_litellm_model(settings)
+    response = _mk_response(cost=float("inf"))
+    cost = model.calculate_cost(response)
+
+    assert cost == 0.0
+    assert model.evaluation_cost == 0.0
+
+
+def test_litellm_calculate_cost_rejects_negative(
+    settings, patch_completion_cost
+):
+    """A negative cost (proxy bug) must not subtract from the accumulator."""
+    patch_completion_cost(lambda **_: None)
+    model = _mk_litellm_model(settings)
+    response = _mk_response(cost=-1.5)
+    cost = model.calculate_cost(response)
+
+    assert cost == 0.0
+    assert model.evaluation_cost == 0.0
+
+
+def test_litellm_calculate_cost_rejects_bool(settings, patch_completion_cost):
+    """bool is an int subclass — float(True) == 1.0 would silently bill $1
+    per call. Reject explicitly."""
+    patch_completion_cost(lambda **_: None)
+    model = _mk_litellm_model(settings)
+    response = _mk_response(cost=True)
+    cost = model.calculate_cost(response)
+
+    assert cost == 0.0
+    assert model.evaluation_cost == 0.0
+
+
+def test_litellm_calculate_cost_reads_dict_usage(
+    settings, patch_completion_cost
+):
+    """Some LiteLLM proxy / raw-JSON responses serialize ``usage`` as a
+    plain dict. ``getattr`` does not read dict keys, so the previous code
+    silently dropped token counts."""
+    patch_completion_cost(lambda **_: 0.005)
+    model = _mk_litellm_model(settings)
+    response = SimpleNamespace(
+        usage={"prompt_tokens": 100, "completion_tokens": 50},
+    )
+    cost = model.calculate_cost(response)
+
+    assert cost == pytest.approx(0.005)
+    assert cost.input_tokens == 100
+    assert cost.output_tokens == 50
+
+
+def test_litellm_calculate_cost_falls_back_to_usage_cost(
+    settings, patch_completion_cost
+):
+    """When ``response.cost`` is unset but ``response.usage.cost`` is set
+    (OpenRouter-style), use it and skip the pricing registry."""
+    called = {"hit": False}
+
+    def boom(**_):
+        called["hit"] = True
+        return 0.0
+
+    patch_completion_cost(boom)
+
+    model = _mk_litellm_model(settings)
+    usage = SimpleNamespace(
+        prompt_tokens=100, completion_tokens=50, cost=0.0123
+    )
+    response = SimpleNamespace(usage=usage)
+    cost = model.calculate_cost(response)
+
+    assert cost == pytest.approx(0.0123)
+    assert cost.input_tokens == 100
+    assert cost.output_tokens == 50
+    assert called["hit"] is False
+
+
+def test_litellm_calculate_cost_handles_completion_cost_import_error(
+    settings, monkeypatch, caplog
+):
+    """If ``from litellm import completion_cost`` fails (old install, broken
+    package), the warning must clearly point at the missing symbol — not
+    a generic 'lookup failed'."""
+    original = sys.modules["litellm"]
+    monkeypatch.setitem(
+        sys.modules,
+        "litellm",
+        types.SimpleNamespace(
+            completion=original.completion,
+            acompletion=original.acompletion,
+            get_llm_provider=original.get_llm_provider,
+            # completion_cost intentionally absent.
+        ),
+    )
+
+    model = _mk_litellm_model(settings)
+    response = _mk_response(prompt_tokens=10, completion_tokens=5)
+
+    with caplog.at_level("WARNING"):
+        cost = model.calculate_cost(response)
+
+    assert cost == 0.0
+    assert any(
+        "litellm.completion_cost unavailable" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_litellm_calculate_cost_rejects_invalid_completion_cost_value(
+    settings, patch_completion_cost, caplog
+):
+    """If litellm.completion_cost itself returns NaN/negative (its own bug),
+    we must not let it poison our accumulator."""
+    patch_completion_cost(lambda **_: float("nan"))
+    model = _mk_litellm_model(settings)
+    response = _mk_response(prompt_tokens=10, completion_tokens=5)
+
+    with caplog.at_level("WARNING"):
+        cost = model.calculate_cost(response)
+
+    assert cost == 0.0
+    assert model.evaluation_cost == 0.0
+    assert any(
+        "litellm.completion_cost returned invalid value" in rec.message
+        for rec in caplog.records
+    )
+
+
+###############################################
+# Raw-response paths preserve EvaluationCost  #
+###############################################
+
+
+def test_litellm_generate_raw_response_preserves_evaluation_cost_subclass(
+    settings, patch_completion_cost, monkeypatch
+):
+    """``generate_raw_response`` previously wrapped its cost in ``float()``,
+    stripping the ``EvaluationCost`` subclass — so ``accrue_token_usage``'s
+    isinstance check silently dropped tokens for g_eval / log-probs paths."""
+    patch_completion_cost(lambda **_: 0.001)
+
+    fake_response = SimpleNamespace(
+        usage=SimpleNamespace(prompt_tokens=42, completion_tokens=7)
+    )
+    monkeypatch.setattr(
+        sys.modules["litellm"], "completion", lambda **_: fake_response
+    )
+
+    model = _mk_litellm_model(settings)
+    _resp, cost = model.generate_raw_response("prompt")
+
+    assert isinstance(cost, EvaluationCost)
+    assert cost.input_tokens == 42
+    assert cost.output_tokens == 7

--- a/tests/test_core/test_models/test_litellm_model.py
+++ b/tests/test_core/test_models/test_litellm_model.py
@@ -16,9 +16,8 @@ if "litellm" not in sys.modules:
         get_llm_provider=lambda model: "stub-provider",
         completion_cost=lambda **k: None,
     )
-elif (
-    isinstance(sys.modules["litellm"], types.SimpleNamespace)
-    and not hasattr(sys.modules["litellm"], "completion_cost")
+elif isinstance(sys.modules["litellm"], types.SimpleNamespace) and not hasattr(
+    sys.modules["litellm"], "completion_cost"
 ):
     # Only ever patch our own test stub — never the real litellm module.
     sys.modules["litellm"].completion_cost = lambda **k: None
@@ -328,7 +327,9 @@ def test_litellm_calculate_cost_rejects_nan(settings, patch_completion_cost):
     == NaN). Must be treated as invalid and report 0.0."""
     patch_completion_cost(lambda **_: None)
     model = _mk_litellm_model(settings)
-    response = _mk_response(prompt_tokens=10, completion_tokens=5, cost=float("nan"))
+    response = _mk_response(
+        prompt_tokens=10, completion_tokens=5, cost=float("nan")
+    )
     cost = model.calculate_cost(response)
 
     assert cost == 0.0


### PR DESCRIPTION
## What

`LiteLLMModel.calculate_cost` charged a hardcoded $0.0001/input + $0.0002/output per token whenever `response.cost` was missing, which is the common case, since LiteLLM doesn't attach `.cost` to its `ChatCompletion`. For gpt-4o-mini that's ~666× the real price; for Claude Haiku, ~100×.

Now we defer to `litellm.completion_cost(completion_response=...)`, which uses LiteLLM's own per-model pricing registry. When pricing is genuinely unknown, we report `0.0` with token counts preserved — never a fabricated rate.

## Also fixed (surfaced during review)

- **NaN / Inf / negative / bool guards.** A single bad `response.cost` could poison `evaluation_cost` for the whole run (`NaN + x == NaN`). `bool` is worse — `float(True) == 1.0` silently bills $1 per call. All rejected now via a small `_coerce_cost` helper.
- **`usage` as dict.** Proxy / raw-JSON responses serialize `usage` as a plain dict; `getattr` silently dropped the token counts. Handle both shapes.
- **`response.usage.cost` fallback.** OpenRouter-style responses put cost on the usage block — check there too before falling through to the registry.
- **`EvaluationCost` preserved in `generate_raw_response`.** The `float(cost)` wrap was stripping the subclass, so `accrue_token_usage`'s isinstance check silently dropped tokens for g-eval / log-probs paths.

## Tests

22 unit tests in `tests/test_core/test_models/test_litellm_model.py` (13 existing + 9 new), covering the regression, each guard, dict-usage, the usage.cost fallback, the import-error path, and the raw-response subclass preservation. Broader models suite (210 tests) still green.

## Out of scope

A few smaller items the review flagged but I left for a follow-up to keep this PR focused: tenacity retries double-counting cost on transient failures, pinning a minimum `litellm` version in pyproject, and the `cost == 0` vs `cost is None` ambiguity in the priority chain.