### PR TITLE
fix(dataset): assign each golden its index as _dataset_rank, not the dataset size

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -105,8 +105,8 @@ class EvaluationDataset:
 
         self._goldens = []
         self._conversational_goldens = []
-        for golden in goldens:
-            golden._dataset_rank = len(goldens)
+        for index, golden in enumerate(goldens):
+            golden._dataset_rank = index
             if self._multi_turn:
                 self._add_conversational_golden(golden)
             else:
@@ -139,7 +139,7 @@ class EvaluationDataset:
         self._goldens = []
         self._conversational_goldens = []
         try:
-            for golden in goldens:
+            for index, golden in enumerate(goldens):
                 if not isinstance(golden, Golden) and not isinstance(
                     golden, ConversationalGolden
                 ):
@@ -149,7 +149,7 @@ class EvaluationDataset:
 
                 golden._dataset_alias = self._alias
                 golden._dataset_id = self._id
-                golden._dataset_rank = len(goldens)
+                golden._dataset_rank = index
                 if self._multi_turn:
                     self._add_conversational_golden(golden)
                 else:

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -587,3 +587,16 @@ class TestSaveAndLoad:
 
         assert len(test_cases) == 1
         assert test_cases[0].expected_outcome == "User gets flight options"
+
+
+class TestDatasetRank:
+    def test_constructor_assigns_sequential_rank_to_goldens(self):
+        """Each golden's _dataset_rank must be its position, not the dataset size."""
+        goldens = [Golden(input="a"), Golden(input="b"), Golden(input="c")]
+        dataset = EvaluationDataset(goldens)
+        assert [g._dataset_rank for g in dataset.goldens] == [0, 1, 2]
+
+    def test_goldens_setter_assigns_sequential_rank_to_goldens(self):
+        dataset = EvaluationDataset()
+        dataset.goldens = [Golden(input="a"), Golden(input="b")]
+        assert [g._dataset_rank for g in dataset.goldens] == [0, 1]


### PR DESCRIPTION
## Summary

`EvaluationDataset.__init__` and the `goldens` setter assign `golden._dataset_rank` inside a plain `for golden in goldens` loop:

```python
for golden in goldens:
    golden._dataset_rank = len(goldens)   # same value for every golden
```

`len(goldens)` is the **total count**, so every golden in a dataset gets the *same* rank (the dataset size) instead of its position `0, 1, 2, …`.

`_dataset_rank` is read as the test case `order` in `deepeval/test_case/api.py`:

```python
order = test_case._dataset_rank if test_case._dataset_rank is not None else index
...
name = os.getenv(PYTEST_RUN_TEST_NAME, f"test_case_{order}")   # and conversational_test_case_{order}
```

So goldens supplied via the constructor or the `goldens` setter produce **collided `order` values and duplicate auto-generated test-case names**. Goldens created through `deepeval/dataset/utils.py` are unaffected because that path already uses `enumerate` — making the behavior inconsistent depending on how goldens are loaded.

## Fix

Use `enumerate()` at both sites, matching the existing correct sibling in `deepeval/dataset/utils.py` (`for index, golden in enumerate(goldens): _dataset_rank=index`).

## Verification

Added `TestDatasetRank` in `tests/test_core/test_datasets/test_dataset.py`: builds an `EvaluationDataset` from 3 goldens (and via the setter) and asserts `[g._dataset_rank for g in dataset.goldens] == [0, 1, 2]`. Verified it fails before the fix (all ranks equal the dataset size) and passes after. `black` clean. (Note: a few pre-existing `TestSaveAndLoad` failures in that file are unrelated — they raise `ModuleNotFoundError` from an optional dependency on both the clean tree and this branch.)