### PR TITLE
[codex] Add contextual precision grouping

### DIFF
--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Type, Union
+from typing import Any, Callable, Hashable, Optional, List, Type, Union
 
 from deepeval.utils import (
     get_or_create_event_loop,
@@ -40,6 +40,7 @@ class ContextualPrecisionMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        group_by: Optional[Callable[[Any], Hashable]] = None,
         evaluation_template: Type[
             ContextualPrecisionTemplate
         ] = ContextualPrecisionTemplate,
@@ -51,6 +52,7 @@ class ContextualPrecisionMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.group_by = group_by
         self.evaluation_template = evaluation_template
 
     def measure(
@@ -92,17 +94,26 @@ class ContextualPrecisionMetric(BaseMetric):
             else:
                 input = test_case.input
                 expected_output = test_case.expected_output
+                retrieval_context = test_case.retrieval_context
                 grouped_retrieval_context = self._group_retrieval_contexts(
                     test_case.retrieval_context
+                )
+                verdict_retrieval_context = (
+                    self._get_raw_retrieval_contexts(retrieval_context)
+                    if self.group_by is not None
+                    else grouped_retrieval_context
                 )
 
                 self.verdicts: List[cpschema.ContextualPrecisionVerdict] = (
                     self._generate_verdicts(
                         input,
                         expected_output,
-                        grouped_retrieval_context,
+                        verdict_retrieval_context,
                         multimodal,
                     )
+                )
+                self._score_verdicts = self._get_score_verdicts(
+                    retrieval_context
                 )
                 self.score = self._calculate_score()
                 self.reason = self._generate_reason(input, multimodal)
@@ -147,18 +158,25 @@ class ContextualPrecisionMetric(BaseMetric):
         ):
             input = test_case.input
             expected_output = test_case.expected_output
+            retrieval_context = test_case.retrieval_context
             grouped_retrieval_context = self._group_retrieval_contexts(
                 test_case.retrieval_context
+            )
+            verdict_retrieval_context = (
+                self._get_raw_retrieval_contexts(retrieval_context)
+                if self.group_by is not None
+                else grouped_retrieval_context
             )
 
             self.verdicts: List[cpschema.ContextualPrecisionVerdict] = (
                 await self._a_generate_verdicts(
                     input,
                     expected_output,
-                    grouped_retrieval_context,
+                    verdict_retrieval_context,
                     multimodal,
                 )
             )
+            self._score_verdicts = self._get_score_verdicts(retrieval_context)
             self.score = self._calculate_score()
             self.reason = await self._a_generate_reason(input, multimodal)
             self.success = self.score >= self.threshold
@@ -177,7 +195,7 @@ class ContextualPrecisionMetric(BaseMetric):
 
         retrieval_contexts_verdicts = [
             {"verdict": verdict.verdict, "reason": verdict.reason}
-            for verdict in self.verdicts
+            for verdict in getattr(self, "_score_verdicts", self.verdicts)
         ]
         prompt = self.evaluation_template.generate_reason(
             input=input,
@@ -200,7 +218,7 @@ class ContextualPrecisionMetric(BaseMetric):
 
         retrieval_contexts_verdicts = [
             {"verdict": verdict.verdict, "reason": verdict.reason}
-            for verdict in self.verdicts
+            for verdict in getattr(self, "_score_verdicts", self.verdicts)
         ]
         prompt = self.evaluation_template.generate_reason(
             input=input,
@@ -300,15 +318,56 @@ class ContextualPrecisionMetric(BaseMetric):
 
         return processed_contexts
 
+    def _get_raw_retrieval_contexts(
+        self, retrieval_contexts: List[Union[str, RetrievedContextData]]
+    ) -> List[str]:
+        return [
+            (
+                context.context
+                if isinstance(context, RetrievedContextData)
+                else context
+            )
+            for context in retrieval_contexts
+        ]
+
+    def _get_score_verdicts(
+        self,
+        retrieval_contexts: List[Union[str, RetrievedContextData]],
+    ) -> List[cpschema.ContextualPrecisionVerdict]:
+        if self.group_by is None:
+            return self.verdicts
+
+        grouped_verdicts = {}
+        score_verdicts = []
+
+        for index, verdict in enumerate(self.verdicts):
+            context = retrieval_contexts[index]
+            group_key = self.group_by(context)
+            if group_key is None:
+                score_verdicts.append(verdict)
+                continue
+
+            if group_key not in grouped_verdicts:
+                grouped_verdicts[group_key] = len(score_verdicts)
+                score_verdicts.append(verdict)
+                continue
+
+            score_index = grouped_verdicts[group_key]
+            if verdict.verdict.strip().lower() == "yes":
+                score_verdicts[score_index] = verdict
+
+        return score_verdicts
+
     def _calculate_score(self):
-        number_of_verdicts = len(self.verdicts)
+        score_verdicts = getattr(self, "_score_verdicts", self.verdicts)
+        number_of_verdicts = len(score_verdicts)
         if number_of_verdicts == 0:
             return 0
 
         # Convert verdicts to a binary list where 'yes' is 1 and others are 0
         node_verdicts = [
             1 if v.verdict.strip().lower() == "yes" else 0
-            for v in self.verdicts
+            for v in score_verdicts
         ]
 
         sum_weighted_precision_at_k = 0.0

--- a/tests/test_metrics/test_contextual_precision_grouping.py
+++ b/tests/test_metrics/test_contextual_precision_grouping.py
@@ -1,0 +1,132 @@
+import pytest
+
+import deepeval.metrics.contextual_precision.contextual_precision as cp_module
+from deepeval.metrics.contextual_precision.contextual_precision import (
+    ContextualPrecisionMetric,
+)
+from deepeval.metrics.contextual_precision.schema import (
+    ContextualPrecisionVerdict,
+)
+from deepeval.test_case import RetrievedContextData
+
+
+class _FakeModel:
+    def get_model_name(self):
+        return "fake-model"
+
+
+def _make_metric(verdicts, group_by=None):
+    metric = object.__new__(ContextualPrecisionMetric)
+    metric.threshold = 0.5
+    metric.strict_mode = False
+    metric.group_by = group_by
+    metric.verdicts = [
+        ContextualPrecisionVerdict(verdict=verdict, reason="")
+        for verdict in verdicts
+    ]
+    return metric
+
+
+def test_contextual_precision_accepts_group_by(monkeypatch):
+    def group_by(context):
+        return context
+
+    monkeypatch.setattr(
+        cp_module,
+        "initialize_model",
+        lambda model: (_FakeModel(), False),
+    )
+
+    metric = ContextualPrecisionMetric(group_by=group_by)
+
+    assert metric.group_by is group_by
+
+
+def test_contextual_precision_group_by_scores_retrieval_units():
+    retrieval_context = [
+        "doc=10k section=revenue chunk=1",
+        "doc=10k section=revenue chunk=2",
+        "doc=10k section=risk chunk=3",
+    ]
+    metric = _make_metric(
+        ["no", "yes", "no"],
+        group_by=lambda context: context.split(" chunk=")[0],
+    )
+
+    metric._score_verdicts = metric._get_score_verdicts(retrieval_context)
+
+    assert [verdict.verdict for verdict in metric._score_verdicts] == [
+        "yes",
+        "no",
+    ]
+    assert metric._calculate_score() == 1.0
+
+
+def test_contextual_precision_keeps_ungrouped_contexts_as_singletons():
+    retrieval_context = [
+        "unrelated singleton",
+        "doc=10k section=revenue chunk=1",
+        "doc=10k section=revenue chunk=2",
+    ]
+
+    def group_by(context):
+        if "section=revenue" in context:
+            return "revenue"
+        return None
+
+    metric = _make_metric(["no", "yes", "no"], group_by=group_by)
+
+    metric._score_verdicts = metric._get_score_verdicts(retrieval_context)
+
+    assert [verdict.verdict for verdict in metric._score_verdicts] == [
+        "no",
+        "yes",
+    ]
+    assert metric._calculate_score() == pytest.approx(0.5)
+
+
+def test_contextual_precision_does_not_merge_none_group_keys():
+    metric = _make_metric(["no", "yes"], group_by=lambda context: None)
+
+    metric._score_verdicts = metric._get_score_verdicts(["chunk 1", "chunk 2"])
+
+    assert [verdict.verdict for verdict in metric._score_verdicts] == [
+        "no",
+        "yes",
+    ]
+    assert metric._calculate_score() == pytest.approx(0.5)
+
+
+def test_contextual_precision_group_by_uses_retrieved_context_metadata():
+    retrieval_context = [
+        RetrievedContextData(
+            source="revenue",
+            context="Revenue table first overlapping window",
+        ),
+        RetrievedContextData(
+            source="revenue",
+            context="Revenue table second overlapping window",
+        ),
+        RetrievedContextData(
+            source="risk",
+            context="Risk factor section",
+        ),
+    ]
+
+    metric = _make_metric(
+        ["no", "yes", "no"], group_by=lambda item: item.source
+    )
+
+    assert metric._get_raw_retrieval_contexts(retrieval_context) == [
+        "Revenue table first overlapping window",
+        "Revenue table second overlapping window",
+        "Risk factor section",
+    ]
+
+    metric._score_verdicts = metric._get_score_verdicts(retrieval_context)
+
+    assert [verdict.verdict for verdict in metric._score_verdicts] == [
+        "yes",
+        "no",
+    ]
+    assert metric._calculate_score() == 1.0


### PR DESCRIPTION
## Summary

- Add an optional `group_by` hook to `ContextualPrecisionMetric` for scoring overlapping retrieval chunks as retrieval units.
- Preserve current per-context scoring when `group_by` is not provided.
- Keep ungrouped contexts as singleton units when `group_by` returns `None`.
- Use raw context text for verdict generation while allowing `group_by` to inspect the original retrieval context item, including `RetrievedContextData.source`.

Closes #2594

## Context

PR #2659 currently remains open but conflicting. This PR applies the same current-main direction as a focused opt-in grouping implementation with deterministic tests.

## Validation

- `poetry run pytest tests/test_metrics/test_contextual_precision_grouping.py -q`
- `OPENAI_API_KEY= poetry run pytest tests/test_metrics/test_contextual_precision_metric.py tests/test_metrics/test_contextual_precision_grouping.py -q`
- `poetry run black --check deepeval/metrics/contextual_precision/contextual_precision.py tests/test_metrics/test_contextual_precision_grouping.py`
- `poetry run ruff check deepeval/metrics/contextual_precision/contextual_precision.py tests/test_metrics/test_contextual_precision_grouping.py`

Note: running the existing OpenAI-backed contextual precision tests with the local `OPENAI_API_KEY` present fails in this environment before metric execution because the machine has a SOCKS proxy configured and `socksio` is not installed. The command above clears `OPENAI_API_KEY` so those integration-style tests follow the repository skip rule while the new deterministic tests run.
