### PR TITLE
fix: add deepseek-v4 models, fix calculate_cost, and improve error ha…

### DIFF
--- a/deepeval/models/llms/constants.py
+++ b/deepeval/models/llms/constants.py
@@ -1100,6 +1100,22 @@ DEEPSEEK_MODELS_DATA = ModelDataRegistry(
             input_price=1.00 / 1e6,
             output_price=2.00 / 1e6,
         ),
+        "deepseek-v4-flash": make_model_data(
+            supports_log_probs=False,
+            supports_multimodal=False,
+            supports_structured_outputs=True,
+            supports_json=True,
+            input_price=None,
+            output_price=None,
+        ),
+        "deepseek-v4-pro": make_model_data(
+            supports_log_probs=False,
+            supports_multimodal=False,
+            supports_structured_outputs=True,
+            supports_json=True,
+            input_price=None,
+            output_price=None,
+        ),
     }
 )
 

--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -27,6 +27,7 @@ from deepeval.models.base_model import (
     DeepEvalBaseEmbeddingModel,
     DeepEvalBaseLLM,
 )
+from deepeval.errors import DeepEvalError
 from deepeval.utils import update_pbar, add_pbar, remove_pbars
 from deepeval.config.settings import get_settings
 
@@ -209,6 +210,7 @@ class ContextGenerator:
             update_pbar(progress, pbar_id, remove=False)
 
             # process each doc end-to-end (sync), with per-doc error logging
+            docs_with_errors: List[str] = []
             for path, chunker in source_file_to_chunker_map.items():
                 collection = None
                 try:
@@ -267,6 +269,7 @@ class ContextGenerator:
                     source_files.extend([path] * len(ctxs_for_doc))
 
                 except Exception as exc:
+                    docs_with_errors.append(path)
                     # record and continue with other docs
                     show_trace = bool(get_settings().DEEPEVAL_LOG_STACK_TRACES)
                     exc_info = (
@@ -304,6 +307,12 @@ class ContextGenerator:
                     SynthesizerStatus.WARNING,
                     "Filtering not applied",
                     "Not enough chunks in smallest document",
+                )
+
+            if docs_with_errors and not contexts:
+                raise DeepEvalError(
+                    f"Context generation failed for all {len(docs_with_errors)} "
+                    f"document(s). Check the logs above for per-document errors."
                 )
 
             return contexts, source_files, scores
@@ -432,8 +441,10 @@ class ContextGenerator:
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
             # Collect results, surface any errors after cleanup
+            docs_with_errors: List[str] = []
             for path, res in zip(paths, results):
                 if isinstance(res, Exception):
+                    docs_with_errors.append(path)
                     logger.error(
                         "Document pipeline failed for %s",
                         path,
@@ -461,6 +472,12 @@ class ContextGenerator:
                     SynthesizerStatus.WARNING,
                     "Filtering not applied",
                     "Not enough chunks in smallest document",
+                )
+
+            if docs_with_errors and not contexts:
+                raise DeepEvalError(
+                    f"Context generation failed for all {len(docs_with_errors)} "
+                    f"document(s). Check the logs above for per-document errors."
                 )
 
             return contexts, source_files, scores
@@ -837,7 +854,8 @@ class ContextGenerator:
         prompt = FilterTemplate.evaluate_context(chunk)
         if self.using_native_model:
             res, cost = self.model.generate(prompt, schema=ContextScore)
-            self.total_cost += cost
+            if cost is not None:
+                self.total_cost += cost
             return (res.clarity + res.depth + res.structure + res.relevance) / 4
         else:
             try:
@@ -862,7 +880,8 @@ class ContextGenerator:
         prompt = FilterTemplate.evaluate_context(chunk)
         if self.using_native_model:
             res, cost = await self.model.a_generate(prompt, schema=ContextScore)
-            self.total_cost += cost
+            if cost is not None:
+                self.total_cost += cost
             return (res.clarity + res.depth + res.structure + res.relevance) / 4
         else:
 

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -15,6 +15,7 @@ import csv
 import os
 from contextlib import nullcontext
 
+from deepeval.errors import DeepEvalError
 from deepeval.utils import get_or_create_event_loop
 from deepeval.synthesizer.chunking.context_generator import ContextGenerator
 from deepeval.metrics.utils import (
@@ -486,6 +487,11 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
+                if not contexts:
+                    raise DeepEvalError(
+                        "No contexts were generated from the provided documents. "
+                        "This may be caused by an incompatible model or invalid document format."
+                    )
                 if self.synthesis_cost:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
@@ -605,6 +611,11 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
+            if not contexts:
+                raise DeepEvalError(
+                    "No contexts were generated from the provided documents. "
+                    "This may be caused by an incompatible model or invalid document format."
+                )
             if self.synthesis_cost:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(
@@ -1686,7 +1697,7 @@ class Synthesizer:
     ) -> BaseModel:
         if is_native_model(model):
             res, cost = model.generate(prompt, schema)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -1712,7 +1723,7 @@ class Synthesizer:
     ) -> BaseModel:
         if is_native_model(model):
             res, cost = await model.a_generate(prompt, schema)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -1733,7 +1744,7 @@ class Synthesizer:
     def _generate(self, prompt: str) -> str:
         if self.using_native_model:
             res, cost = self.model.generate(prompt)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -1747,7 +1758,7 @@ class Synthesizer:
     async def _a_generate(self, prompt: str) -> str:
         if self.using_native_model:
             res, cost = await self.model.a_generate(prompt)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -2119,6 +2130,11 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
+                if not contexts:
+                    raise DeepEvalError(
+                        "No contexts were generated from the provided documents. "
+                        "This may be caused by an incompatible model or invalid document format."
+                    )
                 if self.synthesis_cost:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
@@ -2236,6 +2252,11 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
+            if not contexts:
+                raise DeepEvalError(
+                    "No contexts were generated from the provided documents. "
+                    "This may be caused by an incompatible model or invalid document format."
+                )
             if self.synthesis_cost:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(


### PR DESCRIPTION
## Summary

- Register `deepseek-v4-flash` and `deepseek-v4-pro` in `DEEPSEEK_MODELS_DATA`
- Guard against `None` cost at call sites to prevent silent `TypeError` crashes
- Fix `ContextGenerator` and `Synthesizer` to surface errors instead of silently returning empty results

## Details

### Problem

When a model's pricing is unknown (e.g., a new model not yet in the registry like `deepseek-v4-flash`), `calculate_cost()` returns `None`. Call sites in `ContextGenerator.evaluate_chunk()` and `Synthesizer._generate_schema()` attempted `total += None`, causing a `TypeError`. This error was caught by a broad `except Exception` in `generate_contexts()` and only logged — never surfaced — resulting in empty goldens with no visible error to the user.

### Changes (3 files)

| File | Change |
|---|---|
| `deepeval/models/llms/constants.py` (+16) | Register `deepseek-v4-flash` and `deepseek-v4-pro` in `DEEPSEEK_MODELS_DATA` |
| `deepeval/synthesizer/chunking/context_generator.py` (+23/-2) | Guard `evaluate_chunk` and `a_evaluate_chunk` against `None` cost (`if cost is not None: self.total_cost += cost`); raise `DeepEvalError` when all document pipelines fail instead of silently returning empty contexts |
| `deepeval/synthesizer/synthesizer.py` (+29/-3) | Guard `_generate_schema`, `_a_generate_schema`, `_generate`, `_a_generate` against `None` cost; raise `DeepEvalError` when generated contexts list is empty |

### Design Decision

`calculate_cost()` returning `None` is left untouched — "unknown price" ≠ "zero price". The fix is at the **call sites** (the `evaluate_chunk` boundary), safely skipping `None` costs without misleading users about evaluation cost. No changes to other model providers or tests.

### Related

- Complementary to PR #2882, which fixes the `0` falsy bug at the same cost-accrual sites (`if self.synthesis_cost:` → `if self.synthesis_cost is not None:`). Both fixes coexist cleanly in `synthesizer.py`; happy to rebase whichever lands second.

### Why this matters now

Per [DeepSeek API docs](https://api-docs.deepseek.com/), `deepseek-chat` and `deepseek-reasoner` will be deprecated on **2026-07-24** in favor of `deepseek-v4-flash` and `deepseek-v4-pro`. Without this fix, all DeepSeek users will be unable to use `Synthesizer` after the deprecation date.

Closes #2884