### PR TITLE
fix(bedrock): honor user-supplied per-token costs in AmazonBedrockModel

### DIFF
--- a/deepeval/models/llms/amazon_bedrock_model.py
+++ b/deepeval/models/llms/amazon_bedrock_model.py
@@ -144,6 +144,8 @@ class AmazonBedrockModel(DeepEvalBaseLLM):
             cost_per_input_token,
             cost_per_output_token,
         )
+        self.model_data.input_price = cost_per_input_token
+        self.model_data.output_price = cost_per_output_token
 
         # Final attributes
         self.region = region

--- a/tests/test_core/test_models/test_amazon_bedrock_model.py
+++ b/tests/test_core/test_models/test_amazon_bedrock_model.py
@@ -2,6 +2,7 @@ import copy
 import pytest
 from contextlib import asynccontextmanager
 from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
 
 from tests.test_core.stubs import _RecordingClient
 from deepeval.models.llms.amazon_bedrock_model import AmazonBedrockModel
@@ -209,3 +210,38 @@ def test_bedrock_calculate_cost_with_zero_tokens():
     model = _mk_model_with_prices(0.003, 0.006)
     cost = model.calculate_cost(input_tokens=0, output_tokens=0)
     assert cost == 0.0
+
+
+@patch("deepeval.models.llms.amazon_bedrock_model.require_dependency")
+def test_bedrock_user_supplied_costs_are_written_to_model_data(
+    mock_require_dep, settings
+):
+    """
+    For an unregistered model id, explicit ``cost_per_input_token`` /
+    ``cost_per_output_token`` must be written back onto ``self.model_data`` so
+    that ``calculate_cost`` (which reads only ``model_data.input_price`` /
+    ``.output_price``) returns the user-supplied cost instead of ``None``.
+
+    The sibling providers (anthropic, openai, azure, deepseek, grok, kimi,
+    gemini) already do this writeback in ``__init__``; Bedrock was the only one
+    missing it.
+    """
+    mock_require_dep.return_value = MagicMock()
+
+    with settings.edit(persist=False):
+        settings.AWS_BEDROCK_REGION = "us-east-1"
+
+    model = AmazonBedrockModel(
+        model="my-custom-unregistered-model",
+        cost_per_input_token=0.003,
+        cost_per_output_token=0.006,
+    )
+
+    # The resolved per-token costs landed on model_data ...
+    assert model.model_data.input_price == 0.003
+    assert model.model_data.output_price == 0.006
+
+    # ... so calculate_cost returns the real value, not None.
+    cost = model.calculate_cost(input_tokens=1000, output_tokens=500)
+    assert cost is not None
+    assert cost == 1000 * 0.003 + 500 * 0.006


### PR DESCRIPTION
Thanks for DeepEval and for maintaining the model-cost plumbing.

Fixes #2752

`AmazonBedrockModel` is the one provider of eight whose `__init__` doesn't write the resolved per-token costs back onto `self.model_data`, so for an unregistered/custom Bedrock model id explicit costs are dropped and `calculate_cost()` returns `None`.

## Change

2 lines, mirroring `anthropic_model.py` (L104-105) — write the resolved costs onto `self.model_data` right after `require_costs(...)`. Plus a regression test.

| Behavior | Before | After |
|---|---|---|
| Custom model + explicit costs → `calculate_cost(1000,500)` | ❌ `None` | ✅ `4.5` |
| `model_data.input_price/.output_price` after `__init__` | ❌ `None` | ✅ user values |
| Registered model with registry prices | ✅ unchanged | ✅ unchanged |
| Public API / constructor args / return shape | ✅ unchanged | ✅ unchanged |
| Other 7 providers | ✅ untouched | ✅ untouched |

Test before/after: fix reverted → new test fails with `assert None == 0.003`; restored → passes; full bedrock test file 15 passed. Local `black --check` clean.

## Relation to #2736

Complementary. #2736 changes the *read* side (`calculate_cost` returns `0.0` instead of `None` when prices are unknown); this PR fixes the *write* side (user-supplied costs reach `model_data` in the first place). Happy to coordinate merge order / rebase whichever lands second.

---

_This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, rationale, and test results before submission._
