### PR TITLE
fix: incorrect import path

### DIFF
--- a/deepeval/cli/test/command.py
+++ b/deepeval/cli/test/command.py
@@ -7,7 +7,7 @@ import pytest
 import typer
 from typing_extensions import Annotated
 
-from deepeval.deepeval.config.settings import get_settings
+from deepeval.config.settings import get_settings
 from deepeval.telemetry import capture_evaluation_run
 from deepeval.test_run import (
     TEMP_FILE_PATH,


### PR DESCRIPTION
This is currently causing the official tutorial here https://deepeval.com/tutorials/tutorial-setup to fail on `deepeval test run test_app.py` with the following traceback:

```shell
OPENAI_API_KEY='<redacted>' deepeval test run test_app.py 

Traceback (most recent call last):
  File "/private/tmp/deepeval-test/.venv/bin/deepeval", line 4, in <module>
    from deepeval.cli.main import app
  File "/private/tmp/deepeval-test/.venv/lib/python3.14/site-packages/deepeval/cli/main.py", line 48, in <module>
    from deepeval.cli.test.command import app as test_app
  File "/private/tmp/deepeval-test/.venv/lib/python3.14/site-packages/deepeval/cli/test/command.py", line 10, in <module>
    from deepeval.deepeval.config.settings import get_settings
ModuleNotFoundError: No module named 'deepeval.deepeval'
```

Closes #2754