### PR TITLE
docs: fix incorrect metric class name in TurnRelevancyMetric standalone section

### DIFF
--- a/docs/content/docs/(multi-turn)/metrics-turn-relevancy.mdx
+++ b/docs/content/docs/(multi-turn)/metrics-turn-relevancy.mdx
@@ -53,7 +53,7 @@ There are **SEVEN** optional parameters when creating a `TurnRelevancyMetric`:
 
 ### As a standalone
 
-You can also run the `ContextualRelevancyMetric` on a single test case as a standalone, one-off execution.
+You can also run the `TurnRelevancyMetric` on a single test case as a standalone, one-off execution.
 
 ```python
 ...


### PR DESCRIPTION
## What
Fixed a copy-paste error in the `TurnRelevancyMetric` documentation where the standalone section incorrectly referenced `ContextualRelevancyMetric` instead of `TurnRelevancyMetric`.

## Why
The standalone section heading and all surrounding text correctly refer to `TurnRelevancyMetric`, but line 56 in `metrics-turn-relevancy.mdx` read:

> "You can also run the `ContextualRelevancyMetric` on a single test case as a standalone, one-off execution."

This misleads users into thinking they need a different metric class to run standalone evaluation.

## Changes
- `docs/content/docs/(multi-turn)/metrics-turn-relevancy.mdx` — changed `ContextualRelevancyMetric` to `TurnRelevancyMetric` in the standalone section (line 56)