### PR TITLE
feat(answer-relevancy): add penalize_ambiguous_claims parameter

### DIFF
--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -37,6 +37,7 @@ class AnswerRelevancyMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        penalize_ambiguous_claims: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
@@ -45,6 +46,7 @@ class AnswerRelevancyMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.penalize_ambiguous_claims = penalize_ambiguous_claims
 
     def measure(
         self,
@@ -163,6 +165,11 @@ class AnswerRelevancyMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() == "no":
                 irrelevant_statements.append(verdict.reason)
+            if (
+                verdict.verdict.strip().lower() == "idk"
+                and self.penalize_ambiguous_claims
+            ):
+                irrelevant_statements.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self._get_prompt(
             "generate_reason",
@@ -188,6 +195,11 @@ class AnswerRelevancyMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() == "no":
                 irrelevant_statements.append(verdict.reason)
+            if (
+                verdict.verdict.strip().lower() == "idk"
+                and self.penalize_ambiguous_claims
+            ):
+                irrelevant_statements.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self._get_prompt(
             "generate_reason",
@@ -302,6 +314,12 @@ class AnswerRelevancyMetric(BaseMetric):
         for verdict in self.verdicts:
             if verdict.verdict.strip().lower() != "no":
                 relevant_count += 1
+
+            if (
+                self.penalize_ambiguous_claims
+                and verdict.verdict.strip().lower() == "idk"
+            ):
+                relevant_count -= 1
 
         score = relevant_count / number_of_verdicts
         return 0 if self.strict_mode and score < self.threshold else score

--- a/tests/test_metrics/test_answer_relevancy_metric.py
+++ b/tests/test_metrics/test_answer_relevancy_metric.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from deepeval.metrics import AnswerRelevancyMetric
+from deepeval.metrics.answer_relevancy.schema import AnswerRelevancyVerdict
 from deepeval.test_case import LLMTestCase, MLLMImage, ToolCall
 from deepeval import evaluate
 
@@ -150,6 +151,29 @@ class TestAnswerRelevancyMetric:
         results = evaluate([test_case], [metric])
 
         assert results is not None
+
+    def test_penalize_ambiguous_claims_reduces_score(self):
+        metric = AnswerRelevancyMetric(
+            async_mode=False, penalize_ambiguous_claims=True
+        )
+        metric.verdicts = [
+            AnswerRelevancyVerdict(verdict="yes", reason="relevant"),
+            AnswerRelevancyVerdict(verdict="idk", reason="unclear"),
+            AnswerRelevancyVerdict(verdict="idk", reason="ambiguous"),
+        ]
+        score_with_penalty = metric._calculate_score()
+
+        metric_no_penalty = AnswerRelevancyMetric(
+            async_mode=False, penalize_ambiguous_claims=False
+        )
+        metric_no_penalty.verdicts = metric.verdicts
+        score_without_penalty = metric_no_penalty._calculate_score()
+
+        assert score_with_penalty < score_without_penalty
+
+    def test_penalize_ambiguous_claims_default_false(self):
+        metric = AnswerRelevancyMetric(async_mode=False)
+        assert metric.penalize_ambiguous_claims is False
 
     def test_multimodal_evaluate_method(self):
         image = MLLMImage(url=CAR)


### PR DESCRIPTION
## What
Added `penalize_ambiguous_claims: bool = False` parameter to `AnswerRelevancyMetric`, mirroring the same flag already present on `FaithfulnessMetric` and `HallucinationMetric` (PR #2704).

## Why
`AnswerRelevancyMetric` LLM verdicts can return `"idk"` for statements that are unclear or ambiguous. Currently these count as relevant (score is not penalized). With `penalize_ambiguous_claims=True`, `"idk"` verdicts reduce the score, giving users stricter control over relevancy evaluation.

Closes #2300

## Changes
- `deepeval/metrics/answer_relevancy/answer_relevancy.py` — add `penalize_ambiguous_claims` param to `__init__`, update `_calculate_score()` to decrement count on `"idk"` when flag is True, update `_generate_reason()` and `_a_generate_reason()` to surface ambiguous verdicts in the reason output
- `tests/test_metrics/test_answer_relevancy_metric.py` — add unit tests verifying score is reduced when flag is True and that default is `False`