### PR TITLE
fix(synthesizer): correct parameter name in validate_chunk_size error message

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -930,7 +930,7 @@ class ContextGenerator:
             # 1. Suggest adjusting the number of contexts if applicable.
             if num_chunks > 0:
                 error_lines.append(
-                    f"{suggestion_num}. Adjust the `min_contexts_per_document` to no more than {num_chunks}."
+                    f"{suggestion_num}. Adjust the `min_contexts_per_source_file` to no more than {num_chunks}."
                 )
                 suggestion_num += 1
 


### PR DESCRIPTION
## What
Fixed a wrong parameter name in the `validate_chunk_size()` error message suggestion inside `context_generator.py`.

## Why
When chunking fails due to insufficient chunks, the error message suggested adjusting `` `min_contexts_per_document` `` — a parameter that doesn't exist in the public API. The actual parameter is `` `min_contexts_per_source_file` ``. Users following the error message to fix their `ContextGenerator` call would find no such parameter and be stuck.

**Before:**
```
1. Adjust the `min_contexts_per_document` to no more than 3.
```

**After:**
```
1. Adjust the `min_contexts_per_source_file` to no more than 3.
```

## Changes
- `deepeval/synthesizer/chunking/context_generator.py` — line 933: renamed `min_contexts_per_document` → `min_contexts_per_source_file` in the error suggestion string

Closes #2467