### PR TITLE
docs: add migration note for deprecated ConversationRelevancyMetric

### DIFF
--- a/docs/content/docs/(multi-turn)/metrics-turn-relevancy.mdx
+++ b/docs/content/docs/(multi-turn)/metrics-turn-relevancy.mdx
@@ -10,6 +10,22 @@ sidebar_label: Turn Relevancy
   rag={true}
 />
 
+:::caution Migrating from ConversationRelevancyMetric
+`ConversationRelevancyMetric` was removed in deepeval v3.7.x and replaced by `TurnRelevancyMetric`.
+
+The key behavioral difference: `TurnRelevancyMetric` evaluates relevancy using a sliding window of turns (default `window_size=10`), which produces higher scores than the deprecated metric's full-conversation scoring. If you need stricter scoring, reduce `window_size` or use `strict_mode=True`.
+
+```python
+# Before (v3.6.x and earlier — now raises ImportError)
+# from deepeval.metrics import ConversationRelevancyMetric
+# metric = ConversationRelevancyMetric(threshold=0.5)
+
+# After (v3.7.x+)
+from deepeval.metrics import TurnRelevancyMetric
+metric = TurnRelevancyMetric(threshold=0.5, window_size=10)
+```
+:::
+
 The turn relevancy metric is a conversational metric that determines whether your LLM chatbot is able to consistently generate relevant responses **throughout a conversation**.
 
 ## Required Arguments


### PR DESCRIPTION
## What
Added a `:::caution` callout at the top of the `TurnRelevancyMetric` documentation page explaining the `ConversationRelevancyMetric` → `TurnRelevancyMetric` migration path.

## Why
Users upgrading from deepeval v3.6.x get an `ImportError` with no documentation explaining what replaced `ConversationRelevancyMetric` or how to migrate. The `TurnRelevancyMetric` page had no mention of the old class at all, making it hard to discover via search.

The callout explains:
- Which version removed `ConversationRelevancyMetric` (v3.7.x)
- What replaced it (`TurnRelevancyMetric`)
- The key behavioral difference (sliding window vs full-conversation scoring)
- A before/after code snippet

Note: this is complementary to PR #2750 (which fixes the scoring logic) — this PR is documentation-only and does not conflict.

## Changes
- `docs/content/docs/(multi-turn)/metrics-turn-relevancy.mdx` — added migration caution callout before the metric description

Closes #2321