### PR TITLE
fix(base-metric): add _required_test_case_params to BaseConversationalMetric

### DIFF
--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -7,6 +7,7 @@ from deepeval.test_case import (
     LLMTestCase,
     ConversationalTestCase,
     SingleTurnParams,
+    MultiTurnParams,
     ArenaTestCase,
 )
 from deepeval.templates.resolver import (
@@ -106,6 +107,7 @@ class BaseMetric(PromptMixin):
 
 
 class BaseConversationalMetric(PromptMixin):
+    _required_test_case_params = List[MultiTurnParams]
     threshold: float
     score: Optional[float] = None
     score_breakdown: Dict = None


### PR DESCRIPTION
## What
Added `_required_test_case_params = List[MultiTurnParams]` class-level declaration to `BaseConversationalMetric`, mirroring the existing `_required_params = List[SingleTurnParams]` already declared on `BaseMetric`.

## Why
All concrete subclasses of `BaseConversationalMetric` (e.g. `TurnRelevancyMetric`, `TurnContextualRelevancyMetric`) define `_required_test_case_params`. The base class had no declaration, so type checkers flagged access to `self._required_test_case_params` in any code that holds a reference typed as `BaseConversationalMetric` rather than a concrete subclass.

## Changes
- `deepeval/metrics/base_metric.py` — added `MultiTurnParams` to the import from `deepeval.test_case`; added `_required_test_case_params = List[MultiTurnParams]` to `BaseConversationalMetric`