### PR TITLE
docs: clarify GEval scoring behavior for models without log probability support

### DIFF
--- a/docs/content/docs/(custom)/metrics-llm-evals.mdx
+++ b/docs/content/docs/(custom)/metrics-llm-evals.mdx
@@ -262,6 +262,10 @@ class MyCustomModel(DeepEvalBaseLLM):
 
 </details>
 
+**Not all OpenAI models support log probabilities.** The o-series models (`o1`, `o1-mini`, `o3-mini`, `o4-mini`) and `gpt-5-mini` do not return log probs. When you use one of these as your `GEval` judge, `deepeval` automatically falls back to parsing the raw integer score from the model's text output instead of using weighted summation. Scores from the fallback path tend to be less granular and may differ from scores produced by log-prob-capable models like `gpt-4o` or `gpt-4.1`.
+
+If you need consistent, log-prob-based scoring, use a model that supports it (e.g. `gpt-4o`, `gpt-4.1`, `gpt-4.1-mini`).
+
 :::
 
 ## Examples


### PR DESCRIPTION
## What
Added a note inside the existing GEval "Did You Know?" tip block clarifying which OpenAI models do not support log probabilities and how that affects scoring.

## Why
Issue #2280 reported errors when using `gpt-5-mini` as a GEval judge. The root cause (missing `gpt-5-mini` from `OPENAI_MODELS_DATA`) was fixed in the codebase, but the docs never explained:
- Which models lack log prob support (o-series, gpt-5-mini)
- That deepeval automatically falls back to raw integer scoring in those cases
- That fallback scores may differ from weighted log-prob scores

Users hitting unexpected scores or needing consistent results had no guidance.

## Changes
- `docs/content/docs/(custom)/metrics-llm-evals.mdx` — added paragraph after the custom logprobs `<details>` block explaining the fallback behavior and which models trigger it

Closes #2280