### PR TITLE
feat(tracing): add cached_input_token_count to LlmSpan

### DIFF
--- a/deepeval/openai_agents/extractors.py
+++ b/deepeval/openai_agents/extractors.py
@@ -114,11 +114,11 @@ def update_span_properties_from_response_span_data(
     )
     # Update Span
     metadata = {
-        "cached_input_tokens": cached_input_tokens,
         "ouptut_reasoning_tokens": ouptut_reasoning_tokens,
     }
     span.input_token_count = input_tokens
     span.output_token_count = output_tokens
+    span.cached_input_token_count = cached_input_tokens
     span.metadata = metadata
     span.model = "NA" if response.model is None else str(response.model)
     span.provider = infer_provider_from_model(span.model)

--- a/deepeval/tracing/api.py
+++ b/deepeval/tracing/api.py
@@ -100,6 +100,9 @@ class BaseApiSpan(BaseModel):
     prompt: Optional[PromptApi] = None
     input_token_count: Optional[float] = Field(None, alias="inputTokenCount")
     output_token_count: Optional[float] = Field(None, alias="outputTokenCount")
+    cached_input_token_count: Optional[float] = Field(
+        None, alias="cachedInputTokenCount"
+    )
     cost_per_input_token: Optional[float] = Field(
         None, alias="costPerInputToken"
     )

--- a/deepeval/tracing/context.py
+++ b/deepeval/tracing/context.py
@@ -188,6 +188,7 @@ def update_llm_span(
     model: Optional[str] = None,
     input_token_count: Optional[float] = None,
     output_token_count: Optional[float] = None,
+    cached_input_token_count: Optional[float] = None,
     cost_per_input_token: Optional[float] = None,
     cost_per_output_token: Optional[float] = None,
     token_intervals: Optional[Dict[float, str]] = None,
@@ -202,6 +203,8 @@ def update_llm_span(
         current_span.input_token_count = input_token_count
     if output_token_count:
         current_span.output_token_count = output_token_count
+    if cached_input_token_count:
+        current_span.cached_input_token_count = cached_input_token_count
     if cost_per_input_token:
         current_span.cost_per_input_token = cost_per_input_token
     if cost_per_output_token:

--- a/deepeval/tracing/types.py
+++ b/deepeval/tracing/types.py
@@ -142,6 +142,9 @@ class LlmSpan(BaseSpan):
     output_token_count: Optional[float] = Field(
         None, serialization_alias="outputTokenCount"
     )
+    cached_input_token_count: Optional[float] = Field(
+        None, serialization_alias="cachedInputTokenCount"
+    )
     cost_per_input_token: Optional[float] = Field(
         None, serialization_alias="costPerInputToken"
     )


### PR DESCRIPTION
## What
Added `cached_input_token_count` as a first-class field on `LlmSpan`, `BaseApiSpan`, and `update_llm_span()`. Promoted the field out of `span.metadata` in the OpenAI Agents extractor where it was previously stashed invisibly.

## Why
All major LLM providers now bill cached input tokens at a discount (OpenAI ~50%, Anthropic ~10%). `LlmSpan` had no field for this, causing two problems:

1. **Cost overestimation** — `input_token_count × cost_per_input_token` always bills cached tokens at the full rate.
2. **Lost data** — the OpenAI Agents extractor already extracted `usage.input_tokens_details.cached_tokens` but had to stuff it into `span.metadata` (invisible to cost/token analytics).

Closes #2741

## Changes
- `deepeval/tracing/types.py` — `cached_input_token_count: Optional[float]` on `LlmSpan` (serialized as `cachedInputTokenCount`)
- `deepeval/tracing/api.py` — same field on `BaseApiSpan` (aliased as `cachedInputTokenCount`)
- `deepeval/tracing/context.py` — `cached_input_token_count` param added to `update_llm_span()`
- `deepeval/openai_agents/extractors.py` — move `cached_input_tokens` from `span.metadata` to `span.cached_input_token_count`