### PR TITLE
docs: add generate_verdicts custom template example for AnswerRelevancyMetric

### DIFF
--- a/docs/content/docs/(rag)/metrics-answer-relevancy.mdx
+++ b/docs/content/docs/(rag)/metrics-answer-relevancy.mdx
@@ -193,6 +193,39 @@ metric = AnswerRelevancyMetric(evaluation_template=CustomTemplate)
 metric.measure(...)
 ```
 
+You can also override `generate_verdicts` to change how the metric decides whether each statement is relevant. This is useful when the default yes/no/idk verdict logic doesn't match your domain — for example, if you want to treat all ambiguous statements as irrelevant, or if you want to add domain-specific instructions:
+
+```python
+from deepeval.metrics import AnswerRelevancyMetric
+from deepeval.metrics.answer_relevancy import AnswerRelevancyTemplate
+
+class StrictRelevancyTemplate(AnswerRelevancyTemplate):
+    @staticmethod
+    def generate_verdicts(input: str, statements: str, multimodal: bool = False):
+        return f"""For each statement below, determine if it directly and specifically addresses the input.
+Be strict: only mark a statement 'yes' if it clearly answers the question asked.
+Mark 'no' if the statement is off-topic, generic, or only tangentially related.
+Do not use 'idk' — every statement must be 'yes' or 'no'.
+
+Input: {input}
+
+Statements: {statements}
+
+Return JSON in this exact format:
+{{
+    "verdicts": [
+        {{"verdict": "yes"}},
+        {{"verdict": "no", "reason": "Statement does not address the input."}}
+    ]
+}}
+
+JSON:
+"""
+
+metric = AnswerRelevancyMetric(evaluation_template=StrictRelevancyTemplate)
+metric.measure(...)
+```
+
 ## FAQs
 
 <FAQs


### PR DESCRIPTION
## What
Extended the "Customize Your Template" section in the `AnswerRelevancyMetric` docs with a second example showing how to override `generate_verdicts`.

## Why
The existing section only showed how to override `generate_statements`. The more impactful customization point is `generate_verdicts`, which controls the yes/no/idk relevancy decision. Users who want stricter relevancy criteria, domain-specific rules, or different handling of ambiguous statements had no example to follow.

## Changes
- `docs/content/docs/(rag)/metrics-answer-relevancy.mdx` — added `StrictRelevancyTemplate` example after the existing `generate_statements` example, showing how to override `generate_verdicts` with custom verdict logic