### PR TITLE
docs: document chunk_size and min_contexts tuning for short documents in Synthesizer

### DIFF
--- a/docs/content/docs/(generate-goldens)/synthesizer-generate-from-docs.mdx
+++ b/docs/content/docs/(generate-goldens)/synthesizer-generate-from-docs.mdx
@@ -154,6 +154,36 @@ These text chunks are then embedded by the `embedder` and stored in a vector dat
 The synthesizer will raise an error if `chunk_size` is too large to generate n=`max_contexts_per_document` unique contexts.
 :::
 
+**Tuning for short documents:** If you're synthesizing from short documents (e.g., FAQ entries, short articles, or single-page PDFs), you may hit the following error:
+
+```
+Impossible to generate N contexts from a document with M chunks.
+```
+
+This happens when a document is too short to be split into enough chunks to satisfy `min_contexts_per_document`. To fix it, adjust one or more of the following in your `ContextConstructionConfig`:
+
+| Parameter | Effect |
+|-----------|--------|
+| Reduce `chunk_size` | Smaller chunks → more chunks per document |
+| Reduce `chunk_overlap` | Less overlap → slightly more unique chunks |
+| Reduce `min_contexts_per_document` | Require fewer contexts per document |
+
+For example, if your documents average ~500 tokens and the default `chunk_size=1024` produces only 1 chunk per document, reduce `chunk_size` to `256` so each document yields more chunks:
+
+```python
+from deepeval.synthesizer import Synthesizer
+from deepeval.synthesizer.config import ContextConstructionConfig
+
+synthesizer = Synthesizer()
+synthesizer.generate_goldens_from_docs(
+    document_paths=["short_doc.pdf"],
+    context_construction_config=ContextConstructionConfig(
+        chunk_size=256,           # reduced from default 1024
+        min_contexts_per_document=1,
+    ),
+)
+```
+
 ### Context Selection
 
 In the **context selection** step, random nodes are selected from the vector database that contains the previously indexed nodes. Each time a node is selected, it is subject to filtering. This is because chunked contexts can result in trivial or undesirable content, such as a series of white spaces or unwanted characters from document structures, which is why filtering is important to ensure subsequently generated goldens are meaningful, relevant, and coherent.


### PR DESCRIPTION
## What
Expanded the "Document Parsing" section in `synthesizer-generate-from-docs.mdx` with actionable guidance for the "Impossible to generate N contexts from a document with M chunks" error.

## Why
Issue #2467 reports users hitting this error with no documentation to guide them. The existing caution note only stated that the error exists, not how to fix it. Users with short documents (FAQ entries, short PDFs) had no way to know they should reduce `chunk_size` or `min_contexts_per_document`.

## Changes
- `docs/content/docs/(generate-goldens)/synthesizer-generate-from-docs.mdx` — added tuning table and concrete code example below the existing caution, explaining the relationship between document length, `chunk_size`, `chunk_overlap`, and `min_contexts_per_document`

Closes #2467