### PR TITLE
fix(pydantic-ai): populate tools_called on agent spans

### DIFF
--- a/deepeval/tracing/otel/exporter.py
+++ b/deepeval/tracing/otel/exporter.py
@@ -25,6 +25,7 @@ from deepeval.tracing.types import (
 )
 from deepeval.tracing.otel.utils import (
     check_pydantic_ai_agent_input_output,
+    check_pydantic_ai_tools_called,
     check_pydantic_ai_trace_input_output,
     check_tool_input_parameters_from_gen_ai_attributes,
     check_span_type_from_gen_ai_attributes,
@@ -698,6 +699,7 @@ class ConfidentSpanExporter(SpanExporter):
                     pass
 
             input, output = check_pydantic_ai_agent_input_output(span)
+            tools_called = check_pydantic_ai_tools_called(span)
             agent_span = AgentSpan(
                 uuid=uuid,
                 status=status,
@@ -712,6 +714,7 @@ class ConfidentSpanExporter(SpanExporter):
                 agent_handoffs=agent_handoffs,
                 input=input,
                 output=output,
+                tools_called=tools_called,
             )
             return agent_span
 

--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -557,6 +557,62 @@ def check_pydantic_ai_agent_input_output(
     return system_instructions + input_val, output_val
 
 
+def check_pydantic_ai_tools_called(
+    span: ReadableSpan,
+) -> Optional[List[ToolCall]]:
+    """Extract tool calls (and their resuls) from pydantic-ai message history
+
+    Tool call live inside `pydantic_ai.all_messages` as parts of type
+    `̀tool_call` ({id, name, arguments}) paired with `tool_call_response`
+    parts ({id, name, result}). We rebuild structured `ToolCall` objects,
+    matching responses to call by `id`.
+    """
+    try:
+        normalized = normalize_pydantic_ai_messages(span)
+        if not normalized:
+            return None
+
+        calls_by_id: dict = {}
+        ordered: List[ToolCall] = []
+
+        for message in normalized:
+            if not isinstance(message, dict):
+                continue
+            for part in message.get("parts", []) or []:
+                if not isinstance(part, dict):
+                    continue
+                part_type = part.get("type")
+
+                if part_type == "tool_call":
+                    raw_args = part.get("arguments")
+                    input_parameters = {}
+                    if isinstance(raw_args, str):
+                        try:
+                            input_parameters = json.loads(raw_args)
+                        except Exception:
+                            input_parameters = {}
+                    elif isinstance(raw_args, dict):
+                        input_parameters = raw_args
+
+                    tool_call = ToolCall(
+                        name=part.get("name", ""),
+                        input_parameters=input_parameters,
+                    )
+                    ordered.append(tool_call)
+                    call_id = part.get("id")
+                    if call_id is not None:
+                        calls_by_id[call_id] = tool_call
+
+                elif part_type == "tool_call_response":
+                    call_id = part.get("id")
+                    if call_id in calls_by_id:
+                        calls_by_id[call_id].output = part.get("result")
+
+        return ordered or None
+    except Exception:
+        return None
+
+
 def check_tool_output(span: ReadableSpan):
     try:
         return span.attributes.get("tool_response")

--- a/tests/test_integrations/test_exporter/test_pydantic_ai.py
+++ b/tests/test_integrations/test_exporter/test_pydantic_ai.py
@@ -1,4 +1,3 @@
-import asyncio
 from deepeval.tracing.otel.exporter import ConfidentSpanExporter
 from tests.test_integrations.test_exporter.readable_spans import (
     list_of_readable_spans,
@@ -74,6 +73,31 @@ async def test_llm_trace():
         assert (
             actual_dict["llmSpans"][0]["outputTokenCount"] == 500
         ), f"Expected output token count to be 500, got {actual_dict['llmSpans'][0]['outputTokenCount']}"
+
+    finally:
+        trace_testing_manager.test_name = None
+        trace_testing_manager.test_dict = None
+
+
+async def test_pydantic_ai_tools_called():
+    try:
+        trace_testing_manager.test_name = "any_name"
+        exporter.export(list_of_readable_spans)
+        actual_dict = await trace_testing_manager.wait_for_test_dict()
+
+        tools_called = actual_dict["agentSpans"][0]["toolsCalled"]
+        assert (
+            len(tools_called) == 1
+        ), f"Expected 1 tool call, got {len(tools_called)}"
+        assert (
+            tools_called[0]["name"] == "test_tool"
+        ), f"Expected tool name 'test_tool', got {tools_called[0]['name']}"
+        assert tools_called[0]["inputParameters"] == {
+            "query": "test query"
+        }, f"Expected inputParameters, got {tools_called[0]['inputParameters']}"
+        assert (
+            tools_called[0]["output"] == "Test tool result"
+        ), f"Expected output 'Test tool result', got {tools_called[0]['output']}"
 
     finally:
         trace_testing_manager.test_name = None


### PR DESCRIPTION
## Problem

When using the pydantic-ai integration via `ConfidentInstrumentationSettings`, the resulting `LLMTestCase` had `tools_called=None`. This crashes `ToolCorrectnessMetric` (`MissingTestCaseParamsError`) and prevents tool-aware evaluation of pydantic-ai agents.

Closes #2508.

## Root cause

The OTel exporter builds the `AgentSpan` with `input`/`output` only (via `check_pydantic_ai_agent_input_output`) and never populates `tools_called`. Tool calls *are* present in `pydantic_ai.all_messages` as `tool_call` / `tool_call_response` parts, but nothing extracted them — so the field stayed `None` all the way down to the `LLMTestCase` built in `evaluate/execute/agentic.py`.

## Change

- New `check_pydantic_ai_tools_called()` in `deepeval/tracing/otel/utils.py`: rebuilds structured `ToolCall` objects from the normalized message history, matching `tool_call_response` results to their `tool_call` by `id`. Reuses the existing `normalize_pydantic_ai_messages()` helper.
- Wired into the agent-span branch of `ConfidentSpanExporter` (`deepeval/tracing/otel/exporter.py`).
- No schema / API changes.

## Tests

Added `test_pydantic_ai_tools_called` in `tests/test_integrations/test_exporter/test_pydantic_ai.py`, reusing the existing synthetic agent span (no API key required). Asserts the extracted tool call name, `inputParameters`, and `output`.

> Note: `test_llm_trace` fails locally without a `CONFIDENT_API_KEY` (prompt-hash lookup) — this is pre-existing and unrelated to this PR, reproducible on `main`.

## Follow-up (out of scope)

`expected_tools` comes from the `Golden`, not the trace, so it's intentionally left out to keep this PR atomic — happy to address it separately.

cc @Fizza-Mukhtar — built on your diagnosis from #2515, rebased on current `main`.