### PR TITLE
fix: trim_and_load_json in models/llms corrupts valid JSON string values

### DIFF
--- a/deepeval/models/llms/utils.py
+++ b/deepeval/models/llms/utils.py
@@ -17,12 +17,18 @@ def trim_and_load_json(
         input_string = input_string + "}"
         end = len(input_string)
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
-    jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
+
     try:
         return json.loads(jsonStr)
     except json.JSONDecodeError:
-        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
-        raise DeepEvalError(error_str)
+        # Some models emit a trailing comma before a closing ] or }. Strip it
+        # and retry, but only after a direct parse fails, so valid JSON string
+        # values containing ", ]" or ", }" are never corrupted.
+        try:
+            return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
+        except json.JSONDecodeError:
+            error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+            raise DeepEvalError(error_str)
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
 

--- a/tests/test_core/test_trim_and_load_json.py
+++ b/tests/test_core/test_trim_and_load_json.py
@@ -1,22 +1,27 @@
 """Regression tests for trimAndLoadJson trailing-comma handling.
 
-Both the metrics and dataset copies stripped ``,\\s*`` before a closing ``]``/``}``
-unconditionally, which corrupted valid JSON whose string values happened to
-contain ``", ]"`` or ``", }"``. The cleanup must only run as a fallback when a
-direct parse fails.
+The metrics, dataset, and models copies stripped ``,\\s*`` before a closing
+``]``/``}`` unconditionally, which corrupted valid JSON whose string values
+happened to contain ``", ]"`` or ``", }"``. The cleanup must only run as a
+fallback when a direct parse fails.
 """
 
 import json
 
 import pytest
 
+from deepeval.errors import DeepEvalError
 from deepeval.dataset.utils import trimAndLoadJson as trim_dataset
 from deepeval.metrics.utils import trimAndLoadJson as trim_metrics
+from deepeval.models.llms.utils import trim_and_load_json as trim_models
 
+# The metrics and dataset copies raise ``ValueError`` on invalid JSON; the
+# models copy raises ``DeepEvalError``. Group them where the distinction matters.
 TRIM_FNS = [trim_metrics, trim_dataset]
+ALL_TRIM_FNS = [trim_metrics, trim_dataset, trim_models]
 
 
-@pytest.mark.parametrize("trim", TRIM_FNS)
+@pytest.mark.parametrize("trim", ALL_TRIM_FNS)
 @pytest.mark.parametrize(
     "raw",
     [
@@ -28,7 +33,7 @@ def test_valid_json_string_values_are_preserved(trim, raw):
     assert trim(raw) == json.loads(raw)
 
 
-@pytest.mark.parametrize("trim", TRIM_FNS)
+@pytest.mark.parametrize("trim", ALL_TRIM_FNS)
 def test_trailing_comma_is_still_stripped(trim):
     assert trim('{"a": [1, 2, ]}') == {"a": [1, 2]}
 
@@ -37,3 +42,8 @@ def test_trailing_comma_is_still_stripped(trim):
 def test_invalid_json_still_raises(trim):
     with pytest.raises(ValueError):
         trim("not json at all {[")
+
+
+def test_models_copy_invalid_json_raises():
+    with pytest.raises(DeepEvalError):
+        trim_models("not json at all {[")


### PR DESCRIPTION
Fixes #2770

### Problem

#2701 (commit `2340aab`) fixed `trimAndLoadJson` corrupting valid JSON whose string values contain `", ]"` or `", }"`, but only in `deepeval/metrics/utils.py` and `deepeval/dataset/utils.py`. The third copy, `deepeval/models/llms/utils.py::trim_and_load_json`, was missed.

That copy is imported by **every** concrete model backend (`openai_model`, `anthropic_model`, `azure_model`, `amazon_bedrock_model`, `gemini`/`local_model`, `deepseek_model`, `litellm_model`, `grok_model`, `kimi_model`, `gateway_model`) to parse generated output, so it still corrupts valid JSON string values:

```python
from deepeval.models.llms.utils import trim_and_load_json

trim_and_load_json('{"reason": "score is 1,} good"}')
# returns {'reason': 'score is 1} good'} — the comma is silently dropped
```

### Fix

Apply the same approach already used in the other two copies: attempt a direct `json.loads` first, and only fall back to the comma-stripping regex when the direct parse raises `JSONDecodeError`. This keeps trailing-comma tolerance while never mutating valid JSON string content.

### Testing

Extended the existing regression test `tests/test_core/test_trim_and_load_json.py` to also cover this copy.

- `pytest tests/test_core/test_trim_and_load_json.py` → 12 passed (the two new `..._string_values_are_preserved[...trim_and_load_json]` cases fail before this change).
- `black --check` on both files → clean.
- Broader `pytest tests/test_core` shows only pre-existing unrelated failures (optional `chromadb`/`ollama` deps), identical on `main`.
