### PR TITLE
fix: use `is not None` for shots_dataset checks in GSM8K and HellaSwag benchmarks

### DIFF
--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -94,7 +94,7 @@ class GSM8K(DeepEvalBaseBenchmark):
     def predict(self, model: DeepEvalBaseLLM, golden: Golden) -> Dict:
         # Define prompt template
         assert (
-            self.shots_dataset != None
+            self.shots_dataset is not None
         ), "Example dataset is empty. Call load_benchmark."
         prompt: dict = GSM8KTemplate.generate_output(
             train_set=self.shots_dataset,

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -172,7 +172,7 @@ class HellaSwag(DeepEvalBaseBenchmark):
     ) -> Dict:
         # Define prompt template
         assert (
-            self.shots_dataset != None
+            self.shots_dataset is not None
         ), "Example dataset is empty. Call load_benchmark."
         prompt: dict = HellaSwagTemplate.generate_output(
             train_set=self.shots_dataset,
@@ -206,7 +206,7 @@ class HellaSwag(DeepEvalBaseBenchmark):
     ) -> List[Dict]:
         # Define prompt template
         assert (
-            self.shots_dataset != None
+            self.shots_dataset is not None
         ), "Example dataset is empty. Call load_benchmark."
 
         prompts = []


### PR DESCRIPTION
## Summary

`GSM8K.predict`, `HellaSwag.predict`, and `HellaSwag.batch_predict` guard prompt
construction with `assert self.shots_dataset != None`. Comparing to `None` with `!=`:

- trips Ruff/flake8 **E711** (`comparison to None should be 'cond is not None'`), and
- diverges from the sibling **DROP** benchmark, which already uses
  `self.shots_dataset is not None` (`deepeval/benchmarks/drop/drop.py:172,214`).

This aligns the three call sites with the idiomatic identity check.

## Changes

- `deepeval/benchmarks/gsm8k/gsm8k.py` — 1 assert
- `deepeval/benchmarks/hellaswag/hellaswag.py` — 2 asserts

## Notes

- No behavioral change — `shots_dataset` is a `List[Dict]`, so `is not None` is
  equivalent here, just correct and lint-clean.
- `ruff check --select E711` passes; `black --check` reports no changes.
