### PR TITLE
fix(execute): resolve #2216 — AsyncConfig import problem

### DIFF
--- a/deepeval/evaluate/execute/_common.py
+++ b/deepeval/evaluate/execute/_common.py
@@ -8,9 +8,7 @@ from typing import (
 )
 import asyncio
 
-from deepeval.evaluate.configs import (
-    ErrorConfig,
-)
+from deepeval.evaluate.configs import AsyncConfig, ErrorConfig
 from deepeval.tracing.tracing import (
     trace_manager,
     Trace,


### PR DESCRIPTION
## Summary

Fixes #2216 — AsyncConfig import problem

## Root Cause

The import statement is incorrect. It should directly import `AsyncConfig` from `deepeval.evaluate.configs`.

## Changes

- **`_common.py`** — patched the root-cause code path

## Verification

- [x] AST syntax check passed
- [x] Undefined-variable guard passed
- [x] Fix is minimal — no unrelated changes
- [ ] Regression test added

---
*Automated fix — please review before merging.*
