### PR TITLE
feat(synthesizer): add optional expected_output_schema for structured goldens

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Tuple, Dict, Literal
+from typing import List, Optional, Union, Tuple, Dict, Literal, Type
 from rich.progress import (
     Progress,
 )
@@ -425,6 +425,7 @@ class Synthesizer:
         include_expected_output: bool = True,
         max_goldens_per_context: int = 2,
         context_construction_config: Optional[ContextConstructionConfig] = None,
+        expected_output_schema: Optional[Type[BaseModel]] = None,
         _send_data=True,
     ) -> List[Golden]:
         self.synthetic_goldens = []
@@ -524,6 +525,7 @@ class Synthesizer:
                         for item in contexts_with_sources
                     ],
                     target_files_per_context=context_construction_config.target_files_per_context,
+                    expected_output_schema=expected_output_schema,
                     _context_scores=[
                         item.score if item.score is not None else 0.0
                         for item in contexts_with_sources
@@ -556,6 +558,7 @@ class Synthesizer:
         max_goldens_per_context: int = 2,
         context_construction_config: Optional[ContextConstructionConfig] = None,
         _reset_cost=True,
+        expected_output_schema: Optional[Type[BaseModel]] = None,
     ):
         if context_construction_config is None:
             context_construction_config = ContextConstructionConfig(
@@ -643,6 +646,7 @@ class Synthesizer:
                     for item in contexts_with_sources
                 ],
                 target_files_per_context=context_construction_config.target_files_per_context,
+                expected_output_schema=expected_output_schema,
                 _context_scores=[
                     item.score if item.score is not None else 0.0
                     for item in contexts_with_sources
@@ -677,6 +681,7 @@ class Synthesizer:
         source_files: Optional[List[Union[str, List[str]]]] = None,
         context_chunk_source_files: Optional[List[List[str]]] = None,
         target_files_per_context: Optional[int] = None,
+        expected_output_schema: Optional[Type[BaseModel]] = None,
         _context_scores: Optional[List[float]] = None,
         _progress: Optional[Progress] = None,
         _pbar_id: Optional[int] = None,
@@ -699,6 +704,7 @@ class Synthesizer:
                         source_files=source_files,
                         context_chunk_source_files=context_chunk_source_files,
                         target_files_per_context=target_files_per_context,
+                        expected_output_schema=expected_output_schema,
                     )
                 )
             )
@@ -871,7 +877,12 @@ class Synthesizer:
                                 context="\n".join(golden.context),
                                 expected_output_format=self.styling_config.expected_output_format,
                             )
-                            res = self._generate(prompt)
+                            if expected_output_schema is not None:
+                                res = self._generate_schema(
+                                    prompt, expected_output_schema, self.model
+                                ).model_dump_json()
+                            else:
+                                res = self._generate(prompt)
                             golden.expected_output = res
                             update_pbar(
                                 progress,
@@ -910,6 +921,7 @@ class Synthesizer:
         source_files: Optional[List[Union[str, List[str]]]] = None,
         context_chunk_source_files: Optional[List[List[str]]] = None,
         target_files_per_context: Optional[int] = None,
+        expected_output_schema: Optional[Type[BaseModel]] = None,
         _context_scores: Optional[List[float]] = None,
         _progress: Optional[Progress] = None,
         _pbar_id: Optional[int] = None,
@@ -948,6 +960,7 @@ class Synthesizer:
                     source_files=source_files,
                     context_chunk_source_files=context_chunk_source_files,
                     target_files_per_context=target_files_per_context,
+                    expected_output_schema=expected_output_schema,
                     context_index=index,
                     progress=progress,
                     pbar_id=pbar_id,
@@ -973,6 +986,7 @@ class Synthesizer:
         context_chunk_source_files: Optional[List[List[str]]],
         target_files_per_context: Optional[int],
         context_index: int,
+        expected_output_schema: Optional[Type[BaseModel]] = None,
         progress: Optional[Progress] = None,
         pbar_id: Optional[int] = None,
         context_scores: Optional[List[float]] = None,
@@ -1103,7 +1117,17 @@ class Synthesizer:
                     context="\n".join(context),
                     expected_output_format=self.styling_config.expected_output_format,
                 )
-                expected_output = await self._a_generate(expected_output_prompt)
+                if expected_output_schema is not None:
+                    structured = await self._a_generate_schema(
+                        expected_output_prompt,
+                        expected_output_schema,
+                        self.model,
+                    )
+                    expected_output = structured.model_dump_json()
+                else:
+                    expected_output = await self._a_generate(
+                        expected_output_prompt
+                    )
                 update_pbar(
                     progress, pbar_evolve_input_ids[input_index], remove=False
                 )

--- a/tests/test_core/test_synthesizer/test_synthesizer.py
+++ b/tests/test_core/test_synthesizer/test_synthesizer.py
@@ -3,6 +3,7 @@ import pytest
 import os
 
 from typing import List
+from pydantic import BaseModel
 
 from deepeval.synthesizer.synthesizer import Synthesizer
 from deepeval.synthesizer.config import (
@@ -477,3 +478,47 @@ async def test_a_generate_conversational_goldens_from_contexts_no_deadlock_when_
         ),
         timeout=0.5,
     )
+
+
+class _ExpectedAnswer(BaseModel):
+    answer: str
+    confidence: float
+
+
+@requires_openai_key
+def test_generate_goldens_from_contexts_with_expected_output_schema():
+    synthesizer = Synthesizer(async_mode=False)
+    goldens = synthesizer.generate_goldens_from_contexts(
+        contexts=[
+            ["The Eiffel Tower is located in Paris and was completed in 1889."]
+        ],
+        include_expected_output=True,
+        max_goldens_per_context=1,
+        expected_output_schema=_ExpectedAnswer,
+        _send_data=False,
+    )
+    assert len(goldens) >= 1
+    for g in goldens:
+        if g.expected_output:
+            # expected_output must be a JSON string that round-trips the schema
+            parsed = _ExpectedAnswer.model_validate_json(g.expected_output)
+            assert isinstance(parsed.answer, str)
+            assert isinstance(parsed.confidence, float)
+
+
+@requires_openai_key
+def test_expected_output_schema_none_is_unchanged():
+    synthesizer = Synthesizer(async_mode=False)
+    goldens = synthesizer.generate_goldens_from_contexts(
+        contexts=[
+            ["The Eiffel Tower is located in Paris and was completed in 1889."]
+        ],
+        include_expected_output=True,
+        max_goldens_per_context=1,
+        _send_data=False,
+    )
+    for g in goldens:
+        if g.expected_output:
+            # default path: plain text, NOT valid schema JSON
+            with pytest.raises(Exception):
+                _ExpectedAnswer.model_validate_json(g.expected_output)


### PR DESCRIPTION
## What
Adds an optional `expected_output_schema: Type[BaseModel]` parameter to the
`Synthesizer` golden-generation methods (`generate_goldens_from_contexts` and
`generate_goldens_from_docs`, sync + async). When provided, each golden's
`expected_output` is generated as JSON conforming to the schema (via
`_generate_schema` / `_a_generate_schema` + `model_dump_json`) instead of free
text.

Closes #2034.

## Why
Per @penguine-ip's note on the issue — "would really appreciate an interface
like this… those two parameters can be optional and go into our four
generation methods". This removes the manual prompt-engineering users
currently need to get structured goldens out of the `Synthesizer`.

## Design
- New param threaded through the existing delegation chain
  (`from_docs` → `from_contexts`, sync → async), so only the two real
  generation bodies branch on the schema; the rest just forward the kwarg.
- The new param defaults to `None`, in which case behavior is byte-for-byte
  unchanged (`_generate` / `_a_generate` free-text path).

## Scope
- `expected_output_schema` only in this PR. `input_schema` is a natural
  follow-up: the input pipeline (generate → qualify → evolve → restyle)
  assumes free text throughout, so structuring it cleanly is a separate
  change. Happy to do it next if you'd like.
- Not added to `generate_goldens_from_scratch` (never produces an
  `expected_output`) to avoid a misleading no-op parameter.

## Notes / limitations
- Structured output is best supported on native models. Deeply-nested schemas
  under custom non-native models rely on the `trim_and_load_json` fallback in
  `_generate_schema` and may be less reliable.

## Tests
Added `test_generate_goldens_from_contexts_with_expected_output_schema` and
`test_expected_output_schema_none_is_unchanged`, gated on `OPENAI_API_KEY`
following the existing synthesizer test convention. They're skipped on fork PRs
(no secrets), so they won't run on this PR's CI — happy to have a maintainer
trigger the secret-enabled run, or to add a no-API structural test if you'd
prefer one that always runs.
