### PR TITLE
Fix HallucinationMetric silently passing when context is empty

### DIFF
--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -14,6 +14,7 @@ from deepeval.metrics.utils import (
     generate_with_schema_and_extract,
 )
 from deepeval.models import DeepEvalBaseLLM
+from deepeval.errors import MissingTestCaseParamsError
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.hallucination.schema import (
     HallucinationVerdict,
@@ -64,6 +65,7 @@ class HallucinationMetric(BaseMetric):
             self.model,
             multimodal,
         )
+        self._check_context_not_empty(test_case)
 
         self.evaluation_cost = 0 if self.using_native_model else None
         self.input_tokens = 0 if self.using_native_model else None
@@ -118,6 +120,7 @@ class HallucinationMetric(BaseMetric):
             self.model,
             multimodal,
         )
+        self._check_context_not_empty(test_case)
 
         self.evaluation_cost = 0 if self.using_native_model else None
         self.input_tokens = 0 if self.using_native_model else None
@@ -236,6 +239,20 @@ class HallucinationMetric(BaseMetric):
                 HallucinationVerdict(**item) for item in data["verdicts"]
             ],
         )
+
+    def _check_context_not_empty(self, test_case: LLMTestCase) -> None:
+        # `context` is a required param, but `check_llm_test_case_params` only
+        # rejects `None`. An empty list slips through and produces an empty
+        # verdict list, which `_calculate_score` turns into a passing score of
+        # 0 ("no hallucination") even though there was nothing to check the
+        # output against. Treat an empty context the same as a missing one so
+        # it surfaces as an error / skip instead of a misleading pass.
+        if len(test_case.context) == 0:
+            error_str = (
+                f"'context' cannot be empty for the '{self.__name__}' metric"
+            )
+            self.error = error_str
+            raise MissingTestCaseParamsError(error_str)
 
     def _calculate_score(self) -> float:
         number_of_verdicts = len(self.verdicts)

--- a/tests/test_metrics/test_hallucination_metric_empty_context.py
+++ b/tests/test_metrics/test_hallucination_metric_empty_context.py
@@ -1,0 +1,59 @@
+"""Regression tests for HallucinationMetric's empty-context handling.
+
+`context` is a required param, but the shared param check only rejects `None`.
+An empty list used to slip through, produce zero verdicts, and get scored as
+0 ("no hallucination") -- a silent passing score on a test case the metric
+never actually checked. An empty context is now treated the same as a missing
+one and raises `MissingTestCaseParamsError`, which the evaluate pipeline can
+surface as an error or skip (via `skip_on_missing_params`) instead of a
+misleading pass.
+
+These tests use a stub model, so they run without an LLM provider API key. The
+stub's generate methods raise if called, proving the metric short-circuits
+before ever reaching the judge model.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.errors import MissingTestCaseParamsError
+from deepeval.metrics import HallucinationMetric
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM that never calls out to a provider."""
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        raise AssertionError("generate should not be called in this test")
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        raise AssertionError("a_generate should not be called in this test")
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+def _test_case() -> LLMTestCase:
+    return LLMTestCase(
+        input="What is the capital of France?",
+        actual_output="The capital of France is Paris.",
+        context=[],
+    )
+
+
+def test_sync_empty_context_raises():
+    metric = HallucinationMetric(model=_StubLLM(), async_mode=False)
+    with pytest.raises(MissingTestCaseParamsError):
+        metric.measure(_test_case())
+
+
+def test_async_empty_context_raises():
+    metric = HallucinationMetric(model=_StubLLM())
+    with pytest.raises(MissingTestCaseParamsError):
+        asyncio.run(metric.a_measure(_test_case()))


### PR DESCRIPTION
### What

`HallucinationMetric` now raises `MissingTestCaseParamsError` when `context` is an empty list (`[]`), treating it the same as a missing (`None`) context — instead of silently returning a passing score.

### Why

`context` is a required parameter for `HallucinationMetric`, but the shared `check_llm_test_case_params` validation only rejects `None`. An empty list slipped through:

1. `_generate_verdicts()` is called with zero contexts → returns an empty verdict list.
2. `_calculate_score()` hits its `if number_of_verdicts == 0: return 0` guard.
3. A score of `0` means **"no hallucination → test passes."**

So any test case with an empty `context` is silently reported as fully grounded, regardless of the output. This is a false negative: the metric reports a confident pass on a case it never actually evaluated. This commonly happens at scale — e.g. building test cases from a dataset with missing rows, or feeding a RAG retriever's output as context when retrieval returns zero chunks.

That `return 0` is a divide-by-zero guard (the next line divides by `number_of_verdicts`), not a deliberate empty-context policy — the same guard returns inconsistent values across the sibling RAG metrics (`Faithfulness` returns `1`, `ContextualPrecision`/`ContextualRecall` return `0`), confirming no coherent empty-input handling was intended.

### How

Added a `_check_context_not_empty()` guard called in both `measure()` and `a_measure()`, right after `check_llm_test_case_params`, before the judge model is ever invoked. Because it raises `MissingTestCaseParamsError`, it plugs into the existing evaluate-pipeline handling, so developers keep full control:

- default → a clear error: `'context' cannot be empty for the 'Hallucination' metric`
- `skip_on_missing_params=True` → the case is **skipped** (`success=None`, no misleading score)
- `ignore_errors=True` → recorded as an error

`None` and `[]` context now behave identically.

### Tests

Added `tests/test_metrics/test_hallucination_metric_empty_context.py` covering the sync and async paths. It uses a stub model (mirroring the existing `test_turn_faithfulness_metric_empty_verdicts.py`), so it runs without an LLM provider API key and asserts the model is never called.

Verified: full `tests/test_metrics/` suite passes (70 passed, 0 failed); `black` and `ruff` clean.

### Scope note

This same empty-input inconsistency exists across the other RAG metrics; this PR keeps the change scoped to `HallucinationMetric`. Happy to follow up on the others if maintainers want.