### PR TITLE
fix(dag): make DAGMetric instances safely reusable across measure() calls

### DIFF
--- a/deepeval/metrics/dag/dag.py
+++ b/deepeval/metrics/dag/dag.py
@@ -72,6 +72,10 @@ class DAGMetric(BaseMetric):
             multimodal,
         )
 
+        # Reset accumulated verbose log so this metric can be reused across
+        # calls without leaking entries from prior traversals.
+        self._verbose_steps = []
+
         self.evaluation_cost = 0 if self.using_native_model else None
         self.input_tokens = 0 if self.using_native_model else None
         self.output_tokens = 0 if self.using_native_model else None
@@ -117,6 +121,8 @@ class DAGMetric(BaseMetric):
             self.model,
             multimodal,
         )
+
+        self._verbose_steps = []
 
         self.evaluation_cost = 0 if self.using_native_model else None
         self.input_tokens = 0 if self.using_native_model else None

--- a/deepeval/metrics/dag/nodes.py
+++ b/deepeval/metrics/dag/nodes.py
@@ -54,6 +54,35 @@ def decrement_indegree(node: BaseNode):
     node._indegree -= 1
 
 
+def propagate_skip(node: Optional["BaseNode"]) -> None:
+    """Decrement ``_indegree`` on a node and cascade through its construction-
+    time descendants when the counter reaches zero.
+
+    JudgementNodes call this on each non-selected ``VerdictNode`` sibling so
+    that any indegree the dead branch contributed during construction flows
+    back out. Without it, a downstream node reachable from both a dead and a
+    live verdict branch stays gated on the dead branch's contribution and
+    never fires.
+
+    The ``_indegree == 0`` check is what keeps diamond shapes correct: a node
+    with N dead incoming edges receives N calls, and only the last one
+    cascades into its own ``__post_init__`` contributions — so each
+    downstream node is decremented exactly N times to match.
+    """
+    if not isinstance(node, BaseNode):
+        return
+    decrement_indegree(node)
+    if node._indegree != 0:
+        return
+
+    if isinstance(node, (TaskNode, BinaryJudgementNode, NonBinaryJudgementNode)):
+        for child in node.children:
+            propagate_skip(child)
+    elif isinstance(node, VerdictNode):
+        if isinstance(node.child, BaseNode):
+            propagate_skip(node.child)
+
+
 @dataclass
 class VerdictNode(BaseNode):
     verdict: Union[str, bool]
@@ -472,10 +501,18 @@ class BinaryJudgementNode(BaseNode):
         metric._verbose_steps.append(
             construct_node_verbose_log(self, self._depth)
         )
-        for children in self.children:
-            children._execute(
-                metric=metric, test_case=test_case, depth=self._depth + 1
-            )
+        # Release the dead branch's pre-incremented indegree before the live
+        # branch reaches any shared downstream node.
+        for child in self.children:
+            if child.verdict != self._verdict.verdict:
+                propagate_skip(child)
+        for child in self.children:
+            if child.verdict == self._verdict.verdict:
+                child._execute(
+                    metric=metric,
+                    test_case=test_case,
+                    depth=self._depth + 1,
+                )
 
     async def _a_execute(
         self, metric: BaseMetric, test_case: LLMTestCase, depth: int
@@ -515,12 +552,18 @@ class BinaryJudgementNode(BaseNode):
         metric._verbose_steps.append(
             construct_node_verbose_log(self, self._depth)
         )
+        for child in self.children:
+            if child.verdict != self._verdict.verdict:
+                propagate_skip(child)
         await asyncio.gather(
             *(
                 child._a_execute(
-                    metric=metric, test_case=test_case, depth=self._depth + 1
+                    metric=metric,
+                    test_case=test_case,
+                    depth=self._depth + 1,
                 )
                 for child in self.children
+                if child.verdict == self._verdict.verdict
             )
         )
 
@@ -620,10 +663,18 @@ class NonBinaryJudgementNode(BaseNode):
         metric._verbose_steps.append(
             construct_node_verbose_log(self, self._depth)
         )
-        for children in self.children:
-            children._execute(
-                metric=metric, test_case=test_case, depth=self._depth + 1
-            )
+        # Release the dead branches' pre-incremented indegree before the live
+        # branch reaches any shared downstream node.
+        for child in self.children:
+            if child.verdict != self._verdict.verdict:
+                propagate_skip(child)
+        for child in self.children:
+            if child.verdict == self._verdict.verdict:
+                child._execute(
+                    metric=metric,
+                    test_case=test_case,
+                    depth=self._depth + 1,
+                )
 
     async def _a_execute(
         self, metric: BaseMetric, test_case: LLMTestCase, depth: int
@@ -665,12 +716,18 @@ class NonBinaryJudgementNode(BaseNode):
         metric._verbose_steps.append(
             construct_node_verbose_log(self, self._depth)
         )
+        for child in self.children:
+            if child.verdict != self._verdict.verdict:
+                propagate_skip(child)
         await asyncio.gather(
             *(
                 child._a_execute(
-                    metric=metric, test_case=test_case, depth=self._depth + 1
+                    metric=metric,
+                    test_case=test_case,
+                    depth=self._depth + 1,
                 )
                 for child in self.children
+                if child.verdict == self._verdict.verdict
             )
         )
 

--- a/deepeval/metrics/dag/nodes.py
+++ b/deepeval/metrics/dag/nodes.py
@@ -75,7 +75,9 @@ def propagate_skip(node: Optional["BaseNode"]) -> None:
     if node._indegree != 0:
         return
 
-    if isinstance(node, (TaskNode, BinaryJudgementNode, NonBinaryJudgementNode)):
+    if isinstance(
+        node, (TaskNode, BinaryJudgementNode, NonBinaryJudgementNode)
+    ):
         for child in node.children:
             propagate_skip(child)
     elif isinstance(node, VerdictNode):

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -356,12 +356,16 @@ class TestDAGMetricReuse:
             children=[outer_judge],
         )
         dag = DeepAcyclicGraph(root_nodes=[task])
-        metric = DAGMetric(name="test", dag=dag, async_mode=False, _include_dag_suffix=False)
+        metric = DAGMetric(
+            name="test", dag=dag, async_mode=False, _include_dag_suffix=False
+        )
 
         outer_iter = iter(outer_verdicts)
         inner_iter = iter(inner_verdicts)
 
-        def fake_extract(metric, prompt, schema_cls, extract_schema, extract_json):
+        def fake_extract(
+            metric, prompt, schema_cls, extract_schema, extract_json
+        ):
             if schema_cls is BinaryJudgementVerdict:
                 # The two judges share the same schema; distinguish by which
                 # iter still has elements (outer is consumed first per turn).
@@ -373,6 +377,7 @@ class TestDAGMetricReuse:
                     verdict=next(inner_iter), reason="mocked"
                 )
             from deepeval.metrics.dag.schema import TaskNodeOutput
+
             return TaskNodeOutput(output="mocked task output")
 
         patcher = patch(
@@ -384,6 +389,7 @@ class TestDAGMetricReuse:
     def test_score_resets_across_measure_calls(self):
         """Consecutive measurements with different verdicts produce different scores."""
         from deepeval.test_case import LLMTestCase
+
         metric, patcher = self._build_metric_with_mocked_judge(
             outer_verdicts=[True, False],
             inner_verdicts=[True],
@@ -444,6 +450,7 @@ class TestDAGMetricReuse:
 
     def test_verbose_steps_does_not_accumulate(self):
         from deepeval.test_case import LLMTestCase
+
         metric, patcher = self._build_metric_with_mocked_judge(
             outer_verdicts=[True, True, True],
             inner_verdicts=[True, False, True],

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -13,6 +13,7 @@ from deepeval.metrics.dag.utils import (
     copy_graph,
     is_valid_dag,
 )
+from deepeval.metrics.dag.nodes import propagate_skip
 
 
 class TestDeepAcyclicGraph:
@@ -269,3 +270,192 @@ class TestDeepAcyclicGraph:
         task = TaskNode("Check", "result", [], [judge])
         dag = DeepAcyclicGraph(root_nodes=[task])
         assert is_valid_dag_from_roots(dag.root_nodes, multiturn=False)
+
+
+class TestPropagateSkip:
+    """Tests for ``propagate_skip``."""
+
+    def test_decrements_self_indegree(self):
+        leaf = VerdictNode(verdict=True, score=10)
+        BinaryJudgementNode(
+            criteria="?",
+            children=[VerdictNode(verdict=False, score=0), leaf],
+        )
+        assert leaf._indegree == 1
+        propagate_skip(leaf)
+        assert leaf._indegree == 0
+
+    def test_recurses_through_verdict_child_into_subtree(self):
+        inner_yes = VerdictNode(verdict=True, score=10)
+        inner_no = VerdictNode(verdict=False, score=0)
+        inner_judge = BinaryJudgementNode(
+            criteria="inner?", children=[inner_yes, inner_no]
+        )
+        outer_a = VerdictNode(verdict="a", child=inner_judge)
+        outer_b = VerdictNode(verdict="b", score=0)
+        NonBinaryJudgementNode(criteria="outer?", children=[outer_a, outer_b])
+
+        propagate_skip(outer_a)
+
+        assert outer_a._indegree == 0
+        assert inner_judge._indegree == 0
+        assert inner_yes._indegree == 0
+        assert inner_no._indegree == 0
+
+    def test_shared_downstream_node_decrements_once_per_dead_path(self):
+        """Each construction-time +1 must be matched by exactly one skip."""
+        shared_leaf_t = VerdictNode(verdict=True, score=10)
+        shared_leaf_f = VerdictNode(verdict=False, score=0)
+        shared_judge = BinaryJudgementNode(
+            criteria="shared?", children=[shared_leaf_t, shared_leaf_f]
+        )
+        a = VerdictNode(verdict="a", child=shared_judge)
+        b = VerdictNode(verdict="b", child=shared_judge)
+        NonBinaryJudgementNode(criteria="?", children=[a, b])
+        assert shared_judge._indegree == 2
+
+        propagate_skip(a)
+        propagate_skip(b)
+
+        assert shared_judge._indegree == 0
+        assert shared_leaf_t._indegree == 0
+        assert shared_leaf_f._indegree == 0
+
+    def test_no_op_on_non_basenode(self):
+        propagate_skip(None)
+        propagate_skip("not a node")
+
+
+class TestDAGMetricReuse:
+    """End-to-end: a ``DAGMetric`` instance must produce correct scores and
+    clean verbose logs across repeated ``.measure()`` calls on the same dag."""
+
+    def _build_metric_with_mocked_judge(self, outer_verdicts, inner_verdicts):
+        from unittest.mock import patch
+        from deepeval.metrics import DAGMetric
+        from deepeval.metrics.dag.schema import BinaryJudgementVerdict
+
+        inner_true = VerdictNode(verdict=True, score=10)
+        inner_false = VerdictNode(verdict=False, score=5)
+        inner_judge = BinaryJudgementNode(
+            criteria="inner?",
+            children=[inner_true, inner_false],
+            evaluation_params=[SingleTurnParams.INPUT],
+        )
+        outer_true = VerdictNode(verdict=True, child=inner_judge)
+        outer_false = VerdictNode(verdict=False, score=0)
+        outer_judge = BinaryJudgementNode(
+            criteria="outer?",
+            children=[outer_true, outer_false],
+            evaluation_params=[SingleTurnParams.INPUT],
+        )
+        task = TaskNode(
+            instructions="dummy",
+            output_label="result",
+            evaluation_params=[SingleTurnParams.INPUT],
+            children=[outer_judge],
+        )
+        dag = DeepAcyclicGraph(root_nodes=[task])
+        metric = DAGMetric(name="test", dag=dag, async_mode=False, _include_dag_suffix=False)
+
+        outer_iter = iter(outer_verdicts)
+        inner_iter = iter(inner_verdicts)
+
+        def fake_extract(metric, prompt, schema_cls, extract_schema, extract_json):
+            if schema_cls is BinaryJudgementVerdict:
+                # The two judges share the same schema; distinguish by which
+                # iter still has elements (outer is consumed first per turn).
+                if "outer?" in prompt:
+                    return BinaryJudgementVerdict(
+                        verdict=next(outer_iter), reason="mocked"
+                    )
+                return BinaryJudgementVerdict(
+                    verdict=next(inner_iter), reason="mocked"
+                )
+            from deepeval.metrics.dag.schema import TaskNodeOutput
+            return TaskNodeOutput(output="mocked task output")
+
+        patcher = patch(
+            "deepeval.metrics.dag.nodes.generate_with_schema_and_extract",
+            side_effect=fake_extract,
+        )
+        return metric, patcher
+
+    def test_score_resets_across_measure_calls(self):
+        """Consecutive measurements with different verdicts produce different scores."""
+        from deepeval.test_case import LLMTestCase
+        metric, patcher = self._build_metric_with_mocked_judge(
+            outer_verdicts=[True, False],
+            inner_verdicts=[True],
+        )
+        patcher.start()
+        try:
+            metric.measure(LLMTestCase(input="first", actual_output="x"))
+            first_score = metric.score  # outer=True → inner=True → 10/10
+            metric.measure(LLMTestCase(input="second", actual_output="x"))
+            second_score = metric.score  # outer=False → 0
+            assert first_score == 1.0
+            assert second_score == 0
+        finally:
+            patcher.stop()
+
+    def test_shared_downstream_judgement_node_fires_via_either_path(self):
+        """JudgementNode shared between two sibling verdict branches must fire
+        on whichever branch the verdict picks.
+        """
+        from unittest.mock import patch
+        from deepeval.metrics import DAGMetric
+        from deepeval.metrics.dag.schema import BinaryJudgementVerdict
+        from deepeval.test_case import LLMTestCase
+
+        shared_judge = BinaryJudgementNode(
+            criteria="shared?",
+            children=[
+                VerdictNode(verdict=True, score=10),
+                VerdictNode(verdict=False, score=5),
+            ],
+            evaluation_params=[SingleTurnParams.INPUT],
+        )
+        root = BinaryJudgementNode(
+            criteria="root?",
+            children=[
+                VerdictNode(verdict=True, child=shared_judge),
+                VerdictNode(verdict=False, child=shared_judge),
+            ],
+            evaluation_params=[SingleTurnParams.INPUT],
+        )
+        metric = DAGMetric(
+            name="t",
+            dag=DeepAcyclicGraph(root_nodes=[root]),
+            async_mode=False,
+            _include_dag_suffix=False,
+        )
+
+        def fake(metric, prompt, schema_cls, **_):
+            return BinaryJudgementVerdict(verdict=True, reason="m")
+
+        with patch(
+            "deepeval.metrics.dag.nodes.generate_with_schema_and_extract",
+            side_effect=fake,
+        ):
+            metric.measure(LLMTestCase(input="x", actual_output="y"))
+
+        assert metric.score == 1.0
+
+    def test_verbose_steps_does_not_accumulate(self):
+        from deepeval.test_case import LLMTestCase
+        metric, patcher = self._build_metric_with_mocked_judge(
+            outer_verdicts=[True, True, True],
+            inner_verdicts=[True, False, True],
+        )
+        patcher.start()
+        try:
+            metric.measure(LLMTestCase(input="A", actual_output="x"))
+            first = len(metric._verbose_steps)
+            metric.measure(LLMTestCase(input="B", actual_output="x"))
+            second = len(metric._verbose_steps)
+            metric.measure(LLMTestCase(input="C", actual_output="x"))
+            third = len(metric._verbose_steps)
+            assert first == second == third
+        finally:
+            patcher.stop()


### PR DESCRIPTION
## Summary

Reusing a single `DAGMetric` instance across multiple `.measure()` calls produced incorrect output for two independent reasons:

1. **`_verbose_steps` accumulated** across calls, so `verbose_logs` on the N-th measurement contained entries from measurements 1..N-1.
2. **A `JudgementNode`'s selected verdict pointed at a downstream node also reachable from a non-selected verdict sibling** (directly, or via another `JudgementNode`'s verdict chain). That shared node's `_indegree` never dropped to zero, the `if self._indegree > 0: return` gate inside `_execute` blocked, and the chain silently skipped — leaving `metric.score` at its prior value or `None`.

The second issue also bites a **single** `.measure()` call when the DAG itself has a shared-downstream shape (one `JudgementNode` reachable from two different verdict paths). This bug ia fixed in this PR.

## Root cause

`Binary/NonBinaryJudgementNode.__post_init__` pre-increments `_indegree` for every `VerdictNode` child **and** every `VerdictNode.child`. But exactly one verdict fires per evaluation — the non-selected siblings never decrement what they contributed. Any node reachable from multiple of those sibling chains (or from multiple JudgementNodes whose verdicts are not all selected) stays gated forever.

## Fix

- `nodes.py`: new `propagate_skip(node)` helper. A `JudgementNode` now skip-propagates through each non-selected verdict child **before** firing the selected one, walking the dead branch's subtree and decrementing the indegree contributions it would have made if it had fired. The `_indegree == 0` gate inside `propagate_skip` keeps shared/diamond shapes correct: a node with N dead incoming edges receives N calls and only the last one cascades into its own `__post_init__`-contributed descendants, so each downstream node is decremented exactly the number of times its construction-time contributors are now dead.
- `dag.py`: reset `_verbose_steps` at the start of each `measure()` / `a_measure()`.

No public API changes. No behavior change for DAGs whose shape was already correct under the old executor.

## Tests

- `TestPropagateSkip` (4 unit tests): self-decrement, recursion through verdict chains, shared-downstream-once-per-dead-path, no-op safety on non-`BaseNode` input.
- `test_shared_downstream_judgement_node_fires_via_either_path`: end-to-end regression. Fails on stock `deepeval` with `metric.score == None`; passes with this fix at `metric.score == 1.0`.
- `test_score_resets_across_measure_calls` and `test_verbose_steps_does_not_accumulate`: pin the reuse invariants for the two original bugs.

Full DAG suite (`tests/test_metrics/test_dag.py` + `tests/test_metrics/test_dag_serialization.py`): 45/45 pass.

## Test plan

- [x] DAG unit + integration tests pass on the fork
- [x] Validated against a downstream evaluator that hit the shared-downstream bug — removing the local workaround (per-call rebuild of `DAGMetric`) and dropping in this fix produces identical scores
- [ ] Maintainer-side CI on `confident-ai/deepeval`