### PR TITLE
fix typos for medical chatbot tutorial pages reported in issue #2799

### DIFF
--- a/docs/content/tutorials/medical-chatbot/development.mdx
+++ b/docs/content/tutorials/medical-chatbot/development.mdx
@@ -14,7 +14,7 @@ We will be using `langchain` and `qdrant` to build our chatbot, with functionali
 We'll also implement our chatbot with an independent **model and system prompt** variable - which we'll be evaluating in the next section.
 
 :::tip
-If you already have a multi-turn chatbot that you want to evaluate, feel free to skip to the [**evaluation section of this tuorial**](/tutorials/medical-chatbot/evaluation).
+If you already have a multi-turn chatbot that you want to evaluate, feel free to skip to the [**evaluation section of this tutorial**](/tutorials/medical-chatbot/evaluation).
 :::
 
 ## Setup Your Model
@@ -102,7 +102,7 @@ class MedicalChatbot:
         )
 ```
 
-Then, simply run your `index_knowledge` method usign the encyclopedia you've downloaded as `.txt`:
+Then, simply run your `index_knowledge` method using the encyclopedia you've downloaded as `.txt`:
 
 ```python title="main.py"
 chatbot = MedicalChatbot()
@@ -134,7 +134,7 @@ class MedicalChatbot:
 
     @tool
     def retrieve_knowledge(self, query: str) -> str:
-        """"A tool to retrive data on various diagnosis methods from gale encyclopedia"""
+        """"A tool to retrieve data on various diagnosis methods from gale encyclopedia"""
         hits = self.client.query_points(collection_name="gale_encyclopedia", query=self.encoder.encode(query).tolist(), limit=3).points
 
         contexts = [hit.payload['content'] for hit in hits]
@@ -285,7 +285,7 @@ class MedicalChatbot:
     ...
 ```
 
-🎉🥳 Congratulations! You've just created a fully functional medical chatbot with memory, the abiliy to diagnose users, and book appointments when needed.
+🎉🥳 Congratulations! You've just created a fully functional medical chatbot with memory, the ability to diagnose users, and book appointments when needed.
 
 ## Eyeball Your First Output
 

--- a/docs/content/tutorials/medical-chatbot/evaluation.mdx
+++ b/docs/content/tutorials/medical-chatbot/evaluation.mdx
@@ -74,7 +74,7 @@ This example assumes each conversation is a list of messages following the OpenA
 
 ### Manual prompting
 
-To generate conversations manually, you have to create `turn`s from interacting with your chatbot and constructing a `ConversationalTestCase` once a conversation has compeleted:
+To generate conversations manually, you have to create `turn`s from interacting with your chatbot and constructing a `ConversationalTestCase` once a conversation has completed:
 
 ```python
 from deepeval.test_case import ConversationalTestCase, Turn
@@ -119,7 +119,7 @@ It is highly recommended to simulate turns instead, because you:
 - Avoid **manual prompting** and can fully automate the process
 - Create **consistent benchmarks**, e.g., simulating a fixed number of conversations across the same scenarios, which makes performance comparisons straightforward (more on this later)
 
-First standardize your testing dataset by createing a list of goldens ([click here](/docs/evaluation-datasets#what-are-goldens) to learn more):
+First standardize your testing dataset by creating a list of goldens ([click here](/docs/evaluation-datasets#what-are-goldens) to learn more):
 
 ```python title="main.py"
 from deepeval.dataset import EvaluationDataset, ConversationalGolden


### PR DESCRIPTION
Closes #2799

Fixed typos found in mdx files reported in the above issue.

No logic changes.