### PR TITLE
docs: note logprob-less gpt-5 models are unsupported for G-Eval (#2280)

### DIFF
--- a/docs/content/integrations/models/openai.mdx
+++ b/docs/content/integrations/models/openai.mdx
@@ -141,3 +141,7 @@ Below is a list of commonly used OpenAI models:
 - `gpt-3.5-turbo-16k-0613`
 - `davinci-002`
 - `babbage-002`
+
+:::caution[G-Eval requires log probabilities]
+`GEval` and `ConversationalGEval` compute scores from token-level log probabilities, which some OpenAI models do not expose. The `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat-latest`, `gpt-5.1`, and `gpt-5.2` models return no log probabilities, so passing any of them as the judge model for these metrics raises `AttributeError: log_probs unsupported.`. For `GEval` and `ConversationalGEval`, use a log-probability-capable model such as `gpt-5.4` (the default) or `gpt-4.1`. Other metrics are unaffected.
+:::


### PR DESCRIPTION
## What

Adds a caution note to the OpenAI models integration page warning that the logprob-less `gpt-5` family models cannot be used as the judge model for `GEval` / `ConversationalGEval`, and points users to a log-probability-capable model instead.

## Why

`GEval` and `ConversationalGEval` score from token-level log probabilities. The `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat-latest`, `gpt-5.1`, and `gpt-5.2` models expose no log probabilities (`supports_log_probs=False` in `deepeval/models/llms/constants.py`), so `deepeval/metrics/g_eval/utils.py::no_log_prob_support` triggers `AttributeError: log_probs unsupported.` in `g_eval.py` / `conversational_g_eval.py`.

The models page currently lists `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` under "Available OpenAI Models" with no compatibility note. In #2280 a user picked `gpt-5-mini` as a G-Eval judge based on that list and hit the cryptic crash; the maintainer confirmed in-thread that the failure is expected behaviour, leaving only this documentation gap to address.

## How

Single-file docs change: a `:::caution` admonition placed directly under the "Available OpenAI Models" list. No code or behaviour change.

## Testing

- Verified every model named in the caution has `supports_log_probs=False`, and the recommended fallbacks (`gpt-5.4`, the current default, and `gpt-4.1`) have `supports_log_probs=True`, against `deepeval/models/llms/constants.py`.
- Confirmed the admonition matches the repo's existing `:::caution[...]` directive syntax (e.g. `integrations/frameworks/langchain.mdx`); directive nesting and inline code spans are balanced.

Refs #2280
