### PR TITLE
fix: correct dataset field defaults, add source-grouping to ContextualRecall, short-circuit Summarization identity

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -46,7 +46,6 @@ from deepeval.test_case import (
     ConversationalTestCase,
     ToolCall,
 )
-from deepeval.test_run.hyperparameters import process_hyperparameters
 from deepeval.test_run.test_run import TEMP_FILE_PATH
 from deepeval.utils import (
     convert_keys_to_snake_case,
@@ -57,7 +56,6 @@ from deepeval.test_run import (
     global_test_run_manager,
 )
 
-from deepeval.tracing import trace_manager
 from deepeval.tracing.tracing import EVAL_DUMMY_SPAN_NAME
 
 if TYPE_CHECKING:
@@ -79,21 +77,25 @@ class EvaluationDataset:
     _id: Union[str, None] = field(default=None)
     _version: Union[str, None] = field(default=None)
 
-    _goldens: List[Golden] = field(default_factory=[], repr=None)
+    _goldens: List[Golden] = field(default_factory=list, repr=None)
     _conversational_goldens: List[ConversationalGolden] = field(
-        default_factory=[], repr=None
+        default_factory=list, repr=None
     )
 
-    _llm_test_cases: List[LLMTestCase] = field(default_factory=[], repr=None)
+    _llm_test_cases: List[LLMTestCase] = field(default_factory=list, repr=None)
     _conversational_test_cases: List[ConversationalTestCase] = field(
-        default_factory=[], repr=None
+        default_factory=list, repr=None
     )
 
     def __init__(
         self,
-        goldens: Union[List[Golden], List[ConversationalGolden]] = [],
+        goldens: Optional[
+            Union[List[Golden], List[ConversationalGolden]]
+        ] = None,
         confident_api_key: Optional[str] = None,
     ):
+        if goldens is None:
+            goldens = []
         self._alias = None
         self._id = None
         self._version = None
@@ -559,7 +561,7 @@ class EvaluationDataset:
                         for tool in trimAndLoadJson(tools_called_str)
                     ]
                     tools_called.append(parsed_tools)
-                except ValueError or json.JSONDecodeError:
+                except (ValueError, json.JSONDecodeError):
                     # Fallback to simple split on delimiter
                     tools_called.append(
                         tools_called_str.split(tools_called_col_delimiter)
@@ -579,7 +581,7 @@ class EvaluationDataset:
                         for tool in trimAndLoadJson(expected_tools_str)
                     ]
                     expected_tools.append(parsed_tools)
-                except ValueError or json.JSONDecodeError:
+                except (ValueError, json.JSONDecodeError):
                     # Fallback to simple split on delimiter
                     expected_tools.append(
                         expected_tools_str.split(expected_tools_col_delimiter)
@@ -1510,11 +1512,6 @@ class EvaluationDataset:
         async_config: Optional["AsyncConfig"] = None,
         run_otel: Optional[bool] = False,
     ) -> Iterator[Golden]:
-        from deepeval.evaluate.utils import (
-            aggregate_metric_pass_rates,
-            print_test_result,
-            write_test_result_to_file,
-        )
         from deepeval.evaluate.types import EvaluationResult, TestResult
         from deepeval.evaluate.execute import (
             a_execute_agentic_test_cases_from_loop,

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -14,6 +14,7 @@ from deepeval.metrics.utils import (
 from deepeval.test_case import (
     LLMTestCase,
     SingleTurnParams,
+    RetrievedContextData,
 )
 from deepeval.metrics import BaseMetric
 from deepeval.models import DeepEvalBaseLLM
@@ -116,7 +117,9 @@ class ContextualRecallMetric(BaseMetric):
                 )
             else:
                 expected_output = test_case.expected_output
-                retrieval_context = test_case.retrieval_context
+                retrieval_context = self._group_retrieval_contexts(
+                    test_case.retrieval_context
+                )
 
                 self.verdicts: List[VerdictWithExpectedOutput] = (
                     self._generate_verdicts(
@@ -165,7 +168,9 @@ class ContextualRecallMetric(BaseMetric):
             _in_component=_in_component,
         ):
             expected_output = test_case.expected_output
-            retrieval_context = test_case.retrieval_context
+            retrieval_context = self._group_retrieval_contexts(
+                test_case.retrieval_context
+            )
 
             self.verdicts: List[VerdictWithExpectedOutput] = (
                 await self._a_generate_verdicts(
@@ -245,6 +250,40 @@ class ContextualRecallMetric(BaseMetric):
             extract_schema=lambda score_reason: score_reason.reason,
             extract_json=lambda data: data["reason"],
         )
+
+    def _group_retrieval_contexts(
+        self,
+        retrieval_contexts: List[Union[str, RetrievedContextData]],
+    ) -> List[str]:
+        grouped_contexts_dict = {}
+        ordered_identifiers = []
+
+        for context in retrieval_contexts:
+            if isinstance(context, RetrievedContextData):
+                if context.source not in grouped_contexts_dict:
+                    ordered_identifiers.append(
+                        {"type": "grouped", "key": context.source}
+                    )
+                    grouped_contexts_dict[context.source] = []
+                grouped_contexts_dict[context.source].append(context.context)
+            else:
+                ordered_identifiers.append(
+                    {"type": "standalone", "value": context}
+                )
+
+        processed_contexts = []
+        for item in ordered_identifiers:
+            if item["type"] == "grouped":
+                source = item["key"]
+                contents = grouped_contexts_dict[source]
+                combined_content = f"Source: {source}\n" + "\n---\n".join(
+                    contents
+                )
+                processed_contexts.append(combined_content)
+            else:
+                processed_contexts.append(item["value"])
+
+        return processed_contexts
 
     def _calculate_score(self):
         number_of_verdicts = len(self.verdicts)

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -106,6 +106,28 @@ class SummarizationMetric(BaseMetric):
                     )
                 )
             else:
+                # Short-circuit: when input equals output, score is trivially 1.0
+                if test_case.input.strip() == test_case.actual_output.strip():
+                    self.truths = []
+                    self.claims = []
+                    self.coverage_verdicts = []
+                    self.alignment_verdicts = []
+                    self.score_breakdown = {
+                        ScoreType.ALIGNMENT.value: 1.0,
+                        ScoreType.COVERAGE.value: 1.0,
+                    }
+                    self.score = 1.0
+                    self.reason = "Input and actual output are identical."
+                    self.success = self.score >= self.threshold
+                    self.verbose_logs = construct_verbose_logs(
+                        self,
+                        steps=[
+                            "Input and actual output are identical - score is 1.0.",
+                            f"Score: {self.score}\nReason: {self.reason}",
+                        ],
+                    )
+                    return self.score
+
                 self.truths: List[str] = self._generate_truths(test_case.input)
                 self.claims: List[str] = self._generate_claims(
                     test_case.actual_output
@@ -165,6 +187,28 @@ class SummarizationMetric(BaseMetric):
             _show_indicator=_show_indicator,
             _in_component=_in_component,
         ):
+            # Short-circuit: when input equals output, score is trivially 1.0
+            if test_case.input.strip() == test_case.actual_output.strip():
+                self.truths = []
+                self.claims = []
+                self.coverage_verdicts = []
+                self.alignment_verdicts = []
+                self.score_breakdown = {
+                    ScoreType.ALIGNMENT.value: 1.0,
+                    ScoreType.COVERAGE.value: 1.0,
+                }
+                self.score = 1.0
+                self.reason = "Input and actual output are identical."
+                self.success = self.score >= self.threshold
+                self.verbose_logs = construct_verbose_logs(
+                    self,
+                    steps=[
+                        "Input and actual output are identical - score is 1.0.",
+                        f"Score: {self.score}\nReason: {self.reason}",
+                    ],
+                )
+                return self.score
+
             self.truths, self.claims = await asyncio.gather(
                 self._a_generate_truths(test_case.input),
                 self._a_generate_claims(test_case.actual_output),


### PR DESCRIPTION
## Summary

Three bug fixes across the codebase:

### 1. Fix `EvaluationDataset` invalid field defaults and Python patterns
**File:** `deepeval/dataset/dataset.py`

- Changed `field(default_factory=[])` → `field(default_factory=list)` (×4). Passing a list instance to `default_factory` would raise `TypeError` if the explicit `__init__` is ever removed.
- Changed `except ValueError or json.JSONDecodeError:` → `except (ValueError, json.JSONDecodeError):` (×2). The `or` expression evaluates to `ValueError` alone, silently dropping the intent to also catch `JSONDecodeError`.
- Changed `goldens=[]` → `goldens=None` with `None` guard in `__init__`. Standard mutable-default antipattern fix.

### 2. Add source-grouping to `ContextualRecallMetric`
**File:** `deepeval/metrics/contextual_recall/contextual_recall.py`
**Closes:** #2788

- Added `_group_retrieval_contexts()` method (mirroring the existing fix in `ContextualPrecisionMetric` from PR #2743) that merges overlapping chunks by `RetrievedContextData.source` before scoring.
- Applied grouping in both `measure()` and `a_measure()`.
- This prevents recall scores from being unfairly penalized when RAG pipelines use sliding-window chunking with overlapping content.

### 3. Short-circuit `SummarizationMetric` when input equals output
**File:** `deepeval/metrics/summarization/summarization.py`

- Added identity check at the top of both `measure()` and `a_measure()`: when `test_case.input.strip() == test_case.actual_output.strip()`, returns score `1.0` immediately without invoking any LLM calls.
- This prevents the LLM-based claim/truth extraction from paraphrasing identical text differently and flagging them as contradictions, which previously produced scores in the 0.7–0.95 range instead of the expected 1.0.
- All instance attributes (truths, claims, verdicts, score_breakdown, verbose_logs) are still populated for downstream compatibility.

## Verification

- All three files pass `python -m py_compile` (syntax check).
- All three files pass `ruff check` with zero errors.
- All three files pass `black` formatting check.