### PR TITLE
fix(task_completion): pass tools_called_formatted to the extract_goal_and_outcome template

### DIFF
--- a/deepeval/metrics/task_completion/task_completion.py
+++ b/deepeval/metrics/task_completion/task_completion.py
@@ -5,6 +5,7 @@ from deepeval.metrics.utils import (
     construct_verbose_logs,
     check_llm_test_case_params,
     initialize_model,
+    print_tools_called,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
 )
@@ -193,7 +194,9 @@ class TaskCompletionMetric(BaseMetric):
                 "extract_goal_and_outcome",
                 input=test_case.input,
                 actual_output=test_case.actual_output,
-                tools_called=test_case.tools_called,
+                tools_called_formatted=print_tools_called(
+                    test_case.tools_called
+                ),
             )
         return await a_generate_with_schema_and_extract(
             metric=self,
@@ -219,7 +222,9 @@ class TaskCompletionMetric(BaseMetric):
                 "extract_goal_and_outcome",
                 input=test_case.input,
                 actual_output=test_case.actual_output,
-                tools_called=test_case.tools_called,
+                tools_called_formatted=print_tools_called(
+                    test_case.tools_called
+                ),
             )
         return generate_with_schema_and_extract(
             metric=self,

--- a/tests/test_metrics/test_task_completion_tools_called.py
+++ b/tests/test_metrics/test_task_completion_tools_called.py
@@ -1,0 +1,154 @@
+"""Regression test for the TaskCompletionMetric `tools_called` -> jinja
+`tools_called_formatted` mismatch (issue #2807).
+
+The non-trace branch of `TaskCompletionMetric._extract_task_and_outcome` /
+`_a_extract_task_and_outcome` renders the `extract_goal_and_outcome` template,
+which references `{{ tools_called_formatted }}`. Previously the metric passed
+`tools_called=test_case.tools_called` (the wrong kwarg, and an un-stringified
+`List[ToolCall]`), so under `jinja2.StrictUndefined` the render raised
+`MetricTemplateInterpolationError` and the formatted tool list never reached
+the prompt.
+
+The tool names used below (`quantum_router`, `cryo_vault`) are deliberately
+absent from the template's own static example block, so a positive
+`"quantum_router" in prompt` assertion can only pass if the value the metric
+formats actually reaches the render -- it cannot be satisfied by template
+boilerplate. This keeps the assertions non-vacuous even against a future
+silent "renders to empty string" regression.
+"""
+
+import asyncio
+
+import pytest
+
+import deepeval.metrics.task_completion.task_completion as task_completion_module
+from deepeval.metrics import TaskCompletionMetric
+from deepeval.metrics.utils import print_tools_called
+from deepeval.templates.resolver import (
+    MetricTemplateInterpolationError,
+    clear_metric_template_cache,
+)
+from deepeval.test_case import LLMTestCase, ToolCall
+
+# Names chosen so they do NOT appear anywhere in the template's static example
+# text -- their presence in the rendered prompt proves the user's tools_called
+# reached the template.
+_TOOL_A = "quantum_router"
+_TOOL_B = "cryo_vault"
+
+
+def _make_test_case() -> LLMTestCase:
+    return LLMTestCase(
+        input="Can you help me plan a trip to New York this weekend?",
+        actual_output="Sure! Here are some flights and hotels.",
+        tools_called=[
+            ToolCall(name=_TOOL_A),
+            ToolCall(name=_TOOL_B),
+        ],
+    )
+
+
+def _metric_with_captured_prompt(monkeypatch):
+    """Build a TaskCompletionMetric whose extract path is exercised without a
+    real model call, capturing the prompt handed to the (a_)generate helper."""
+    metric = TaskCompletionMetric.__new__(TaskCompletionMetric)
+    metric.task = None
+    metric._is_task_provided = False
+
+    captured = {}
+
+    def _fake_generate(*, metric, prompt, schema_cls, extract_schema, **kwargs):
+        captured["prompt"] = prompt
+        return ("the task", "the outcome")
+
+    async def _fake_a_generate(
+        *, metric, prompt, schema_cls, extract_schema, **kwargs
+    ):
+        captured["prompt"] = prompt
+        return ("the task", "the outcome")
+
+    monkeypatch.setattr(
+        task_completion_module,
+        "generate_with_schema_and_extract",
+        _fake_generate,
+    )
+    monkeypatch.setattr(
+        task_completion_module,
+        "a_generate_with_schema_and_extract",
+        _fake_a_generate,
+    )
+    return metric, captured
+
+
+def test_sync_extract_includes_tools_called(monkeypatch):
+    """Regression proof for the call-site fix (sync path). Fails on the buggy
+    code with MetricTemplateInterpolationError before any prompt is produced."""
+    clear_metric_template_cache()
+    metric, captured = _metric_with_captured_prompt(monkeypatch)
+
+    task, outcome = metric._extract_task_and_outcome(_make_test_case())
+
+    assert (task, outcome) == ("the task", "the outcome")
+    prompt = captured["prompt"]
+    # Non-vacuous: these names exist only in the user's tools_called, never in
+    # the template boilerplate, so they can only appear via a real render.
+    assert _TOOL_A in prompt
+    assert _TOOL_B in prompt
+    # The unrendered jinja variable must not leak into the prompt.
+    assert "tools_called_formatted" not in prompt
+    assert "{{" not in prompt
+
+
+def test_async_extract_includes_tools_called(monkeypatch):
+    """Regression proof for the call-site fix (async path)."""
+    clear_metric_template_cache()
+    metric, captured = _metric_with_captured_prompt(monkeypatch)
+
+    task, outcome = asyncio.run(
+        metric._a_extract_task_and_outcome(_make_test_case())
+    )
+
+    assert (task, outcome) == ("the task", "the outcome")
+    prompt = captured["prompt"]
+    assert _TOOL_A in prompt
+    assert _TOOL_B in prompt
+    assert "tools_called_formatted" not in prompt
+    assert "{{" not in prompt
+
+
+def test_buggy_kwarg_raises_under_strict_undefined():
+    """Document the root cause: the template requires `tools_called_formatted`
+    under StrictUndefined, so building the prompt WITHOUT it (the pre-fix call
+    shape, which passed `tools_called=`) raises. Guards against anyone
+    re-rendering this template without supplying the formatted kwarg."""
+    clear_metric_template_cache()
+    metric = TaskCompletionMetric.__new__(TaskCompletionMetric)
+
+    with pytest.raises(MetricTemplateInterpolationError):
+        metric._get_prompt(
+            "extract_goal_and_outcome",
+            input="plan a trip",
+            actual_output="done",
+            # tools_called_formatted intentionally omitted -> the
+            # StrictUndefined render must fail, exactly as in issue #2807.
+        )
+
+
+def test_extract_goal_and_outcome_template_renders_tool_names():
+    """Template-contract check (NOT the call-site fix proof -- tests 1 and 2
+    are that). Given the correct `tools_called_formatted` kwarg directly, the
+    template renders without a StrictUndefined error and embeds the tool
+    names."""
+    clear_metric_template_cache()
+    metric = TaskCompletionMetric.__new__(TaskCompletionMetric)
+    tools_called = [ToolCall(name=_TOOL_A), ToolCall(name=_TOOL_B)]
+
+    prompt = metric._get_prompt(
+        "extract_goal_and_outcome",
+        input="plan a trip",
+        actual_output="done",
+        tools_called_formatted=print_tools_called(tools_called),
+    )
+
+    assert _TOOL_A in prompt
+    assert _TOOL_B in prompt


### PR DESCRIPTION
## Summary

`TaskCompletionMetric` raised `MetricTemplateInterpolationError` whenever the non-trace path ran with a real test case (the common case). The `extract_goal_and_outcome` template renders `{{ tools_called_formatted }}`, but both call sites passed `tools_called=test_case.tools_called` — the wrong kwarg, and an un-stringified `List[ToolCall]`. Because `_get_prompt` runs under `jinja2.StrictUndefined`, the template variable was never supplied and the render hard-failed, so the tool list never reached the prompt. This is the error reported in #2807.

## Fix

At both call sites (`_a_extract_task_and_outcome` and `_extract_task_and_outcome`, non-trace branch) pass:

```python
tools_called_formatted=print_tools_called(test_case.tools_called)
```

`print_tools_called` (from `deepeval.metrics.utils`) is the existing helper already used by `tool_correctness` and `goal_accuracy` for exactly this — it JSON-serializes the `ToolCall` list and returns `""` for `None`/empty, so the no-tools case renders cleanly. No template or `templates.json` change is needed (the template already expects `tools_called_formatted`), so the bundle stays in sync. The trace branch is untouched (it uses a different template).

## Tests

`tests/test_metrics/test_task_completion_tools_called.py` (new, API-free — the model call is monkeypatched, so it needs no key):

- `test_sync_extract_includes_tools_called` / `test_async_extract_includes_tools_called` drive the real prompt-construction path and assert the tool names reach the rendered prompt. The tool names (`quantum_router`, `cryo_vault`) are deliberately absent from the template's own example text, so these assertions can only pass if the user's `tools_called` actually reaches the render — they stay non-vacuous even against a future "renders to empty string" regression. Both **fail on the old `tools_called=` kwarg** (with the exact `MetricTemplateInterpolationError`) and pass on the fix.
- `test_buggy_kwarg_raises_under_strict_undefined` documents the root cause: rendering the template without `tools_called_formatted` raises under `StrictUndefined`.
- `test_extract_goal_and_outcome_template_renders_tool_names` is a template-contract check (tests 1 & 2 are the call-site fix proof).

Verified: `pytest tests/test_metrics/test_task_completion_tools_called.py` → 4 passed; reverting just the source fix makes the two call-site tests fail. `black --check` and `ruff check` clean.

Fixes #2807
