### PR TITLE
fix: expose TypeScript package subpaths

### DIFF
--- a/.github/workflows/typescript_test.yml
+++ b/.github/workflows/typescript_test.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/typescript_test.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -26,6 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
+        id: install
         run: npm ci
 
       - name: Run Jest tests
@@ -34,3 +38,7 @@ jobs:
           CONFIDENT_API_KEY: ${{ secrets.CONFIDENT_API_KEY }}
           CONFIDENT_TRACE_VERBOSE: 0
         run: npm test
+
+      - name: Validate package exports
+        if: ${{ always() && steps.install.outcome == 'success' }}
+        run: npm run test:package-exports

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -18,15 +18,40 @@
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./annotation": {
+      "import": "./dist/annotation/index.js",
+      "require": "./dist/annotation/index.js",
+      "types": "./dist/annotation/index.d.ts"
+    },
     "./dataset": {
       "import": "./dist/dataset/index.js",
       "require": "./dist/dataset/index.js",
       "types": "./dist/dataset/index.d.ts"
     },
+    "./metrics": {
+      "import": "./dist/metrics/index.js",
+      "require": "./dist/metrics/index.js",
+      "types": "./dist/metrics/index.d.ts"
+    },
+    "./models": {
+      "import": "./dist/models/index.js",
+      "require": "./dist/models/index.js",
+      "types": "./dist/models/index.d.ts"
+    },
     "./testCase": {
       "import": "./dist/test-case/index.js",
       "require": "./dist/test-case/index.js",
       "types": "./dist/test-case/index.d.ts"
+    },
+    "./test-case": {
+      "import": "./dist/test-case/index.js",
+      "require": "./dist/test-case/index.js",
+      "types": "./dist/test-case/index.d.ts"
+    },
+    "./evaluate": {
+      "import": "./dist/evaluate/index.js",
+      "require": "./dist/evaluate/index.js",
+      "types": "./dist/evaluate/index.d.ts"
     },
     "./tracing": {
       "import": "./dist/tracing/index.js",
@@ -72,8 +97,20 @@
       "dataset": [
         "dist/dataset/index.d.ts"
       ],
+      "metrics": [
+        "dist/metrics/index.d.ts"
+      ],
+      "models": [
+        "dist/models/index.d.ts"
+      ],
       "testCase": [
         "dist/test-case/index.d.ts"
+      ],
+      "test-case": [
+        "dist/test-case/index.d.ts"
+      ],
+      "evaluate": [
+        "dist/evaluate/index.d.ts"
       ],
       "tracing": [
         "dist/tracing/index.d.ts"
@@ -107,6 +144,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
+    "test:package-exports": "npm run build && node test/test-core/package-exports-smoke.cjs",
     "lint": "eslint",
     "lint:fix": "eslint --fix"
   },

--- a/typescript/test/test-core/package-exports-smoke.cjs
+++ b/typescript/test/test-core/package-exports-smoke.cjs
@@ -1,0 +1,264 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const packageRoot = path.resolve(__dirname, "../..");
+const packageJson = require(path.join(packageRoot, "package.json"));
+
+const packageSubpaths = Object.keys(packageJson.exports)
+  .filter((exportKey) => exportKey !== ".")
+  .map((exportKey) => ({
+    exportKey,
+    specifier: `deepeval/${exportKey.slice(2)}`,
+  }));
+
+const loadablePackageSubpaths = [
+  "deepeval/annotation",
+  "deepeval/metrics",
+  "deepeval/models",
+  "deepeval/test-case",
+  "deepeval/evaluate",
+  "deepeval/testCase",
+];
+
+const privateSubpaths = ["deepeval/annotation/utils"];
+
+const optionalPeerSubpaths = [
+  {
+    specifier: "deepeval/integrations/langchain",
+    missingPeerSpecifier: "@langchain/core",
+    missingPeerPattern: /@langchain\/core/,
+  },
+];
+
+const optionalPeerSpecifiers = new Set(
+  optionalPeerSubpaths.map(({ specifier }) => specifier),
+);
+
+const consumerLoadableSubpaths = packageSubpaths
+  .map(({ specifier }) => specifier)
+  .filter((specifier) => !optionalPeerSpecifiers.has(specifier));
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function formatSubpaths(subpaths) {
+  return subpaths.length > 0 ? subpaths.join(", ") : "<none>";
+}
+
+function assertExportFilesExist(exportKey) {
+  const exportEntry = packageJson.exports[exportKey];
+  assert(exportEntry, `Missing package export ${exportKey}`);
+
+  for (const field of ["import", "require", "types"]) {
+    const relativePath = exportEntry[field];
+    assert(
+      fs.existsSync(path.resolve(packageRoot, relativePath)),
+      `Missing ${field} file for ${exportKey}: ${relativePath}`,
+    );
+  }
+}
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    stdio: "pipe",
+    encoding: "utf8",
+    ...options,
+  });
+}
+
+function loadSpecifier(specifier) {
+  require(specifier);
+  return import(specifier);
+}
+
+async function assertOptionalPeerImport(specifier, missingPeerPattern) {
+  try {
+    await loadSpecifier(specifier);
+  } catch (error) {
+    assert(
+      error.code === "MODULE_NOT_FOUND" &&
+        missingPeerPattern.test(error.message),
+      `${specifier} failed for an unexpected reason: ${error.message}`,
+    );
+    return;
+  }
+}
+
+function createConsumerScript() {
+  return `
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+const loadableSubpaths = ${JSON.stringify(consumerLoadableSubpaths, null, 2)};
+const optionalPeerSubpaths = ${JSON.stringify(
+    optionalPeerSubpaths.map(
+      ({ specifier, missingPeerSpecifier, missingPeerPattern }) => ({
+        specifier,
+        missingPeerSpecifier,
+        missingPeerPattern: missingPeerPattern.source,
+      }),
+    ),
+    null,
+    2,
+  )};
+
+(async () => {
+  for (const specifier of loadableSubpaths) {
+    require.resolve(specifier);
+    require(specifier);
+    await import(specifier);
+  }
+
+  for (const { specifier, missingPeerSpecifier, missingPeerPattern } of optionalPeerSubpaths) {
+    require.resolve(specifier);
+
+    let peerResolveError;
+    try {
+      require.resolve(missingPeerSpecifier);
+    } catch (error) {
+      peerResolveError = error;
+    }
+
+    assert(
+      peerResolveError && peerResolveError.code === "MODULE_NOT_FOUND",
+      missingPeerSpecifier + " should not be installed in the packed consumer smoke test",
+    );
+
+    let commonJsError;
+    try {
+      require(specifier);
+    } catch (error) {
+      commonJsError = error;
+    }
+
+    const expectedMissingPeer = new RegExp(missingPeerPattern);
+    assert(
+      commonJsError &&
+        commonJsError.code === "MODULE_NOT_FOUND" &&
+        expectedMissingPeer.test(commonJsError.message),
+      specifier + " should fail with missing optional peer " + missingPeerSpecifier,
+    );
+
+    let esmError;
+    try {
+      await import(specifier);
+    } catch (error) {
+      esmError = error;
+    }
+
+    assert(
+      esmError &&
+        esmError.code === "MODULE_NOT_FOUND" &&
+        expectedMissingPeer.test(esmError.message),
+      specifier + " ESM import should fail with missing optional peer " + missingPeerSpecifier,
+    );
+  }
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+`;
+}
+
+function assertPackedArtifactConsumerInstall() {
+  const packDir = fs.mkdtempSync(path.join(os.tmpdir(), "deepeval-pack-"));
+  const consumerDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "deepeval-consumer-"),
+  );
+
+  try {
+    const tarball = execFileSync(
+      "npm",
+      ["pack", "--pack-destination", packDir, "--silent"],
+      { cwd: packageRoot, encoding: "utf8" },
+    ).trim();
+    const tarballPath = path.join(packDir, tarball);
+
+    fs.writeFileSync(
+      path.join(consumerDir, "package.json"),
+      JSON.stringify({ private: true }, null, 2),
+    );
+
+    run(
+      "npm",
+      [
+        "install",
+        "--ignore-scripts",
+        "--omit=dev",
+        "--no-audit",
+        "--no-fund",
+        tarballPath,
+      ],
+      { cwd: consumerDir },
+    );
+
+    run("node", ["-e", createConsumerScript()], { cwd: consumerDir });
+  } finally {
+    fs.rmSync(packDir, { recursive: true, force: true });
+    fs.rmSync(consumerDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const typesVersionSubpaths = Object.keys(packageJson.typesVersions["*"])
+    .filter((subpath) => subpath !== "*")
+    .map((subpath) => `./${subpath}`);
+
+  const exportKeys = packageSubpaths.map(({ exportKey }) => exportKey);
+  const missingTypesVersions = exportKeys.filter(
+    (exportKey) => !typesVersionSubpaths.includes(exportKey),
+  );
+  const extraTypesVersions = typesVersionSubpaths.filter(
+    (subpath) => !exportKeys.includes(subpath),
+  );
+
+  assert(
+    missingTypesVersions.length === 0 && extraTypesVersions.length === 0,
+    [
+      "Package exports and typesVersions drift detected.",
+      `Missing typesVersions entries for exports: ${formatSubpaths(missingTypesVersions)}`,
+      `Extra typesVersions entries without exports: ${formatSubpaths(extraTypesVersions)}`,
+    ].join("\n"),
+  );
+
+  for (const { exportKey, specifier } of packageSubpaths) {
+    assertExportFilesExist(exportKey);
+    require.resolve(specifier, { paths: [packageRoot] });
+    assert(
+      typesVersionSubpaths.includes(exportKey),
+      `Missing typesVersions entry for ${exportKey}`,
+    );
+  }
+
+  for (const specifier of loadablePackageSubpaths) {
+    await loadSpecifier(specifier);
+  }
+
+  for (const { specifier, missingPeerPattern } of optionalPeerSubpaths) {
+    await assertOptionalPeerImport(specifier, missingPeerPattern);
+  }
+
+  for (const specifier of privateSubpaths) {
+    try {
+      require.resolve(specifier, { paths: [packageRoot] });
+      throw new Error(`Expected ${specifier} to be private`);
+    } catch (error) {
+      if (error.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+        throw error;
+      }
+    }
+  }
+
+  assertPackedArtifactConsumerInstall();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/typescript/test/test-core/package-exports.test.ts
+++ b/typescript/test/test-core/package-exports.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "fs";
+import * as path from "path";
+
+type PackageJson = {
+  exports: Record<
+    string,
+    {
+      import: string;
+      require: string;
+      types: string;
+    }
+  >;
+  typesVersions: Record<string, Record<string, string[]>>;
+};
+
+const packageRoot = path.resolve(__dirname, "../..");
+const packageJsonPath = path.join(packageRoot, "package.json");
+const packageJson = JSON.parse(
+  fs.readFileSync(packageJsonPath, "utf8"),
+) as PackageJson;
+
+const rootTypesVersionKeys = Object.keys(packageJson.typesVersions["*"]).filter(
+  (subpath) => subpath !== "*",
+);
+
+const subpathExportKeys = Object.keys(packageJson.exports).filter(
+  (subpath) => subpath !== ".",
+);
+
+describe("package exports", () => {
+  test("keeps package exports and typesVersions in sync", () => {
+    expect(subpathExportKeys.map((subpath) => subpath.slice(2)).sort()).toEqual(
+      rootTypesVersionKeys.sort(),
+    );
+  });
+
+  test.each(subpathExportKeys)(
+    "exports %s with matching runtime and type targets",
+    (subpath) => {
+      const exportEntry = packageJson.exports[subpath];
+      const typesVersionPath = subpath.replace(/^\.\//, "");
+      const typesVersionsEntry =
+        packageJson.typesVersions["*"][typesVersionPath];
+
+      expect(typesVersionsEntry).toEqual([exportEntry.types.slice(2)]);
+      for (const field of ["import", "require", "types"] as const) {
+        expect(typeof exportEntry[field]).toBe("string");
+        expect(exportEntry[field].length).toBeGreaterThan(0);
+      }
+    },
+  );
+
+  test("exports the documented TypeScript entrypoints", () => {
+    for (const subpath of [
+      "./metrics",
+      "./models",
+      "./test-case",
+      "./evaluate",
+    ]) {
+      expect(packageJson.exports[subpath]).toBeDefined();
+    }
+  });
+
+  test("keeps the legacy camelCase testCase subpath available", () => {
+    expect(packageJson.exports["./testCase"]).toEqual({
+      import: "./dist/test-case/index.js",
+      require: "./dist/test-case/index.js",
+      types: "./dist/test-case/index.d.ts",
+    });
+    expect(packageJson.typesVersions["*"].testCase).toEqual([
+      "dist/test-case/index.d.ts",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

The TypeScript package documents imports such as `deepeval/metrics`,
`deepeval/models`, `deepeval/test-case`, and `deepeval/evaluate`, but those
subpaths were not exposed through the package export map. The broken examples are
in `typescript/src/metrics/README.md` lines 22-23, 196, and 205, plus
`typescript/src/models/README.md` line 116. This adds the missing export and
`typesVersions` entries, preserves the existing camelCase `deepeval/testCase`
alias for compatibility, and reconciles the already-advertised
`deepeval/annotation` type subpath with a runtime export.

## Changes

- Add package exports for `./metrics`, `./models`, `./test-case`, and
  `./evaluate`.
- Map the new subpaths to documented examples: metrics/model imports use
  `./metrics` and `./models`, test-case examples use kebab-case `./test-case`,
  and evaluation examples use `./evaluate`.
- Add `./annotation` to match the existing `typesVersions.annotation` entry.
- Add matching TypeScript declaration paths in `typesVersions`.
- Add a Jest smoke test that keeps package exports and `typesVersions` in sync,
  while also covering the currently documented subpaths and the existing
  `./testCase` compatibility alias.
- Add a build-backed package export smoke script and run it from TypeScript CI,
  even when the broader Jest suite fails earlier.
- Limit the TypeScript workflow token to read-only repository contents, which is
  sufficient for checkout and package validation.

## Why this matters

Users following the TypeScript examples should be able to import the documented
SDK entrypoints through the published package. TypeScript users also should not
see type metadata for a subpath that fails at runtime. The new tests make the
current package metadata and built export contract explicit so future export-map
regressions are caught early.

## Tests

Commands run:

- `cd typescript && npm ci` — passed
- `cd typescript && npm test -- package-exports.test.ts` — passed
  (17 tests)
- `cd typescript && npm run test:package-exports` — passed
- `cd typescript && npm run lint` — passed with existing warnings in
  `src/test-case/llm-test-case.ts` and `src/tracing/tracing.ts`
- `cd typescript && npx prettier --check test/test-core/package-exports.test.ts test/test-core/package-exports-smoke.cjs`
  — passed
- `cd typescript && npm run build` — passed as part of
  `npm run test:package-exports`
- Node `require.resolve`, `require`, dynamic `import()`, and emitted file checks
  for `deepeval/metrics`, `deepeval/models`, `deepeval/test-case`,
  `deepeval/evaluate`, `deepeval/testCase`, and safe package subpaths after build
  — passed through `npm run test:package-exports`
- Packed-package consumer install check with `npm pack` and
  `npm install --omit=dev` — passed through `npm run test:package-exports`
- Packed-package optional-peer check for `deepeval/integrations/langchain` —
  passed; the smoke test verifies `@langchain/core` is absent in the production
  consumer install and that CJS/ESM imports fail with the expected missing-peer
  error
- Temporary external TypeScript consumer compile check with a
  `node_modules/deepeval` symlink and imports from `deepeval/annotation`,
  `deepeval/metrics`, `deepeval/models`, `deepeval/test-case`,
  `deepeval/evaluate`, and `deepeval/testCase` — passed
- `git diff --check origin/main...HEAD` — passed before commit

Also run:

- `cd typescript && npm test -- --runInBand` — failed for pre-existing local
  environment/repo reasons: missing `OPENAI_API_KEY`, missing
  `CONFIDENT_API_KEY`, optional OpenAI Agents MCP dependency resolution, and an
  existing bad import in `test/test-core/evaluate.test.ts`. The
  `evaluate.test.ts` failure imports an internal source path
  (`../../src/confident/evaluate`) that is absent on `main`; it is separate from
  the `deepeval/evaluate` package subpath added here.
- The full Jest suite remains red for pre-existing unrelated issues. This change
  runs export validation after successful dependency installation even when
  unrelated Jest failures occur earlier in the job, so the new package-export
  contract remains visible.
- The existing TypeScript Prettier workflow remains red for pre-existing
  formatting drift in 66 source files. The PR-owned test files pass targeted
  Prettier checks and are no longer listed by that workflow.

## Risk

Risk level: low

The change is additive package metadata and keeps the existing `./testCase`
entrypoint intact. Rollback is straightforward: remove the added export/type
entries and the package export smoke test.

## Issue

No existing issue. This was discovered during repository analysis.

## Notes for maintainers

This intentionally supports only the subpaths already used by the TypeScript
examples, the existing compatibility alias, or an existing `typesVersions` public
type entry. Other namespace-style entrypoints can be considered separately if
maintainers want broader export-map symmetry.
