### PR TITLE
Fix TypeError: unhashable type in ToolCorrectnessMetric for unhashable tool outputs (#2815)

### DIFF
--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -229,7 +229,16 @@ def _make_hashable(obj):
         # Handle frozenset that might contain unhashable elements
         return frozenset(_make_hashable(item) for item in obj)
     else:
-        # For primitive hashable types (str, int, float, bool, etc.)
+        # Primitive hashable types (str, int, float, bool, etc.) pass through
+        # unchanged. Some objects reach here while being unhashable, e.g. a
+        # LangChain ToolMessage or a pydantic model that defines __eq__ without
+        # __hash__. Returning those as-is makes ToolCall.__hash__ raise
+        # ``TypeError: unhashable type`` (#2815), so fall back to a stable
+        # string representation for anything that is not hashable.
+        try:
+            hash(obj)
+        except TypeError:
+            return repr(obj)
         return obj
 
 

--- a/tests/test_core/test_test_case/test_single_turn.py
+++ b/tests/test_core/test_test_case/test_single_turn.py
@@ -450,6 +450,43 @@ class TestToolCallFunctionality:
         hash_value = hash(tool_call)
         assert isinstance(hash_value, int)
 
+    def test_tool_call_hashing_with_unhashable_types(self):
+        """Regression test for #2815.
+
+        ToolCall must stay hashable even when its output (or a value nested in
+        input_parameters) is an arbitrary unhashable object, such as a
+        LangChain ToolMessage or a pydantic model that defines __eq__ without
+        __hash__. ToolCorrectnessMetric puts ToolCall instances into a set, so a
+        crash here breaks component-level evaluation of agent traces.
+        """
+
+        class _Unhashable:
+            # Mirrors objects that define __eq__ without __hash__, which Python
+            # then makes unhashable.
+            __hash__ = None
+
+            def __init__(self, value):
+                self.value = value
+
+            def __repr__(self):
+                return f"_Unhashable({self.value!r})"
+
+        # Sanity check: the helper object really is unhashable.
+        with pytest.raises(TypeError):
+            hash(_Unhashable("x"))
+
+        # Unhashable object as the output.
+        tool_output = ToolCall(name="tool", output=_Unhashable("x"))
+        assert isinstance(hash(tool_output), int)
+        assert len({tool_output}) == 1  # usable in a set
+
+        # Unhashable object nested inside input_parameters.
+        tool_input = ToolCall(
+            name="tool", input_parameters={"arg": _Unhashable("y")}
+        )
+        assert isinstance(hash(tool_input), int)
+        assert len({tool_input}) == 1
+
     def test_tool_call_repr(self):
         tool_call = ToolCall(
             name="test_tool",


### PR DESCRIPTION
## Summary

Fixes #2815. `ToolCorrectnessMetric` raises `TypeError: unhashable type` during component-level evaluation (`evals_iterator()`) when a tool call's `output`, or a value nested in its `input_parameters`, is an arbitrary unhashable object, e.g. a LangChain `ToolMessage` or a pydantic model that defines `__eq__` without `__hash__`.

## Root cause

`ToolCorrectnessMetric._calculate_non_exact_match_score` puts `ToolCall` instances into a `set`, which calls `ToolCall.__hash__`. That routes `input_parameters` and `output` through `_make_hashable` (`deepeval/test_case/llm_test_case.py`). Its final branch returned any non-collection object unchanged, assuming it was a primitive hashable type:

```python
else:
    # For primitive hashable types (str, int, float, bool, etc.)
    return obj
```

When `obj` is unhashable, `hash((self.name, input_params_hashable, output_hashable))` then raises `TypeError`.

## Fix

Fall back to a stable `repr()` for any value that is not hashable. Primitives and already-hashable objects are returned unchanged, so existing behavior is preserved; only the previously-crashing path changes.

```python
else:
    try:
        hash(obj)
    except TypeError:
        return repr(obj)
    return obj
```

## Reproduction (before the fix)

```python
from deepeval.test_case import ToolCall

class ToolMessage:          # any object that is unhashable
    __hash__ = None

hash(ToolCall(name="t", output=ToolMessage()))           # TypeError: unhashable type
hash(ToolCall(name="t", input_parameters={"x": ToolMessage()}))  # TypeError
```

Both return an `int` after the fix and the tool calls can be placed in a `set`.

## Tests

Adds `test_tool_call_hashing_with_unhashable_types` in `tests/test_core/test_test_case/test_single_turn.py`, covering an unhashable object both as `output` and nested in `input_parameters`. No API key required.

```
$ pytest tests/test_core/test_test_case/test_single_turn.py -q
37 passed
```

`black --check` and the existing hashing tests are clean.

---
Disclosure: authored with AI assistance (Claude), reviewed and verified before submitting.