### PR TITLE
fix(metrics): use None default for turn_params in convert_turn_to_dict

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -122,11 +122,10 @@ def format_turns(
 
 def convert_turn_to_dict(
     turn: Turn,
-    turn_params: List[MultiTurnParams] = [
-        MultiTurnParams.CONTENT,
-        MultiTurnParams.ROLE,
-    ],
+    turn_params: Optional[List[MultiTurnParams]] = None,
 ) -> Dict:
+    if turn_params is None:
+        turn_params = [MultiTurnParams.CONTENT, MultiTurnParams.ROLE]
     result = {}
     for param in turn_params:
         if param in (


### PR DESCRIPTION
`convert_turn_to_dict` uses a mutable list literal as the default for `turn_params`. Same footgun as `goldens` in #2792 — every call shares one list object.

Not a live bug today (the body doesn't mutate `turn_params`), but 5 modules already call this helper (conversational_g_eval, knowledge_retention, role_adherence, conversation_completeness, turn_relevancy). Replaces the mutable default with `None` + guard, matching #2792.

- `deepeval/metrics/utils.py:convert_turn_to_dict`
- `+3 -4`, `black --check` and `ruff check` clean.
