### PR TITLE
feat(evaluate): honor DisplayConfig.display_option to show only failing/passing cases

### DIFF
--- a/deepeval/evaluate/console_report.py
+++ b/deepeval/evaluate/console_report.py
@@ -10,6 +10,7 @@ from rich.tree import Tree
 from rich.terminal_theme import TerminalTheme
 
 from deepeval.evaluate.types import TestResult
+from deepeval.test_run.test_run import TestRunResultDisplay
 
 LIGHT_THEME = TerminalTheme(
     background=(0, 0, 0),
@@ -61,7 +62,27 @@ class EvaluationConsoleReport:
         )
         self.console = Console()
 
-    def _build_display_elements(self, truncate: bool = True) -> Group:
+    @staticmethod
+    def _should_skip_case(
+        case: TestResult, display_option: TestRunResultDisplay
+    ) -> bool:
+        """Determine if a test case should be hidden based on the display filter.
+
+        Mirrors ``TestRunManager._should_skip_test_case`` so the ``evaluate()``
+        console output honors ``DisplayConfig.display_option`` exactly like the
+        ``deepeval test run --display`` CLI. ``None`` is treated as ``ALL``.
+        """
+        if display_option == TestRunResultDisplay.PASSING and not case.success:
+            return True
+        elif display_option == TestRunResultDisplay.FAILING and case.success:
+            return True
+        return False
+
+    def _build_display_elements(
+        self,
+        truncate: bool = True,
+        display_option: TestRunResultDisplay = TestRunResultDisplay.ALL,
+    ) -> Group:
 
         renderables = [
             Panel(
@@ -70,7 +91,11 @@ class EvaluationConsoleReport:
             )
         ]
 
+        displayed_any = False
         for case in self.test_results:
+            if self._should_skip_case(case, display_option):
+                continue
+            displayed_any = True
             status_color = DEEPEVAL_GREEN if case.success else FAIL_RED
             status_icon = "✅" if case.success else "❌"
 
@@ -150,6 +175,22 @@ class EvaluationConsoleReport:
                 )
             )
 
+        # When a display filter hides every case, surface a short note instead
+        # of showing only the header + aggregate, so the output isn't confusing.
+        if not displayed_any and self.test_results:
+            filter_label = (
+                display_option.value
+                if isinstance(display_option, TestRunResultDisplay)
+                else TestRunResultDisplay.ALL.value
+            )
+            renderables.append(
+                Panel(
+                    f"No {filter_label} test cases to display.",
+                    border_style=DEEPEVAL_PURPLE,
+                    expand=True,
+                )
+            )
+
         # Calculate aggregate metrics
         metric_aggregates = {}
         for case in self.test_results:
@@ -205,10 +246,17 @@ class EvaluationConsoleReport:
 
         return Group(*renderables)
 
-    def render_to_terminal(self, truncate_passing_cases: bool = True):
+    def render_to_terminal(
+        self,
+        truncate_passing_cases: bool = True,
+        display_option: TestRunResultDisplay = TestRunResultDisplay.ALL,
+    ):
         self.console.print()
         self.console.print(
-            self._build_display_elements(truncate=truncate_passing_cases)
+            self._build_display_elements(
+                truncate=truncate_passing_cases,
+                display_option=display_option,
+            )
         )
         self.console.print()
 

--- a/deepeval/evaluate/evaluate.py
+++ b/deepeval/evaluate/evaluate.py
@@ -228,7 +228,8 @@ def evaluate(
         if display_config.print_results:
             console_report = EvaluationConsoleReport(test_results)
             console_report.render_to_terminal(
-                truncate_passing_cases=display_config.truncate_passing_cases
+                truncate_passing_cases=display_config.truncate_passing_cases,
+                display_option=display_config.display_option,
             )
 
             # Handle full, un-truncated file exports

--- a/tests/test_core/test_evaluation/test_console_report.py
+++ b/tests/test_core/test_evaluation/test_console_report.py
@@ -131,3 +131,108 @@ def test_evaluation_console_report_aggregate_metrics():
     assert list(table.columns[1].cells)[0] == "0.50"
     assert list(table.columns[2].cells)[0] == "50.00%"
     assert list(table.columns[3].cells)[0] == "2"
+
+
+def _make_metric(success: bool) -> MetricData:
+    return MetricData(
+        name="Answer Relevancy",
+        score=1.0 if success else 0.0,
+        threshold=0.5,
+        reason=None,
+        success=success,
+        strictMode=False,
+        evaluationModel=None,
+        error=None,
+        evaluationCost=None,
+        verboseLogs=None,
+    )
+
+
+def _make_case(name: str, success: bool) -> EvalTestResult:
+    return EvalTestResult(
+        name=name,
+        success=success,
+        input="test input",
+        actual_output="test output",
+        conversational=False,
+        metrics_data=[_make_metric(success)],
+        turns=None,
+    )
+
+
+def _render_text(report: EvaluationConsoleReport, **kwargs) -> str:
+    from rich.console import Console
+
+    console = Console(record=True, width=200)
+    console.print(report._build_display_elements(**kwargs))
+    return console.export_text()
+
+
+def test_display_option_failing_hides_passing_cases():
+    from deepeval.test_run.test_run import TestRunResultDisplay
+
+    report = EvaluationConsoleReport(
+        [_make_case("passing_case", True), _make_case("failing_case", False)]
+    )
+
+    text = _render_text(
+        report,
+        truncate=True,
+        display_option=TestRunResultDisplay.FAILING,
+    )
+
+    assert "failing_case" in text
+    assert "passing_case" not in text
+    # Aggregate is computed over ALL cases regardless of the filter.
+    assert "Aggregate Metrics" in text
+
+
+def test_display_option_passing_hides_failing_cases():
+    from deepeval.test_run.test_run import TestRunResultDisplay
+
+    report = EvaluationConsoleReport(
+        [_make_case("passing_case", True), _make_case("failing_case", False)]
+    )
+
+    text = _render_text(
+        report,
+        truncate=False,
+        display_option=TestRunResultDisplay.PASSING,
+    )
+
+    assert "passing_case" in text
+    assert "failing_case" not in text
+
+
+def test_display_option_all_shows_every_case():
+    from deepeval.test_run.test_run import TestRunResultDisplay
+
+    report = EvaluationConsoleReport(
+        [_make_case("passing_case", True), _make_case("failing_case", False)]
+    )
+
+    # Explicit ALL and the default should both render every case.
+    text_explicit = _render_text(
+        report, truncate=False, display_option=TestRunResultDisplay.ALL
+    )
+    assert "passing_case" in text_explicit
+    assert "failing_case" in text_explicit
+
+    text_default = _render_text(report, truncate=False)
+    assert "passing_case" in text_default
+    assert "failing_case" in text_default
+
+
+def test_display_option_filter_all_hidden_shows_note():
+    from deepeval.test_run.test_run import TestRunResultDisplay
+
+    report = EvaluationConsoleReport([_make_case("passing_case", True)])
+
+    text = _render_text(
+        report,
+        truncate=True,
+        display_option=TestRunResultDisplay.FAILING,
+    )
+
+    assert "passing_case" not in text
+    assert "No failing test cases to display." in text


### PR DESCRIPTION
## Problem

Closes #1235.

`evaluate()` (and `assert_test()`) have no way to show **only failed test cases** in the terminal — a common ask for CI / git pre-push hooks where full output is noisy. `DisplayConfig` already exposes `display_option: TestRunResultDisplay` (`ALL` / `FAILING` / `PASSING`, default `ALL`), and the `deepeval test run` CLI honors it via `--display`, but the Python `evaluate()` path ignored it.

## Root cause

The `evaluate()` console output is rendered by `EvaluationConsoleReport.render_to_terminal()` (`deepeval/evaluate/console_report.py`), which only accepted `truncate_passing_cases`. In `evaluate.py`, `render_to_terminal(...)` was called **without** `display_config.display_option`, so the option was silently dropped. Passing cases were always rendered (merely truncated to a one-line summary); there was no way to hide them entirely.

(`assert_test()` doesn't render a full report — it raises `AssertionError` — and the `deepeval test run` final table uses a separate path that already filters, so those are unaffected.)

## Change

- `deepeval/evaluate/console_report.py`
  - Add `_should_skip_case(case, display_option)`, mirroring `TestRunManager._should_skip_test_case()` so semantics match the CLI exactly (`FAILING` → hide passes, `PASSING` → hide failures, `ALL`/`None` → show all).
  - Thread a `display_option` parameter (default `TestRunResultDisplay.ALL`) through `_build_display_elements()` and `render_to_terminal()`, skipping non-matching per-case panels.
  - Show a short note (e.g. `No failing test cases to display.`) when the filter hides every case.
- `deepeval/evaluate/evaluate.py`
  - Pass `display_option=display_config.display_option` into `render_to_terminal(...)`.

### Design decisions
- **Reuses the existing `TestRunResultDisplay` enum** and skip logic rather than adding a new flag — identical semantics to `deepeval test run --display`.
- **Aggregate Metrics panel is still computed over all cases** so the overall pass-rate summary stays truthful regardless of the filter.
- **File exports (HTML/MD) remain unfiltered** — `export_to_html()` calls `_build_display_elements(truncate=False)` which defaults to `ALL`.
- **Default `ALL` everywhere** → fully backward compatible; no public API/schema changes.

Usage:

```python
from deepeval import evaluate
from deepeval.evaluate.configs import DisplayConfig
from deepeval.test_run.test_run import TestRunResultDisplay

evaluate(
    test_cases=[...],
    metrics=[...],
    display_config=DisplayConfig(display_option=TestRunResultDisplay.FAILING),
)
```

## Tests

Extended `tests/test_core/test_evaluation/test_console_report.py` (renders via a recording `rich.Console` and asserts on the output text):
- `FAILING` → only failing case shown, passing hidden, aggregate still present.
- `PASSING` → only passing case shown, failing hidden.
- `ALL` (explicit and default) → every case shown (backward compat).
- All-filtered-out → friendly note shown.

Commands run locally:
- `python -m pytest tests/test_core/test_evaluation/test_console_report.py -v` → 6 passed
- `python -m pytest tests/test_core/test_evaluation tests/test_core/test_run tests/test_core/test_config -q` → all passed
- `black` on the three changed files → clean

---

_This contribution was prepared with the help of an AI agent; a human reviewed the change, rationale, and test results before submission._
