### PR TITLE
fix(models): preserve JSON string values with comma-bracket sequences in trim_and_load_json

### DIFF
--- a/deepeval/models/llms/utils.py
+++ b/deepeval/models/llms/utils.py
@@ -17,6 +17,13 @@ def trim_and_load_json(
         input_string = input_string + "}"
         end = len(input_string)
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
+    # Attempt direct parse first to avoid corrupting valid JSON whose string
+    # values contain ", ]" or ", }" (issue #2770).
+    try:
+        return json.loads(jsonStr)
+    except json.JSONDecodeError:
+        pass
+    # Fallback: strip trailing commas that LLMs sometimes emit and retry.
     jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
     try:
         return json.loads(jsonStr)

--- a/tests/test_core/test_trim_and_load_json.py
+++ b/tests/test_core/test_trim_and_load_json.py
@@ -1,9 +1,10 @@
 """Regression tests for trimAndLoadJson trailing-comma handling.
 
-Both the metrics and dataset copies stripped ``,\\s*`` before a closing ``]``/``}``
+The metrics and dataset copies stripped ``,\\s*`` before a closing ``]``/``}``
 unconditionally, which corrupted valid JSON whose string values happened to
-contain ``", ]"`` or ``", }"``. The cleanup must only run as a fallback when a
-direct parse fails.
+contain ``", ]"`` or ``", }"``. PR #2701 fixed those two copies; this file
+also covers the third copy in ``deepeval.models.llms.utils`` (issue #2770).
+The cleanup must only run as a fallback when a direct parse fails.
 """
 
 import json
@@ -12,6 +13,7 @@ import pytest
 
 from deepeval.dataset.utils import trimAndLoadJson as trim_dataset
 from deepeval.metrics.utils import trimAndLoadJson as trim_metrics
+from deepeval.models.llms.utils import trim_and_load_json as trim_models
 
 TRIM_FNS = [trim_metrics, trim_dataset]
 
@@ -37,3 +39,27 @@ def test_trailing_comma_is_still_stripped(trim):
 def test_invalid_json_still_raises(trim):
     with pytest.raises(ValueError):
         trim("not json at all {[")
+
+
+# --- models/llms/utils.py copy (issue #2770) ---
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"reason": "score is 1,} good"}',
+        '{"note": "the set is {x, y, } here"}',
+        '{"items": "found A, B, ] then done"}',
+    ],
+)
+def test_models_utils_valid_json_string_values_are_preserved(raw):
+    assert trim_models(raw) == json.loads(raw)
+
+
+def test_models_utils_trailing_comma_is_still_stripped():
+    assert trim_models('{"a": [1, 2, ]}') == {"a": [1, 2]}
+
+
+def test_models_utils_markdown_fence_is_stripped():
+    fenced = '```json\n{"verdict": "yes"}\n```'
+    assert trim_models(fenced) == {"verdict": "yes"}


### PR DESCRIPTION
﻿## Problem

deepeval/models/llms/utils.py::trim_and_load_json unconditionally runs re.sub before parsing, which silently corrupts valid JSON whose string values contain `, ]` or `, }`.

Reproduction:

```python
from deepeval.models.llms.utils import trim_and_load_json
trim_and_load_json('{"reason": "score is 1,} good"}')
# Returns: {'reason': 'score is 1} good'}  -- comma dropped
```

This affects every concrete model backend (openai, anthropic, azure, bedrock, gemini, litellm, etc.) which all import trim_and_load_json to parse LLM output.

Closes #2770.

## Root cause

PR #2701 fixed the same bug in deepeval/metrics/utils.py and deepeval/dataset/utils.py but the third copy in deepeval/models/llms/utils.py was missed.

## Fix

Apply the same pattern established by #2701: try json.loads directly first, and only fall back to the trailing-comma-stripping regex when the direct parse fails.

## Tests

Extended the existing tests/test_core/test_trim_and_load_json.py to also cover deepeval.models.llms.utils.trim_and_load_json:

- Valid JSON with `, ]` / `, }` in string values is preserved unchanged
- Trailing commas in actual JSON structure are still stripped correctly
- Markdown-fenced JSON is handled

All 13 tests pass.
