### PR TITLE
fix markup

### DIFF
--- a/docs/content/docs/(concepts)/(test-cases)/evaluation-test-cases.mdx
+++ b/docs/content/docs/(concepts)/(test-cases)/evaluation-test-cases.mdx
@@ -43,7 +43,7 @@ test_case = LLMTestCase(
 ```
 
 :::info
-Since <C id="module::deepeval"/> is an LLM evaluation framework, the ** `input` and <C id="field::actual_output"/> are always mandatory.** However, this does not mean they are necessarily used for evaluation, and you can also add additional parameters such as the <C id="field::tools_called"/> for each <C id="class::LLMTestCase"/>.
+Since <C id="module::deepeval"/> is an LLM evaluation framework, the **`input` and <C id="field::actual_output"/> are always mandatory.** However, this does not mean they are necessarily used for evaluation, and you can also add additional parameters such as the <C id="field::tools_called"/> for each <C id="class::LLMTestCase"/>.
 
 <video width="100%" autoPlay loop muted playsInline>
   <source


### PR DESCRIPTION
The space between the asterisks and the backtick stops the bold from rendering.

See: https://deepeval.com/docs/evaluation-test-cases