### PR TITLE
fix: restrict cached deepeval view link to safe Confident AI test-run URLs

### DIFF
--- a/deepeval/cli/main.py
+++ b/deepeval/cli/main.py
@@ -45,6 +45,7 @@ from deepeval.cli.test.command import app as test_app
 from deepeval.cli.utils import (
     coerce_blank_to_none,
     handle_save_result,
+    is_confident_browser_url,
     is_optional,
     load_service_account_key_file,
     parse_and_validate,
@@ -169,9 +170,18 @@ def view():
             last_test_run_link = (
                 global_test_run_manager.get_latest_test_run_link()
             )
-            if last_test_run_link:
+            if last_test_run_link and is_confident_browser_url(
+                last_test_run_link
+            ):
                 print(f"🔗 View test run: {last_test_run_link}")
                 open_browser(last_test_run_link)
+            elif last_test_run_link:
+                print(
+                    "⚠️ Ignoring an invalid cached Confident AI test-run link; "
+                    "only /test-runs/... links from the configured Confident AI "
+                    "deployment are opened automatically. Uploading instead."
+                )
+                upload_and_open_link(_span=span)
             else:
                 upload_and_open_link(_span=span)
         else:

--- a/deepeval/cli/utils.py
+++ b/deepeval/cli/utils.py
@@ -5,7 +5,7 @@ import shutil
 import pyfiglet
 import typer
 import webbrowser
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, unquote, urlencode, urlsplit, urlunsplit
 
 from pydantic import ValidationError
 from pydantic.fields import FieldInfo
@@ -46,6 +46,117 @@ _CONFIDENT_UTM_HOSTS = frozenset(
     {"confident-ai.com", "www.confident-ai.com", "app.confident-ai.com"}
 )
 _UTM_SOURCE = "deepeval"
+
+
+def _safe_urlsplit(url: str):
+    if not isinstance(url, str):
+        return None
+    try:
+        return urlsplit(url)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _normalize_default_port(scheme: str, port: Optional[int]) -> Optional[int]:
+    if (scheme == "https" and port == 443) or (scheme == "http" and port == 80):
+        return None
+    return port
+
+
+def _origin_tuple(url: str) -> Optional[Tuple[str, str, Optional[int]]]:
+    parts = _safe_urlsplit(url)
+    if parts is None:
+        return None
+    try:
+        hostname = parts.hostname
+        port = parts.port
+    except ValueError:
+        return None
+    if not parts.scheme or not hostname:
+        return None
+    scheme = parts.scheme.lower()
+    return (scheme, hostname.lower(), _normalize_default_port(scheme, port))
+
+
+def _safe_browser_path(path: str) -> Optional[str]:
+    try:
+        decoded_path = unquote(path, errors="strict")
+    except UnicodeDecodeError:
+        return None
+
+    for candidate in (path, decoded_path):
+        if "\\" in candidate:
+            return None
+        if any(segment in {".", ".."} for segment in candidate.split("/")):
+            return None
+
+    return decoded_path
+
+
+def _base_path_prefix(url: str) -> Optional[str]:
+    parts = _safe_urlsplit(url)
+    if parts is None:
+        return None
+    path = _safe_browser_path(parts.path)
+    if path is None:
+        return None
+    path = path.rstrip("/")
+    return "" if path == "/" else path
+
+
+def _allowed_confident_browser_targets() -> (
+    set[Tuple[Tuple[str, str, Optional[int]], str]]
+):
+    targets: set[Tuple[Tuple[str, str, Optional[int]], str]] = set()
+    hosted_origin = _origin_tuple(PROD)
+    if hosted_origin is not None:
+        targets.add((hosted_origin, ""))
+
+    custom_base_url = get_settings().CONFIDENT_BASE_URL
+    if custom_base_url:
+        custom_url = str(custom_base_url).rstrip("/")
+        custom_origin = _origin_tuple(custom_url)
+        custom_path_prefix = _base_path_prefix(custom_url)
+        if custom_origin is not None and custom_path_prefix is not None:
+            targets.add((custom_origin, custom_path_prefix))
+
+    return targets
+
+
+def _is_test_run_path(path: str, base_path_prefix: str) -> bool:
+    safe_path = _safe_browser_path(path)
+    if safe_path is None:
+        return False
+    expected_prefix = (
+        f"{base_path_prefix}/test-runs/" if base_path_prefix else "/test-runs/"
+    )
+    return path.startswith(expected_prefix) and safe_path.startswith(
+        expected_prefix
+    )
+
+
+def is_confident_browser_url(url: str) -> bool:
+    """Return True only for safe Confident AI ``/test-runs/...`` browser links.
+
+    Guards the cached ``deepeval view`` link so a tampered local ``.deepeval``
+    state file cannot redirect the browser to an arbitrary URL. A link is
+    accepted only when its origin matches the configured Confident AI
+    deployment (hosted ``PROD`` or ``CONFIDENT_BASE_URL``) and its path is a
+    ``/test-runs/...`` path, with no userinfo, backslashes, or dot-segments.
+    """
+    if not url:
+        return False
+    parts = _safe_urlsplit(url)
+    if parts is None:
+        return False
+    if parts.username or parts.password:
+        return False
+    origin = _origin_tuple(url)
+    return any(
+        origin == allowed_origin
+        and _is_test_run_path(parts.path, base_path_prefix)
+        for allowed_origin, base_path_prefix in _allowed_confident_browser_targets()
+    )
 
 
 def with_utm(

--- a/tests/test_core/test_cli/test_view_url_guard.py
+++ b/tests/test_core/test_cli/test_view_url_guard.py
@@ -1,0 +1,44 @@
+"""Regression tests for the ``deepeval view`` cached-link safety guard.
+
+`is_confident_browser_url` gates the cached test-run link that `deepeval view`
+opens in the browser, so a tampered local `.deepeval` state file cannot redirect
+the browser to an arbitrary URL.
+"""
+
+import pytest
+
+from deepeval.cli.utils import is_confident_browser_url
+
+PROD = "https://app.confident-ai.com"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"{PROD}/test-runs/abc123",
+        f"{PROD}/test-runs/abc123?tab=metrics",
+        f"{PROD}/test-runs/abc123/spans",
+    ],
+)
+def test_accepts_hosted_test_run_links(url):
+    assert is_confident_browser_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not a url",
+        "https://evil.com/test-runs/abc",  # wrong origin
+        "https://app.confident-ai.com.evil.com/test-runs/abc",  # lookalike host
+        f"{PROD}/settings",  # not a /test-runs/ path
+        f"{PROD}/test-runsX/abc",  # prefix must be a full path segment
+        "https://user:pw@app.confident-ai.com/test-runs/abc",  # embedded userinfo
+        f"{PROD}/test-runs/../admin",  # dot-segment escape
+        f"{PROD}/test-runs/%2e%2e/admin",  # encoded dot-segment escape
+        "http://app.confident-ai.com/test-runs/abc",  # wrong scheme
+        "javascript:alert(1)//test-runs/",  # non-http scheme, no host
+    ],
+)
+def test_rejects_unsafe_links(url):
+    assert is_confident_browser_url(url) is False


### PR DESCRIPTION
## Summary

`deepeval view` opened the cached last-test-run link from local `.deepeval` state in the browser **without validating it**, so a tampered state file could redirect the browser to an arbitrary URL. This adds `is_confident_browser_url()` and gates the cached link so only `/test-runs/...` paths on the configured Confident AI deployment (hosted `PROD` or `CONFIDENT_BASE_URL`) are opened automatically. Malformed URLs, embedded userinfo, origin mismatches, look-alike hosts, base-path escapes, backslashes, and encoded dot-segment paths are ignored and fall back to a safe upload instead.

## Scope

- `deepeval/cli/utils.py` — `is_confident_browser_url()` + URL-safety helpers.
- `deepeval/cli/main.py` — gate the `view` command's cached-link `open_browser` call.
- `tests/test_core/test_cli/test_view_url_guard.py` — 14 cases.

3 files, +167 / −2.

## Note on scope

This PR was **rescoped**. An earlier revision bundled broader settings/auth hardening that `main` has since implemented independently (the login flow moved into `deepeval/cli/auth.py`, and save-target validation now lives in `utils.handle_save_result`). To avoid a conflicting / partly-duplicate change, it now contains only the one piece `main` still lacks — the `deepeval view` cached-link safety guard — re-based cleanly on latest `main`.

## Test

`pytest tests/test_core/test_cli/test_view_url_guard.py` → **14 passed** (accepts hosted `/test-runs/` links; rejects wrong origin, look-alike host, embedded userinfo, path escape, encoded dot-segment, wrong scheme, and non-test-run paths). Black + Ruff clean.
