### PR TITLE
fix: quiet pytest plugin side effects outside DeepEval runs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# telemetry.py is stored with CRLF in main; allow CR at EOL for whitespace checks.
+deepeval/telemetry.py whitespace=cr-at-eol

--- a/deepeval/cli/test/command.py
+++ b/deepeval/cli/test/command.py
@@ -123,77 +123,88 @@ def run(
     delete_file_if_exists(TEMP_FILE_PATH)
     delete_file_if_exists(TEMP_CACHE_FILE_NAME)
     check_if_valid_file(test_file_or_directory)
+    previous_deepeval = os.environ.get("DEEPEVAL")
     set_is_running_deepeval(True)
 
-    if official and not SETTINGS.CONFIDENT_API_KEY:
-        print(
-            "Warning: --official requires a CONFIDENT_API_KEY environment variable to be set. Skipping."
+    try:
+        if official and not SETTINGS.CONFIDENT_API_KEY:
+            print(
+                "Warning: --official requires a CONFIDENT_API_KEY environment variable to be set. Skipping."
+            )
+            official = False
+
+        should_use_cache = use_cache and repeat is None
+        set_should_use_cache(should_use_cache)
+        set_should_ignore_errors(ignore_errors)
+        set_should_skip_on_missing_params(skip_on_missing_params)
+        set_verbose_mode(verbose)
+        set_identifier(identifier)
+        set_test_run_official(official)
+
+        global_test_run_manager.reset()
+
+        pytest_args = [test_file_or_directory]
+
+        if exit_on_first_failure:
+            pytest_args.insert(0, "-x")
+
+        pytest_args.extend(
+            [
+                "--verbose" if verbose else "--quiet",
+                f"--color={color}",
+                f"--durations={durations}",
+                "-s",
+            ]
         )
-        official = False
 
-    should_use_cache = use_cache and repeat is None
-    set_should_use_cache(should_use_cache)
-    set_should_ignore_errors(ignore_errors)
-    set_should_skip_on_missing_params(skip_on_missing_params)
-    set_verbose_mode(verbose)
-    set_identifier(identifier)
-    set_test_run_official(official)
+        if pdb:
+            pytest_args.append("--pdb")
+        if not show_warnings:
+            pytest_args.append("--disable-warnings")
+        if num_processes is not None:
+            pytest_args.extend(["-n", str(num_processes)])
 
-    global_test_run_manager.reset()
+        if repeat is not None:
+            pytest_args.extend(["--count", str(repeat)])
+            if repeat < 1:
+                raise ValueError("The repeat argument must be at least 1.")
 
-    pytest_args = [test_file_or_directory]
+        if mark:
+            pytest_args.extend(["-m", mark])
+        if identifier:
+            pytest_args.extend(["--identifier", identifier])
 
-    if exit_on_first_failure:
-        pytest_args.insert(0, "-x")
+        # Block the installed entry point name before loading the import-safe
+        # module directly; otherwise pytest can register the same module twice
+        # under `deepeval` and `deepeval_pytest_plugin.plugin`.
+        pytest_args.extend(
+            ["-p", "no:deepeval", "-p", "deepeval_pytest_plugin.plugin"]
+        )
+        # Append the extra arguments collected by allow_extra_args=True
+        # Pytest will raise its own error if the arguments are invalid (error:
+        if ctx.args:
+            pytest_args.extend(ctx.args)
 
-    pytest_args.extend(
-        [
-            "--verbose" if verbose else "--quiet",
-            f"--color={color}",
-            f"--durations={durations}",
-            "-s",
-        ]
-    )
+        start_time = time.perf_counter()
+        with capture_evaluation_run("deepeval test run"):
+            pytest_retcode = pytest.main(pytest_args)
+        end_time = time.perf_counter()
+        run_duration = end_time - start_time
+        global_test_run_manager.wrap_up_test_run(run_duration, True, display)
 
-    if pdb:
-        pytest_args.append("--pdb")
-    if not show_warnings:
-        pytest_args.append("--disable-warnings")
-    if num_processes is not None:
-        pytest_args.extend(["-n", str(num_processes)])
+        invoke_test_run_end_hook()
 
-    if repeat is not None:
-        pytest_args.extend(["--count", str(repeat)])
-        if repeat < 1:
-            raise ValueError("The repeat argument must be at least 1.")
+        # Propagate any non-zero pytest exit code so failures surface in CI.
+        # pytest distinguishes: 1=tests failed, 2=interrupted (e.g. -x stop on
+        # first failure, which is how xdist/-n reports a halted run), 3=internal
+        # error, 4=usage error, 5=no tests collected. Typer ignores a command's
+        # return value, so we must sys.exit explicitly to set the process code.
+        if pytest_retcode != 0:
+            sys.exit(int(pytest_retcode))
 
-    if mark:
-        pytest_args.extend(["-m", mark])
-    if identifier:
-        pytest_args.extend(["--identifier", identifier])
-
-    # Add the deepeval plugin file to pytest arguments
-    pytest_args.extend(["-p", "deepeval"])
-    # Append the extra arguments collected by allow_extra_args=True
-    # Pytest will raise its own error if the arguments are invalid (error:
-    if ctx.args:
-        pytest_args.extend(ctx.args)
-
-    start_time = time.perf_counter()
-    with capture_evaluation_run("deepeval test run"):
-        pytest_retcode = pytest.main(pytest_args)
-    end_time = time.perf_counter()
-    run_duration = end_time - start_time
-    global_test_run_manager.wrap_up_test_run(run_duration, True, display)
-
-    invoke_test_run_end_hook()
-
-    # Propagate any non-zero pytest exit code so failures surface in CI.
-    # pytest distinguishes: 1=tests failed, 2=interrupted (e.g. -x stop on
-    # first failure, which is how xdist/-n reports a halted run), 3=internal
-    # error, 4=usage error, 5=no tests collected. Typer ignores a command's
-    # return value, so we must sys.exit explicitly to set the process code.
-    if pytest_retcode != 0:
-        sys.exit(int(pytest_retcode))
-
-    return pytest_retcode
+        return pytest_retcode
+    finally:
+        if previous_deepeval is None:
+            os.environ.pop("DEEPEVAL", None)
+        else:
+            os.environ["DEEPEVAL"] = previous_deepeval

--- a/deepeval/plugins/plugin.py
+++ b/deepeval/plugins/plugin.py
@@ -1,78 +1,25 @@
-import pytest
-import os
-from rich import print
-from typing import Optional, Any
-from deepeval.constants import (
+from deepeval_pytest_plugin.plugin import (
     PYTEST_RUN_TEST_NAME,
     PYTEST_TRACE_TEST_WRAPPER_SPAN_NAME,
+    get_is_running_deepeval,
+    pytest_addoption,
+    pytest_configure,
+    pytest_runtest_call,
+    pytest_runtest_protocol,
+    pytest_sessionfinish,
+    pytest_sessionstart,
+    pytest_terminal_summary,
 )
-from deepeval.test_run import global_test_run_manager
-from deepeval.utils import get_is_running_deepeval
 
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--identifier",
-        action="store",
-        default=None,
-        help="Custom identifier for the test run",
-    )
-
-
-def pytest_sessionstart(session: pytest.Session):
-    is_running_deepeval = get_is_running_deepeval()
-    identifier = session.config.getoption("identifier", None)
-
-    if is_running_deepeval:
-        global_test_run_manager.save_to_disk = True
-        global_test_run_manager.create_test_run(
-            identifier=identifier,
-            file_name=session.config.getoption("file_or_dir")[0],
-        )
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_runtest_protocol(
-    item: pytest.Item, nextitem: Optional[pytest.Item]
-) -> Optional[Any]:
-    os.environ[PYTEST_RUN_TEST_NAME] = item.nodeid.split("::")[-1]
-    return None
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call(item: pytest.Item):
-    """Wrap each test in a deepeval evaluation scope so `@observe` spans get
-    attached to the in-flight test run via `assert_test(golden=..., metrics=...)`.
-    """
-    if not get_is_running_deepeval():
-        yield
-        return
-
-    from deepeval.tracing.tracing import Observer, trace_manager
-    from deepeval.tracing.types import EvalMode, EvalSession
-
-    prev_session = trace_manager.eval_session
-    trace_manager.eval_session = EvalSession(mode=EvalMode.EVALUATE)
-    observer = Observer("custom", func_name=PYTEST_TRACE_TEST_WRAPPER_SPAN_NAME)
-    observer.__enter__()
-    try:
-        yield
-    finally:
-        try:
-            observer.__exit__(None, None, None)
-        finally:
-            trace_manager.eval_session = prev_session
-
-
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_sessionfinish(session: pytest.Session, exitstatus):
-    print("Running teardown with pytest sessionfinish...")
-
-    yield
-
-
-def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    for report in terminalreporter.getreports("skipped"):
-        if report.skipped:
-            reason = report.longreprtext.split("\n")[-1]
-            print(f"Test {report.nodeid} was skipped. Reason: {reason}")
+__all__ = [
+    "PYTEST_RUN_TEST_NAME",
+    "PYTEST_TRACE_TEST_WRAPPER_SPAN_NAME",
+    "get_is_running_deepeval",
+    "pytest_addoption",
+    "pytest_configure",
+    "pytest_runtest_call",
+    "pytest_runtest_protocol",
+    "pytest_sessionfinish",
+    "pytest_sessionstart",
+    "pytest_terminal_summary",
+]

--- a/deepeval/telemetry.py
+++ b/deepeval/telemetry.py
@@ -128,8 +128,8 @@ if not telemetry_opt_out():
 
 if (
     get_settings().ERROR_REPORTING
-    and not blocked_by_firewall()
     and not telemetry_opt_out()
+    and not blocked_by_firewall()
 ):
     # Chain to the host's previous excepthook instead of clobbering it.
     _previous_excepthook = sys.excepthook or sys.__excepthook__

--- a/deepeval_pytest_plugin/__init__.py
+++ b/deepeval_pytest_plugin/__init__.py
@@ -1,0 +1,1 @@
+"""Import-safe pytest plugin package for DeepEval."""

--- a/deepeval_pytest_plugin/plugin.py
+++ b/deepeval_pytest_plugin/plugin.py
@@ -1,0 +1,126 @@
+import os
+from typing import Any, Optional, cast
+
+import pytest
+
+
+PYTEST_RUN_TEST_NAME = "CONFIDENT_AI_RUN_TEST_NAME"
+PYTEST_TRACE_TEST_WRAPPER_SPAN_NAME = (
+    "__deepeval_internal_pytest_test_wrapper__"
+)
+_TRUTHY = frozenset({"1", "true", "t", "yes", "y", "on", "enable", "enabled"})
+
+
+def _clear_run_test_name() -> None:
+    os.environ.pop(PYTEST_RUN_TEST_NAME, None)
+
+
+def get_is_running_deepeval() -> bool:
+    value = os.getenv("DEEPEVAL")
+    if value is None:
+        return False
+
+    return str(value).strip().strip('"').strip("'").lower() in _TRUTHY
+
+
+def pytest_addoption(parser):
+    if not get_is_running_deepeval():
+        return
+
+    parser.addoption(
+        "--identifier",
+        action="store",
+        default=None,
+        help="Custom identifier for the test run",
+    )
+
+
+def pytest_configure(config: pytest.Config):
+    if not get_is_running_deepeval():
+        _clear_run_test_name()
+
+
+def pytest_sessionstart(session: pytest.Session):
+    if not get_is_running_deepeval():
+        _clear_run_test_name()
+        return
+
+    from deepeval.test_run import global_test_run_manager
+
+    identifier = cast(
+        Optional[str], session.config.getoption("identifier", None)
+    )
+    file_or_dir = cast(list[str], session.config.getoption("file_or_dir"))
+    global_test_run_manager.save_to_disk = True
+    global_test_run_manager.create_test_run(
+        identifier=identifier,
+        file_name=file_or_dir[0],
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_protocol(
+    item: pytest.Item, nextitem: Optional[pytest.Item]
+) -> Optional[Any]:
+    if not get_is_running_deepeval():
+        _clear_run_test_name()
+        return None
+
+    os.environ[PYTEST_RUN_TEST_NAME] = item.nodeid.split("::")[-1]
+    return None
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item: pytest.Item):
+    """Wrap each test in a deepeval evaluation scope so `@observe` spans get
+    attached to the in-flight test run via `assert_test(golden=..., metrics=...)`.
+    """
+    if not get_is_running_deepeval():
+        yield
+        return
+
+    from deepeval.tracing.tracing import Observer, trace_manager
+    from deepeval.tracing.types import EvalMode, EvalSession
+
+    prev_session = trace_manager.eval_session
+    trace_manager.eval_session = EvalSession(mode=EvalMode.EVALUATE)
+    observer = Observer("custom", func_name=PYTEST_TRACE_TEST_WRAPPER_SPAN_NAME)
+    observer.__enter__()
+    try:
+        yield
+    finally:
+        try:
+            observer.__exit__(None, None, None)
+        finally:
+            trace_manager.eval_session = prev_session
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus):
+    if get_is_running_deepeval():
+        from rich import print
+
+        print("Running teardown with pytest sessionfinish...")
+    else:
+        _clear_run_test_name()
+
+    try:
+        yield
+    finally:
+        _clear_run_test_name()
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if not get_is_running_deepeval():
+        return
+
+    from rich import print
+
+    for report in terminalreporter.getreports("skipped"):
+        if report.skipped:
+            reason = report.longreprtext.split("\n")[-1]
+            print(f"Test {report.nodeid} was skipped. Reason: {reason}")
+
+
+if not get_is_running_deepeval():
+    _clear_run_test_name()

--- a/docs/content/docs/command-line-interface.mdx
+++ b/docs/content/docs/command-line-interface.mdx
@@ -109,6 +109,19 @@ For a deeper walkthrough, see the [Golden Synthesizer](/docs/golden-synthesizer#
 
 Use `deepeval test run` to run evaluation test files through `pytest` with the `deepeval` pytest plugin enabled.
 
+:::tip[Plain pytest suites]
+If DeepEval is installed in the same environment as a plain `pytest` suite, the
+pytest plugin is named `deepeval`. Disable only this plugin with
+`pytest -p no:deepeval`, or disable third-party plugin autoloading with
+`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` when your suite does not need other third-party
+pytest plugins.
+
+If another import path still loads the main `deepeval` package during a restricted
+plain pytest run, set process-level flags before pytest starts and before any
+code imports `deepeval`, such as `DEEPEVAL_DISABLE_DOTENV=1` to skip DeepEval
+dotenv autoloading and `DEEPEVAL_TELEMETRY_OPT_OUT=1` to opt out of telemetry.
+:::
+
 ```bash
 deepeval test --help
 deepeval test run --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,17 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/confident-ai/deepeval"
 documentation = "https://deepeval.com"
+packages = [
+    { include = "deepeval" },
+    { include = "deepeval_pytest_plugin" },
+]
 exclude = ["tests/*", "scripts/*", "typescript/*"]
 
 [tool.poetry.scripts]
 deepeval = 'deepeval.cli.main:app'
 
 [tool.poetry.plugins."pytest11"]
-deepeval = "deepeval.plugins.plugin"
+deepeval = "deepeval_pytest_plugin.plugin"
 
 [tool.poetry.dependencies]
 python = ">=3.9, <4.0"

--- a/tests/test_core/test_cli/test_cli.py
+++ b/tests/test_core/test_cli/test_cli.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
+import os
 import json
 import re
 import pytest
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Tuple
+from types import SimpleNamespace
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple
 from typer.testing import CliRunner
 from dataclasses import dataclass
 
+import deepeval.cli.test.command as test_cli_command
 import deepeval.cli.generate.command as generate_cli
 from deepeval.cli.main import app as cli_app
 from deepeval.cli.utils import USE_EMBED_KEYS, USE_LLM_KEYS
@@ -167,6 +171,101 @@ def test_settings_set_coerces_and_persists_dotenv(
     assert "No changes to save" in out2
     assert _count_key_occurrences(env_path, "LOG_LEVEL") == 1
     assert _count_key_occurrences(env_path, "TEMPERATURE") == 1
+
+
+@pytest.mark.parametrize(
+    ("previous_deepeval", "pytest_retcode"),
+    [
+        ("preexisting", 0),
+        (None, 1),
+    ],
+)
+def test_test_run_restores_deepeval_env_after_in_process_pytest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    previous_deepeval: Optional[str],
+    pytest_retcode: int,
+) -> None:
+    test_file = tmp_path / "test_eval.py"
+    test_file.write_text("def test_eval():\n    assert True\n")
+    if previous_deepeval is None:
+        monkeypatch.delenv("DEEPEVAL", raising=False)
+    else:
+        monkeypatch.setenv("DEEPEVAL", previous_deepeval)
+
+    seen_pytest_args: list[list[str]] = []
+
+    def fake_pytest_main(args):
+        seen_pytest_args.append(args)
+        assert os.environ["DEEPEVAL"] == "1"
+        return pytest_retcode
+
+    monkeypatch.setattr(test_cli_command.pytest, "main", fake_pytest_main)
+    monkeypatch.setattr(
+        test_cli_command,
+        "capture_evaluation_run",
+        lambda feature: nullcontext(),
+    )
+    monkeypatch.setattr(
+        test_cli_command.global_test_run_manager, "reset", lambda: None
+    )
+    monkeypatch.setattr(
+        test_cli_command.global_test_run_manager,
+        "wrap_up_test_run",
+        lambda run_duration, save, display: None,
+    )
+    monkeypatch.setattr(
+        test_cli_command, "invoke_test_run_end_hook", lambda: None
+    )
+
+    def run_test_command():
+        return test_cli_command.run(
+            ctx=SimpleNamespace(args=[]),
+            test_file_or_directory=str(test_file),
+            color="yes",
+            durations=10,
+            pdb=False,
+            exit_on_first_failure=False,
+            show_warnings=False,
+            identifier="run-id",
+            num_processes=None,
+            repeat=None,
+            use_cache=False,
+            ignore_errors=False,
+            skip_on_missing_params=False,
+            verbose=False,
+            display=test_cli_command.TestRunResultDisplay.ALL.value,
+            mark=None,
+            official=False,
+        )
+
+    if pytest_retcode == 0:
+        assert run_test_command() == 0
+    else:
+        with pytest.raises(SystemExit) as exc_info:
+            run_test_command()
+        assert exc_info.value.code == pytest_retcode
+
+    if previous_deepeval is None:
+        assert "DEEPEVAL" not in os.environ
+    else:
+        assert os.environ["DEEPEVAL"] == previous_deepeval
+    assert seen_pytest_args == [
+        [
+            str(test_file),
+            "--quiet",
+            "--color=yes",
+            "--durations=10",
+            "-s",
+            "--disable-warnings",
+            "--identifier",
+            "run-id",
+            "-p",
+            "no:deepeval",
+            "-p",
+            "deepeval_pytest_plugin.plugin",
+        ]
+    ]
 
 
 def test_settings_unset_removes_key_from_dotenv(

--- a/tests/test_core/test_plugins/test_plugin.py
+++ b/tests/test_core/test_plugins/test_plugin.py
@@ -1,0 +1,497 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
+import pytest
+
+from deepeval_pytest_plugin import plugin
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_PLAIN_PYTEST_ENV_KEYS = (
+    "CONFIDENT_AI_RUN_TEST_NAME",
+    "DEEPEVAL",
+    "DEEPEVAL_DISABLE_DOTENV",
+    "DEEPEVAL_TELEMETRY_OPT_OUT",
+    "DEEPEVAL_UPDATE_WARNING_OPT_IN",
+    "ERROR_REPORTING",
+    "PYTEST_ADDOPTS",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+)
+
+
+class _SkippedReport:
+    skipped = True
+    nodeid = "test_sample.py::test_skipped"
+    longreprtext = "Skipped: explicit reason"
+
+
+class _TerminalReporter:
+    def __init__(self):
+        self.requested_report_names = []
+
+    def getreports(self, name):
+        self.requested_report_names.append(name)
+        return [_SkippedReport()]
+
+
+class _Parser:
+    def __init__(self):
+        self.options = []
+
+    def addoption(self, *args, **kwargs):
+        self.options.append((args, kwargs))
+
+
+def _run_hookwrapper(generator):
+    next(generator)
+    with pytest.raises(StopIteration):
+        next(generator)
+
+
+def _plain_pytest_env() -> dict:
+    env = os.environ.copy()
+    for key in _PLAIN_PYTEST_ENV_KEYS:
+        env.pop(key, None)
+    return env
+
+
+def test_package_metadata_uses_import_safe_pytest_plugin():
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    poetry_config = pyproject["tool"]["poetry"]
+
+    assert {"include": "deepeval_pytest_plugin"} in poetry_config["packages"]
+    assert (
+        poetry_config["plugins"]["pytest11"]["deepeval"]
+        == "deepeval_pytest_plugin.plugin"
+    )
+
+
+def test_legacy_plugin_module_reexports_constants():
+    from deepeval.plugins import plugin as legacy_plugin
+
+    assert legacy_plugin.PYTEST_RUN_TEST_NAME == plugin.PYTEST_RUN_TEST_NAME
+    assert (
+        legacy_plugin.PYTEST_TRACE_TEST_WRAPPER_SPAN_NAME
+        == plugin.PYTEST_TRACE_TEST_WRAPPER_SPAN_NAME
+    )
+    assert legacy_plugin.pytest_configure is plugin.pytest_configure
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("0", False),
+        ("false", False),
+        ("off", False),
+        ("disabled", False),
+        ("unknown", False),
+        ("1", True),
+        ("true", True),
+        (" YES ", True),
+        ('"enabled"', True),
+    ],
+)
+def test_is_running_deepeval_uses_env_bool_semantics(
+    monkeypatch, value, expected
+):
+    if value is None:
+        monkeypatch.delenv("DEEPEVAL", raising=False)
+    else:
+        monkeypatch.setenv("DEEPEVAL", value)
+
+    assert plugin.get_is_running_deepeval() is expected
+
+
+def test_import_safe_pytest_plugin_does_not_import_deepeval():
+    env = _plain_pytest_env()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(REPO_ROOT), env.get("PYTHONPATH")])
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys\n"
+                "import deepeval_pytest_plugin.plugin\n"
+                "assert 'deepeval' not in sys.modules\n"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_addoption_is_gated_to_deepeval_runs(monkeypatch):
+    parser = _Parser()
+    monkeypatch.delenv("DEEPEVAL", raising=False)
+
+    plugin.pytest_addoption(parser)
+
+    assert parser.options == []
+
+    monkeypatch.setenv("DEEPEVAL", "1")
+    plugin.pytest_addoption(parser)
+
+    assert parser.options == [
+        (
+            ("--identifier",),
+            {
+                "action": "store",
+                "default": None,
+                "help": "Custom identifier for the test run",
+            },
+        )
+    ]
+
+
+def test_configure_clears_stale_name_outside_deepeval_run(monkeypatch):
+    monkeypatch.delenv("DEEPEVAL", raising=False)
+    monkeypatch.setenv(
+        plugin.PYTEST_RUN_TEST_NAME, "stale-from-prior-deepeval-run"
+    )
+
+    plugin.pytest_configure(config=SimpleNamespace())
+
+    assert os.environ.get(plugin.PYTEST_RUN_TEST_NAME) is None
+
+
+def test_installed_pytest_entrypoint_autoloads_import_safe_plugin(tmp_path):
+    installed_site = tmp_path / "site-packages"
+    dist_info = installed_site / "deepeval-0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: deepeval\nVersion: 0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "entry_points.txt").write_text(
+        "[pytest11]\ndeepeval=deepeval_pytest_plugin.plugin\n",
+        encoding="utf-8",
+    )
+
+    run_dir = tmp_path / "installed-autoload-run"
+    run_dir.mkdir()
+    (run_dir / "conftest.py").write_text(
+        "import os\n\n"
+        "def pytest_configure(config):\n"
+        "    assert os.environ.get('CONFIDENT_AI_RUN_TEST_NAME') is None\n",
+        encoding="utf-8",
+    )
+    test_file = run_dir / "test_plain_autoload.py"
+    test_file.write_text(
+        "import importlib.metadata as metadata\n"
+        "import os\n"
+        "from pathlib import Path\n"
+        "import sys\n\n"
+        "def _entry_points(group):\n"
+        "    entry_points = metadata.entry_points()\n"
+        "    if hasattr(entry_points, 'select'):\n"
+        "        return list(entry_points.select(group=group))\n"
+        "    return list(entry_points.get(group, []))\n\n"
+        "def test_plain_autoload():\n"
+        "    values = [\n"
+        "        (entry_point.name, entry_point.value)\n"
+        "        for entry_point in _entry_points('pytest11')\n"
+        "        if entry_point.name == 'deepeval'\n"
+        "    ]\n"
+        "    assert ('deepeval', 'deepeval_pytest_plugin.plugin') in values\n"
+        "    assert 'deepeval' not in sys.modules\n"
+        "    assert os.environ.get('DEEPEVAL_PLUGIN_SENTINEL') is None\n"
+        "    assert os.environ.get('CONFIDENT_AI_RUN_TEST_NAME') is None\n"
+        "    assert not Path('.deepeval').exists()\n",
+        encoding="utf-8",
+    )
+    (run_dir / ".env").write_text(
+        "DEEPEVAL_PLUGIN_SENTINEL=loaded\n", encoding="utf-8"
+    )
+
+    env = _plain_pytest_env()
+    env["DEEPEVAL"] = "false"
+    env["CONFIDENT_AI_RUN_TEST_NAME"] = "stale-from-prior-run"
+    env["PYTHONPATH"] = os.pathsep.join([str(installed_site), str(REPO_ROOT)])
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(test_file), "-q"],
+        cwd=run_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Running teardown with pytest sessionfinish..." not in result.stdout
+    assert "was skipped. Reason:" not in result.stdout
+
+
+def test_explicit_plugin_load_blocks_installed_entrypoint_duplicate(tmp_path):
+    installed_site = tmp_path / "site-packages"
+    dist_info = installed_site / "deepeval-0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: deepeval\nVersion: 0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "entry_points.txt").write_text(
+        "[pytest11]\ndeepeval=deepeval_pytest_plugin.plugin\n",
+        encoding="utf-8",
+    )
+
+    run_dir = tmp_path / "explicit-plugin-run"
+    run_dir.mkdir()
+    test_file = run_dir / "test_plain.py"
+    test_file.write_text(
+        "def test_plain():\n    assert True\n", encoding="utf-8"
+    )
+
+    env = _plain_pytest_env()
+    env["PYTHONPATH"] = os.pathsep.join([str(installed_site), str(REPO_ROOT)])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:deepeval",
+            "-p",
+            "deepeval_pytest_plugin.plugin",
+            str(test_file),
+            "-q",
+        ],
+        cwd=run_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "Plugin already registered" not in output
+
+
+def test_sessionstart_creates_test_run_during_deepeval_run(monkeypatch):
+    monkeypatch.setenv("DEEPEVAL", "1")
+    from deepeval.test_run import global_test_run_manager
+
+    calls = []
+
+    def create_test_run(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        global_test_run_manager, "save_to_disk", False, raising=False
+    )
+    monkeypatch.setattr(
+        global_test_run_manager, "create_test_run", create_test_run
+    )
+    options = {
+        "identifier": "custom-run",
+        "file_or_dir": ["tests/evals/test_example.py"],
+    }
+    session = SimpleNamespace(
+        config=SimpleNamespace(
+            getoption=lambda name, default=None: options.get(name, default)
+        )
+    )
+
+    plugin.pytest_sessionstart(session)
+
+    assert global_test_run_manager.save_to_disk is True
+    assert calls == [
+        {
+            "identifier": "custom-run",
+            "file_name": "tests/evals/test_example.py",
+        }
+    ]
+
+
+def test_sessionstart_clears_stale_name_outside_deepeval_run(monkeypatch):
+    monkeypatch.delenv("DEEPEVAL", raising=False)
+    monkeypatch.setenv(
+        plugin.PYTEST_RUN_TEST_NAME, "stale-from-prior-deepeval-run"
+    )
+
+    plugin.pytest_sessionstart(session=SimpleNamespace())
+
+    assert os.environ.get(plugin.PYTEST_RUN_TEST_NAME) is None
+
+
+def test_runtest_protocol_clears_stale_name_outside_deepeval_run(monkeypatch):
+    monkeypatch.delenv("DEEPEVAL", raising=False)
+    monkeypatch.setenv(
+        plugin.PYTEST_RUN_TEST_NAME, "stale-from-prior-deepeval-run"
+    )
+
+    result = plugin.pytest_runtest_protocol(
+        item=SimpleNamespace(nodeid="test_plain.py::test_plain"),
+        nextitem=None,
+    )
+
+    assert result is None
+    assert os.environ.get(plugin.PYTEST_RUN_TEST_NAME) is None
+
+
+def test_runtest_protocol_sets_name_during_deepeval_run(monkeypatch):
+    monkeypatch.setenv("DEEPEVAL", "1")
+
+    result = plugin.pytest_runtest_protocol(
+        item=SimpleNamespace(nodeid="test_eval.py::TestEval::test_metric"),
+        nextitem=None,
+    )
+
+    assert result is None
+    assert os.environ[plugin.PYTEST_RUN_TEST_NAME] == "test_metric"
+
+
+def test_runtest_call_restores_eval_session_when_test_errors(monkeypatch):
+    monkeypatch.setenv("DEEPEVAL", "1")
+    from deepeval.tracing.tracing import trace_manager
+    from deepeval.tracing.types import EvalMode, EvalSession
+
+    previous_session = EvalSession()
+    trace_manager.eval_session = previous_session
+
+    hook = plugin.pytest_runtest_call(SimpleNamespace())
+    next(hook)
+    assert trace_manager.eval_session.mode == EvalMode.EVALUATE
+
+    with pytest.raises(RuntimeError):
+        hook.throw(RuntimeError("test body failed"))
+
+    assert trace_manager.eval_session is previous_session
+
+
+def test_sessionfinish_is_quiet_outside_deepeval_run(monkeypatch, capsys):
+    monkeypatch.delenv("DEEPEVAL", raising=False)
+
+    _run_hookwrapper(
+        plugin.pytest_sessionfinish(
+            session=SimpleNamespace(),
+            exitstatus=0,
+        )
+    )
+
+    assert capsys.readouterr().out == ""
+
+
+def test_sessionfinish_prints_during_deepeval_run(monkeypatch, capsys):
+    monkeypatch.setenv("DEEPEVAL", "1")
+    monkeypatch.setenv(plugin.PYTEST_RUN_TEST_NAME, "test_metric")
+
+    _run_hookwrapper(
+        plugin.pytest_sessionfinish(
+            session=SimpleNamespace(),
+            exitstatus=0,
+        )
+    )
+
+    assert (
+        capsys.readouterr().out
+        == "Running teardown with pytest sessionfinish...\n"
+    )
+    assert os.environ.get(plugin.PYTEST_RUN_TEST_NAME) is None
+
+
+def test_terminal_summary_is_quiet_outside_deepeval_run(monkeypatch, capsys):
+    monkeypatch.delenv("DEEPEVAL", raising=False)
+    reporter = _TerminalReporter()
+
+    plugin.pytest_terminal_summary(
+        terminalreporter=reporter,
+        exitstatus=0,
+        config=SimpleNamespace(),
+    )
+
+    assert reporter.requested_report_names == []
+    assert capsys.readouterr().out == ""
+
+
+def test_terminal_summary_prints_skips_during_deepeval_run(monkeypatch, capsys):
+    monkeypatch.setenv("DEEPEVAL", "1")
+    reporter = _TerminalReporter()
+
+    plugin.pytest_terminal_summary(
+        terminalreporter=reporter,
+        exitstatus=0,
+        config=SimpleNamespace(),
+    )
+
+    assert reporter.requested_report_names == ["skipped"]
+    assert (
+        capsys.readouterr().out
+        == "Test test_sample.py::test_skipped was skipped. Reason: Skipped: explicit reason\n"
+    )
+
+
+def test_public_pytest_plugin_is_quiet_in_plain_pytest_run(tmp_path):
+    run_dir = tmp_path / "plain-run"
+    run_dir.mkdir()
+    test_file = run_dir / "test_plain_pytest.py"
+    test_file.write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "import pytest\n\n"
+        "import sys\n\n"
+        "def test_plain_skip():\n"
+        "    assert 'deepeval' not in sys.modules\n"
+        "    assert os.environ.get('DEEPEVAL_PLUGIN_SENTINEL') is None\n"
+        "    assert os.environ.get('CONFIDENT_AI_RUN_TEST_NAME') is None\n"
+        "    assert not Path('.deepeval').exists()\n"
+        "    pytest.skip('plain pytest skip')\n",
+        encoding="utf-8",
+    )
+    (run_dir / ".env").write_text(
+        "DEEPEVAL_PLUGIN_SENTINEL=loaded\n", encoding="utf-8"
+    )
+
+    env = _plain_pytest_env()
+    env["CONFIDENT_AI_RUN_TEST_NAME"] = "stale-from-prior-run"
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(REPO_ROOT), env.get("PYTHONPATH")])
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "deepeval_pytest_plugin.plugin",
+            str(test_file),
+            "-q",
+        ],
+        cwd=run_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Running teardown with pytest sessionfinish..." not in result.stdout
+    assert "was skipped. Reason:" not in result.stdout

--- a/tests/test_core/test_telemetry.py
+++ b/tests/test_core/test_telemetry.py
@@ -1,10 +1,12 @@
 import os
-import pytest
+from pathlib import Path
+import subprocess
+import sys
 import shutil
 
-import deepeval.telemetry as telemetry_mod
+import pytest
 
-from pathlib import Path
+import deepeval.telemetry as telemetry_mod
 
 
 def _no_hidden_store_dir(base: Path):
@@ -26,3 +28,37 @@ def test_telemetry_writes_create_dir_when_missing(tmp_path, monkeypatch):
     uid = telemetry_mod.get_unique_id()
     assert isinstance(uid, str) and len(uid) > 0
     assert os.path.exists(".deepeval/.deepeval_telemetry.txt")
+
+
+def test_telemetry_opt_out_skips_error_reporting_firewall_probe():
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["DEEPEVAL_DISABLE_DOTENV"] = "1"
+    env["DEEPEVAL_TELEMETRY_OPT_OUT"] = "1"
+    env["DEEPEVAL_UPDATE_WARNING_OPT_IN"] = "0"
+    env["ERROR_REPORTING"] = "1"
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(repo_root), env.get("PYTHONPATH")])
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import socket\n"
+                "def fail_if_socket_opened(*args, **kwargs):\n"
+                "    raise AssertionError('telemetry opt-out should not open sockets')\n"
+                "socket.create_connection = fail_if_socket_opened\n"
+                "import deepeval.telemetry\n"
+            ),
+        ],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

DeepEval's pytest plugin is auto-loaded in any pytest environment where the package is installed. The previous pytest entry point lived under `deepeval.plugins.plugin`, which meant plain pytest startup imported the main `deepeval` package before hook-level runtime guards could prevent dotenv, telemetry, or local state side effects.

This PR moves the pytest entry point to a tiny import-safe package and lazily imports DeepEval internals only after `DEEPEVAL` runtime state is active. It also keeps ordinary pytest sessions quiet by gating DeepEval-specific teardown output, skipped-test summary output, and the per-test environment marker behind that same runtime state.

## Changes

- Register the pytest plugin as `deepeval_pytest_plugin.plugin` so pytest auto-load does not import the main `deepeval` package.
- Add an import-safe pytest plugin module with a lightweight `DEEPEVAL` env gate and lazy DeepEval imports for active DeepEval runs.
- Keep the old `deepeval.plugins.plugin` module forwarding the hook names and constants for direct imports, while pytest auto-load no longer uses that side-effectful package path.
- Gate the pytest teardown message, skipped-test terminal summary, generic `--identifier` pytest option, and `CONFIDENT_AI_RUN_TEST_NAME` marker so they do not affect plain pytest runs.
- Clear a stale `CONFIDENT_AI_RUN_TEST_NAME` value during import/configure, plain pytest session start, per-test execution, and session finish paths.
- Run `deepeval test run` through the import-safe pytest plugin module after blocking the installed `deepeval` entry point name, and restore the previous `DEEPEVAL` environment value afterward so in-process pytest callers do not inherit active DeepEval runtime state.
- Check telemetry opt-out before the import-time error-reporting firewall probe.
- Document the pytest plugin name, disable command, and process-level pytest environment flags in the CLI docs.
- Add regression tests for package metadata, the installed pytest entry point, import-safe auto-load behavior, plain pytest behavior, telemetry opt-out ordering, and preserved DeepEval-run hook behavior.
- Add a narrow `.gitattributes` whitespace rule for `deepeval/telemetry.py`, which is stored with CRLF in `main`, so the two-line telemetry condition reorder remains reviewable without whole-file line-ending churn.

## Why this matters

Users who install DeepEval should be able to run unrelated pytest suites without importing DeepEval, loading local dotenv values, creating DeepEval state, keeping stale DeepEval test-name env markers, or seeing DeepEval-specific stdout. This addresses the observable pytest-plugin side effects discussed in #1419 while preserving current behavior for `deepeval test run`.

The telemetry ordering fix also keeps the restricted-environment guidance honest: when telemetry is opted out, the import-time error-reporting path no longer performs the firewall probe.

## Tests

Commands run:

- `.venv/bin/python -m pytest tests/test_core/test_plugins/test_plugin.py -q` — passed, 26 tests.
- `.venv/bin/python -m pytest tests/test_core/test_plugins/test_plugin.py tests/test_core/test_telemetry.py tests/test_core/test_imports.py tests/test_core/test_cli/test_cli.py -q` — passed, 75 tests.
- `.venv/bin/python -m py_compile deepeval/cli/test/command.py deepeval/plugins/plugin.py deepeval_pytest_plugin/plugin.py deepeval_pytest_plugin/__init__.py deepeval/telemetry.py tests/test_core/test_plugins/test_plugin.py tests/test_core/test_telemetry.py tests/test_core/test_cli/test_cli.py` — passed.
- `.venv/bin/black --check deepeval/cli/test/command.py deepeval/plugins/plugin.py deepeval_pytest_plugin/plugin.py deepeval_pytest_plugin/__init__.py deepeval/telemetry.py tests/test_core/test_plugins/test_plugin.py tests/test_core/test_telemetry.py tests/test_core/test_cli/test_cli.py` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `.venv/bin/python - <<'PY' ... build_wheel temp metadata smoke ... PY` — passed; built wheel contains `deepeval_pytest_plugin` files and `pytest11` maps `deepeval` to `deepeval_pytest_plugin.plugin`.
- Manual docs review of `docs/content/docs/command-line-interface.mdx` — completed.

Not run:

- Full repository pytest suite — not run locally because this is a focused pytest plugin/telemetry change and the nearby plugin/import/CLI coverage passed.
- Repository-wide Black check — not run locally; earlier campaign verification found unrelated repo-wide Black failures outside this PR scope.

## Risk

Risk level: medium

The main compatibility risk is packaging-level: the pytest entry point now targets a new import-safe top-level package. The old `deepeval.plugins.plugin` module remains importable for direct imports, but like any `deepeval.*` submodule it still executes `deepeval/__init__.py`; the import-safety guarantee applies to pytest's installed entry point, not to direct imports under the main package.

The runtime behavior for active DeepEval runs is preserved through the same hooks, option name, test run setup, trace wrapper, teardown output, and skipped-test summary.

Rollback is straightforward: point the pytest11 entry point back to `deepeval.plugins.plugin`, remove the import-safe package, restore the previous telemetry condition order, and remove the focused regression/docs additions.

## Issue

Related to #1419.

## Notes for maintainers

This PR intentionally does not remove the pytest plugin. Active DeepEval-run behavior is preserved; the only CLI behavior changes are that `deepeval test run` now blocks duplicate loading of the installed `deepeval` entry point before invoking the import-safe plugin module directly, and restores the prior `DEEPEVAL` env value after completion for in-process callers. It narrows plain-pytest side effects by making plugin auto-load import-safe and by keeping DeepEval-specific hook behavior behind the existing `DEEPEVAL` runtime gate.

Direct imports from `deepeval.*` remain outside this PR's import-safety scope because Python executes the parent `deepeval/__init__.py` before loading any submodule. If validating this branch from an existing editable install, rerun the editable install (for example, `pip install -e .`) or install the rebuilt wheel first so pytest sees the updated `pytest11` entry point rather than stale installed metadata.
