### PR TITLE
fix: redundant version notation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Let's pretend your LLM application is a RAG based customer support chatbot; here
 
 ## Installation
 
-Deepeval works with **Python>=3.9+**.
+Deepeval works with **Python 3.9+**.
 
 ```
 pip install -U deepeval


### PR DESCRIPTION
## Summary
The installation section of the README says "Python>=3.9+" which mixes two different notations for the same thing (`>=3.9` and `3.9+` both mean "3.9 or higher"). The standard way to write this is `Python 3.9+`.

## How to reproduce
Open README.md and look at the Installation section — line reads: `Deepeval works with **Python>=3.9+**.`

## Test plan
Verify the updated line reads `Deepeval works with **Python 3.9+**.` and matches the convention used elsewhere in the ecosystem.