### PR TITLE
feat(benchmarks): add batch evaluation support to the GSM8K benchmark

### DIFF
--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -9,6 +9,7 @@ from deepeval.benchmarks.base_benchmark import (
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.gsm8k.template import GSM8KTemplate
 from deepeval.benchmarks.schema import NumberSchema
+from deepeval.benchmarks.utils import should_use_batch
 from deepeval.telemetry import capture_benchmark_run
 
 
@@ -43,7 +44,11 @@ class GSM8K(DeepEvalBaseBenchmark):
             self.confinement_instructions = confinement_instructions
 
     def evaluate(
-        self, model: DeepEvalBaseLLM, *args, **kwargs
+        self,
+        model: DeepEvalBaseLLM,
+        *args,
+        batch_size: Union[int, None] = None,
+        **kwargs,
     ) -> DeepEvalBaseBenchmarkResult:
         import pandas as pd
 
@@ -51,29 +56,59 @@ class GSM8K(DeepEvalBaseBenchmark):
             overall_correct_predictions = 0
             overall_total_predictions = self.n_problems
             predictions_row = []
+            use_batch = should_use_batch(model, batch_size)
 
             # Solving each problem
             goldens = self.load_benchmark_dataset()[: self.n_problems]
-            for idx, golden in enumerate(
-                tqdm(goldens, desc=f"Processing {self.n_problems} problems")
-            ):
-                result = self.predict(model, golden)
-                prediction = result["prediction"]
-                score = result["score"]
 
-                if score:
-                    overall_correct_predictions += 1
-                predictions_row.append(
-                    (golden.input, prediction, golden.expected_output, score)
-                )
-                if self.verbose_mode:
-                    self.print_verbose_logs(
-                        idx,
-                        golden.input,
-                        golden.expected_output,
-                        prediction,
-                        score,
+            if use_batch:
+                for i in tqdm(
+                    range(0, len(goldens), batch_size),
+                    desc=f"Batch Processing {self.n_problems} problems (batch_size={batch_size})",
+                ):
+                    goldens_batch = goldens[i : i + batch_size]
+                    batch_predictions = self.batch_predict(model, goldens_batch)
+                    for golden, prediction_dict in zip(
+                        goldens_batch, batch_predictions
+                    ):
+                        prediction = prediction_dict["prediction"]
+                        score = prediction_dict["score"]
+                        if score:
+                            overall_correct_predictions += 1
+                        predictions_row.append(
+                            (
+                                golden.input,
+                                prediction,
+                                golden.expected_output,
+                                score,
+                            )
+                        )
+            else:
+                for idx, golden in enumerate(
+                    tqdm(goldens, desc=f"Processing {self.n_problems} problems")
+                ):
+                    result = self.predict(model, golden)
+                    prediction = result["prediction"]
+                    score = result["score"]
+
+                    if score:
+                        overall_correct_predictions += 1
+                    predictions_row.append(
+                        (
+                            golden.input,
+                            prediction,
+                            golden.expected_output,
+                            score,
+                        )
                     )
+                    if self.verbose_mode:
+                        self.print_verbose_logs(
+                            idx,
+                            golden.input,
+                            golden.expected_output,
+                            prediction,
+                            score,
+                        )
 
             # Calculate overall accuracy
             overall_accuracy = (
@@ -126,6 +161,58 @@ class GSM8K(DeepEvalBaseBenchmark):
         )
 
         return {"prediction": prediction, "score": score}
+
+    def batch_predict(
+        self, model: DeepEvalBaseLLM, goldens: List[Golden]
+    ) -> List[Dict]:
+        assert (
+            self.shots_dataset != None
+        ), "Example dataset is empty. Call load_benchmark."
+
+        prompts = []
+        for golden in goldens:
+            prompt = GSM8KTemplate.generate_output(
+                train_set=self.shots_dataset,
+                input=golden.input,
+                n_shots=self.n_shots,
+                enable_cot=self.enable_cot,
+            )
+            prompts.append(prompt)
+
+        try:
+            responses = model.batch_generate(
+                prompts=prompts, schemas=[NumberSchema for _ in prompts]
+            )
+            if not isinstance(responses, list):
+                raise TypeError(
+                    "batch_generate must return a list of responses"
+                )
+            predictions = [
+                self._extract_prediction_from_response(res) for res in responses
+            ]
+        except (TypeError, AttributeError):
+            prompts = [
+                prompt + f"\n\n{self.confinement_instructions}"
+                for prompt in prompts
+            ]
+            responses = model.batch_generate(prompts)
+            predictions = [
+                self._extract_prediction_from_response(res) for res in responses
+            ]
+
+        if len(predictions) != len(goldens):
+            raise ValueError(
+                "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
+            )
+
+        res = []
+        for prediction, golden in zip(predictions, goldens):
+            score = self.scorer.exact_match_score(
+                golden.expected_output, prediction
+            )
+            res.append({"prediction": prediction, "score": score})
+
+        return res
 
     def _extract_prediction_from_response(self, res) -> str:
         """

--- a/tests/test_core/test_benchmarks/test_gsm8k.py
+++ b/tests/test_core/test_benchmarks/test_gsm8k.py
@@ -1,6 +1,12 @@
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+try:
+    import datasets  # noqa: F401
+except ImportError:
+    sys.modules["datasets"] = MagicMock()
 
 from deepeval.benchmarks.gsm8k.gsm8k import GSM8K
 from deepeval.benchmarks.schema import NumberSchema

--- a/tests/test_core/test_benchmarks/test_gsm8k.py
+++ b/tests/test_core/test_benchmarks/test_gsm8k.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.benchmarks.gsm8k.gsm8k import GSM8K
+from deepeval.benchmarks.schema import NumberSchema
+from deepeval.dataset import Golden
+
+
+@pytest.fixture
+def goldens():
+    return [
+        Golden(input="q1", expected_output="5"),
+        Golden(input="q2", expected_output="7"),
+    ]
+
+
+def test_gsm8k_batch_predict_batches_and_scores(goldens):
+    benchmark = GSM8K(n_shots=0)
+    benchmark.shots_dataset = []
+
+    model = MagicMock()
+    model.batch_generate.return_value = [
+        NumberSchema(answer=5),
+        NumberSchema(answer=7),
+    ]
+
+    with patch(
+        "deepeval.benchmarks.gsm8k.gsm8k.GSM8KTemplate.generate_output",
+        side_effect=lambda **kwargs: f"prompt::{kwargs['input']}",
+    ):
+        results = benchmark.batch_predict(model, goldens)
+
+    model.batch_generate.assert_called_once()
+    assert model.batch_generate.call_args.kwargs["prompts"] == [
+        "prompt::q1",
+        "prompt::q2",
+    ]
+    assert [r["prediction"] for r in results] == ["5", "7"]
+    assert all(r["score"] for r in results)
+
+
+def test_gsm8k_evaluate_routes_to_batch_when_batch_size_set(goldens):
+    benchmark = GSM8K(n_shots=0, n_problems=2)
+    model = MagicMock()
+
+    with patch(
+        "deepeval.benchmarks.gsm8k.gsm8k.capture_benchmark_run"
+    ), patch.object(
+        benchmark, "load_benchmark_dataset", return_value=goldens
+    ), patch.object(
+        benchmark,
+        "batch_predict",
+        return_value=[
+            {"prediction": "5", "score": True},
+            {"prediction": "7", "score": True},
+        ],
+    ) as mock_batch, patch.object(
+        benchmark, "predict"
+    ) as mock_predict:
+        benchmark.evaluate(model, batch_size=2)
+
+    mock_batch.assert_called_once()
+    mock_predict.assert_not_called()
+    assert benchmark.overall_score == 1.0


### PR DESCRIPTION
## Summary

`GSM8K.evaluate` processes problems one at a time by calling `predict` for each golden, so a model that implements `batch_generate` cannot benefit from batched inference the way MMLU, DROP, HellaSwag, TruthfulQA and the other batch-enabled benchmarks already do.

This adds `batch_size` support to `GSM8K`, mirroring that existing pattern. `evaluate` now accepts a `batch_size`, uses `should_use_batch` to decide whether to batch, and a new `batch_predict` builds the prompts for a batch and calls `model.batch_generate` once. When `batch_size` is not passed, or the model does not implement `batch_generate`, the behavior is unchanged and it keeps using the per-item `predict` path.

## Tests

`tests/test_core/test_benchmarks/test_gsm8k.py`:

- `test_gsm8k_batch_predict_batches_and_scores`: `batch_predict` builds one prompt per golden, calls `batch_generate` exactly once with all the prompts, and scores each response.
- `test_gsm8k_evaluate_routes_to_batch_when_batch_size_set`: with a `batch_size` and a model exposing `batch_generate`, `evaluate` routes through `batch_predict` and does not fall back to the per-item `predict`.
