### PR TITLE
fix: include metric compatibility metadata in cache reuse

### DIFF
--- a/deepeval/test_run/cache.py
+++ b/deepeval/test_run/cache.py
@@ -10,12 +10,12 @@ from deepeval.utils import make_model_config
 
 from deepeval.test_case import SingleTurnParams, LLMTestCase, ToolCallParams
 from deepeval.test_run.api import MetricData
+from deepeval.test_run.cache_identity import CacheIdentity
 from deepeval.utils import (
     delete_file_if_exists,
     is_read_only_env,
     serialize,
 )
-from deepeval.metrics import BaseMetric
 from deepeval.constants import HIDDEN_DIR
 
 logger = logging.getLogger(__name__)
@@ -39,20 +39,24 @@ class MetricConfiguration(BaseModel):
     model_config = make_model_config(arbitrary_types_allowed=True)
 
     ##### Required fields #####
-    threshold: float
+    threshold: Union[float, str]
     evaluation_model: Optional[str] = None
-    strict_mode: bool = False
+    strict_mode: Union[bool, str] = False
     criteria: Optional[str] = None
-    include_reason: Optional[bool] = None
-    n: Optional[int] = None
+    include_reason: Optional[Union[bool, str]] = None
+    n: Optional[Union[int, str]] = None
 
     ##### Optional fields #####
-    evaluation_steps: Optional[List[str]] = None
-    assessment_questions: Optional[List[str]] = None
+    language: Optional[str] = None
+    evaluation_steps: Optional[Union[List[str], str]] = None
+    assessment_questions: Optional[Union[List[str], str]] = None
     embeddings: Optional[str] = None
     evaluation_params: Optional[
-        Union[List[SingleTurnParams], List[ToolCallParams]]
+        Union[List[SingleTurnParams], List[ToolCallParams], str]
     ] = None
+    # Stores constructor-parameter fingerprints/sentinels for cache compatibility.
+    # This field intentionally never contains raw constructor values.
+    custom_parameters: Optional[Dict[str, str]] = None
 
 
 class CachedMetricData(BaseModel):
@@ -310,95 +314,8 @@ global_test_run_cache_manager = TestRunCacheManager()
 ############ Helper Functions #############
 
 
-class Cache:
-    @staticmethod
-    def get_metric_data(
-        metric: BaseMetric, cached_test_case: Optional[CachedTestCase]
-    ) -> Optional[CachedMetricData]:
-        if not cached_test_case:
-            return None
-        for cached_metric_data in cached_test_case.cached_metrics_data:
-            if (
-                cached_metric_data.metric_data.name == metric.__name__
-                and Cache.same_metric_configs(
-                    metric,
-                    cached_metric_data.metric_configuration,
-                )
-            ):
-                return cached_metric_data
-        return None
+CacheIdentity._METRIC_CONFIGURATION_CLASS = MetricConfiguration
 
-    @staticmethod
-    def same_metric_configs(
-        metric: BaseMetric,
-        metric_configuration: MetricConfiguration,
-    ) -> bool:
-        config_fields = [
-            "threshold",
-            "evaluation_model",
-            "strict_mode",
-            "include_reason",
-            "n",
-            "language",
-            "embeddings",
-            "evaluation_params",
-            "assessment_questions",
-            "evaluation_steps",
-        ]
 
-        for field in config_fields:
-            metric_value = getattr(metric, field, None)
-            cached_value = getattr(metric_configuration, field, None)
-
-            # TODO: Refactor. This won't work well with custom metrics
-            if field == "evaluation_steps":
-                if metric_value is not None:
-                    if metric_value == cached_value:
-                        continue
-                else:
-                    try:
-                        # For GEval only
-                        if metric.criteria is not None:
-                            criteria_value = getattr(metric, "criteria", None)
-                            cached_criteria_value = getattr(
-                                metric_configuration, "criteria", None
-                            )
-                            if criteria_value != cached_criteria_value:
-                                return False
-                            continue
-                    except Exception:
-                        # For non-GEval
-                        continue
-
-            if field == "embeddings" and metric_value is not None:
-                metric_value = metric_value.__class__.__name__
-
-            if metric_value != cached_value:
-                return False
-
-        return True
-
-    @staticmethod
-    def create_metric_configuration(metric: BaseMetric) -> MetricConfiguration:
-        config_kwargs = {}
-        config_fields = [
-            "threshold",
-            "evaluation_model",
-            "strict_mode",
-            "include_reason",  # checked
-            "n",  # checked
-            "criteria",  # checked
-            "language",  # can't check
-            "embeddings",  #
-            "strict_mode",  # checked
-            "evaluation_steps",  # checked
-            "evaluation_params",  # checked
-            "assessment_questions",  # checked
-        ]
-        for field in config_fields:
-            value = getattr(metric, field, None)
-            if field == "embeddings" and value is not None:
-                value = value.__class__.__name__
-            config_kwargs[field] = value
-
-        return MetricConfiguration(**config_kwargs)
+class Cache(CacheIdentity):
+    pass

--- a/deepeval/test_run/cache_identity.py
+++ b/deepeval/test_run/cache_identity.py
@@ -1,0 +1,1920 @@
+import hashlib
+import inspect
+import json
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Dict, List, Optional, get_args, get_origin
+from urllib.parse import parse_qsl, unquote, unquote_plus, urlsplit
+
+from pydantic import BaseModel
+
+from deepeval.metrics import BaseConversationalMetric, BaseMetric
+
+try:
+    from pydantic.v1 import BaseModel as LegacyBaseModel
+except ImportError:
+    LegacyBaseModel = None
+
+
+class CacheIdentity:
+    _MISSING_ATTRIBUTE = object()
+    _UNSAFE_ATTRIBUTE = object()
+    _METRIC_CONFIGURATION_CLASS: Any = None
+    _CONFIG_FIELDS = [
+        "threshold",
+        "evaluation_model",
+        "strict_mode",
+        "criteria",
+        "include_reason",
+        "n",
+        "language",
+        "embeddings",
+        "evaluation_params",
+        "assessment_questions",
+        "evaluation_steps",
+    ]
+    _CREATE_CONFIG_FIELDS = _CONFIG_FIELDS
+    _FREE_FORM_CONFIG_FIELDS = {
+        "criteria",
+        "assessment_questions",
+        "evaluation_steps",
+    }
+    _FINGERPRINTED_CONFIG_FIELDS = _FREE_FORM_CONFIG_FIELDS | {
+        "embeddings",
+        "evaluation_params",
+    }
+    _CONSTRUCTOR_PARAMETER_EXCLUDE_FIELDS = set(_CREATE_CONFIG_FIELDS) | {
+        # Identity/name is already compared through MetricData.name.
+        "name",
+        # Execution/display controls do not change metric scoring semantics.
+        "async_mode",
+        "verbose_mode",
+        # Model objects are represented by evaluation_model when relevant.
+        "model",
+        "using_native_model",
+        # Runtime result fields must not affect cache compatibility.
+        "score",
+        "score_breakdown",
+        "reason",
+        "success",
+        "error",
+        "evaluation_cost",
+        "input_tokens",
+        "output_tokens",
+        "verbose_logs",
+        "skipped",
+        # Internal telemetry/display toggles do not change metric scoring.
+        "_track",
+        "_include_g_eval_suffix",
+        "_include_dag_suffix",
+    }
+    _SENSITIVE_PARAMETER_NAMES = {
+        "api_key",
+        "apikey",
+        "authorization",
+        "auth_header",
+        "auth_headers",
+        "bearer",
+        "headers",
+        "password",
+        "passwd",
+        "pwd",
+        "token",
+        "cookie",
+        "private_key",
+        "client_cert",
+        "session_id",
+        "connection_string",
+        "conn_str",
+        "dsn",
+        "database_url",
+        "broker_url",
+        "jdbc_url",
+        "redis_url",
+    }
+    _SENSITIVE_PARAMETER_PARTS = {
+        "auth",
+        "authorization",
+        "bearer",
+        "cookie",
+        "credential",
+        "credentials",
+        "signature",
+        "sig",
+        "password",
+        "secret",
+        "token",
+    }
+    _SENSITIVE_PARAMETER_SUFFIXES = (
+        "_api_key",
+        "_access_key",
+        "_access_key_id",
+        "_secret_key",
+        "_access_token",
+        "_refresh_token",
+        "_id_token",
+        "_private_key",
+        "_client_cert",
+        "_session_id",
+    )
+    _SENSITIVE_PARAMETER_COMPACT_NAMES = {
+        "apikey",
+        "accesskey",
+        "accesskeyid",
+        "secretkey",
+        "accesstoken",
+        "refreshtoken",
+        "idtoken",
+        "authtoken",
+        "sessiontoken",
+        "clientsecret",
+        "privatekey",
+        "clientcert",
+        "sessionid",
+        "connectionstring",
+        "connstr",
+        "dsn",
+        "databaseurl",
+        "brokerurl",
+        "jdbcurl",
+        "redisurl",
+        "token",
+        "secret",
+        "credential",
+        "credentials",
+        "signature",
+        "sig",
+        "password",
+        "jwt",
+        "pat",
+        "key",
+    }
+    _SENSITIVE_PARAMETER_COMPACT_SUFFIXES = tuple(
+        sorted(
+            _SENSITIVE_PARAMETER_COMPACT_NAMES - {"key"},
+            key=len,
+            reverse=True,
+        )
+    )
+    _PYDANTIC_FREE_FORM_SCHEMA_METADATA_FIELDS = (
+        "title",
+        "description",
+        "examples",
+        "json_schema_extra",
+        "discriminator",
+    )
+    _PYDANTIC_LEGACY_CONFIG_FIELDS = (
+        "allow_mutation",
+        "allow_population_by_field_name",
+        "anystr_lower",
+        "anystr_strip_whitespace",
+        "anystr_upper",
+        "arbitrary_types_allowed",
+        "extra",
+        "frozen",
+        "max_anystr_length",
+        "min_anystr_length",
+        "orm_mode",
+        "smart_union",
+        "use_enum_values",
+        "validate_all",
+        "validate_assignment",
+    )
+    _NATIVE_MODEL_CACHE_IDENTITY_FIELDS = (
+        "name",
+        "model_name",
+        "base_url",
+        "deployment_name",
+        "api_version",
+        "temperature",
+        "max_tokens",
+        "_max_tokens",
+        "generation_kwargs",
+        "kwargs",
+        "async_http_client",
+        "model_data",
+        "project",
+        "location",
+        "region",
+        "use_vertexai",
+        "model_safety_settings",
+    )
+    _KNOWN_DAG_NODE_TYPES = {
+        "deepeval.metrics.dag.nodes.VerdictNode",
+        "deepeval.metrics.dag.nodes.TaskNode",
+        "deepeval.metrics.dag.nodes.BinaryJudgementNode",
+        "deepeval.metrics.dag.nodes.NonBinaryJudgementNode",
+        "deepeval.metrics.conversational_dag.nodes.ConversationalVerdictNode",
+        "deepeval.metrics.conversational_dag.nodes.ConversationalTaskNode",
+        "deepeval.metrics.conversational_dag.nodes.ConversationalBinaryJudgementNode",
+        "deepeval.metrics.conversational_dag.nodes.ConversationalNonBinaryJudgementNode",
+    }
+    _MAX_CACHE_PARAMETER_DEPTH = 24
+    _MAX_CACHE_PARAMETER_ITEMS = 2048
+    _MAX_CACHE_PARAMETER_COLLECTION_ITEMS = 256
+    _MAX_CACHE_PARAMETER_STRING_LENGTH = 8192
+    _MAX_URL_DECODE_PASSES = 4
+    _MAX_DAG_CACHE_NODES = 512
+    _UNCACHEABLE_CACHE_VALUE = "<uncacheable>"
+
+    @staticmethod
+    def get_metric_data(metric: BaseMetric, cached_test_case: Any) -> Any:
+        if not cached_test_case:
+            return None
+        for cached_metric_data in cached_test_case.cached_metrics_data:
+            if (
+                cached_metric_data.metric_data.name == metric.__name__
+                and CacheIdentity.same_metric_configs(
+                    metric,
+                    cached_metric_data.metric_configuration,
+                )
+            ):
+                return cached_metric_data
+        return None
+
+    @staticmethod
+    def same_metric_configs(
+        metric: BaseMetric,
+        metric_configuration: Any,
+    ) -> bool:
+        for field in CacheIdentity._CONFIG_FIELDS:
+            metric_value = CacheIdentity._cache_config_field_value(
+                metric, field
+            )
+            cached_value = getattr(metric_configuration, field, None)
+
+            if (
+                metric_value == CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                or cached_value == CacheIdentity._UNCACHEABLE_CACHE_VALUE
+            ):
+                return False
+
+            # Preserve GEval's legacy criteria fallback when
+            # evaluation_steps is absent.
+            if field == "evaluation_steps":
+                if metric_value is not None:
+                    if metric_value == cached_value:
+                        continue
+                else:
+                    try:
+                        # For GEval only
+                        criteria_value = (
+                            CacheIdentity._cache_config_field_value(
+                                metric, "criteria"
+                            )
+                        )
+                        if criteria_value is not None:
+                            cached_criteria_value = getattr(
+                                metric_configuration, "criteria", None
+                            )
+                            if (
+                                criteria_value
+                                == CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                                or cached_criteria_value
+                                == CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                            ):
+                                return False
+                            if criteria_value != cached_criteria_value:
+                                return False
+                            continue
+                    except Exception:
+                        # For non-GEval
+                        continue
+
+            if metric_value != cached_value:
+                return False
+
+        constructor_parameters = CacheIdentity._constructor_parameters(metric)
+        cached_parameters = metric_configuration.custom_parameters
+        if CacheIdentity._has_uncacheable_parameter(
+            constructor_parameters
+        ) or CacheIdentity._has_uncacheable_parameter(cached_parameters):
+            return False
+
+        if constructor_parameters != cached_parameters:
+            # Older cache files do not have constructor fingerprints. Treat
+            # those entries as misses for constructor-sensitive metrics rather
+            # than reusing a potentially stale custom/built-in metric result.
+            return False
+
+        return True
+
+    @staticmethod
+    def create_metric_configuration(metric: BaseMetric) -> Any:
+        config_kwargs = {}
+        for field in CacheIdentity._CREATE_CONFIG_FIELDS:
+            config_kwargs[field] = CacheIdentity._cache_config_field_value(
+                metric, field
+            )
+
+        config_kwargs["custom_parameters"] = (
+            CacheIdentity._constructor_parameters(metric)
+        )
+
+        try:
+            return CacheIdentity._METRIC_CONFIGURATION_CLASS(**config_kwargs)
+        except Exception:
+            # Invalid or hostile config values should not abort cache writes or
+            # lookups after a metric run. Store an uncacheable configuration so
+            # comparisons miss closed instead.
+            return CacheIdentity._METRIC_CONFIGURATION_CLASS(
+                threshold=CacheIdentity._UNCACHEABLE_CACHE_VALUE,
+                custom_parameters={
+                    "__configuration__": CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                },
+            )
+
+    @staticmethod
+    def _cache_config_field_value(metric: BaseMetric, field: str) -> Any:
+        value = CacheIdentity._passive_metric_config_field_value(metric, field)
+        if value is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        if value is CacheIdentity._MISSING_ATTRIBUTE:
+            if field == "threshold":
+                return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+            return None
+        if isinstance(value, float) and not math.isfinite(value):
+            return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        if field == "threshold":
+            if type(value) in (int, float):
+                return value
+            return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        if field in ("strict_mode", "include_reason"):
+            if value is None or type(value) is bool:
+                return value
+            return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        if field == "n":
+            if value is None or type(value) is int:
+                return value
+            return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        if field == "language":
+            if value is None:
+                return None
+            if isinstance(value, str) and not (
+                CacheIdentity._is_sensitive_parameter_value(field, value)
+            ):
+                return value
+            return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        if field in CacheIdentity._FINGERPRINTED_CONFIG_FIELDS:
+            if value is None:
+                return None
+            return CacheIdentity._cache_parameter_fingerprint(field, value)
+        if field == "evaluation_model":
+            model_name = CacheIdentity._metric_model_name(metric)
+            if value is not None and not isinstance(value, str):
+                return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+            if model_name is not None and value == model_name:
+                # Derived string model identifiers are represented by
+                # custom_parameters["model"].
+                return None
+            if (
+                value is not None
+                and CacheIdentity._metric_has_non_string_model(metric)
+                and not CacheIdentity._metric_uses_native_model(metric)
+            ):
+                return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+            if (
+                value is not None
+                and CacheIdentity._is_sensitive_parameter_value(field, value)
+            ):
+                return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        return value
+
+    @staticmethod
+    def _passive_metric_config_field_value(
+        metric: BaseMetric, field: str
+    ) -> Any:
+        instance_fields = CacheIdentity._passive_instance_fields(metric)
+        if instance_fields is None:
+            return CacheIdentity._UNSAFE_ATTRIBUTE
+        if field in instance_fields:
+            return instance_fields[field]
+
+        metric_type = type(metric)
+        for cls in metric_type.__mro__:
+            class_fields = CacheIdentity._passive_class_attribute(
+                cls, "__dict__"
+            )
+            if not isinstance(class_fields, MappingProxyType):
+                continue
+            if field not in class_fields:
+                continue
+            value = class_fields[field]
+            if hasattr(type(value), "__get__"):
+                return CacheIdentity._UNSAFE_ATTRIBUTE
+            return value
+
+        return CacheIdentity._MISSING_ATTRIBUTE
+
+    @staticmethod
+    def _constructor_parameters(
+        metric: BaseMetric,
+    ) -> Optional[Dict[str, str]]:
+        if type(metric).__init__ is object.__init__:
+            return None
+
+        try:
+            signature = inspect.signature(type(metric).__init__)
+        except (TypeError, ValueError):
+            return {"__signature__": CacheIdentity._UNCACHEABLE_CACHE_VALUE}
+
+        instance_fields = CacheIdentity._passive_instance_fields(metric)
+        if instance_fields is None:
+            return CacheIdentity._uncacheable_constructor_parameters(signature)
+
+        parameters: Dict[str, str] = {}
+        for name, parameter in signature.parameters.items():
+            if name == "self":
+                continue
+            if parameter.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
+                parameters[name] = CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                continue
+            if name == "model":
+                # Model objects can share a deployment/name while differing in
+                # behavior. Only string model identifiers are safe to fingerprint;
+                # opaque model objects miss closed.
+                if name in instance_fields:
+                    value = instance_fields[name]
+                elif f"_{name}" in instance_fields:
+                    value = instance_fields[f"_{name}"]
+                else:
+                    parameters[name] = CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                    continue
+                if not isinstance(value, str):
+                    model_identity = CacheIdentity._native_model_cache_identity(
+                        value
+                    )
+                    if (
+                        CacheIdentity._metric_uses_native_model(metric)
+                        and model_identity is not None
+                    ):
+                        # Real DeepEval metrics commonly initialize a native
+                        # model object from a string/default constructor value.
+                        # Fingerprint a small passive allowlist of behavior-
+                        # relevant model fields so identical model names with
+                        # different temperature/base URL/generation kwargs do
+                        # not share stale cache entries.
+                        parameters[name] = (
+                            CacheIdentity._cache_parameter_fingerprint(
+                                name, model_identity
+                            )
+                        )
+                        continue
+                    parameters[name] = CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                    continue
+                parameters[name] = CacheIdentity._cache_parameter_fingerprint(
+                    name, value
+                )
+                continue
+            if name in CacheIdentity._CONSTRUCTOR_PARAMETER_EXCLUDE_FIELDS:
+                continue
+            if name in instance_fields:
+                value = instance_fields[name]
+            elif f"_{name}" in instance_fields:
+                value = instance_fields[f"_{name}"]
+            else:
+                parameters[name] = CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                continue
+
+            parameters[name] = CacheIdentity._cache_parameter_fingerprint(
+                name, value
+            )
+
+        return parameters or None
+
+    @staticmethod
+    def _uncacheable_constructor_parameters(
+        signature: inspect.Signature,
+    ) -> Optional[Dict[str, str]]:
+        parameters: Dict[str, str] = {}
+        for name in signature.parameters:
+            if name == "self":
+                continue
+            if name == "model":
+                parameters[name] = CacheIdentity._UNCACHEABLE_CACHE_VALUE
+                continue
+            if name in CacheIdentity._CONSTRUCTOR_PARAMETER_EXCLUDE_FIELDS:
+                continue
+            parameters[name] = CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        return parameters or None
+
+    @staticmethod
+    def _cache_parameter_fingerprint(name: str, value: Any) -> str:
+        normalized = CacheIdentity._normalize_cache_parameter(
+            name, value, set()
+        )
+        if CacheIdentity._contains_uncacheable_parameter(normalized):
+            return CacheIdentity._UNCACHEABLE_CACHE_VALUE
+        encoded = json.dumps(
+            normalized,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        return f"sha256:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()}"
+
+    @staticmethod
+    def _normalize_cache_parameter(
+        name: str,
+        value: Any,
+        seen: set[int],
+        depth: int = 0,
+        budget: Optional[Dict[str, int]] = None,
+    ) -> Any:
+        if budget is None:
+            budget = {"items": 0}
+        budget["items"] += 1
+        if (
+            depth > CacheIdentity._MAX_CACHE_PARAMETER_DEPTH
+            or budget["items"] > CacheIdentity._MAX_CACHE_PARAMETER_ITEMS
+        ):
+            return CacheIdentity._uncacheable_parameter(
+                "budget-exceeded", value
+            )
+
+        if CacheIdentity._is_sensitive_parameter_name(
+            name
+        ) and not CacheIdentity._should_descend_sensitive_parameter(
+            name, value
+        ):
+            return CacheIdentity._uncacheable_parameter("sensitive")
+
+        if value is None:
+            return value
+
+        value_type = type(value)
+
+        if issubclass(value_type, Enum):
+            return {
+                "__type__": CacheIdentity._type_name(value_type),
+                "__value__": CacheIdentity._normalize_cache_parameter(
+                    name, value.value, seen, depth + 1, budget
+                ),
+            }
+
+        if issubclass(value_type, (int, bool)):
+            return value
+
+        if issubclass(value_type, str):
+            if len(value) > CacheIdentity._MAX_CACHE_PARAMETER_STRING_LENGTH:
+                return CacheIdentity._uncacheable_parameter(
+                    "budget-exceeded", value
+                )
+            if CacheIdentity._is_sensitive_parameter_value(
+                name, value
+            ) and not CacheIdentity._should_descend_sensitive_parameter(
+                name, value
+            ):
+                return CacheIdentity._uncacheable_parameter("sensitive")
+            return value
+
+        if issubclass(value_type, float):
+            if not math.isfinite(value):
+                return CacheIdentity._uncacheable_parameter(
+                    "non-finite-float", value
+                )
+            return value
+
+        if issubclass(value_type, Path):
+            path_value = str(value)
+            if (
+                len(path_value)
+                > CacheIdentity._MAX_CACHE_PARAMETER_STRING_LENGTH
+            ):
+                return CacheIdentity._uncacheable_parameter(
+                    "budget-exceeded", value
+                )
+            if CacheIdentity._is_sensitive_parameter_value(
+                name, path_value
+            ) and not CacheIdentity._should_descend_sensitive_parameter(
+                name, value
+            ):
+                return CacheIdentity._uncacheable_parameter("sensitive")
+            return {
+                "__type__": CacheIdentity._type_name(value_type),
+                "__value__": path_value,
+            }
+
+        value_id = id(value)
+        if value_id in seen:
+            return CacheIdentity._uncacheable_parameter("circular", value)
+
+        if value_type is dict:
+            if len(value) > CacheIdentity._MAX_CACHE_PARAMETER_COLLECTION_ITEMS:
+                return CacheIdentity._uncacheable_parameter(
+                    "budget-exceeded", value
+                )
+            if any(not isinstance(key, str) for key in value):
+                return CacheIdentity._uncacheable_parameter(
+                    "non-string-mapping-key", value
+                )
+            seen.add(value_id)
+            try:
+                return {
+                    key: CacheIdentity._normalize_cache_parameter(
+                        key, item, seen, depth + 1, budget
+                    )
+                    for key, item in sorted(value.items())
+                }
+            finally:
+                seen.remove(value_id)
+
+        if value_type in (list, tuple):
+            if len(value) > CacheIdentity._MAX_CACHE_PARAMETER_COLLECTION_ITEMS:
+                return CacheIdentity._uncacheable_parameter(
+                    "budget-exceeded", value
+                )
+            seen.add(value_id)
+            try:
+                return {
+                    "__type__": CacheIdentity._type_name(value_type),
+                    "__items__": [
+                        CacheIdentity._normalize_cache_parameter(
+                            name, item, seen, depth + 1, budget
+                        )
+                        for item in value
+                    ],
+                }
+            finally:
+                seen.remove(value_id)
+
+        if value_type in (set, frozenset):
+            if len(value) > CacheIdentity._MAX_CACHE_PARAMETER_COLLECTION_ITEMS:
+                return CacheIdentity._uncacheable_parameter(
+                    "budget-exceeded", value
+                )
+            seen.add(value_id)
+            try:
+                normalized_items = [
+                    CacheIdentity._normalize_cache_parameter(
+                        name, item, seen, depth + 1, budget
+                    )
+                    for item in value
+                ]
+                return {
+                    "__type__": CacheIdentity._type_name(value_type),
+                    "__items__": sorted(
+                        normalized_items,
+                        key=lambda item: json.dumps(
+                            item, sort_keys=True, ensure_ascii=True
+                        ),
+                    ),
+                }
+            finally:
+                seen.remove(value_id)
+
+        if CacheIdentity._is_pydantic_model_class(value_type):
+            seen.add(value_id)
+            try:
+                if (
+                    CacheIdentity._pydantic_model_has_custom_getattribute(
+                        value_type
+                    )
+                    or CacheIdentity._pydantic_model_has_private_attrs(
+                        value_type
+                    )
+                    or CacheIdentity._pydantic_instance_has_private_values(
+                        value
+                    )
+                ):
+                    return CacheIdentity._uncacheable_parameter(
+                        "pydantic-private", value
+                    )
+                return {
+                    "__type__": CacheIdentity._type_name(value_type),
+                    "__schema__": CacheIdentity._safe_pydantic_model_schema(
+                        value_type
+                    ),
+                    "__fields__": CacheIdentity._normalize_cache_parameter(
+                        name,
+                        CacheIdentity._safe_pydantic_field_values(value),
+                        seen,
+                        depth + 1,
+                        budget,
+                    ),
+                }
+            except Exception:
+                return CacheIdentity._uncacheable_parameter("opaque", value)
+            finally:
+                seen.remove(value_id)
+
+        if is_dataclass(value_type) and not issubclass(value_type, type):
+            seen.add(value_id)
+            try:
+                return {
+                    "__type__": CacheIdentity._type_name(value_type),
+                    "__fields__": {
+                        field.name: CacheIdentity._normalize_cache_parameter(
+                            field.name,
+                            CacheIdentity._safe_dataclass_field_value(
+                                value, field.name
+                            ),
+                            seen,
+                            depth + 1,
+                            budget,
+                        )
+                        for field in fields(value)
+                    },
+                }
+            except Exception:
+                return CacheIdentity._uncacheable_parameter("opaque", value)
+            finally:
+                seen.remove(value_id)
+
+        if issubclass(value_type, type):
+            if CacheIdentity._is_pydantic_model_class(value):
+                if CacheIdentity._pydantic_model_has_custom_getattribute(
+                    value
+                ) or CacheIdentity._pydantic_model_has_private_attrs(value):
+                    return CacheIdentity._uncacheable_parameter(
+                        "pydantic-private", value
+                    )
+                return {
+                    "__type__": CacheIdentity._type_name(value),
+                    "__fields__": CacheIdentity._safe_pydantic_model_schema(
+                        value
+                    ),
+                }
+            return {"__type__": CacheIdentity._type_name(value)}
+
+        if CacheIdentity._is_deep_acyclic_graph(value):
+            seen.add(value_id)
+            try:
+                return {
+                    "__type__": CacheIdentity._type_name(type(value)),
+                    "__graph__": CacheIdentity._canonicalize_dag(value),
+                }
+            except Exception:
+                return CacheIdentity._uncacheable_parameter("opaque", value)
+            finally:
+                seen.remove(value_id)
+
+        # Avoid serializing arbitrary object graphs, reprs, or __dict__ values
+        # into the cache. Those can contain secrets, clients, sessions, or
+        # large runtime state. Unsupported objects are marked uncacheable so
+        # cache lookup misses closed instead of colliding by type alone.
+        return CacheIdentity._uncacheable_parameter("opaque", value)
+
+    @staticmethod
+    def _safe_pydantic_field_values(value: BaseModel) -> Any:
+        raw_values = CacheIdentity._passive_instance_fields(value)
+        if raw_values is None:
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-fields", value
+            )
+        fields_map = CacheIdentity._pydantic_fields_map(type(value))
+        if fields_map is None:
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-fields", value
+            )
+        field_names = sorted(fields_map)
+        values: Dict[str, Any] = {}
+        for field_name, field in sorted(
+            fields_map.items(), key=lambda item: item[0]
+        ):
+            if field_name not in raw_values:
+                continue
+            cache_name = CacheIdentity._pydantic_default_parameter_name(
+                field_name, field
+            )
+            if cache_name is None:
+                values[field_name] = CacheIdentity._uncacheable_parameter(
+                    "pydantic-alias", raw_values[field_name]
+                )
+                continue
+            if cache_name in values:
+                values[cache_name] = CacheIdentity._uncacheable_parameter(
+                    "pydantic-alias", raw_values[field_name]
+                )
+                continue
+            values[cache_name] = raw_values[field_name]
+
+        extra_values = CacheIdentity._passive_object_attribute(
+            value, "__pydantic_extra__"
+        )
+        if extra_values is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return CacheIdentity._uncacheable_parameter("pydantic-extra", value)
+        if type(extra_values) is dict:
+            if any(type(key) is not str for key in extra_values):
+                return CacheIdentity._uncacheable_parameter(
+                    "pydantic-extra", value
+                )
+            values.update(extra_values)
+        elif (
+            extra_values is not None
+            and extra_values is not CacheIdentity._MISSING_ATTRIBUTE
+        ):
+            return CacheIdentity._uncacheable_parameter("pydantic-extra", value)
+
+        if not values and not field_names:
+            values.update(
+                {
+                    key: item
+                    for key, item in raw_values.items()
+                    if not key.startswith("_")
+                }
+            )
+
+        return values
+
+    @staticmethod
+    def _pydantic_field_names(model_cls: type) -> List[str]:
+        fields_map = CacheIdentity._pydantic_fields_map(model_cls)
+        if fields_map is None:
+            return []
+        return sorted(fields_map)
+
+    @staticmethod
+    def _pydantic_fields_map(model_cls: type) -> Optional[Dict[Any, Any]]:
+        model_fields = CacheIdentity._passive_class_attribute(
+            model_cls, "model_fields"
+        )
+        if type(model_fields) is dict:
+            if any(type(key) is not str for key in model_fields):
+                return None
+            return model_fields
+        if model_fields is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return None
+        if (
+            model_fields is not None
+            and model_fields is not CacheIdentity._MISSING_ATTRIBUTE
+        ):
+            return None
+
+        legacy_fields = CacheIdentity._passive_class_attribute(
+            model_cls, "__fields__"
+        )
+        if type(legacy_fields) is dict:
+            if any(type(key) is not str for key in legacy_fields):
+                return None
+            return legacy_fields
+        if legacy_fields is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return None
+        if (
+            legacy_fields is not None
+            and legacy_fields is not CacheIdentity._MISSING_ATTRIBUTE
+        ):
+            return None
+
+        return {}
+
+    @staticmethod
+    def _safe_pydantic_model_schema(model_cls: type) -> Dict[str, Any]:
+        fields_map = CacheIdentity._pydantic_fields_map(model_cls)
+        if fields_map is None:
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-fields", model_cls
+            )
+        schema: Dict[str, Any] = {
+            "fields": {
+                str(name): CacheIdentity._safe_pydantic_field_schema(
+                    name, field
+                )
+                for name, field in sorted(
+                    fields_map.items(), key=lambda item: item[0]
+                )
+            },
+            "config": CacheIdentity._safe_pydantic_model_config(model_cls),
+        }
+        if CacheIdentity._pydantic_model_has_validators(model_cls):
+            schema["validators"] = CacheIdentity._uncacheable_parameter(
+                "pydantic-validator", model_cls
+            )
+        return schema
+
+    @staticmethod
+    def _safe_pydantic_model_config(model_cls: type) -> Any:
+        config: Dict[str, Any] = {}
+        model_config = CacheIdentity._passive_class_attribute(
+            model_cls, "model_config"
+        )
+        if type(model_config) is dict:
+            config.update(model_config)
+        elif model_config is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-model-config", model_cls
+            )
+        elif (
+            model_config is not None
+            and model_config is not CacheIdentity._MISSING_ATTRIBUTE
+        ):
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-model-config", model_config
+            )
+
+        legacy_config = CacheIdentity._passive_class_attribute(
+            model_cls, "__config__"
+        )
+        if legacy_config is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-model-config", model_cls
+            )
+        if (
+            legacy_config is not None
+            and legacy_config is not CacheIdentity._MISSING_ATTRIBUTE
+        ):
+            legacy_values = {}
+            legacy_config_fields = CacheIdentity._passive_class_attribute(
+                legacy_config, "__dict__"
+            )
+            if not isinstance(legacy_config_fields, MappingProxyType):
+                return CacheIdentity._uncacheable_parameter(
+                    "pydantic-model-config", legacy_config
+                )
+            for field in CacheIdentity._PYDANTIC_LEGACY_CONFIG_FIELDS:
+                if field in legacy_config_fields:
+                    legacy_values[field] = legacy_config_fields[field]
+            if legacy_values:
+                config["__legacy_config__"] = legacy_values
+
+        return CacheIdentity._normalize_cache_parameter(
+            "model_config", config, set()
+        )
+
+    @staticmethod
+    def _pydantic_model_has_validators(model_cls: type) -> bool:
+        decorators = CacheIdentity._passive_class_attribute(
+            model_cls, "__pydantic_decorators__"
+        )
+        if decorators is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return True
+        if (
+            decorators is not None
+            and decorators is not CacheIdentity._MISSING_ATTRIBUTE
+        ):
+            for attr in (
+                "validators",
+                "field_validators",
+                "root_validators",
+                "model_validators",
+            ):
+                value = CacheIdentity._passive_object_attribute(
+                    decorators, attr
+                )
+                if CacheIdentity._safe_truthy_builtin(value):
+                    return True
+
+        for attr in (
+            "__validators__",
+            "__pre_root_validators__",
+            "__post_root_validators__",
+        ):
+            legacy_validators = CacheIdentity._passive_class_attribute(
+                model_cls, attr
+            )
+            if CacheIdentity._safe_truthy_builtin(legacy_validators):
+                return True
+        return False
+
+    @staticmethod
+    def _pydantic_model_has_private_attrs(model_cls: type) -> bool:
+        private_attrs = CacheIdentity._passive_class_attribute(
+            model_cls, "__private_attributes__"
+        )
+        if private_attrs is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return True
+        if type(private_attrs) is dict:
+            return bool(private_attrs)
+        return (
+            private_attrs is not None
+            and private_attrs is not CacheIdentity._MISSING_ATTRIBUTE
+        )
+
+    @staticmethod
+    def _pydantic_instance_has_private_values(value: BaseModel) -> bool:
+        private_values = CacheIdentity._passive_object_attribute(
+            value, "__pydantic_private__"
+        )
+        if private_values is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return True
+        if type(private_values) is dict:
+            return bool(private_values)
+        return (
+            private_values is not None
+            and private_values is not CacheIdentity._MISSING_ATTRIBUTE
+        )
+
+    @staticmethod
+    def _pydantic_model_has_custom_getattribute(model_cls: type) -> bool:
+        getattribute = CacheIdentity._passive_class_attribute(
+            model_cls, "__getattribute__"
+        )
+        legacy_getattribute = (
+            getattr(LegacyBaseModel, "__getattribute__", None)
+            if LegacyBaseModel is not None
+            else None
+        )
+        return (
+            getattribute is not object.__getattribute__
+            and getattribute is not BaseModel.__getattribute__
+            and getattribute is not legacy_getattribute
+            and getattribute is not CacheIdentity._MISSING_ATTRIBUTE
+            and getattribute is not CacheIdentity._UNSAFE_ATTRIBUTE
+        )
+
+    @staticmethod
+    def _is_safe_pydantic_field_object(field: Any) -> bool:
+        return CacheIdentity._type_name(type(field)) in {
+            "pydantic.fields.FieldInfo",
+            "pydantic.v1.fields.ModelField",
+        }
+
+    @staticmethod
+    def _pydantic_field_attribute(
+        field: Any,
+        name: str,
+        default: Any = None,
+    ) -> Any:
+        value = CacheIdentity._passive_object_attribute(field, name)
+        if value is CacheIdentity._MISSING_ATTRIBUTE:
+            return default
+        return value
+
+    @staticmethod
+    def _pydantic_field_annotation(field: Any) -> Any:
+        for name in ("annotation", "outer_type_", "type_"):
+            value = CacheIdentity._pydantic_field_attribute(
+                field, name, CacheIdentity._MISSING_ATTRIBUTE
+            )
+            if value is CacheIdentity._UNSAFE_ATTRIBUTE:
+                return CacheIdentity._UNSAFE_ATTRIBUTE
+            if value is not CacheIdentity._MISSING_ATTRIBUTE:
+                return value
+        return None
+
+    @staticmethod
+    def _safe_pydantic_field_schema(field_name: str, field: Any) -> Any:
+        if not CacheIdentity._is_safe_pydantic_field_object(field):
+            return CacheIdentity._uncacheable_parameter("pydantic-field", field)
+        default = CacheIdentity._pydantic_field_attribute(
+            field, "default", None
+        )
+        default_factory = CacheIdentity._pydantic_field_attribute(
+            field, "default_factory", None
+        )
+        metadata = CacheIdentity._pydantic_field_attribute(
+            field, "metadata", None
+        )
+        if metadata is None:
+            field_info = CacheIdentity._pydantic_field_attribute(
+                field, "field_info", None
+            )
+            metadata = CacheIdentity._pydantic_field_attribute(
+                field_info, "metadata", None
+            )
+        if (
+            default is CacheIdentity._UNSAFE_ATTRIBUTE
+            or default_factory is CacheIdentity._UNSAFE_ATTRIBUTE
+            or metadata is CacheIdentity._UNSAFE_ATTRIBUTE
+        ):
+            return CacheIdentity._uncacheable_parameter("pydantic-field", field)
+        annotation = CacheIdentity._pydantic_field_annotation(field)
+        if annotation is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return CacheIdentity._uncacheable_parameter("pydantic-field", field)
+
+        return {
+            "annotation": CacheIdentity._annotation_fingerprint(annotation),
+            "alias": CacheIdentity._pydantic_alias_identity(
+                CacheIdentity._pydantic_field_attribute(field, "alias", None)
+            ),
+            "validation_alias": CacheIdentity._pydantic_alias_identity(
+                CacheIdentity._pydantic_field_attribute(
+                    field, "validation_alias", None
+                )
+            ),
+            "serialization_alias": CacheIdentity._pydantic_alias_identity(
+                CacheIdentity._pydantic_field_attribute(
+                    field, "serialization_alias", None
+                )
+            ),
+            "required": CacheIdentity._pydantic_field_is_required(field),
+            "default": CacheIdentity._safe_schema_default(
+                CacheIdentity._pydantic_default_parameter_name(
+                    field_name, field
+                ),
+                default,
+            ),
+            "default_factory": CacheIdentity._callable_fingerprint(
+                default_factory
+            ),
+            "metadata": CacheIdentity._safe_pydantic_field_metadata(metadata),
+            "json_schema": CacheIdentity._safe_pydantic_json_schema_metadata(
+                field
+            ),
+        }
+
+    @staticmethod
+    def _safe_pydantic_field_metadata(metadata: Any) -> Any:
+        if metadata is None:
+            return []
+        if type(metadata) not in (list, tuple):
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-field-metadata", metadata
+            )
+        metadata_items = list(metadata)
+        if not metadata_items:
+            return []
+        return CacheIdentity._uncacheable_parameter(
+            "pydantic-field-metadata", metadata_items
+        )
+
+    @staticmethod
+    def _safe_pydantic_json_schema_metadata(field: Any) -> Dict[str, Any]:
+        metadata = {
+            "deprecated": CacheIdentity._normalize_cache_parameter(
+                "deprecated",
+                CacheIdentity._pydantic_field_attribute(
+                    field, "deprecated", None
+                ),
+                set(),
+            )
+        }
+        for name in CacheIdentity._PYDANTIC_FREE_FORM_SCHEMA_METADATA_FIELDS:
+            value = CacheIdentity._pydantic_field_attribute(field, name, None)
+            if value is None:
+                metadata[name] = None
+            else:
+                # Free-form schema metadata can contain prompts, examples, or
+                # secrets under generic names. Do not persist deterministic
+                # fingerprints for it; miss closed instead.
+                metadata[name] = CacheIdentity._uncacheable_parameter(
+                    "pydantic-json-schema-metadata", value
+                )
+        return metadata
+
+    @staticmethod
+    def _pydantic_field_is_required(field: Any) -> Any:
+        required = CacheIdentity._pydantic_field_attribute(
+            field, "required", CacheIdentity._MISSING_ATTRIBUTE
+        )
+        if isinstance(required, bool):
+            return required
+        if (
+            required is not None
+            and required is not CacheIdentity._MISSING_ATTRIBUTE
+            and required is not CacheIdentity._UNSAFE_ATTRIBUTE
+        ):
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-required", field
+            )
+        default = CacheIdentity._pydantic_field_attribute(
+            field, "default", CacheIdentity._MISSING_ATTRIBUTE
+        )
+        default_factory = CacheIdentity._pydantic_field_attribute(
+            field, "default_factory", None
+        )
+        if (
+            default is CacheIdentity._UNSAFE_ATTRIBUTE
+            or default_factory is CacheIdentity._UNSAFE_ATTRIBUTE
+        ):
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-required", field
+            )
+        return (
+            CacheIdentity._is_pydantic_undefined(default)
+            and default_factory is None
+        )
+
+    @staticmethod
+    def _pydantic_default_parameter_name(
+        field_name: str, field: Any
+    ) -> Optional[str]:
+        unknown_alias = False
+        candidates: List[str] = [field_name]
+        for alias in (
+            CacheIdentity._pydantic_field_attribute(field, "alias", None),
+            CacheIdentity._pydantic_field_attribute(
+                field, "validation_alias", None
+            ),
+            CacheIdentity._pydantic_field_attribute(
+                field, "serialization_alias", None
+            ),
+        ):
+            if alias is CacheIdentity._UNSAFE_ATTRIBUTE:
+                unknown_alias = True
+                continue
+            alias_candidates = CacheIdentity._pydantic_alias_candidates(alias)
+            if alias is not None and not alias_candidates:
+                unknown_alias = True
+            candidates.extend(alias_candidates)
+
+        for candidate in candidates:
+            if CacheIdentity._is_sensitive_parameter_name(candidate):
+                return candidate
+        if unknown_alias:
+            return None
+        return field_name
+
+    @staticmethod
+    def _pydantic_alias_candidates(alias: Any) -> List[str]:
+        if alias is None:
+            return []
+        if isinstance(alias, str):
+            return [alias]
+        if isinstance(alias, (list, tuple)):
+            candidates: List[str] = []
+            for item in alias:
+                candidates.extend(
+                    CacheIdentity._pydantic_alias_candidates(item)
+                )
+            return candidates
+
+        for attribute in ("choices", "path"):
+            value = CacheIdentity._pydantic_alias_attribute(alias, attribute)
+            if (
+                value is CacheIdentity._UNSAFE_ATTRIBUTE
+                or value is CacheIdentity._MISSING_ATTRIBUTE
+            ):
+                continue
+            if value is not None:
+                return CacheIdentity._pydantic_alias_candidates(value)
+
+        return []
+
+    @staticmethod
+    def _pydantic_alias_identity(alias: Any) -> Any:
+        if alias is None:
+            return None
+        if isinstance(alias, str):
+            return alias
+        if isinstance(alias, (list, tuple)):
+            return [
+                CacheIdentity._pydantic_alias_identity(item) for item in alias
+            ]
+
+        for attribute in ("choices", "path"):
+            value = CacheIdentity._pydantic_alias_attribute(alias, attribute)
+            if (
+                value is CacheIdentity._UNSAFE_ATTRIBUTE
+                or value is CacheIdentity._MISSING_ATTRIBUTE
+            ):
+                continue
+            if value is not None:
+                return {
+                    attribute: CacheIdentity._pydantic_alias_identity(value)
+                }
+
+        return CacheIdentity._uncacheable_parameter("pydantic-alias", alias)
+
+    @staticmethod
+    def _pydantic_alias_attribute(alias: Any, attribute: str) -> Any:
+        alias_fields = CacheIdentity._passive_instance_fields(alias)
+        if type(alias_fields) is dict:
+            return alias_fields.get(attribute)
+
+        type_name = CacheIdentity._type_name(type(alias))
+        if (
+            attribute == "choices"
+            and type_name == "pydantic.aliases.AliasChoices"
+        ) or (
+            attribute == "path" and type_name == "pydantic.aliases.AliasPath"
+        ):
+            return CacheIdentity._passive_object_attribute(alias, attribute)
+
+        return CacheIdentity._UNSAFE_ATTRIBUTE
+
+    @staticmethod
+    def _safe_schema_default(name: Optional[str], default: Any) -> Any:
+        if CacheIdentity._is_pydantic_undefined(default):
+            return {"__missing__": True}
+        if name is None:
+            return CacheIdentity._uncacheable_parameter(
+                "pydantic-alias", default
+            )
+        return CacheIdentity._normalize_cache_parameter(name, default, set())
+
+    @staticmethod
+    def _is_pydantic_undefined(value: Any) -> bool:
+        if value is CacheIdentity._MISSING_ATTRIBUTE:
+            return True
+        if value is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return False
+        type_name = CacheIdentity._type_name(type(value))
+        return type_name.endswith(
+            ".PydanticUndefinedType"
+        ) or type_name.endswith(".UndefinedType")
+
+    @staticmethod
+    def _annotation_fingerprint(annotation: Any) -> Any:
+        if annotation is None:
+            return None
+
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+        if origin is not None:
+            return {
+                "origin": CacheIdentity._annotation_origin_fingerprint(origin),
+                "args": [
+                    CacheIdentity._annotation_fingerprint(arg) for arg in args
+                ],
+            }
+
+        if isinstance(annotation, type):
+            return CacheIdentity._type_name(annotation)
+
+        return CacheIdentity._annotation_literal_fingerprint(annotation)
+
+    @staticmethod
+    def _annotation_origin_fingerprint(origin: Any) -> Any:
+        if isinstance(origin, type):
+            return CacheIdentity._type_name(origin)
+
+        module = getattr(origin, "__module__", None)
+        qualname = getattr(origin, "__qualname__", None)
+        name = getattr(origin, "_name", None)
+        if isinstance(module, str) and isinstance(qualname, str):
+            return f"{module}.{qualname}"
+        if isinstance(module, str) and isinstance(name, str):
+            return f"{module}.{name}"
+        return CacheIdentity._uncacheable_parameter("annotation-origin", origin)
+
+    @staticmethod
+    def _annotation_literal_fingerprint(annotation: Any) -> Any:
+        annotation_type = type(annotation)
+        if issubclass(annotation_type, (str, int, bool, float, Enum, Path)):
+            normalized = CacheIdentity._normalize_cache_parameter(
+                "annotation", annotation, set()
+            )
+            if CacheIdentity._contains_uncacheable_parameter(normalized):
+                return normalized
+            return {
+                "__type__": CacheIdentity._type_name(type(annotation)),
+                "__value__": normalized,
+            }
+        return CacheIdentity._uncacheable_parameter("annotation", annotation)
+
+    @staticmethod
+    def _callable_fingerprint(value: Any) -> Any:
+        if value is None:
+            return None
+        return CacheIdentity._uncacheable_parameter("callable", value)
+
+    @staticmethod
+    def _safe_dataclass_field_value(value: Any, name: str) -> Any:
+        try:
+            instance_fields = vars(value)
+        except TypeError as exc:
+            raise AttributeError(name) from exc
+        if name in instance_fields:
+            return instance_fields[name]
+        raise AttributeError(name)
+
+    @staticmethod
+    def _uncacheable_parameter(
+        reason: str, value: Optional[Any] = None
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"__deepeval_uncacheable__": reason}
+        if value is not None:
+            payload["__type__"] = CacheIdentity._type_name(type(value))
+        return payload
+
+    @staticmethod
+    def _contains_uncacheable_parameter(value: Any) -> bool:
+        if isinstance(value, Mapping):
+            if "__deepeval_uncacheable__" in value:
+                return True
+            return any(
+                CacheIdentity._contains_uncacheable_parameter(item)
+                for item in value.values()
+            )
+
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return any(
+                CacheIdentity._contains_uncacheable_parameter(item)
+                for item in value
+            )
+
+        return False
+
+    @staticmethod
+    def _has_uncacheable_parameter(
+        parameters: Optional[Dict[str, str]],
+    ) -> bool:
+        if not parameters:
+            return False
+        return any(
+            value == CacheIdentity._UNCACHEABLE_CACHE_VALUE
+            for value in parameters.values()
+        )
+
+    @staticmethod
+    def _metric_configuration_has_uncacheable_value(
+        configuration: Any,
+    ) -> bool:
+        if CacheIdentity._has_uncacheable_parameter(
+            configuration.custom_parameters
+        ):
+            return True
+        return any(
+            getattr(configuration, field, None)
+            == CacheIdentity._UNCACHEABLE_CACHE_VALUE
+            for field in CacheIdentity._CREATE_CONFIG_FIELDS
+        )
+
+    @staticmethod
+    def _passive_object_attribute(value: Any, name: str) -> Any:
+        try:
+            return object.__getattribute__(value, name)
+        except AttributeError:
+            return CacheIdentity._MISSING_ATTRIBUTE
+        except Exception:
+            return CacheIdentity._UNSAFE_ATTRIBUTE
+
+    @staticmethod
+    def _passive_class_attribute(value: type, name: str) -> Any:
+        try:
+            return type.__getattribute__(value, name)
+        except AttributeError:
+            return CacheIdentity._MISSING_ATTRIBUTE
+        except Exception:
+            return CacheIdentity._UNSAFE_ATTRIBUTE
+
+    @staticmethod
+    def _safe_truthy_builtin(value: Any) -> bool:
+        if value is CacheIdentity._UNSAFE_ATTRIBUTE:
+            return True
+        if value is None or value is CacheIdentity._MISSING_ATTRIBUTE:
+            return value is CacheIdentity._UNSAFE_ATTRIBUTE
+        value_type = type(value)
+        if value_type in (dict, list, tuple, set, frozenset, str, bytes):
+            return len(value) > 0
+        if value_type in (bool, int, float):
+            return bool(value)
+        return True
+
+    @staticmethod
+    def _type_name(value_type: type) -> str:
+        try:
+            module = type.__getattribute__(value_type, "__module__")
+            qualname = type.__getattribute__(value_type, "__qualname__")
+        except Exception:
+            return "<unknown>"
+        return f"{module}.{qualname}"
+
+    @staticmethod
+    def _safe_text_identity(value: Any) -> str:
+        return CacheIdentity._type_name(type(value))
+
+    @staticmethod
+    def _is_pydantic_model_class(value: type) -> bool:
+        try:
+            model_classes = (
+                (BaseModel,)
+                if LegacyBaseModel is None
+                else (BaseModel, LegacyBaseModel)
+            )
+            return issubclass(value, model_classes)
+        except TypeError:
+            return False
+
+    @staticmethod
+    def _is_deep_acyclic_graph(value: Any) -> bool:
+        return (
+            CacheIdentity._type_name(type(value))
+            == "deepeval.metrics.dag.graph.DeepAcyclicGraph"
+        )
+
+    @staticmethod
+    def _canonicalize_dag(dag: Any) -> Any:
+        dag_fields = CacheIdentity._passive_instance_fields(dag)
+        if dag_fields is None or "root_nodes" not in dag_fields:
+            return CacheIdentity._uncacheable_parameter("dag", dag)
+
+        root_nodes = CacheIdentity._safe_dag_sequence(
+            dag_fields.get("root_nodes"), default_empty=True
+        )
+        if root_nodes is None:
+            return CacheIdentity._uncacheable_parameter("dag", dag)
+        canonical_ids: Dict[int, str] = {}
+        node_by_identity: Dict[int, Any] = {}
+
+        def assign(node: Any, stack: set[int]) -> bool:
+            if CacheIdentity._safe_dag_node_fields(
+                node
+            ) is None or not CacheIdentity._dag_node_children_are_supported(
+                node
+            ):
+                return False
+            node_identity = id(node)
+            if node_identity in stack:
+                return False
+            if node_identity in canonical_ids:
+                return True
+            if len(stack) > CacheIdentity._MAX_CACHE_PARAMETER_DEPTH:
+                return False
+            if len(canonical_ids) >= CacheIdentity._MAX_DAG_CACHE_NODES:
+                return False
+
+            canonical_ids[node_identity] = f"n{len(canonical_ids)}"
+            node_by_identity[node_identity] = node
+            next_stack = set(stack)
+            next_stack.add(node_identity)
+            for child_node in CacheIdentity._live_dag_child_nodes(node):
+                if not assign(child_node, next_stack):
+                    return False
+            return True
+
+        for root_node in root_nodes:
+            if not assign(root_node, set()):
+                return CacheIdentity._uncacheable_parameter("dag", dag)
+
+        return {
+            "roots": [canonical_ids[id(root)] for root in root_nodes],
+            "nodes": {
+                canonical_ids[node_identity]: CacheIdentity._live_dag_node_spec(
+                    node, canonical_ids
+                )
+                for node_identity, node in node_by_identity.items()
+            },
+        }
+
+    @staticmethod
+    def _safe_dag_node_fields(node: Any) -> Optional[Mapping[str, Any]]:
+        if not CacheIdentity._is_dag_node(node):
+            return None
+        node_fields = CacheIdentity._passive_instance_fields(node)
+        if type(node_fields) is not dict:
+            return None
+        if any(type(key) is not str for key in node_fields):
+            return None
+        return node_fields
+
+    @staticmethod
+    def _safe_dag_sequence(
+        value: Any,
+        default_empty: bool = False,
+    ) -> Optional[Any]:
+        if value is None:
+            return () if default_empty else None
+        if type(value) in (list, tuple):
+            return value
+        return None
+
+    @staticmethod
+    def _dag_node_children_are_supported(node: Any) -> bool:
+        node_fields = CacheIdentity._safe_dag_node_fields(node)
+        if node_fields is None:
+            return False
+
+        children = CacheIdentity._safe_dag_sequence(
+            node_fields.get("children"), default_empty=True
+        )
+        if children is None:
+            return False
+        for child in children:
+            if not CacheIdentity._is_dag_node(child):
+                return False
+
+        child = node_fields.get("child")
+        return (
+            child is None
+            or CacheIdentity._is_dag_node(child)
+            or CacheIdentity._is_metric_instance(child)
+        )
+
+    @staticmethod
+    def _live_dag_child_nodes(node: Any) -> List[Any]:
+        node_fields = CacheIdentity._safe_dag_node_fields(node)
+        if node_fields is None:
+            return []
+
+        children: List[Any] = []
+        child_nodes = CacheIdentity._safe_dag_sequence(
+            node_fields.get("children"), default_empty=True
+        )
+        if child_nodes is None:
+            return []
+        for child in child_nodes:
+            if CacheIdentity._is_dag_node(child):
+                children.append(child)
+
+        child = node_fields.get("child")
+        if CacheIdentity._is_dag_node(child):
+            children.append(child)
+
+        return children
+
+    @staticmethod
+    def _live_dag_node_spec(node: Any, canonical_ids: Dict[int, str]) -> Any:
+        node_fields = CacheIdentity._safe_dag_node_fields(node)
+        if node_fields is None:
+            return CacheIdentity._uncacheable_parameter("dag-node", node)
+
+        spec: Dict[str, Any] = {"type": CacheIdentity._type_name(type(node))}
+        for name, value in sorted(node_fields.items()):
+            if name in {"children", "child"} or name.startswith("_"):
+                continue
+            spec[name] = CacheIdentity._normalize_cache_parameter(
+                name, value, set()
+            )
+
+        if "children" in node_fields:
+            children = CacheIdentity._safe_dag_sequence(
+                node_fields.get("children"), default_empty=True
+            )
+            if children is None:
+                return CacheIdentity._uncacheable_parameter("dag-node", node)
+            spec["children"] = [
+                canonical_ids[id(child)]
+                for child in children
+                if CacheIdentity._is_dag_node(child)
+            ]
+
+        if "child" in node_fields:
+            child = node_fields.get("child")
+            if child is not None:
+                spec["child"] = CacheIdentity._live_dag_child_spec(
+                    child, canonical_ids
+                )
+
+        return spec
+
+    @staticmethod
+    def _live_dag_child_spec(child: Any, canonical_ids: Dict[int, str]) -> Any:
+        if CacheIdentity._is_dag_node(child):
+            return {"type": "node", "ref": canonical_ids[id(child)]}
+        if CacheIdentity._is_metric_instance(child):
+            return CacheIdentity._metric_child_configuration(child)
+        return CacheIdentity._normalize_cache_parameter("child", child, set())
+
+    @staticmethod
+    def _metric_child_configuration(metric: Any) -> Dict[str, Any]:
+        try:
+            configuration = CacheIdentity.create_metric_configuration(metric)
+        except Exception:
+            return CacheIdentity._uncacheable_parameter("metric-child", metric)
+
+        if CacheIdentity._metric_configuration_has_uncacheable_value(
+            configuration
+        ):
+            return CacheIdentity._uncacheable_parameter("metric-child", metric)
+
+        return {
+            "type": "metric",
+            "metric_class": CacheIdentity._type_name(type(metric)),
+            "metric_configuration": configuration.model_dump(mode="json"),
+        }
+
+    @staticmethod
+    def _is_dag_node(value: Any) -> bool:
+        if value is None:
+            return False
+        return (
+            CacheIdentity._type_name(type(value))
+            in CacheIdentity._KNOWN_DAG_NODE_TYPES
+        )
+
+    @staticmethod
+    def _is_metric_instance(value: Any) -> bool:
+        return isinstance(value, (BaseMetric, BaseConversationalMetric))
+
+    @staticmethod
+    def _should_descend_sensitive_parameter(name: str, value: Any) -> bool:
+        normalized = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+        return normalized in {"headers", "auth_headers"} and issubclass(
+            type(value), Mapping
+        )
+
+    @staticmethod
+    def _is_sensitive_parameter_name(name: str) -> bool:
+        normalized = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+        compact = normalized.replace("_", "")
+        parts = set(filter(None, normalized.split("_")))
+
+        if normalized in CacheIdentity._SENSITIVE_PARAMETER_NAMES:
+            return True
+        if compact in CacheIdentity._SENSITIVE_PARAMETER_NAMES:
+            return True
+        if compact in CacheIdentity._SENSITIVE_PARAMETER_COMPACT_NAMES:
+            return True
+        if any(
+            part in parts for part in CacheIdentity._SENSITIVE_PARAMETER_PARTS
+        ):
+            return True
+        if any(
+            normalized.endswith(suffix)
+            for suffix in CacheIdentity._SENSITIVE_PARAMETER_SUFFIXES
+        ):
+            return True
+        return any(
+            compact.endswith(suffix)
+            for suffix in CacheIdentity._SENSITIVE_PARAMETER_COMPACT_SUFFIXES
+        )
+
+    @staticmethod
+    def _is_sensitive_parameter_value(name: str, value: Any) -> bool:
+        if not isinstance(value, str):
+            return False
+        stripped = value.strip()
+        if CacheIdentity._is_sensitive_url_component_value(stripped):
+            return True
+        try:
+            parsed = urlsplit(stripped)
+            _ = parsed.port
+        except ValueError:
+            return True
+        if any(
+            CacheIdentity._url_variant_has_userinfo(decoded_value)
+            for decoded_value in CacheIdentity._decoded_text_variants(
+                stripped, plus=True
+            )
+        ):
+            return True
+        if "://" in stripped and any(char.isspace() for char in stripped):
+            return True
+        for (
+            component_name,
+            component_value,
+        ) in CacheIdentity._url_key_value_pairs(
+            parsed.query
+        ) + CacheIdentity._url_key_value_pairs(
+            parsed.fragment
+        ):
+            if (
+                CacheIdentity._decode_budget_exhausted_with_percent_escape(
+                    component_name, plus=True
+                )
+                or any(
+                    CacheIdentity._is_sensitive_parameter_name(decoded_name)
+                    for decoded_name in CacheIdentity._decoded_text_variants(
+                        component_name, plus=True
+                    )
+                )
+                or CacheIdentity._is_sensitive_url_component_value(
+                    component_value
+                )
+            ):
+                return True
+        if CacheIdentity._is_sensitive_url_component_value(parsed.query or ""):
+            return True
+        if CacheIdentity._is_sensitive_url_component_value(
+            parsed.fragment or ""
+        ):
+            return True
+        if CacheIdentity._is_sensitive_url_component_value(parsed.path or ""):
+            return True
+        if not parsed.scheme or not parsed.netloc:
+            return False
+        if parsed.username or parsed.password:
+            return True
+        return False
+
+    @staticmethod
+    def _url_key_value_pairs(value: str) -> List[tuple[str, str]]:
+        try:
+            return parse_qsl(value, keep_blank_values=True)
+        except ValueError:
+            return []
+
+    @staticmethod
+    def _url_variant_has_userinfo(value: str) -> bool:
+        try:
+            parsed = urlsplit(value)
+            _ = parsed.port
+        except ValueError:
+            return True
+        return bool(parsed.netloc and (parsed.username or parsed.password))
+
+    @staticmethod
+    def _is_sensitive_url_component_value(value: str) -> bool:
+        if CacheIdentity._decode_budget_exhausted_with_percent_escape(
+            value, plus=True
+        ):
+            return True
+        return any(
+            CacheIdentity._has_secret_like_string_value(decoded_value)
+            or CacheIdentity._has_credential_like_dsn_value(decoded_value)
+            for decoded_value in CacheIdentity._decoded_text_variants(
+                value, plus=True
+            )
+        )
+
+    @staticmethod
+    def _decoded_text_variants(value: str, plus: bool = False) -> List[str]:
+        variants = [value]
+        current = value
+        for _ in range(CacheIdentity._MAX_URL_DECODE_PASSES):
+            decoded = unquote_plus(current) if plus else unquote(current)
+            if decoded == current:
+                break
+            variants.append(decoded)
+            current = decoded
+        return variants
+
+    @staticmethod
+    def _decode_budget_exhausted_with_percent_escape(
+        value: str, plus: bool = False
+    ) -> bool:
+        current = value
+        for _ in range(CacheIdentity._MAX_URL_DECODE_PASSES):
+            decoded = unquote_plus(current) if plus else unquote(current)
+            if decoded == current:
+                return False
+            current = decoded
+        return bool(re.search(r"%[0-9a-fA-F]{2}", current))
+
+    @staticmethod
+    def _has_secret_like_string_value(value: str) -> bool:
+        lowered = value.lower().replace("\\", "/")
+        return bool(
+            re.search(
+                r"(^|[^a-z0-9])("
+                r"bearer\s+\S+|"
+                r"sk-[a-z0-9][a-z0-9_-]*|"
+                r"xox[baprs]-[a-z0-9-]+|"
+                r"gh[pousr]_[a-z0-9_]+|"
+                r"github_pat_[a-z0-9_]+|"
+                r"eyj[a-z0-9_-]+\.[a-z0-9_-]+\.[a-z0-9_-]+|"
+                r"(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|"
+                r"auth[_-]?token|session[_-]?token|token|password|passwd|secret|sig|"
+                r"signature|authorization)\s*[:=/]\s*\S+"
+                r")",
+                lowered,
+            )
+        )
+
+    @staticmethod
+    def _has_credential_like_dsn_value(value: str) -> bool:
+        return bool(re.match(r"^[a-z][a-z0-9+.-]*:[^\s/][^\s]*@", value, re.I))
+
+    @staticmethod
+    def _model_object_name(model: Any) -> Optional[str]:
+        if isinstance(model, str):
+            return model
+        return None
+
+    @staticmethod
+    def _metric_model_name(metric: BaseMetric) -> Optional[str]:
+        instance_fields = CacheIdentity._passive_instance_fields(metric)
+        if instance_fields is None:
+            return None
+        for field in ("model", "_model"):
+            model = instance_fields.get(field)
+            if model is None:
+                continue
+            model_name = CacheIdentity._model_object_name(model)
+            if model_name is not None:
+                return model_name
+        return None
+
+    @staticmethod
+    def _metric_uses_native_model(metric: BaseMetric) -> bool:
+        instance_fields = CacheIdentity._passive_instance_fields(metric)
+        if instance_fields is None:
+            return False
+        if instance_fields.get("using_native_model") is not True:
+            return False
+        return any(
+            field in instance_fields
+            and CacheIdentity._is_native_model_object(instance_fields[field])
+            for field in ("model", "_model")
+        )
+
+    @staticmethod
+    def _is_native_model_object(model: Any) -> bool:
+        return CacheIdentity._type_name(type(model)).startswith(
+            "deepeval.models.llms."
+        )
+
+    @staticmethod
+    def _native_model_cache_identity(model: Any) -> Optional[Dict[str, Any]]:
+        if not CacheIdentity._is_native_model_object(model):
+            return None
+        model_fields = CacheIdentity._passive_instance_fields(model)
+        if model_fields is None:
+            return None
+
+        identity: Dict[str, Any] = {
+            "__type__": CacheIdentity._type_name(type(model))
+        }
+        for field in CacheIdentity._NATIVE_MODEL_CACHE_IDENTITY_FIELDS:
+            if field in model_fields:
+                identity[field] = model_fields[field]
+        return identity
+
+    @staticmethod
+    def _metric_has_non_string_model(metric: BaseMetric) -> bool:
+        instance_fields = CacheIdentity._passive_instance_fields(metric)
+        if instance_fields is None:
+            return False
+        return any(
+            field in instance_fields
+            and instance_fields[field] is not None
+            and not isinstance(instance_fields[field], str)
+            for field in ("model", "_model")
+        )
+
+    @staticmethod
+    def _passive_instance_fields(value: Any) -> Optional[Mapping[str, Any]]:
+        try:
+            return vars(value)
+        except Exception:
+            return None

--- a/docs/content/changelog/changelog-2026.mdx
+++ b/docs/content/changelog/changelog-2026.mdx
@@ -20,6 +20,12 @@ First things first, DeepEval exists because of everyone who opened issues, revie
 
 {/* DeepEval release notes start */}
 
+## Unreleased
+
+### Bug Fix
+
+- Fix test-run cache compatibility so constructor-sensitive metrics miss once against pre-upgrade cache entries and regenerate when rerun instead of reusing stale results. Existing cache files still load, cache identity now includes constructor-level metric settings and normalized free-form metric config compatibility metadata when safe, and unsafe or unrecoverable cache identity state intentionally misses cache instead of risking stale reuse.
+
 ## April
 
 April focused on simplifying core APIs while expanding model, tracing, and simulator capabilities. Testing and golden assertions were streamlined by removing legacy hooks, adding configurable structured run outputs, deprecating per-result logs, and tightening error handling so misconfigured eval runs fail loudly. The release added support for new OpenAI and Anthropic models with improved multimodal/structured output handling, more accurate token/cost reporting, and safer behavior when logprob-dependent metrics aren’t supported. Observability and workflow got a major boost with richer trace correlation fields like `turn_id` and `test_case_id`, optional internal span instrumentation, a more in

--- a/tests/test_core/test_run/test_cache.py
+++ b/tests/test_core/test_run/test_cache.py
@@ -1,0 +1,3336 @@
+import json
+from dataclasses import dataclass
+from enum import Enum, IntEnum
+from pathlib import Path
+from typing import Literal
+from urllib.parse import quote
+
+import pytest
+from deepeval.metrics import BaseMetric
+from deepeval.metrics.answer_relevancy.answer_relevancy import (
+    AnswerRelevancyMetric,
+)
+from deepeval.metrics.dag.graph import DeepAcyclicGraph
+from deepeval.metrics.dag.nodes import TaskNode, VerdictNode
+from deepeval.metrics.exact_match.exact_match import ExactMatchMetric
+from deepeval.metrics.pattern_match.pattern_match import PatternMatchMetric
+from deepeval.metrics.tool_correctness.tool_correctness import (
+    ToolCorrectnessMetric,
+)
+from deepeval.models.llms.openai_model import GPTModel
+from pydantic import (
+    BaseModel as PydanticBaseModel,
+    Field,
+    PrivateAttr,
+    create_model,
+)
+
+try:
+    from pydantic import AliasChoices, field_validator
+except ImportError:
+    AliasChoices = None
+    from pydantic import validator as _pydantic_v1_validator
+
+    def field_validator(*fields, **kwargs):
+        def decorator(fn):
+            validator_fn = fn.__func__ if isinstance(fn, classmethod) else fn
+            return _pydantic_v1_validator(*fields, allow_reuse=True)(
+                validator_fn
+            )
+
+        return decorator
+
+
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.test_run import cache_identity as cache_identity_module
+from deepeval.test_run.api import MetricData
+from deepeval.test_run.cache import (
+    Cache,
+    CachedMetricData,
+    CachedTestCase,
+    CachedTestRun,
+    MetricConfiguration,
+)
+
+
+class _ConfigurableMetric(BaseMetric):
+    def __init__(
+        self,
+        rubric: str,
+        weights: dict[str, float],
+        steps=None,
+        threshold: float = 0.5,
+    ):
+        self.rubric = rubric
+        self.weights = weights
+        self.steps = steps or []
+        self.threshold = threshold
+        self.score = None
+        self.reason = None
+        self.success = False
+        self.error = None
+
+    def measure(self, test_case: LLMTestCase, *args, **kwargs) -> float:
+        self.score = 1.0
+        self.success = True
+        return self.score
+
+    async def a_measure(self, test_case: LLMTestCase, *args, **kwargs) -> float:
+        return self.measure(test_case, *args, **kwargs)
+
+    def is_successful(self) -> bool:
+        return bool(self.success)
+
+    @property
+    def __name__(self):
+        return "Configurable Custom"
+
+
+class _MetricWithSecretParameter(_ConfigurableMetric):
+    def __init__(self, rubric: str, api_key: str, client=None):
+        super().__init__(rubric=rubric, weights={"harm": 1.0})
+        self.api_key = api_key
+        self.client = client
+
+
+class _MetricWithUnderscoreSecretParameter(_ConfigurableMetric):
+    def __init__(self, rubric: str, _access_token: str):
+        super().__init__(rubric=rubric, weights={"harm": 1.0})
+        self._access_token = _access_token
+
+
+class _MetricWithNestedConfigParameter(_ConfigurableMetric):
+    def __init__(self, config: dict):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.config = config
+
+
+class _EndpointMetric(_ConfigurableMetric):
+    def __init__(self, endpoint: str):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.endpoint = endpoint
+
+
+class _TokenizerMetric(_ConfigurableMetric):
+    def __init__(self, tokenizer_name: str):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.tokenizer_name = tokenizer_name
+
+
+class _TypeSensitiveCollectionMetric(_ConfigurableMetric):
+    def __init__(self, value):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.value = value
+
+
+class _CacheMode(Enum):
+    STRICT = "strict"
+
+
+class _IntCacheMode(IntEnum):
+    STRICT = 1
+
+
+class _StrCacheMode(str, Enum):
+    STRICT = "strict"
+
+
+class _EmbeddingsConfigMetric(_ConfigurableMetric):
+    def __init__(self, embeddings):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.embeddings = embeddings
+
+
+class _FakeEmbeddings:
+    pass
+
+
+class _AliasedConstructorMetric(_ConfigurableMetric):
+    def __init__(self, prompt_template: str):
+        super().__init__(rubric="internal", weights={"harm": 1.0})
+        self.prompt = prompt_template
+
+
+class _KwargsMetric(_ConfigurableMetric):
+    def __init__(self, **kwargs):
+        super().__init__(rubric="kwargs", weights={"harm": 1.0})
+        self.mode = kwargs["mode"]
+
+
+class _ArgsMetric(_ConfigurableMetric):
+    def __init__(self, *args):
+        super().__init__(rubric="args", weights={"harm": 1.0})
+        self.mode = args[0]
+
+
+class _TelemetryMetric(_ConfigurableMetric):
+    def __init__(self, rubric: str, _track: bool):
+        super().__init__(rubric=rubric, weights={"harm": 1.0})
+        self._track = _track
+
+
+class _PropertyBackedMetric(_ConfigurableMetric):
+    def __init__(self, config: dict):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self._config = config
+
+    @property
+    def config(self):
+        raise AssertionError("cache extraction should not access properties")
+
+
+class _NamedModel:
+    def __init__(self, name: str):
+        self.name = name
+
+    def get_model_name(self):
+        return self.name
+
+
+class _SensitiveNamedModel(_NamedModel):
+    pass
+
+
+class _TunableNamedModel(_NamedModel):
+    def __init__(self, name: str, temperature: float):
+        super().__init__(name)
+        self.temperature = temperature
+
+
+class _ExplodingModelName:
+    def __init__(self, name: str = "model-a"):
+        self.name = name
+
+    def get_model_name(self):
+        raise AssertionError(
+            "cache fingerprinting should not call get_model_name"
+        )
+
+
+class _UnnamedModel:
+    pass
+
+
+class _MetricWithModelWithoutEvaluationModel(_ConfigurableMetric):
+    def __init__(self, model):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.model = model
+
+
+class _MetricWithDerivedEvaluationModel(_MetricWithModelWithoutEvaluationModel):
+    def __init__(self, model):
+        super().__init__(model)
+        self.evaluation_model = self.model.get_model_name()
+
+
+class _MetricWithPrivateDerivedEvaluationModel(_ConfigurableMetric):
+    def __init__(self, model):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self._model = model
+        self.evaluation_model = self._model.get_model_name()
+
+
+class _MetricWithInitializedNativeModel(_ConfigurableMetric):
+    def __init__(self, model: str):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.model = GPTModel(model=model, api_key="sk-test")
+        self.using_native_model = True
+        self.evaluation_model = self.model.get_model_name()
+
+
+class _MetricWithInjectedNativeModel(_ConfigurableMetric):
+    def __init__(self, model):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.model = model
+        self.using_native_model = True
+        self.evaluation_model = model.model_name
+
+
+class _NativeModelWithMaxTokens:
+    __module__ = "deepeval.models.llms.anthropic_model"
+
+    def __init__(self, model_name: str, max_tokens: int):
+        self.model_name = model_name
+        self._max_tokens = max_tokens
+
+
+class _NativeModelWithVertexBackend:
+    __module__ = "deepeval.models.llms.gemini_model"
+
+    def __init__(self, model_name: str, use_vertexai: bool):
+        self.model_name = model_name
+        self.project = "deepeval-test-project"
+        self.location = "us-central1"
+        self.use_vertexai = use_vertexai
+
+
+# Mirrors Pydantic alias helper versions that expose slot-backed attributes
+# rather than a plain __dict__.
+_SlotBackedAliasChoices = type(
+    "AliasChoices",
+    (),
+    {
+        "__module__": "pydantic.aliases",
+        "__slots__": ("choices",),
+        "__init__": lambda self, choices: setattr(self, "choices", choices),
+    },
+)
+
+_SlotBackedAliasPath = type(
+    "AliasPath",
+    (),
+    {
+        "__module__": "pydantic.aliases",
+        "__slots__": ("path",),
+        "__init__": lambda self, path: setattr(self, "path", path),
+    },
+)
+
+
+class _MetricWithEvaluationModelString(_ConfigurableMetric):
+    def __init__(self, evaluation_model: str):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.evaluation_model = evaluation_model
+
+
+class _MetricWithLanguage(_ConfigurableMetric):
+    def __init__(self, language: str):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.language = language
+
+
+class _FreeFormConfigMetric(_ConfigurableMetric):
+    def __init__(
+        self,
+        criteria=None,
+        evaluation_steps=None,
+        assessment_questions=None,
+    ):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.criteria = criteria
+        self.evaluation_steps = evaluation_steps
+        self.assessment_questions = assessment_questions
+
+
+class _HostileCriteriaMetric(_ConfigurableMetric):
+    criteria_accesses = 0
+
+    def __init__(self):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.evaluation_steps = None
+
+    @property
+    def criteria(self):
+        type(self).criteria_accesses += 1
+        raise AssertionError("cache fingerprinting should not access criteria")
+
+
+class _ScalarConfigMetric(_ConfigurableMetric):
+    def __init__(self, field: str, value):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        setattr(self, field, value)
+
+
+class _ExplodingStringValue:
+    def __str__(self):
+        raise AssertionError(
+            "cache fingerprinting should not stringify arbitrary objects"
+        )
+
+
+class _ExplodingClassValue:
+    def __getattribute__(self, name):
+        if name == "__class__":
+            raise AssertionError(
+                "cache fingerprinting should use type(value), not __class__"
+            )
+        return object.__getattribute__(self, name)
+
+
+class _HostileDictMetric(_ConfigurableMetric):
+    def __getattribute__(self, name):
+        if name == "__dict__":
+            raise RuntimeError(
+                "cache fingerprinting should miss closed on hostile __dict__"
+            )
+        return object.__getattribute__(self, name)
+
+
+class _HostileNativeModel:
+    __module__ = "deepeval.models.llms.hostile"
+
+    def __getattribute__(self, name):
+        if name == "__dict__":
+            raise RuntimeError(
+                "cache fingerprinting should miss closed on hostile model fields"
+            )
+        return object.__getattribute__(self, name)
+
+
+class _MetricWithHostileNativeModel(_ConfigurableMetric):
+    def __init__(self, model):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.model = model
+        self.using_native_model = True
+        self.evaluation_model = "hostile-native-model"
+
+
+class _ExplodingDict(dict):
+    def __len__(self):
+        raise AssertionError(
+            "cache fingerprinting should not call custom mapping methods"
+        )
+
+    def __iter__(self):
+        raise AssertionError(
+            "cache fingerprinting should not iterate custom mappings"
+        )
+
+    def items(self):
+        raise AssertionError(
+            "cache fingerprinting should not call custom mapping items"
+        )
+
+
+class _ExplodingList(list):
+    def __len__(self):
+        raise AssertionError(
+            "cache fingerprinting should not call custom sequence methods"
+        )
+
+    def __iter__(self):
+        raise AssertionError(
+            "cache fingerprinting should not iterate custom sequences"
+        )
+
+
+class _MetricWithEvaluationModelObject(_ConfigurableMetric):
+    def __init__(self, evaluation_model):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.evaluation_model = evaluation_model
+
+
+class _DAGChildMetric(_ConfigurableMetric):
+    def __init__(self, setting):
+        super().__init__(rubric="child", weights={"harm": 1.0})
+        self.setting = setting
+
+
+class _FirstSchema(PydanticBaseModel):
+    value: str
+
+
+class _SecondSchema(PydanticBaseModel):
+    value: str
+
+
+class _LiteralIntSchema(PydanticBaseModel):
+    value: Literal[1]
+
+
+class _LiteralStringSchema(PydanticBaseModel):
+    value: Literal["1"]
+
+
+class _ValidatedSchema(PydanticBaseModel):
+    value: int
+
+    @field_validator("value")
+    @classmethod
+    def validate_value(cls, value):
+        return value
+
+
+class _SchemaWithPrivateState(PydanticBaseModel):
+    value: str
+
+    _mode: str = PrivateAttr(default="strict")
+
+
+class _SchemaWithHostileGetattribute(PydanticBaseModel):
+    value: str
+
+    def __getattribute__(self, name):
+        if name == "__pydantic_private__":
+            raise RuntimeError(
+                "cache fingerprinting should not call model __getattribute__"
+            )
+        return super().__getattribute__(name)
+
+
+class _SchemaWithHostileConfig(PydanticBaseModel):
+    value: str
+
+
+class _SchemaWithHostileField(PydanticBaseModel):
+    value: str
+
+
+class _HostileConfigMapping(dict):
+    def __iter__(self):
+        raise AssertionError(
+            "cache fingerprinting should not iterate custom model_config"
+        )
+
+    def items(self):
+        raise AssertionError(
+            "cache fingerprinting should not call custom model_config items"
+        )
+
+
+class _HostilePydanticField:
+    def __getattribute__(self, name):
+        raise AssertionError(
+            "cache fingerprinting should not inspect custom field objects"
+        )
+
+
+class _HostileFieldKey:
+    def __str__(self):
+        raise AssertionError(
+            "cache fingerprinting should not stringify custom field keys"
+        )
+
+
+class _HostileIterable:
+    def __iter__(self):
+        raise AssertionError(
+            "cache fingerprinting should not iterate custom DAG containers"
+        )
+
+
+class _SchemaMetric(_ConfigurableMetric):
+    def __init__(self, expected_schema: PydanticBaseModel):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.expected_schema = expected_schema
+
+
+class _SchemaClassMetric(_ConfigurableMetric):
+    def __init__(self, expected_schema: type[PydanticBaseModel]):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.expected_schema = expected_schema
+
+
+class _NoDictMetric:
+    __slots__ = ("threshold", "strict_mode", "rubric")
+
+    def __init__(self, rubric: str = "safety"):
+        self.threshold = 0.5
+        self.strict_mode = False
+        self.rubric = rubric
+
+    @property
+    def __name__(self):
+        return "No Dict Metric"
+
+
+class _NoInitMetric(BaseMetric):
+    threshold = 0.5
+    strict_mode = False
+
+    def measure(self, test_case: LLMTestCase, *args, **kwargs) -> float:
+        return 1.0
+
+    async def a_measure(self, test_case: LLMTestCase, *args, **kwargs) -> float:
+        return 1.0
+
+    def is_successful(self) -> bool:
+        return True
+
+    @property
+    def __name__(self):
+        return "No Init Metric"
+
+
+class _SlotsModelMetric:
+    __slots__ = ("threshold", "strict_mode", "model")
+
+    def __init__(self, model: str):
+        self.threshold = 0.5
+        self.strict_mode = False
+        self.model = model
+
+    @property
+    def __name__(self):
+        return "Slots Model Metric"
+
+
+class _SignaturelessMetric(_ConfigurableMetric):
+    def __init__(self, rubric: str):
+        super().__init__(rubric=rubric, weights={"harm": 1.0})
+
+
+class _DAGBackedMetric(_ConfigurableMetric):
+    def __init__(self, dag: DeepAcyclicGraph):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.dag = dag
+
+
+class _CustomTaskNode(TaskNode):
+    pass
+
+
+@dataclass
+class _CyclicDataclassConfig:
+    mode: str
+    next_config: object = None
+
+
+class _DataclassConfigMetric(_ConfigurableMetric):
+    def __init__(self, config: _CyclicDataclassConfig):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.config = config
+
+
+class _ModelWithExplodingDump(PydanticBaseModel):
+    value: str
+
+    def model_dump(self, *args, **kwargs):
+        raise AssertionError("cache fingerprinting should not call model_dump")
+
+    @classmethod
+    def model_json_schema(cls, *args, **kwargs):
+        raise AssertionError(
+            "cache fingerprinting should not generate live schemas"
+        )
+
+
+class _ExplodingModelMetric(_ConfigurableMetric):
+    def __init__(self, config: _ModelWithExplodingDump):
+        super().__init__(rubric="safety", weights={"harm": 1.0})
+        self.config = config
+
+
+def _named_schema_default():
+    return "first"
+
+
+def _single_node_dag(instructions: str) -> DeepAcyclicGraph:
+    return DeepAcyclicGraph(
+        root_nodes=[
+            TaskNode(
+                instructions=instructions,
+                output_label="result",
+                children=[],
+                evaluation_params=[SingleTurnParams.INPUT],
+            )
+        ]
+    )
+
+
+def _shared_child_dag(shared: bool) -> DeepAcyclicGraph:
+    first_shared_child = TaskNode(
+        instructions="Shared child",
+        output_label="shared",
+        children=[],
+        evaluation_params=[SingleTurnParams.INPUT],
+    )
+    second_shared_child = (
+        first_shared_child
+        if shared
+        else TaskNode(
+            instructions="Shared child",
+            output_label="shared",
+            children=[],
+            evaluation_params=[SingleTurnParams.INPUT],
+        )
+    )
+    return DeepAcyclicGraph(
+        root_nodes=[
+            TaskNode(
+                instructions="Root A",
+                output_label="a",
+                children=[first_shared_child],
+                evaluation_params=[SingleTurnParams.INPUT],
+            ),
+            TaskNode(
+                instructions="Root B",
+                output_label="b",
+                children=[second_shared_child],
+                evaluation_params=[SingleTurnParams.INPUT],
+            ),
+        ]
+    )
+
+
+def _metric_child_dag(setting) -> DeepAcyclicGraph:
+    return DeepAcyclicGraph(
+        root_nodes=[
+            VerdictNode(
+                verdict=True,
+                child=_DAGChildMetric(setting=setting),
+            )
+        ]
+    )
+
+
+def _metric_child_with_evaluation_model_dag(
+    evaluation_model: str,
+) -> DeepAcyclicGraph:
+    return DeepAcyclicGraph(
+        root_nodes=[
+            VerdictNode(
+                verdict=True,
+                child=_MetricWithEvaluationModelString(evaluation_model),
+            )
+        ]
+    )
+
+
+def _cached_metric_data(metric: BaseMetric) -> CachedMetricData:
+    return CachedMetricData(
+        metric_data=MetricData(
+            name=metric.__name__,
+            threshold=metric.threshold,
+            success=True,
+            score=1.0,
+        ),
+        metric_configuration=Cache.create_metric_configuration(metric),
+    )
+
+
+def _cached_case_for(metric: BaseMetric) -> CachedTestCase:
+    return CachedTestCase(cached_metrics_data=[_cached_metric_data(metric)])
+
+
+def _encode_repeatedly(value: str, passes: int = 5) -> str:
+    for _ in range(passes):
+        value = quote(value, safe="")
+    return value
+
+
+def test_pattern_match_cache_hits_when_constructor_parameters_match():
+    expected_entry = _cached_metric_data(
+        PatternMatchMetric(pattern=r"expected", ignore_case=True)
+    )
+    cached_case = CachedTestCase(
+        cached_metrics_data=[
+            _cached_metric_data(ExactMatchMetric()),
+            expected_entry,
+        ]
+    )
+
+    assert (
+        Cache.get_metric_data(
+            PatternMatchMetric(pattern=r"expected", ignore_case=True),
+            cached_case,
+        )
+        is expected_entry
+    )
+
+
+def test_pattern_match_cache_misses_when_pattern_changes():
+    cached_case = _cached_case_for(
+        PatternMatchMetric(pattern=r"expected", ignore_case=False)
+    )
+
+    assert (
+        Cache.get_metric_data(
+            PatternMatchMetric(pattern=r"actual", ignore_case=False),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_pattern_match_cache_misses_when_ignore_case_changes():
+    cached_case = _cached_case_for(
+        PatternMatchMetric(pattern=r"expected", ignore_case=False)
+    )
+
+    assert (
+        Cache.get_metric_data(
+            PatternMatchMetric(pattern=r"expected", ignore_case=True),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_custom_metric_cache_misses_when_constructor_parameter_changes():
+    cached_case = _cached_case_for(
+        _ConfigurableMetric(
+            rubric="safety",
+            weights={"harm": 1.0, "accuracy": 0.5},
+        )
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _ConfigurableMetric(
+                rubric="quality",
+                weights={"harm": 1.0, "accuracy": 0.5},
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_custom_metric_cache_misses_when_nested_constructor_parameter_changes():
+    cached_case = _cached_case_for(
+        _ConfigurableMetric(
+            rubric="safety",
+            weights={"harm": 1.0, "accuracy": 0.5},
+        )
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _ConfigurableMetric(
+                rubric="safety",
+                weights={"harm": 0.5, "accuracy": 0.5},
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_custom_metric_cache_ignores_dict_insertion_order():
+    cached_case = _cached_case_for(
+        _ConfigurableMetric(
+            rubric="safety",
+            weights={"harm": 1.0, "accuracy": 0.5},
+        )
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _ConfigurableMetric(
+                rubric="safety",
+                weights={"accuracy": 0.5, "harm": 1.0},
+            ),
+            cached_case,
+        )
+        is not None
+    )
+
+
+def test_mapping_constructor_parameters_with_non_string_keys_miss_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithNestedConfigParameter({1: "x"})
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["config"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithNestedConfigParameter({1: "x"}),
+            _cached_case_for(_MetricWithNestedConfigParameter({1: "x"})),
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithNestedConfigParameter({"1": "x"}),
+            _cached_case_for(_MetricWithNestedConfigParameter({1: "x"})),
+        )
+        is None
+    )
+
+
+def test_custom_metric_cache_preserves_ordered_constructor_parameters():
+    cached_case = _cached_case_for(
+        _ConfigurableMetric(
+            rubric="safety",
+            weights={"harm": 1.0},
+            steps=["first", "second"],
+        )
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _ConfigurableMetric(
+                rubric="safety",
+                weights={"harm": 1.0},
+                steps=["second", "first"],
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_collection_constructor_parameter_types_do_not_collide():
+    cached_tuple = _cached_case_for(_TypeSensitiveCollectionMetric(("a", "b")))
+    cached_frozenset = _cached_case_for(
+        _TypeSensitiveCollectionMetric(frozenset({"a", "b"}))
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric(["a", "b"]),
+            cached_tuple,
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric({"a", "b"}),
+            cached_frozenset,
+        )
+        is None
+    )
+
+
+def test_enum_and_path_constructor_parameter_types_do_not_collide_with_strings():
+    cached_enum = _cached_case_for(
+        _TypeSensitiveCollectionMetric(_CacheMode.STRICT)
+    )
+    cached_path = _cached_case_for(
+        _TypeSensitiveCollectionMetric(Path("strict"))
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric(_CacheMode.STRICT),
+            cached_enum,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric("strict"),
+            cached_enum,
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric(Path("strict")),
+            cached_path,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric("strict"),
+            cached_path,
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric(1),
+            _cached_case_for(
+                _TypeSensitiveCollectionMetric(_IntCacheMode.STRICT)
+            ),
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _TypeSensitiveCollectionMetric("strict"),
+            _cached_case_for(
+                _TypeSensitiveCollectionMetric(_StrCacheMode.STRICT)
+            ),
+        )
+        is None
+    )
+
+
+def test_secret_bearing_path_constructor_values_miss_cache_closed():
+    for path_value in (
+        Path("/download/token/abc123"),
+        Path("object/X-Amz-Signature=abc123"),
+        Path("/download%2Ftoken%2Fabc123"),
+        Path("/download%2Fsig%2Fabc123"),
+        Path("/download%252Ftoken%252Fabc123"),
+        Path("object/X-Amz-Signature%253Dabc123"),
+        Path(_encode_repeatedly("/download/token/abc123")),
+        Path(_encode_repeatedly("object/X-Amz-Signature=abc123")),
+        Path(r"C:\downloads\token\abc123"),
+        Path(r"\server\share\sig\abc123"),
+        Path(r"\\server\share\sig\abc123"),
+        Path(_encode_repeatedly(r"C:\downloads\token\abc123")),
+        Path(_encode_repeatedly(r"\\server\share\sig\abc123")),
+    ):
+        normalized = Cache._normalize_cache_parameter(
+            "endpoint", path_value, set()
+        )
+
+        assert normalized == {"__deepeval_uncacheable__": "sensitive"}
+        metric_configuration = Cache.create_metric_configuration(
+            _TypeSensitiveCollectionMetric(path_value)
+        )
+        assert metric_configuration.custom_parameters is not None
+        assert (
+            metric_configuration.custom_parameters["value"]
+            == Cache._UNCACHEABLE_CACHE_VALUE
+        )
+        assert str(path_value) not in json.dumps(
+            metric_configuration.model_dump()
+        )
+        assert (
+            Cache.get_metric_data(
+                _TypeSensitiveCollectionMetric(path_value),
+                _cached_case_for(_TypeSensitiveCollectionMetric(path_value)),
+            )
+            is None
+        )
+
+
+def test_non_finite_float_constructor_values_miss_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _ConfigurableMetric(
+            rubric="safety",
+            weights={"harm": float("inf")},
+            steps=["first"],
+        )
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["weights"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _ConfigurableMetric(
+                rubric="safety",
+                weights={"harm": float("inf")},
+                steps=["first"],
+            ),
+            _cached_case_for(
+                _ConfigurableMetric(
+                    rubric="safety",
+                    weights={"harm": float("inf")},
+                    steps=["first"],
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_non_finite_metric_config_fields_miss_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        ExactMatchMetric(threshold=float("inf"))
+    )
+
+    assert metric_configuration.threshold == Cache._UNCACHEABLE_CACHE_VALUE
+    assert "Infinity" not in json.dumps(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            ExactMatchMetric(threshold=float("inf")),
+            _cached_case_for(ExactMatchMetric(threshold=float("inf"))),
+        )
+        is None
+    )
+
+
+def test_custom_metric_cache_misses_closed_when_constructor_parameter_is_unrecoverable():
+    metric_configuration = Cache.create_metric_configuration(
+        _AliasedConstructorMetric(prompt_template="safety prompt")
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["prompt_template"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _AliasedConstructorMetric(prompt_template="safety prompt"),
+            _cached_case_for(
+                _AliasedConstructorMetric(prompt_template="safety prompt")
+            ),
+        )
+        is None
+    )
+
+
+def test_custom_metric_with_var_kwargs_misses_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _KwargsMetric(mode="strict")
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["kwargs"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _KwargsMetric(mode="strict"),
+            _cached_case_for(_KwargsMetric(mode="strict")),
+        )
+        is None
+    )
+
+
+def test_custom_metric_with_var_args_misses_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _ArgsMetric("strict")
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["args"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _ArgsMetric("strict"),
+            _cached_case_for(_ArgsMetric("strict")),
+        )
+        is None
+    )
+
+
+def test_metric_runtime_fields_do_not_invalidate_cache():
+    cached_case = _cached_case_for(
+        _ConfigurableMetric(
+            rubric="safety",
+            weights={"harm": 1.0, "accuracy": 0.5},
+        )
+    )
+    metric = _ConfigurableMetric(
+        rubric="safety",
+        weights={"harm": 1.0, "accuracy": 0.5},
+    )
+
+    metric.score = 0.0
+    metric.score_breakdown = {"other": 0.25}
+    metric.reason = "fresh runtime details should not be cache config"
+    metric.success = False
+    metric.error = "runtime failure from a later run"
+    metric.evaluation_cost = 123.45
+    metric.input_tokens = 99
+    metric.output_tokens = 101
+    metric.verbose_logs = "runtime-only logs"
+    metric.skipped = True
+
+    cached_metric_data = Cache.get_metric_data(metric, cached_case)
+    assert cached_metric_data is not None
+    assert cached_metric_data.metric_data.name == "Configurable Custom"
+    assert cached_metric_data.metric_data.score == 1.0
+
+
+def test_opaque_embedding_config_field_misses_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _EmbeddingsConfigMetric(_FakeEmbeddings())
+    )
+
+    assert metric_configuration.embeddings == Cache._UNCACHEABLE_CACHE_VALUE
+
+    assert (
+        Cache.get_metric_data(
+            _EmbeddingsConfigMetric(_FakeEmbeddings()),
+            _cached_case_for(_EmbeddingsConfigMetric(_FakeEmbeddings())),
+        )
+        is None
+    )
+
+
+def test_string_model_name_is_fingerprinted_when_evaluation_model_is_not_stored():
+    cached_case = _cached_case_for(
+        _MetricWithModelWithoutEvaluationModel("model-a")
+    )
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.evaluation_model is None
+    assert metric_configuration.custom_parameters is not None
+    assert metric_configuration.custom_parameters["model"].startswith("sha256:")
+    assert "model-a" not in json.dumps(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            _MetricWithModelWithoutEvaluationModel("model-a"),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithModelWithoutEvaluationModel("model-b"),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_safe_direct_evaluation_model_string_hits_and_misses_by_value():
+    cached_case = _cached_case_for(_MetricWithEvaluationModelString("model-a"))
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.evaluation_model == "model-a"
+    assert (
+        Cache.get_metric_data(
+            _MetricWithEvaluationModelString("model-a"),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithEvaluationModelString("model-b"),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_initialized_native_model_objects_reuse_stable_evaluation_model_string():
+    cached_case = _cached_case_for(_MetricWithInitializedNativeModel("model-a"))
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.evaluation_model == "model-a"
+    assert metric_configuration.custom_parameters is not None
+    assert metric_configuration.custom_parameters["model"].startswith("sha256:")
+    assert "sk-test" not in json.dumps(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            _MetricWithInitializedNativeModel("model-a"),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithInitializedNativeModel("model-b"),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_native_model_cache_identity_includes_generation_settings():
+    cached_case = _cached_case_for(
+        AnswerRelevancyMetric(
+            model=GPTModel(
+                model="gpt-4o-mini",
+                temperature=0,
+                generation_kwargs={"top_p": 0.1},
+                api_key="sk-test",
+            ),
+            async_mode=False,
+        )
+    )
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.custom_parameters is not None
+    assert metric_configuration.custom_parameters["model"].startswith("sha256:")
+    assert "sk-test" not in json.dumps(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            AnswerRelevancyMetric(
+                model=GPTModel(
+                    model="gpt-4o-mini",
+                    temperature=0,
+                    generation_kwargs={"top_p": 0.1},
+                    api_key="sk-test",
+                ),
+                async_mode=False,
+            ),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            AnswerRelevancyMetric(
+                model=GPTModel(
+                    model="gpt-4o-mini",
+                    temperature=0.7,
+                    generation_kwargs={"top_p": 0.1},
+                    api_key="sk-test",
+                ),
+                async_mode=False,
+            ),
+            cached_case,
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            AnswerRelevancyMetric(
+                model=GPTModel(
+                    model="gpt-4o-mini",
+                    temperature=0,
+                    generation_kwargs={"top_p": 0.9},
+                    api_key="sk-test",
+                ),
+                async_mode=False,
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_native_model_cache_identity_includes_anthropic_max_tokens():
+    cached_case = _cached_case_for(
+        _MetricWithInjectedNativeModel(
+            _NativeModelWithMaxTokens(
+                model_name="claude-test",
+                max_tokens=256,
+            )
+        )
+    )
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.custom_parameters is not None
+    assert metric_configuration.custom_parameters["model"].startswith("sha256:")
+    assert (
+        Cache.get_metric_data(
+            _MetricWithInjectedNativeModel(
+                _NativeModelWithMaxTokens(
+                    model_name="claude-test",
+                    max_tokens=256,
+                )
+            ),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithInjectedNativeModel(
+                _NativeModelWithMaxTokens(
+                    model_name="claude-test",
+                    max_tokens=1024,
+                )
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_native_model_cache_identity_includes_gemini_vertex_backend_flag():
+    cached_case = _cached_case_for(
+        _MetricWithInjectedNativeModel(
+            _NativeModelWithVertexBackend(
+                model_name="gemini-test",
+                use_vertexai=True,
+            )
+        )
+    )
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.custom_parameters is not None
+    assert metric_configuration.custom_parameters["model"].startswith("sha256:")
+    assert (
+        Cache.get_metric_data(
+            _MetricWithInjectedNativeModel(
+                _NativeModelWithVertexBackend(
+                    model_name="gemini-test",
+                    use_vertexai=True,
+                )
+            ),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithInjectedNativeModel(
+                _NativeModelWithVertexBackend(
+                    model_name="gemini-test",
+                    use_vertexai=False,
+                )
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_real_initialize_model_metric_keeps_cache_hit_for_stable_string_model():
+    cached_case = _cached_case_for(
+        AnswerRelevancyMetric(
+            model=GPTModel(model="gpt-4o-mini", api_key="sk-test"),
+            async_mode=False,
+        )
+    )
+
+    assert (
+        Cache.get_metric_data(
+            AnswerRelevancyMetric(
+                model=GPTModel(model="gpt-4o-mini", api_key="sk-test"),
+                async_mode=False,
+            ),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            AnswerRelevancyMetric(
+                model=GPTModel(model="gpt-4o", api_key="sk-test"),
+                async_mode=False,
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_tool_correctness_metric_with_native_model_keeps_cache_hit_without_evaluation_model():
+    cached_case = _cached_case_for(
+        ToolCorrectnessMetric(
+            model=GPTModel(model="gpt-4o-mini", api_key="sk-test"),
+            async_mode=False,
+        )
+    )
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.evaluation_model is None
+    assert metric_configuration.custom_parameters is not None
+    assert metric_configuration.custom_parameters["model"].startswith("sha256:")
+    assert "sk-test" not in json.dumps(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            ToolCorrectnessMetric(
+                model=GPTModel(model="gpt-4o-mini", api_key="sk-test"),
+                async_mode=False,
+            ),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            ToolCorrectnessMetric(
+                model=GPTModel(model="gpt-4o", api_key="sk-test"),
+                async_mode=False,
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_hostile_native_model_dict_access_misses_cache_closed():
+    metric = _MetricWithHostileNativeModel(_HostileNativeModel())
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert metric_configuration.evaluation_model == "hostile-native-model"
+    assert metric_configuration.custom_parameters == {
+        "model": Cache._UNCACHEABLE_CACHE_VALUE
+    }
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_model_objects_miss_closed_even_when_names_match():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithModelWithoutEvaluationModel(
+            _TunableNamedModel("model-a", temperature=0.0)
+        )
+    )
+
+    assert metric_configuration.evaluation_model is None
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["model"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithModelWithoutEvaluationModel(
+                _TunableNamedModel("model-a", temperature=1.0)
+            ),
+            _cached_case_for(
+                _MetricWithModelWithoutEvaluationModel(
+                    _TunableNamedModel("model-a", temperature=0.0)
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_derived_metric_model_objects_miss_closed_without_persisting_raw_value():
+    metric = _MetricWithDerivedEvaluationModel(_NamedModel("model-a"))
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert (
+        metric_configuration.evaluation_model == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["model"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "model-a" not in json.dumps(metric_configuration.model_dump())
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_model_name_fingerprinting_uses_passive_fields_without_method_calls():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithModelWithoutEvaluationModel(_ExplodingModelName("model-a"))
+    )
+
+    assert metric_configuration.evaluation_model is None
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["model"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithModelWithoutEvaluationModel(
+                _ExplodingModelName("model-a")
+            ),
+            _cached_case_for(
+                _MetricWithModelWithoutEvaluationModel(
+                    _ExplodingModelName("model-a")
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_unidentified_model_objects_miss_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithModelWithoutEvaluationModel(_UnnamedModel())
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["model"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithModelWithoutEvaluationModel(_UnnamedModel()),
+            _cached_case_for(
+                _MetricWithModelWithoutEvaluationModel(_UnnamedModel())
+            ),
+        )
+        is None
+    )
+
+
+def test_sensitive_model_names_miss_cache_closed_without_persisting_raw_value():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithModelWithoutEvaluationModel(
+            _SensitiveNamedModel("https://user:pass@example.com/model")
+        )
+    )
+
+    assert metric_configuration.evaluation_model is None
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["model"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "https://user:pass@example.com/model" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithModelWithoutEvaluationModel(
+                _SensitiveNamedModel("https://user:pass@example.com/model")
+            ),
+            _cached_case_for(
+                _MetricWithModelWithoutEvaluationModel(
+                    _SensitiveNamedModel("https://user:pass@example.com/model")
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_sensitive_direct_evaluation_model_string_misses_closed():
+    metric = _MetricWithEvaluationModelString(
+        "https://user:pass@example.com/model"
+    )
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert (
+        metric_configuration.evaluation_model == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "https://user:pass@example.com/model" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_encoded_query_and_fragment_evaluation_model_secrets_miss_cache_closed():
+    for evaluation_model in (
+        "https://example.com/model?state=Bearer%20secret-token",
+        "https://example.com/model#sig=secret-signature",
+        "https://example.com/model#access_token=secret-token",
+    ):
+        metric = _MetricWithEvaluationModelString(evaluation_model)
+        metric_configuration = Cache.create_metric_configuration(metric)
+
+        assert (
+            metric_configuration.evaluation_model
+            == Cache._UNCACHEABLE_CACHE_VALUE
+        )
+        assert evaluation_model not in json.dumps(
+            metric_configuration.model_dump()
+        )
+        assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_non_string_evaluation_model_misses_closed_without_str_call():
+    metric = _MetricWithEvaluationModelObject(_ExplodingStringValue())
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert (
+        metric_configuration.evaluation_model == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_free_form_metric_config_fields_are_fingerprinted_not_cached_raw():
+    cached_case = _cached_case_for(
+        _FreeFormConfigMetric(
+            criteria="Judge helpfulness",
+            evaluation_steps=["Check whether the answer is helpful"],
+            assessment_questions=["Was the answer useful?"],
+        )
+    )
+    metric_configuration = cached_case.cached_metrics_data[
+        0
+    ].metric_configuration
+
+    assert metric_configuration.criteria.startswith("sha256:")
+    assert metric_configuration.evaluation_steps.startswith("sha256:")
+    assert metric_configuration.assessment_questions.startswith("sha256:")
+    assert "Judge helpfulness" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert (
+        Cache.get_metric_data(
+            _FreeFormConfigMetric(
+                criteria="Judge helpfulness",
+                evaluation_steps=["Check whether the answer is helpful"],
+                assessment_questions=["Was the answer useful?"],
+            ),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _FreeFormConfigMetric(
+                criteria="Judge harmfulness",
+                evaluation_steps=["Check whether the answer is helpful"],
+                assessment_questions=["Was the answer useful?"],
+            ),
+            cached_case,
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _FreeFormConfigMetric(
+                criteria="Judge helpfulness",
+                evaluation_steps=["Check whether the answer is concise"],
+                assessment_questions=["Was the answer useful?"],
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_sensitive_free_form_metric_config_fields_miss_cache_closed():
+    metric = _FreeFormConfigMetric(
+        criteria="Bearer secret-token should not be written",
+        evaluation_steps=["Check sig=secret-signature"],
+        assessment_questions=["Does api_key=sk-secret appear?"],
+    )
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert metric_configuration.criteria == Cache._UNCACHEABLE_CACHE_VALUE
+    assert (
+        metric_configuration.evaluation_steps == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        metric_configuration.assessment_questions
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    serialized = json.dumps(metric_configuration.model_dump())
+    assert "secret-token" not in serialized
+    assert "secret-signature" not in serialized
+    assert "sk-secret" not in serialized
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_uncacheable_evaluation_steps_never_hit_cache_even_when_values_match():
+    metric = _FreeFormConfigMetric(
+        criteria="Judge helpfulness",
+        evaluation_steps=["Check sig=secret-signature"],
+        assessment_questions=["Was the answer useful?"],
+    )
+    cached_case = _cached_case_for(metric)
+
+    assert (
+        cached_case.cached_metrics_data[0].metric_configuration.evaluation_steps
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert Cache.get_metric_data(metric, cached_case) is None
+
+
+def test_hostile_free_form_metric_config_property_misses_cache_closed():
+    _HostileCriteriaMetric.criteria_accesses = 0
+    metric = _HostileCriteriaMetric()
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert metric_configuration.criteria == Cache._UNCACHEABLE_CACHE_VALUE
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+    assert _HostileCriteriaMetric.criteria_accesses == 0
+
+
+def test_sensitive_scalar_metric_config_fields_miss_cache_closed():
+    for field, value, secret in (
+        ("threshold", "sk-threshold-secret", "sk-threshold-secret"),
+        ("strict_mode", "Bearer strict-secret", "strict-secret"),
+        ("include_reason", "token=reason-secret", "reason-secret"),
+        ("n", "sig=n-secret", "n-secret"),
+    ):
+        metric = _ScalarConfigMetric(field, value)
+        metric_configuration = Cache.create_metric_configuration(metric)
+
+        assert (
+            getattr(metric_configuration, field)
+            == Cache._UNCACHEABLE_CACHE_VALUE
+        )
+        assert secret not in json.dumps(metric_configuration.model_dump())
+        cached_case = CachedTestCase(
+            cached_metrics_data=[
+                CachedMetricData(
+                    metric_data=MetricData(
+                        name=metric.__name__,
+                        threshold=0.5,
+                        success=True,
+                        score=1.0,
+                    ),
+                    metric_configuration=metric_configuration,
+                )
+            ]
+        )
+        assert Cache.get_metric_data(metric, cached_case) is None
+
+
+def test_sensitive_derived_model_names_miss_cache_closed_without_persisting_raw_value():
+    metric = _MetricWithDerivedEvaluationModel(
+        _SensitiveNamedModel("https://user:pass@example.com/model")
+    )
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert (
+        metric_configuration.evaluation_model == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["model"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "https://user:pass@example.com/model" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_sensitive_private_model_names_miss_cache_closed_without_persisting_raw_value():
+    metric = _MetricWithPrivateDerivedEvaluationModel(
+        _SensitiveNamedModel("https://user:pass@example.com/model")
+    )
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert (
+        metric_configuration.evaluation_model == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["model"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "https://user:pass@example.com/model" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_metric_constructor_parameters_are_stored_in_cache_configuration():
+    metric_configuration = Cache.create_metric_configuration(
+        _ConfigurableMetric(
+            rubric="safety",
+            weights={"harm": 1.0, "accuracy": 0.5},
+        )
+    )
+
+    custom_parameters = metric_configuration.custom_parameters
+    assert custom_parameters is not None
+    assert set(custom_parameters) == {
+        "rubric",
+        "steps",
+        "weights",
+    }
+    assert all(
+        value.startswith("sha256:") for value in custom_parameters.values()
+    )
+    assert "safety" not in set(custom_parameters.values())
+
+
+def test_no_dict_metric_constructor_parameters_miss_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _NoDictMetric("safety")
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["rubric"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _NoDictMetric("safety"),
+            _cached_case_for(_NoDictMetric("safety")),
+        )
+        is None
+    )
+
+
+def test_hostile_metric_dict_access_misses_cache_closed():
+    metric = _HostileDictMetric(rubric="safety", weights={"harm": 1.0})
+    metric_configuration = Cache.create_metric_configuration(metric)
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["rubric"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        metric_configuration.custom_parameters["weights"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert Cache.get_metric_data(metric, _cached_case_for(metric)) is None
+
+
+def test_metric_with_no_explicit_init_has_no_constructor_state_to_compare():
+    cached_case = _cached_case_for(_NoInitMetric())
+
+    assert (
+        Cache.create_metric_configuration(_NoInitMetric()).custom_parameters
+        is None
+    )
+    assert Cache.get_metric_data(_NoInitMetric(), cached_case) is not None
+
+
+def test_slots_metric_with_unrecoverable_model_misses_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _SlotsModelMetric("model-a")
+    )
+
+    assert metric_configuration.custom_parameters == {
+        "model": Cache._UNCACHEABLE_CACHE_VALUE
+    }
+    assert (
+        Cache.get_metric_data(
+            _SlotsModelMetric("model-a"),
+            _cached_case_for(_SlotsModelMetric("model-a")),
+        )
+        is None
+    )
+
+
+def test_signature_introspection_failure_misses_cache_closed(monkeypatch):
+    original_signature = cache_identity_module.inspect.signature
+
+    def raise_for_signatureless_metric(value, *args, **kwargs):
+        if value is _SignaturelessMetric.__init__:
+            raise ValueError("signature unavailable")
+        return original_signature(value, *args, **kwargs)
+
+    monkeypatch.setattr(
+        cache_identity_module.inspect,
+        "signature",
+        raise_for_signatureless_metric,
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _SignaturelessMetric("safety")
+    )
+
+    assert metric_configuration.custom_parameters == {
+        "__signature__": Cache._UNCACHEABLE_CACHE_VALUE
+    }
+    assert (
+        Cache.get_metric_data(
+            _SignaturelessMetric("safety"),
+            _cached_case_for(_SignaturelessMetric("safety")),
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_class_constructor_parameter_includes_field_shape():
+    first_schema = create_model(
+        "ReusableSchema",
+        value=(str, ...),
+        __module__=__name__,
+    )
+    second_schema = create_model(
+        "ReusableSchema",
+        value=(int, ...),
+        __module__=__name__,
+    )
+    cached_case = _cached_case_for(_SchemaClassMetric(first_schema))
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(first_schema),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(second_schema),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_pydantic_v1_config_affects_schema_identity():
+    pydantic_v1 = pytest.importorskip("pydantic.v1")
+
+    class AllowConfig:
+        extra = "allow"
+
+    class ForbidConfig:
+        extra = "forbid"
+
+    first_schema = pydantic_v1.create_model(
+        "ReusableV1ConfigSchema",
+        value=(str, ...),
+        __module__=__name__,
+        __config__=AllowConfig,
+    )
+    second_schema = pydantic_v1.create_model(
+        "ReusableV1ConfigSchema",
+        value=(str, ...),
+        __module__=__name__,
+        __config__=ForbidConfig,
+    )
+    cached_case = _cached_case_for(_SchemaClassMetric(first_schema))
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(first_schema),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(second_schema),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_free_form_metadata_misses_closed_without_persisting_raw_value():
+    schema = create_model(
+        "DescSchema",
+        value=(
+            str,
+            Field(
+                default="same",
+                title="Answer",
+                description="sk-should-not-be-written",
+                examples=["bearer-should-not-be-written"],
+                json_schema_extra={"format": "secret-should-not-be-written"},
+            ),
+        ),
+        __module__=__name__,
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaClassMetric(schema)
+    )
+    payload = json.dumps(metric_configuration.model_dump())
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "sk-should-not-be-written" not in payload
+    assert "bearer-should-not-be-written" not in payload
+    assert "secret-should-not-be-written" not in payload
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(schema),
+            _cached_case_for(_SchemaClassMetric(schema)),
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_callable_json_schema_extra_misses_cache_closed():
+    def mutate_schema(schema):
+        schema["x-mode"] = "strict"
+
+    schema = create_model(
+        "CallableSchema",
+        value=(str, Field(default="same", json_schema_extra=mutate_schema)),
+        __module__=__name__,
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaClassMetric(schema)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(schema),
+            _cached_case_for(_SchemaClassMetric(schema)),
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_alias_choices_affect_cache_identity():
+    if AliasChoices is None:
+        pytest.skip("AliasChoices requires Pydantic v2")
+
+    first_schema = create_model(
+        "AliasSchema",
+        value=(
+            str,
+            Field(
+                default="same",
+                validation_alias=AliasChoices("answer", "result"),
+            ),
+        ),
+        __module__=__name__,
+    )
+    second_schema = create_model(
+        "AliasSchema",
+        value=(
+            str,
+            Field(
+                default="same",
+                validation_alias=AliasChoices("output", "result"),
+            ),
+        ),
+        __module__=__name__,
+    )
+    cached_case = _cached_case_for(_SchemaClassMetric(first_schema))
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(first_schema),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(second_schema),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_slot_backed_pydantic_alias_helpers_are_cacheable():
+    alias_choices = _SlotBackedAliasChoices(["answer", "result"])
+    alias_path = _SlotBackedAliasPath(["payload", "answer"])
+
+    assert Cache._pydantic_alias_candidates(alias_choices) == [
+        "answer",
+        "result",
+    ]
+    assert Cache._pydantic_alias_identity(alias_choices) == {
+        "choices": ["answer", "result"]
+    }
+    assert Cache._pydantic_alias_candidates(alias_path) == [
+        "payload",
+        "answer",
+    ]
+    assert Cache._pydantic_alias_identity(alias_path) == {
+        "path": ["payload", "answer"]
+    }
+
+
+def test_pydantic_instance_sensitive_alias_values_miss_cache_closed():
+    schema = create_model(
+        "AliasedInstanceSchema",
+        value=(str, Field(alias="Authorization")),
+        __module__=__name__,
+    )
+    instance = schema(Authorization="first-secret")
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaMetric(instance)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "first-secret" not in json.dumps(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            _SchemaMetric(instance),
+            _cached_case_for(_SchemaMetric(instance)),
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_secret_defaults_miss_cache_closed():
+    direct_secret_schema = create_model(
+        "DirectSecretSchema",
+        api_key=(str, "sk-should-not-be-written"),
+        __module__=__name__,
+    )
+    aliased_secret_schema = create_model(
+        "AliasedSecretSchema",
+        value=(
+            str,
+            Field(
+                "bearer-should-not-be-written",
+                alias="Authorization",
+            ),
+        ),
+        __module__=__name__,
+    )
+    schemas = [
+        (direct_secret_schema, "sk-should-not-be-written"),
+        (aliased_secret_schema, "bearer-should-not-be-written"),
+    ]
+    if AliasChoices is not None:
+        alias_choices_secret_schema = create_model(
+            "AliasChoicesSecretSchema",
+            value=(
+                str,
+                Field(
+                    "choice-should-not-be-written",
+                    validation_alias=AliasChoices("Authorization", "trace_id"),
+                ),
+            ),
+            __module__=__name__,
+        )
+        schemas.append(
+            (alias_choices_secret_schema, "choice-should-not-be-written")
+        )
+
+    for schema, secret in schemas:
+        metric_configuration = Cache.create_metric_configuration(
+            _SchemaClassMetric(schema)
+        )
+
+        assert metric_configuration.custom_parameters is not None
+        assert (
+            metric_configuration.custom_parameters["expected_schema"]
+            == Cache._UNCACHEABLE_CACHE_VALUE
+        )
+        assert secret not in json.dumps(metric_configuration.model_dump())
+        assert (
+            Cache.get_metric_data(
+                _SchemaClassMetric(schema),
+                _cached_case_for(_SchemaClassMetric(schema)),
+            )
+            is None
+        )
+
+
+def test_pydantic_private_attributes_miss_cache_closed():
+    schema = _SchemaWithPrivateState(value="same")
+    schema._mode = "strict"
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaMetric(schema)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaMetric(schema),
+            _cached_case_for(_SchemaMetric(schema)),
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_SchemaWithPrivateState),
+            _cached_case_for(_SchemaClassMetric(_SchemaWithPrivateState)),
+        )
+        is None
+    )
+
+
+def test_pydantic_custom_getattribute_misses_cache_closed():
+    schema = _SchemaWithHostileGetattribute(value="same")
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaMetric(schema)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaMetric(schema),
+            _cached_case_for(_SchemaMetric(schema)),
+        )
+        is None
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_SchemaWithHostileGetattribute),
+            _cached_case_for(
+                _SchemaClassMetric(_SchemaWithHostileGetattribute)
+            ),
+        )
+        is None
+    )
+
+
+def test_pydantic_custom_model_config_mapping_misses_cache_closed(monkeypatch):
+    monkeypatch.setattr(
+        _SchemaWithHostileConfig,
+        "model_config",
+        _HostileConfigMapping(extra="allow"),
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaClassMetric(_SchemaWithHostileConfig)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_SchemaWithHostileConfig),
+            _cached_case_for(_SchemaClassMetric(_SchemaWithHostileConfig)),
+        )
+        is None
+    )
+
+
+def test_pydantic_custom_field_object_misses_cache_closed(monkeypatch):
+    monkeypatch.setattr(
+        _SchemaWithHostileField,
+        "model_fields",
+        {"value": _HostilePydanticField()},
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaClassMetric(_SchemaWithHostileField)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_SchemaWithHostileField),
+            _cached_case_for(_SchemaClassMetric(_SchemaWithHostileField)),
+        )
+        is None
+    )
+
+
+def test_pydantic_field_map_with_custom_key_misses_cache_without_str_call(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        _SchemaWithHostileField,
+        "model_fields",
+        {_HostileFieldKey(): _SchemaWithHostileField.model_fields["value"]},
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaClassMetric(_SchemaWithHostileField)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_SchemaWithHostileField),
+            _cached_case_for(_SchemaClassMetric(_SchemaWithHostileField)),
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_with_validator_misses_cache_closed():
+    cached_case = _cached_case_for(_SchemaClassMetric(_ValidatedSchema))
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_ValidatedSchema),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_pydantic_v1_root_validator_misses_cache_closed():
+    pydantic_v1 = pytest.importorskip("pydantic.v1")
+
+    class RootValidatedSchema(pydantic_v1.BaseModel):
+        value: int
+
+        @pydantic_v1.root_validator(pre=True)
+        def validate_root(cls, values):
+            return values
+
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaClassMetric(RootValidatedSchema)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(RootValidatedSchema),
+            _cached_case_for(_SchemaClassMetric(RootValidatedSchema)),
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_with_lambda_default_factory_misses_cache_closed():
+    schema = create_model(
+        "FactorySchema",
+        value=(str, Field(default_factory=lambda: "first")),
+        __module__=__name__,
+    )
+    cached_case = _cached_case_for(_SchemaClassMetric(schema))
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(schema),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_with_named_default_factory_misses_cache_closed():
+    schema = create_model(
+        "NamedFactorySchema",
+        value=(str, Field(default_factory=_named_schema_default)),
+        __module__=__name__,
+    )
+    cached_case = _cached_case_for(_SchemaClassMetric(schema))
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(schema),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_dag_constructor_parameter_uses_structural_identity():
+    cached_case = _cached_case_for(
+        _DAGBackedMetric(_single_node_dag("Extract safety issues"))
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(_single_node_dag("Extract safety issues")),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(_single_node_dag("Extract factual issues")),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_dag_constructor_parameter_preserves_shared_node_topology():
+    cached_case = _cached_case_for(_DAGBackedMetric(_shared_child_dag(True)))
+
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(_shared_child_dag(True)),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(_shared_child_dag(False)),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_dag_constructor_parameter_misses_closed_on_cycles():
+    root = TaskNode(
+        instructions="Root",
+        output_label="root",
+        children=[],
+        evaluation_params=[SingleTurnParams.INPUT],
+    )
+    root.children = [root]
+    dag = DeepAcyclicGraph(root_nodes=[root])
+    metric_configuration = Cache.create_metric_configuration(
+        _DAGBackedMetric(dag)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["dag"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(dag),
+            _cached_case_for(_DAGBackedMetric(dag)),
+        )
+        is None
+    )
+
+
+def test_dag_root_nodes_custom_iterable_misses_cache_without_iteration():
+    root = TaskNode(
+        instructions="Root",
+        output_label="root",
+        children=[],
+        evaluation_params=[SingleTurnParams.INPUT],
+    )
+    dag = DeepAcyclicGraph(root_nodes=[root])
+    dag.root_nodes = _HostileIterable()
+    metric_configuration = Cache.create_metric_configuration(
+        _DAGBackedMetric(dag)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["dag"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(dag),
+            _cached_case_for(_DAGBackedMetric(dag)),
+        )
+        is None
+    )
+
+
+def test_dag_children_custom_iterable_misses_cache_without_iteration():
+    root = TaskNode(
+        instructions="Root",
+        output_label="root",
+        children=[],
+        evaluation_params=[SingleTurnParams.INPUT],
+    )
+    root.children = _HostileIterable()
+    dag = DeepAcyclicGraph(root_nodes=[root])
+    metric_configuration = Cache.create_metric_configuration(
+        _DAGBackedMetric(dag)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["dag"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(dag),
+            _cached_case_for(_DAGBackedMetric(dag)),
+        )
+        is None
+    )
+
+
+def test_dag_metric_child_constructor_parameter_invalidates_cache():
+    cached_case = _cached_case_for(
+        _DAGBackedMetric(_metric_child_dag("strict"))
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(_metric_child_dag("strict")),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(_metric_child_dag("relaxed")),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_dag_metric_child_opaque_constructor_parameter_misses_cache_closed():
+    cached_case = _cached_case_for(
+        _DAGBackedMetric(_metric_child_dag(object()))
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(_metric_child_dag(object())),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_dag_metric_child_uncacheable_config_field_misses_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _DAGBackedMetric(
+            _metric_child_with_evaluation_model_dag(
+                "https://user:pass@example.com/model"
+            )
+        )
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["dag"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "https://user:pass@example.com/model" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(
+                _metric_child_with_evaluation_model_dag(
+                    "https://user:pass@example.com/model"
+                )
+            ),
+            _cached_case_for(
+                _DAGBackedMetric(
+                    _metric_child_with_evaluation_model_dag(
+                        "https://user:pass@example.com/model"
+                    )
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_dag_with_unknown_node_type_misses_cache_closed():
+    dag = DeepAcyclicGraph(
+        root_nodes=[
+            _CustomTaskNode(
+                instructions="Root",
+                output_label="root",
+                children=[],
+                evaluation_params=[SingleTurnParams.INPUT],
+            )
+        ]
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _DAGBackedMetric(dag)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["dag"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(dag),
+            _cached_case_for(_DAGBackedMetric(dag)),
+        )
+        is None
+    )
+
+
+def test_dag_with_unknown_child_node_misses_cache_closed():
+    dag = DeepAcyclicGraph(
+        root_nodes=[
+            TaskNode(
+                instructions="Root",
+                output_label="root",
+                children=[
+                    _CustomTaskNode(
+                        instructions="Unsupported child",
+                        output_label="child",
+                        children=[],
+                        evaluation_params=[SingleTurnParams.INPUT],
+                    )
+                ],
+                evaluation_params=[SingleTurnParams.INPUT],
+            )
+        ]
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _DAGBackedMetric(dag)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["dag"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _DAGBackedMetric(dag),
+            _cached_case_for(_DAGBackedMetric(dag)),
+        )
+        is None
+    )
+
+
+def test_pydantic_schema_constructor_parameter_includes_schema_class_identity():
+    cached_case = _cached_case_for(
+        _SchemaMetric(_FirstSchema(value="same-value"))
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaMetric(_FirstSchema(value="same-value")),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaMetric(_SecondSchema(value="same-value")),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_pydantic_literal_annotation_values_preserve_type_identity():
+    cached_case = _cached_case_for(_SchemaClassMetric(_LiteralIntSchema))
+
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_LiteralIntSchema),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(_LiteralStringSchema),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_pydantic_literal_annotation_opaque_values_miss_closed_without_str_call():
+    schema = create_model(
+        "OpaqueLiteralSchema",
+        value=(Literal[_ExplodingStringValue()], ...),
+        __module__=__name__,
+    )
+    metric_configuration = Cache.create_metric_configuration(
+        _SchemaClassMetric(schema)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["expected_schema"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _SchemaClassMetric(schema),
+            _cached_case_for(_SchemaClassMetric(schema)),
+        )
+        is None
+    )
+
+
+def test_sensitive_constructor_parameters_are_marked_uncacheable_not_cached_raw():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithSecretParameter(
+            rubric="safety",
+            api_key="sk-should-not-be-written",
+            client=object(),
+        )
+    )
+
+    custom_parameters = metric_configuration.custom_parameters
+    assert custom_parameters is not None
+    assert custom_parameters == {
+        "api_key": Cache._UNCACHEABLE_CACHE_VALUE,
+        "client": Cache._UNCACHEABLE_CACHE_VALUE,
+        "rubric": custom_parameters["rubric"],
+    }
+    assert custom_parameters["rubric"].startswith("sha256:")
+    assert "sk-should-not-be-written" not in str(
+        metric_configuration.model_dump()
+    )
+
+
+def test_nested_sensitive_constructor_values_are_marked_uncacheable():
+    first = Cache.create_metric_configuration(
+        _MetricWithNestedConfigParameter(
+            config={
+                "headers": {
+                    "Authorization": "Bearer first-secret",
+                    "X-Trace": "stable",
+                },
+                "mode": "strict",
+            }
+        )
+    )
+    second = Cache.create_metric_configuration(
+        _MetricWithNestedConfigParameter(
+            config={
+                "headers": {
+                    "Authorization": "Bearer second-secret",
+                    "X-Trace": "stable",
+                },
+                "mode": "strict",
+            }
+        )
+    )
+
+    assert "first-secret" not in str(first.model_dump())
+    assert "second-secret" not in str(second.model_dump())
+    assert first.custom_parameters is not None
+    assert second.custom_parameters is not None
+    assert first.custom_parameters["config"] == Cache._UNCACHEABLE_CACHE_VALUE
+    assert second.custom_parameters["config"] == Cache._UNCACHEABLE_CACHE_VALUE
+    assert (
+        Cache.get_metric_data(
+            _MetricWithNestedConfigParameter(
+                config={
+                    "headers": {
+                        "Authorization": "Bearer first-secret",
+                        "X-Trace": "stable",
+                    },
+                    "mode": "strict",
+                }
+            ),
+            _cached_case_for(
+                _MetricWithNestedConfigParameter(
+                    config={
+                        "headers": {
+                            "Authorization": "Bearer first-secret",
+                            "X-Trace": "stable",
+                        },
+                        "mode": "strict",
+                    }
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_secret_shaped_values_under_generic_names_miss_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        PatternMatchMetric(pattern="sk-live-secret", ignore_case=False)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["pattern"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "sk-live-secret" not in json.dumps(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            PatternMatchMetric(pattern="sk-live-secret", ignore_case=False),
+            _cached_case_for(
+                PatternMatchMetric(pattern="sk-live-secret", ignore_case=False)
+            ),
+        )
+        is None
+    )
+
+
+def test_custom_header_secret_values_under_generic_keys_miss_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithNestedConfigParameter(
+            config={
+                "headers": {
+                    "X-Session": "Bearer secret-session-value",
+                    "X-Trace": "stable",
+                },
+                "mode": "strict",
+            }
+        )
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["config"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "secret-session-value" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithNestedConfigParameter(
+                config={
+                    "headers": {
+                        "X-Session": "Bearer secret-session-value",
+                        "X-Trace": "stable",
+                    },
+                    "mode": "strict",
+                }
+            ),
+            _cached_case_for(
+                _MetricWithNestedConfigParameter(
+                    config={
+                        "headers": {
+                            "X-Session": "Bearer secret-session-value",
+                            "X-Trace": "stable",
+                        },
+                        "mode": "strict",
+                    }
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_opaque_constructor_value_with_hostile_class_access_misses_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithNestedConfigParameter(config=_ExplodingClassValue())
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["config"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithNestedConfigParameter(config=_ExplodingClassValue()),
+            _cached_case_for(
+                _MetricWithNestedConfigParameter(config=_ExplodingClassValue())
+            ),
+        )
+        is None
+    )
+
+
+def test_custom_container_constructor_values_miss_closed_without_protocol_calls():
+    for value in (
+        _ExplodingDict({"mode": "strict"}),
+        _ExplodingList(["strict"]),
+    ):
+        metric_configuration = Cache.create_metric_configuration(
+            _MetricWithNestedConfigParameter(config=value)
+        )
+
+        assert metric_configuration.custom_parameters is not None
+        assert (
+            metric_configuration.custom_parameters["config"]
+            == Cache._UNCACHEABLE_CACHE_VALUE
+        )
+        assert (
+            Cache.get_metric_data(
+                _MetricWithNestedConfigParameter(config=value),
+                _cached_case_for(
+                    _MetricWithNestedConfigParameter(config=value)
+                ),
+            )
+            is None
+        )
+
+
+def test_common_secret_name_values_are_marked_uncacheable():
+    for name in (
+        "openaiApiKey",
+        "auth_token",
+        "github_token",
+        "api_token",
+        "access_token",
+        "sessionToken",
+        "bearer_token",
+        "jwt_token",
+        "aws_access_key_id",
+        "Proxy-Authorization",
+        "Set-Cookie",
+        "clientSecret",
+        "key",
+    ):
+        first = Cache._normalize_cache_parameter(name, "first-secret", set())
+        second = Cache._normalize_cache_parameter(name, "second-secret", set())
+
+        assert first == {"__deepeval_uncacheable__": "sensitive"}
+        assert second == {"__deepeval_uncacheable__": "sensitive"}
+        assert "first-secret" not in str(first)
+        assert "second-secret" not in str(second)
+
+
+def test_malformed_url_like_constructor_value_misses_cache_closed():
+    for endpoint in (
+        "http://[bad",
+        "https://example.com:abc/path",
+        "https://exa mple.com/path",
+    ):
+        normalized = Cache._normalize_cache_parameter(
+            "endpoint", endpoint, set()
+        )
+
+        assert normalized == {"__deepeval_uncacheable__": "sensitive"}
+        metric_configuration = Cache.create_metric_configuration(
+            _EndpointMetric(endpoint)
+        )
+        assert metric_configuration.custom_parameters is not None
+        assert (
+            metric_configuration.custom_parameters["endpoint"]
+            == Cache._UNCACHEABLE_CACHE_VALUE
+        )
+        assert endpoint not in json.dumps(metric_configuration.model_dump())
+        assert (
+            Cache.get_metric_data(
+                _EndpointMetric(endpoint),
+                _cached_case_for(_EndpointMetric(endpoint)),
+            )
+            is None
+        )
+
+
+def test_connection_secret_names_and_signed_urls_are_marked_uncacheable():
+    for name in (
+        "connection_string",
+        "conn_str",
+        "dsn",
+        "database_url",
+        "broker_url",
+        "jdbc_url",
+    ):
+        normalized = Cache._normalize_cache_parameter(
+            name, "postgres://user:pass@example.com/db", set()
+        )
+
+        assert normalized == {"__deepeval_uncacheable__": "sensitive"}
+
+    signed_url = Cache._normalize_cache_parameter(
+        "endpoint",
+        "https://example.com/object?X-Amz-Signature=abc123",
+        set(),
+    )
+
+    assert signed_url == {"__deepeval_uncacheable__": "sensitive"}
+
+    metric_configuration = Cache.create_metric_configuration(
+        _EndpointMetric("https://example.com/object?X-Amz-Signature=abc123")
+    )
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["endpoint"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "X-Amz-Signature" not in json.dumps(
+        metric_configuration.model_dump()
+    )
+    assert (
+        Cache.get_metric_data(
+            _EndpointMetric(
+                "https://example.com/object?X-Amz-Signature=abc123"
+            ),
+            _cached_case_for(
+                _EndpointMetric(
+                    "https://example.com/object?X-Amz-Signature=abc123"
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_dsn_and_token_bearing_url_variants_miss_cache_closed():
+    for endpoint in (
+        "postgres:pass@example.com/db",
+        "https://example.com/object#access_token=abc123",
+        "https://example.com/download/token/abc123",
+        "https://example.com/download/token%2Fabc123",
+        "https://example.com/download/X-Amz-Signature%2Fabc123",
+        "https://example.com/object?state=Bearer%2520secret-token",
+        f"https://example.com/object?state={_encode_repeatedly('Bearer secret-token')}",
+        "//user:pass@example.com/path",
+        quote("//user:pass@example.com/path", safe=""),
+        _encode_repeatedly("//user:pass@example.com/path", passes=2),
+        r"C:\downloads\token\abc123",
+        r"\server\share\sig\abc123",
+        r"\\server\share\sig\abc123",
+        _encode_repeatedly(r"C:\downloads\token\abc123"),
+        _encode_repeatedly(r"\\server\share\sig\abc123"),
+        "/download?sig=abc123",
+        "/download#access_token=abc123",
+        "/download%2Ftoken%2Fabc123",
+        "/download%2Fsig%2Fabc123",
+        "/download%252Ftoken%252Fabc123",
+        "/download%252Fsig%252Fabc123",
+        _encode_repeatedly("/download/token/abc123"),
+        _encode_repeatedly("/download/sig/abc123"),
+        _encode_repeatedly("/download/X-Amz-Signature=abc123"),
+    ):
+        normalized = Cache._normalize_cache_parameter(
+            "endpoint", endpoint, set()
+        )
+
+        assert normalized == {"__deepeval_uncacheable__": "sensitive"}
+        metric_configuration = Cache.create_metric_configuration(
+            _EndpointMetric(endpoint)
+        )
+        assert metric_configuration.custom_parameters is not None
+        assert (
+            metric_configuration.custom_parameters["endpoint"]
+            == Cache._UNCACHEABLE_CACHE_VALUE
+        )
+        assert endpoint not in json.dumps(metric_configuration.model_dump())
+        assert (
+            Cache.get_metric_data(
+                _EndpointMetric(endpoint),
+                _cached_case_for(_EndpointMetric(endpoint)),
+            )
+            is None
+        )
+
+
+def test_top_level_sensitive_constructor_value_misses_cache_closed():
+    cached_case = _cached_case_for(
+        _MetricWithSecretParameter(
+            rubric="safety",
+            api_key="same-secret",
+        )
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _MetricWithSecretParameter(
+                rubric="safety",
+                api_key="same-secret",
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_underscore_prefixed_sensitive_constructor_value_misses_cache_closed():
+    metric_configuration = Cache.create_metric_configuration(
+        _MetricWithUnderscoreSecretParameter(
+            rubric="safety",
+            _access_token="secret-token",
+        )
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["_access_token"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert "secret-token" not in str(metric_configuration.model_dump())
+    assert (
+        Cache.get_metric_data(
+            _MetricWithUnderscoreSecretParameter(
+                rubric="safety",
+                _access_token="secret-token",
+            ),
+            _cached_case_for(
+                _MetricWithUnderscoreSecretParameter(
+                    rubric="safety",
+                    _access_token="secret-token",
+                )
+            ),
+        )
+        is None
+    )
+
+
+def test_tokenizer_name_is_not_treated_as_a_secret_parameter():
+    assert (
+        Cache._normalize_cache_parameter("tokenizer_name", "cl100k_base", set())
+        == "cl100k_base"
+    )
+
+
+def test_internal_constructor_parameters_do_not_invalidate_cache():
+    first = Cache.create_metric_configuration(
+        _TelemetryMetric(rubric="safety", _track=True)
+    )
+    second = Cache.create_metric_configuration(
+        _TelemetryMetric(rubric="safety", _track=False)
+    )
+
+    assert first.custom_parameters is not None
+    assert first.custom_parameters == second.custom_parameters
+    assert "_track" not in first.custom_parameters
+
+
+def test_large_constructor_parameter_exceeds_budget_without_traversal():
+    value = list(range(Cache._MAX_CACHE_PARAMETER_COLLECTION_ITEMS + 1))
+
+    normalized = Cache._normalize_cache_parameter("config", value, set())
+
+    assert normalized["__deepeval_uncacheable__"] == "budget-exceeded"
+    assert (
+        Cache._cache_parameter_fingerprint("config", value)
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+
+
+def test_semantic_tokenizer_constructor_parameter_invalidates_cache():
+    cached_case = _cached_case_for(_TokenizerMetric(tokenizer_name="cl100k"))
+
+    assert (
+        Cache.get_metric_data(
+            _TokenizerMetric(tokenizer_name="o200k"),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_private_backed_constructor_parameter_invalidates_cache_without_property_access():
+    cached_case = _cached_case_for(
+        _PropertyBackedMetric(config={"mode": "strict"})
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _PropertyBackedMetric(config={"mode": "strict"}),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _PropertyBackedMetric(config={"mode": "relaxed"}),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_dataclass_constructor_parameter_with_cycle_misses_cache_closed_without_asdict():
+    strict_config = _CyclicDataclassConfig(mode="strict")
+    strict_config.next_config = strict_config
+    metric_configuration = Cache.create_metric_configuration(
+        _DataclassConfigMetric(strict_config)
+    )
+
+    assert metric_configuration.custom_parameters is not None
+    assert (
+        metric_configuration.custom_parameters["config"]
+        == Cache._UNCACHEABLE_CACHE_VALUE
+    )
+    assert (
+        Cache.get_metric_data(
+            _DataclassConfigMetric(strict_config),
+            _cached_case_for(_DataclassConfigMetric(strict_config)),
+        )
+        is None
+    )
+
+
+def test_pydantic_constructor_parameter_uses_raw_fields_without_dump_hooks():
+    cached_case = _cached_case_for(
+        _ExplodingModelMetric(_ModelWithExplodingDump(value="stable"))
+    )
+
+    assert (
+        Cache.get_metric_data(
+            _ExplodingModelMetric(_ModelWithExplodingDump(value="stable")),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _ExplodingModelMetric(_ModelWithExplodingDump(value="changed")),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_legacy_cache_configuration_without_custom_parameters_loads_safely():
+    legacy_configuration = MetricConfiguration(
+        threshold=1.0,
+        strict_mode=False,
+        include_reason=False,
+    )
+
+    assert legacy_configuration.custom_parameters is None
+    assert Cache.same_metric_configs(ExactMatchMetric(), legacy_configuration)
+    assert not Cache.same_metric_configs(
+        PatternMatchMetric(pattern=r"expected", ignore_case=False),
+        legacy_configuration,
+    )
+
+
+def test_current_cache_payload_round_trips_custom_parameters(tmp_path):
+    cache_file = tmp_path / "cache.json"
+    cached_run = CachedTestRun(
+        test_cases_lookup_map={
+            "case": _cached_case_for(
+                _ConfigurableMetric(
+                    rubric="safety",
+                    weights={"harm": 1.0, "accuracy": 0.5},
+                )
+            )
+        }
+    )
+
+    with cache_file.open("w") as file:
+        cached_run.save(file)
+
+    loaded_run = CachedTestRun.load(json.loads(cache_file.read_text()))
+    cached_case = loaded_run.test_cases_lookup_map["case"]
+
+    assert (
+        Cache.get_metric_data(
+            _ConfigurableMetric(
+                rubric="safety",
+                weights={"harm": 1.0, "accuracy": 0.5},
+            ),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _ConfigurableMetric(
+                rubric="quality",
+                weights={"harm": 1.0, "accuracy": 0.5},
+            ),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_current_cache_payload_round_trips_language_config(tmp_path):
+    cache_file = tmp_path / "cache.json"
+    cached_run = CachedTestRun(
+        test_cases_lookup_map={
+            "case": _cached_case_for(_MetricWithLanguage(language="en"))
+        }
+    )
+
+    with cache_file.open("w") as file:
+        cached_run.save(file)
+
+    loaded_payload = json.loads(cache_file.read_text())
+    cached_configuration = loaded_payload["test_cases_lookup_map"]["case"][
+        "cached_metrics_data"
+    ][0]["metric_configuration"]
+
+    assert cached_configuration["language"] == "en"
+
+    loaded_run = CachedTestRun.load(loaded_payload)
+    cached_case = loaded_run.test_cases_lookup_map["case"]
+
+    assert (
+        Cache.get_metric_data(
+            _MetricWithLanguage(language="en"),
+            cached_case,
+        )
+        is not None
+    )
+    assert (
+        Cache.get_metric_data(
+            _MetricWithLanguage(language="es"),
+            cached_case,
+        )
+        is None
+    )
+
+
+def test_legacy_cache_payload_without_custom_parameters_loads_safely():
+    cached_run = CachedTestRun.load(
+        {
+            "test_cases_lookup_map": {
+                "case": {
+                    "cached_metrics_data": [
+                        {
+                            "metric_data": {
+                                "name": "Exact Match",
+                                "threshold": 1.0,
+                                "success": True,
+                                "score": 1.0,
+                            },
+                            "metric_configuration": {
+                                "threshold": 1.0,
+                                "strict_mode": False,
+                                "include_reason": False,
+                            },
+                        },
+                        {
+                            "metric_data": {
+                                "name": "Pattern Match",
+                                "threshold": 1.0,
+                                "success": True,
+                                "score": 1.0,
+                            },
+                            "metric_configuration": {
+                                "threshold": 1.0,
+                                "strict_mode": False,
+                                "include_reason": False,
+                            },
+                        },
+                    ]
+                }
+            }
+        }
+    )
+    cached_case = cached_run.test_cases_lookup_map["case"]
+
+    cached_exact = Cache.get_metric_data(ExactMatchMetric(), cached_case)
+    assert cached_exact is not None
+    assert cached_exact.metric_data.name == "Exact Match"
+
+    assert (
+        Cache.get_metric_data(
+            PatternMatchMetric(pattern=r"expected", ignore_case=False),
+            cached_case,
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

DeepEval's test-run cache previously compared only a fixed set of metric configuration fields before reusing cached metric results. Constructor arguments and free-form metric config fields that can change scoring behavior, such as `PatternMatchMetric.pattern`, `GEval.criteria`, or custom metric settings, were not consistently represented as safe cache-compatibility metadata and could produce stale cached results or stale serialized cache payloads.

This change stores safe constructor-parameter and free-form metric config compatibility metadata in cache metadata and requires them to match before reusing cached metric data. Inputs that cannot be represented safely or passively miss closed instead of being serialized or reused incorrectly.

## Changes

- Add an unreleased changelog note for the user-visible cache invalidation behavior.
- Add constructor-parameter and free-form metric config compatibility metadata to `MetricConfiguration` and cache comparison, with the cache-identity policy isolated in `deepeval/test_run/cache_identity.py`.
- Include built-in/custom metric constructor parameters and free-form config fields in cache compatibility when they can be recovered safely from metric instances.
- Allow native model-backed metrics to reuse cache on subsequent runs once constructor compatibility metadata is written, when safe passive model identity/settings match.
- Miss closed instead of deriving cache metadata for unsafe, sensitive, opaque, cyclic, unrecoverable, or oversized cache identity inputs.
- Add focused regression coverage for cache hit/miss behavior, native and opaque model identity, free-form config redaction, collection/type identity, Pydantic schema identity, DAG structure, secret-bearing path values, custom container fail-closed behavior, and signed/encoded/relative URL handling, current-format save/load, and legacy cache payloads.

## Why this matters

This is a cache-correctness fix, not a new caching feature. It prevents stale metric results from being reused when constructor-level or free-form config scoring inputs change, while preserving reuse on subsequent runs for model-backed metrics when their safe passive native-model identity/settings match.

## Migration / compatibility note

Existing `.deepeval-cache.json` files remain loadable. After this change, cache hits also require constructor and free-form config compatibility metadata, so constructor- or config-sensitive metrics can miss once against pre-upgrade cache entries and regenerate when rerun.

Constructor and free-form config state that cannot be represented safely intentionally does not reuse cache. This includes secret-like values, credential-bearing URL/DSN-like values, opaque objects, callables, variadic or unrecoverable constructor params, non-finite values, unsafe Pydantic/DAG/embedding state, and too-large structures.

## User-visible behavior

- Existing local cache files still load safely.
- Constructor- or config-sensitive metrics can miss once against pre-upgrade cache entries and regenerate when rerun because scoring inputs are now part of cache compatibility.
- Metrics with unsafe or unrecoverable constructor/config state intentionally miss cache on every lookup instead of risking stale reuse.
- Native model-backed metrics keep cache reuse on subsequent runs once constructor compatibility metadata is written and their safe passive model identity/settings match.
- `.deepeval-cache.json` remains local runtime cache state and should not be shared as a portable artifact.

## Security / privacy note

This is conservative best-effort cache redaction, not a secrecy boundary. The cache identity treats obvious secret-like values, credential-bearing inputs, and unsafe runtime state as uncacheable so those cases miss closed instead of storing raw values or deterministic cache metadata.

Heuristics can false-positive on innocuous names and can miss unconventional secret formats. Recoverable non-secret primitive/config values and safe passive native-model identity/settings still participate through deterministic cache metadata, so `.deepeval-cache.json` should remain local runtime cache state rather than a shareable artifact.

## Tests

Commands run:

- `.venv/bin/python -m pytest tests/test_core/test_run/test_cache.py -q` — passed (101 passed)
- `.venv/bin/python -m pytest tests/test_core/test_run/test_cache.py tests/test_core/test_evaluation/test_execute/test_execute_llm_test_case.py -q` — passed (combined 101 passed, 4 skipped because `OPENAI_API_KEY` is not set, 2 warnings)
- `.venv/bin/python -m py_compile deepeval/test_run/cache.py deepeval/test_run/cache_identity.py tests/test_core/test_run/test_cache.py` — passed
- `.venv/bin/black --check deepeval/test_run/cache.py deepeval/test_run/cache_identity.py tests/test_core/test_run/test_cache.py` — passed
- `git diff --check` / `git diff --cached --check` — passed

## Risk

Risk level: medium

This intentionally reduces false cache hits and may cause additional recomputation for metrics whose constructor state was previously ignored or cannot be safely represented. Large or unsupported config/DAG shapes can intentionally miss cache and recompute rather than risk unsafe reuse. Rollback is straightforward by reverting the cache comparison/compatibility-metadata changes and the accompanying test file.

## Issue

No existing issue. Discovered during repository analysis.

## Notes for maintainers

Non-goals:

- This does not try to preserve cache reuse for opaque objects, callables, secrets, free-form schema metadata, unknown DAG nodes, opaque embeddings, or custom metrics whose constructor params cannot be recovered safely.
- This does not add a public metric-owned cache identity hook; that could be a future explicit extension point if maintainers want custom metrics to opt into broader cache reuse safely.
