### PR TITLE
fix: report Bedrock multimodal capability accurately

### DIFF
--- a/typescript/src/models/README.md
+++ b/typescript/src/models/README.md
@@ -75,13 +75,18 @@ All of the above report `supportsStructuredOutputs() = true` and
 |---|---|---|---|---|
 | `GeminiModel` | `gemini-2.5-flash` | `GOOGLE_API_KEY` / `GEMINI_API_KEY` | `@google/genai` | ✅ (fetches+base64s remote images) |
 | `AnthropicModel` | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` | `@anthropic-ai/sdk` | ✅ |
-| `AmazonBedrockModel` | `AWS_BEDROCK_MODEL_NAME` (req.) | AWS creds / region | `@aws-sdk/client-bedrock-runtime` | ⚠️ see discrepancy |
+| `AmazonBedrockModel` | `AWS_BEDROCK_MODEL_NAME` (req.) | AWS creds / region | `@aws-sdk/client-bedrock-runtime` | ❌ TS wrapper text-only |
 | `OllamaModel` | `OLLAMA_MODEL_NAME` (req.) | — (local) | `ollama` | ❌ text-only |
 | `AISDKModel` | from the AI SDK model | (per AI SDK provider) | `ai` (+ a provider, e.g. `@ai-sdk/openai`) | ✅ |
 
 - `GeminiModel` also supports **Vertex AI** (`useVertexAI` / `GOOGLE_GENAI_USE_VERTEXAI`,
   with `project` / `location`).
 - `AnthropicModel` sends `max_tokens` (default `4096`, configurable).
+- DeepEval TS `AmazonBedrockModel` does not yet translate image slugs into Bedrock image
+  content blocks, so it returns `supportsMultimodal() = false`.
+- `AmazonBedrockModel` uses a complete explicit credential bundle when provided, rejects
+  partial explicit or environment credential config, and otherwise leaves credential
+  resolution to the AWS SDK default chain.
 - `AISDKModel` wraps any Vercel AI SDK `LanguageModel` (e.g. `openai("gpt-4o")`); uses
   `generateObject` for schemas, `generateText` otherwise.
 
@@ -92,12 +97,11 @@ Image slugs in the prompt are split into provider-specific text+image parts by
 Wired into: **OpenAI-compatible base** (so OpenAI/Azure/Grok/Kimi/Local/OpenRouter/Portkey),
 **Anthropic**, **Gemini**, **AI SDK**. Plain-text prompts pass through unchanged.
 
-## Gaps & discrepancies vs Python
+## Gaps vs Python
 
-- **`AmazonBedrockModel` reports `supportsMultimodal() = true` but its `generate()` only
-  sends text** (`content: [{ text: prompt }]`, no slug→image conversion). The flag is
-  ahead of the implementation — image slugs would be sent as literal text. Treat Bedrock
-  as text-only until the Converse content builder is added.
+- **DeepEval TS `AmazonBedrockModel` is text-only** until the Converse content builder
+  supports image slugs; unlike Python-capable multimodal providers, it reports
+  `supportsMultimodal() = false`.
 - **`OllamaModel` is text-only** and (unlike the others) does **not** override
   `supportsMultimodal()`, so it returns the base `null`.
 - **No log-prob support anywhere** (`supportsLogProbs()` is `null` for all models) — blocks

--- a/typescript/src/models/providers/bedrock-model.ts
+++ b/typescript/src/models/providers/bedrock-model.ts
@@ -15,11 +15,15 @@ export interface AmazonBedrockModelOptions {
   costPerOutputToken?: number;
 }
 
+type BedrockCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+};
+
 export class AmazonBedrockModel extends DeepEvalBaseLLM {
   private readonly region: string;
-  private readonly awsAccessKeyId?: string;
-  private readonly awsSecretAccessKey?: string;
-  private readonly awsSessionToken?: string;
+  private readonly credentials?: BedrockCredentials;
   private readonly temperature?: number;
   private readonly costPerInputToken?: number;
   private readonly costPerOutputToken?: number;
@@ -33,16 +37,59 @@ export class AmazonBedrockModel extends DeepEvalBaseLLM {
       process.env.AWS_BEDROCK_REGION ??
       process.env.AWS_REGION ??
       DEFAULT_BEDROCK_REGION;
-    this.awsAccessKeyId =
-      options.awsAccessKeyId ?? process.env.AWS_ACCESS_KEY_ID;
-    this.awsSecretAccessKey =
-      options.awsSecretAccessKey ?? process.env.AWS_SECRET_ACCESS_KEY;
-    this.awsSessionToken =
-      options.awsSessionToken ?? process.env.AWS_SESSION_TOKEN;
+    this.credentials = AmazonBedrockModel.resolveCredentials(options);
     // Only sent when explicitly set — some models (e.g. reasoning models) reject `temperature`.
     this.temperature = options.temperature;
     this.costPerInputToken = options.costPerInputToken;
     this.costPerOutputToken = options.costPerOutputToken;
+  }
+
+  private static resolveCredentials(
+    options: AmazonBedrockModelOptions,
+  ): BedrockCredentials | undefined {
+    const hasExplicitCredential =
+      options.awsAccessKeyId !== undefined ||
+      options.awsSecretAccessKey !== undefined ||
+      options.awsSessionToken !== undefined;
+
+    if (hasExplicitCredential) {
+      if (!options.awsAccessKeyId || !options.awsSecretAccessKey) {
+        throw new Error(
+          "Amazon Bedrock explicit credentials require both `awsAccessKeyId` and `awsSecretAccessKey` when any credential option is provided.",
+        );
+      }
+      return {
+        accessKeyId: options.awsAccessKeyId,
+        secretAccessKey: options.awsSecretAccessKey,
+        ...(options.awsSessionToken
+          ? { sessionToken: options.awsSessionToken }
+          : {}),
+      };
+    }
+
+    const envAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
+    const envSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+    const envSessionToken = process.env.AWS_SESSION_TOKEN;
+    const hasEnvCredential =
+      envAccessKeyId !== undefined ||
+      envSecretAccessKey !== undefined ||
+      envSessionToken !== undefined;
+
+    if (!hasEnvCredential) {
+      return undefined;
+    }
+
+    if (!envAccessKeyId || !envSecretAccessKey) {
+      throw new Error(
+        "Amazon Bedrock environment credentials require both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY when any AWS credential environment variable is set.",
+      );
+    }
+
+    return {
+      accessKeyId: envAccessKeyId,
+      secretAccessKey: envSecretAccessKey,
+      ...(envSessionToken ? { sessionToken: envSessionToken } : {}),
+    };
   }
 
   private async getSdk(): Promise<any> {
@@ -58,17 +105,9 @@ export class AmazonBedrockModel extends DeepEvalBaseLLM {
   private async getClient(): Promise<any> {
     if (!this.client) {
       const { BedrockRuntimeClient } = await this.getSdk();
-      const credentials =
-        this.awsAccessKeyId && this.awsSecretAccessKey
-          ? {
-              accessKeyId: this.awsAccessKeyId,
-              secretAccessKey: this.awsSecretAccessKey,
-              sessionToken: this.awsSessionToken,
-            }
-          : undefined;
       this.client = new BedrockRuntimeClient({
         region: this.region,
-        ...(credentials ? { credentials } : {}),
+        ...(this.credentials ? { credentials: this.credentials } : {}),
       });
     }
     return this.client;
@@ -116,6 +155,6 @@ export class AmazonBedrockModel extends DeepEvalBaseLLM {
   }
 
   supportsMultimodal(): boolean {
-    return true;
+    return false;
   }
 }

--- a/typescript/test/test-core/models/bedrock-model.test.ts
+++ b/typescript/test/test-core/models/bedrock-model.test.ts
@@ -1,0 +1,179 @@
+import { AmazonBedrockModel } from "../../../src/models/providers/bedrock-model";
+
+const AWS_CREDENTIAL_ENV_KEYS = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+] as const;
+
+type BedrockCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+};
+
+type BedrockClientConfig = {
+  region?: string;
+  credentials?: BedrockCredentials;
+};
+
+class FakeConverseCommand {
+  constructor(readonly input: unknown) {}
+}
+
+class FakeBedrockRuntimeClient {
+  static lastConfig?: BedrockClientConfig;
+  static lastCommand?: FakeConverseCommand;
+
+  constructor(readonly config: BedrockClientConfig) {}
+
+  async send(command: FakeConverseCommand) {
+    FakeBedrockRuntimeClient.lastConfig = this.config;
+    FakeBedrockRuntimeClient.lastCommand = command;
+    return {
+      output: { message: { content: [{ text: "ok" }] } },
+      usage: {},
+    };
+  }
+}
+
+function installFakeSdk(model: AmazonBedrockModel) {
+  (model as unknown as { sdk: unknown }).sdk = {
+    BedrockRuntimeClient: FakeBedrockRuntimeClient,
+    ConverseCommand: FakeConverseCommand,
+  };
+}
+
+describe("AmazonBedrockModel", () => {
+  const originalCredentialEnv = new Map<string, string | undefined>();
+
+  beforeAll(() => {
+    for (const key of AWS_CREDENTIAL_ENV_KEYS) {
+      originalCredentialEnv.set(key, process.env[key]);
+    }
+  });
+
+  beforeEach(() => {
+    for (const key of AWS_CREDENTIAL_ENV_KEYS) {
+      delete process.env[key];
+    }
+    FakeBedrockRuntimeClient.lastConfig = undefined;
+    FakeBedrockRuntimeClient.lastCommand = undefined;
+  });
+
+  afterAll(() => {
+    for (const key of AWS_CREDENTIAL_ENV_KEYS) {
+      const value = originalCredentialEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("does not advertise multimodal support", () => {
+    const model = new AmazonBedrockModel({
+      model: "anthropic.claude-3-haiku-20240307-v1:0",
+    });
+
+    expect(model.supportsMultimodal()).toBe(false);
+  });
+
+  it("sends prompts as text-only Converse content", async () => {
+    const model = new AmazonBedrockModel({
+      model: "anthropic.claude-3-haiku-20240307-v1:0",
+      region: "us-west-2",
+    });
+    installFakeSdk(model);
+
+    await model.generate("Describe this image: [DEEPEVAL:IMAGE:test-image]");
+
+    expect(FakeBedrockRuntimeClient.lastConfig?.region).toBe("us-west-2");
+    expect(FakeBedrockRuntimeClient.lastCommand?.input).toMatchObject({
+      modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { text: "Describe this image: [DEEPEVAL:IMAGE:test-image]" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("omits explicit credentials when no credential options or env vars are set", async () => {
+    const model = new AmazonBedrockModel({
+      model: "anthropic.claude-3-haiku-20240307-v1:0",
+    });
+    installFakeSdk(model);
+
+    await model.generate("hello");
+
+    expect(FakeBedrockRuntimeClient.lastConfig?.credentials).toBeUndefined();
+  });
+
+  it("uses a complete explicit credential bundle without environment mixing", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-key";
+    process.env.AWS_SECRET_ACCESS_KEY = "env-secret";
+    process.env.AWS_SESSION_TOKEN = "env-token";
+    const model = new AmazonBedrockModel({
+      model: "anthropic.claude-3-haiku-20240307-v1:0",
+      awsAccessKeyId: "explicit-key",
+      awsSecretAccessKey: "explicit-secret",
+      awsSessionToken: "explicit-token",
+    });
+    installFakeSdk(model);
+
+    await model.generate("hello");
+
+    expect(FakeBedrockRuntimeClient.lastConfig?.credentials).toEqual({
+      accessKeyId: "explicit-key",
+      secretAccessKey: "explicit-secret",
+      sessionToken: "explicit-token",
+    });
+  });
+
+  it("uses a complete environment credential bundle", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-key";
+    process.env.AWS_SECRET_ACCESS_KEY = "env-secret";
+    process.env.AWS_SESSION_TOKEN = "env-token";
+    const model = new AmazonBedrockModel({
+      model: "anthropic.claude-3-haiku-20240307-v1:0",
+    });
+    installFakeSdk(model);
+
+    await model.generate("hello");
+
+    expect(FakeBedrockRuntimeClient.lastConfig?.credentials).toEqual({
+      accessKeyId: "env-key",
+      secretAccessKey: "env-secret",
+      sessionToken: "env-token",
+    });
+  });
+
+  it("rejects partial explicit credentials instead of mixing them with the environment", () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-key";
+    process.env.AWS_SECRET_ACCESS_KEY = "env-secret";
+
+    expect(
+      () =>
+        new AmazonBedrockModel({
+          model: "anthropic.claude-3-haiku-20240307-v1:0",
+          awsAccessKeyId: "explicit-key",
+        }),
+    ).toThrow(/explicit credentials require both/);
+  });
+
+  it("rejects partial environment credentials instead of falling through to another AWS principal", () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-key";
+
+    expect(
+      () =>
+        new AmazonBedrockModel({
+          model: "anthropic.claude-3-haiku-20240307-v1:0",
+        }),
+    ).toThrow(/environment credentials require both/);
+  });
+});


### PR DESCRIPTION
## Summary

This updates the TypeScript `AmazonBedrockModel` to stop advertising multimodal support while the wrapper still sends Bedrock Converse requests as text-only content. It also hardens Bedrock credential resolution so explicit credentials are treated as a complete bundle and partial explicit/environment credential config fails closed instead of mixing sources or falling through to another AWS principal.

## Changes

- Return `false` from `AmazonBedrockModel.supportsMultimodal()` until the TypeScript wrapper translates DeepEval image slugs into Bedrock image content blocks.
- Resolve Bedrock AWS credentials as a single bundle:
  - complete explicit credentials are used together;
  - partial explicit credentials throw;
  - complete environment credentials are used together;
  - partial environment credentials throw;
  - no explicit/env credentials leaves credential resolution to the AWS SDK default chain.
- Add focused Jest coverage for Bedrock capability metadata, text-only Converse request content, credential source precedence, fail-closed partial credentials, and default-chain fallback.
- Update the TypeScript model README to describe the DeepEval TS Bedrock wrapper limitation and credential behavior accurately.

## Why this matters

Callers use model capability flags to decide whether multimodal prompts are safe to route through a provider. Returning `true` for Bedrock could cause image slugs to be sent as literal text because this wrapper does not yet build Bedrock image content blocks. The credential change also avoids ambiguous AWS principal selection when users accidentally provide partial explicit or environment credentials.

## Tests

Commands run:

- `cd typescript && npm test -- test/test-core/models/bedrock-model.test.ts --runInBand` — passed (7 tests)
- `cd typescript && npm run build` — passed
- `cd typescript && npm run lint -- src/models/providers/bedrock-model.ts` — passed
- `cd typescript && npx prettier --check src/models/providers/bedrock-model.ts test/test-core/models/bedrock-model.test.ts` — passed
- `cd typescript && npm run lint` — passed with pre-existing warnings outside this PR's files (`dist/evaluate/console-report.js`, `src/test-case/llm-test-case.ts`, `src/tracing/tracing.ts`)
- `git diff --cached --check` — passed

Note: the broader TypeScript Jest suite is not a clean local gate in this environment because existing tests require external API credentials/modules; the new Bedrock test is isolated and does not import the real AWS SDK or use network access.

## Risk

Risk level: low to medium.

The multimodal capability change is conservative: it stops advertising unsupported behavior without changing Bedrock request generation. The credential change intentionally fails closed for partial AWS credential configuration; users with complete explicit credentials, complete environment credentials, or AWS SDK default-chain credentials continue to work. Rollback is isolated to the Bedrock TypeScript wrapper and its tests/docs.

## Issue

No existing open issue found. This was discovered during repository analysis and validated against the current TypeScript Bedrock implementation/docs.

## Notes for maintainers

This does not implement Bedrock multimodal image content support. That should be a separate follow-up that adds a provider-specific image content builder and flips `supportsMultimodal()` back only when request construction is implemented and tested.
