### PR TITLE
feat(community): add AbstentionMetric

### DIFF
--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,11 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .abstention.abstention import (
+    AbstentionMetric,
+)
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "AbstentionMetric",
 ]

--- a/deepeval/metrics/community/abstention/__init__.py
+++ b/deepeval/metrics/community/abstention/__init__.py
@@ -1,0 +1,3 @@
+from .abstention import AbstentionMetric
+
+__all__ = ["AbstentionMetric"]

--- a/deepeval/metrics/community/abstention/abstention.py
+++ b/deepeval/metrics/community/abstention/abstention.py
@@ -1,0 +1,223 @@
+from typing import List, Optional, Union
+
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.metrics import BaseMetric
+from deepeval.utils import get_or_create_event_loop
+from deepeval.metrics.utils import (
+    construct_verbose_logs,
+    check_llm_test_case_params,
+    initialize_model,
+    a_generate_with_schema_and_extract,
+    generate_with_schema_and_extract,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.community.abstention.template import AbstentionTemplate
+from deepeval.metrics.community.abstention.schema import AbstentionVerdict
+
+
+class AbstentionMetric(BaseMetric):
+    """Abstention (answer-vs-decline) correctness.
+
+    Grades whether a retrieval-augmented answer made the right decision about
+    *whether to answer at all*, given its ``retrieval_context``:
+
+    - the context supports an answer and the system answered      -> correct
+    - the context does not support one and the system abstained   -> correct
+    - the context supports one but the system abstained anyway     -> over-refusal
+    - the context does not support one but the system answered     -> unsupported answer
+
+    Where ``FaithfulnessMetric`` and ``HallucinationMetric`` grade the *content*
+    of an answer, ``AbstentionMetric`` grades the *decision to answer or
+    decline*. It rewards a system that says "I don't know" exactly when it
+    should, and penalises both over-refusal (declining an answerable question)
+    and answering a question the context cannot support.
+
+    A single judge makes two boolean determinations in one call — whether the
+    context supports an answer, and whether the output abstained. The decision
+    is correct when ``context_supports_answer`` equals ``not output_abstained``,
+    scoring ``1.0``; otherwise ``0.0``. With the default threshold of ``0.5``,
+    only a correct decision is successful.
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+        SingleTurnParams.RETRIEVAL_CONTEXT,
+    ]
+
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        model: Optional[Union[str, DeepEvalBaseLLM]] = None,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+    ):
+        self.threshold = 1 if strict_mode else threshold
+        self.model, self.using_native_model = initialize_model(model)
+        self.evaluation_model = self.model.get_model_name()
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+        _log_metric_to_confident: bool = True,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            False,
+        )
+
+        self.evaluation_cost = 0 if self.using_native_model else None
+        self.input_tokens = 0 if self.using_native_model else None
+        self.output_tokens = 0 if self.using_native_model else None
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            if self.async_mode:
+                loop = get_or_create_event_loop()
+                loop.run_until_complete(
+                    self.a_measure(
+                        test_case,
+                        _show_indicator=False,
+                        _in_component=_in_component,
+                        _log_metric_to_confident=_log_metric_to_confident,
+                    )
+                )
+            else:
+                self.verdict = self._generate_verdict(test_case)
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason()
+                self.success = self.score >= self.threshold
+                self.verbose_logs = construct_verbose_logs(
+                    self,
+                    steps=[
+                        f"Context supports answer: {self.verdict.context_supports_answer}\n"
+                        f"Output abstained: {self.verdict.output_abstained}",
+                        f"Score: {self.score}\nReason: {self.reason}",
+                    ],
+                )
+
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+        _log_metric_to_confident: bool = True,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            False,
+        )
+
+        self.evaluation_cost = 0 if self.using_native_model else None
+        self.input_tokens = 0 if self.using_native_model else None
+        self.output_tokens = 0 if self.using_native_model else None
+        with metric_progress_indicator(
+            self,
+            async_mode=True,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        ):
+            self.verdict = await self._a_generate_verdict(test_case)
+            self.score = self._calculate_score()
+            self.reason = self._generate_reason()
+            self.success = self.score >= self.threshold
+            self.verbose_logs = construct_verbose_logs(
+                self,
+                steps=[
+                    f"Context supports answer: {self.verdict.context_supports_answer}\n"
+                    f"Output abstained: {self.verdict.output_abstained}",
+                    f"Score: {self.score}\nReason: {self.reason}",
+                ],
+            )
+            return self.score
+
+    def _build_prompt(self, test_case: LLMTestCase) -> str:
+        numbered_passages = AbstentionTemplate.number_passages(
+            test_case.retrieval_context
+        )
+        return AbstentionTemplate.generate_verdict(
+            input=test_case.input,
+            numbered_passages=numbered_passages,
+            actual_output=test_case.actual_output,
+        )
+
+    async def _a_generate_verdict(
+        self, test_case: LLMTestCase
+    ) -> AbstentionVerdict:
+        prompt = self._build_prompt(test_case)
+        return await a_generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=AbstentionVerdict,
+            extract_schema=lambda s: s,
+            extract_json=lambda data: AbstentionVerdict(**data),
+        )
+
+    def _generate_verdict(self, test_case: LLMTestCase) -> AbstentionVerdict:
+        prompt = self._build_prompt(test_case)
+        return generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=AbstentionVerdict,
+            extract_schema=lambda s: s,
+            extract_json=lambda data: AbstentionVerdict(**data),
+        )
+
+    def _decision_is_correct(self) -> bool:
+        return self.verdict.context_supports_answer == (
+            not self.verdict.output_abstained
+        )
+
+    def _generate_reason(self) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+        if self.verdict.reasoning:
+            return self.verdict.reasoning
+        supports = self.verdict.context_supports_answer
+        abstained = self.verdict.output_abstained
+        if supports and not abstained:
+            return "The context supports an answer and the system answered — a correct decision."
+        if not supports and abstained:
+            return "The context does not support an answer and the system abstained — a correct decision."
+        if supports and abstained:
+            return "The context supports an answer but the system abstained — an over-refusal."
+        return "The context does not support an answer but the system answered anyway — an unsupported answer."
+
+    def _calculate_score(self) -> float:
+        score = 1.0 if self._decision_is_correct() else 0.0
+        return 0 if self.strict_mode and score < self.threshold else score
+
+    def is_successful(self) -> bool:
+        if self.error is not None:
+            self.success = False
+        else:
+            try:
+                self.success = self.score >= self.threshold
+            except TypeError:
+                self.success = False
+        return self.success
+
+    @property
+    def __name__(self):
+        return "Abstention"

--- a/deepeval/metrics/community/abstention/schema.py
+++ b/deepeval/metrics/community/abstention/schema.py
@@ -1,0 +1,8 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class AbstentionVerdict(BaseModel):
+    context_supports_answer: bool
+    output_abstained: bool
+    reasoning: Optional[str] = Field(default=None)

--- a/deepeval/metrics/community/abstention/template.py
+++ b/deepeval/metrics/community/abstention/template.py
@@ -1,0 +1,54 @@
+from typing import List
+
+
+class AbstentionTemplate:
+    """Prompt for abstention (answer-vs-decline) correctness.
+
+    The judge makes two independent determinations about a retrieval-augmented
+    answer: (1) whether the retrieved passages actually contain enough
+    information to answer the question, and (2) whether the candidate answer
+    abstained (declined to answer / said the information was not available)
+    rather than giving a substantive answer. The metric then checks that the
+    decision matches: answer when the context supports one, abstain when it does
+    not.
+    """
+
+    @staticmethod
+    def number_passages(retrieval_context: List[str]) -> str:
+        return "\n\n".join(
+            f"[{index + 1}] {passage}"
+            for index, passage in enumerate(retrieval_context)
+        )
+
+    @staticmethod
+    def generate_verdict(
+        input: str, numbered_passages: str, actual_output: str
+    ) -> str:
+        return f"""You are an abstention judge for a retrieval-augmented question answering system.
+You are given a question, a set of numbered retrieved passages, and a candidate answer.
+Make two independent judgments and return them as booleans.
+
+1. context_supports_answer: true if the retrieved passages contain enough information to answer the question; false if the answer is absent from them or the passages are irrelevant to the question. Judge relative to the passages only, not world knowledge.
+2. output_abstained: true if the candidate answer declines to answer — for example it says it does not know, states the information is not in the context, or refuses — instead of giving a substantive answer. A substantive answer counts as not abstaining even if it is wrong.
+
+Return a JSON object with exactly three keys: "context_supports_answer" (boolean), "output_abstained" (boolean), and "reasoning" (one sentence explaining both judgments). Do not return anything else.
+
+Example JSON:
+{{
+    "context_supports_answer": false,
+    "output_abstained": true,
+    "reasoning": "The passages give the tower's height but never its daily visitor capacity, and the answer correctly says the context does not contain that figure."
+}}
+**
+
+Question:
+{input}
+
+Numbered passages:
+{numbered_passages}
+
+Candidate answer:
+{actual_output}
+
+JSON:
+"""

--- a/docs/content/docs/(community)/metrics-abstention.mdx
+++ b/docs/content/docs/(community)/metrics-abstention.mdx
@@ -1,0 +1,77 @@
+---
+id: metrics-abstention
+title: Abstention
+sidebar_label: Abstention
+---
+<MetricTagsDisplayer singleTurn={true} rag={true} referenceless={true} />
+
+The abstention metric uses LLM-as-a-judge to check whether your RAG pipeline made the right decision about **whether to answer at all**. It rewards an `actual_output` that answers when the `retrieval_context` supports one and abstains (says "I don't know" / "the context doesn't cover this") when it does not — penalising both over-refusal and answering a question the context cannot support. `deepeval`'s abstention metric is a self-explaining LLM-Eval, meaning it outputs a reason for its metric score.
+
+:::info
+The `AbstentionMetric` is a **community metric**, contributed and maintained by the `deepeval` community. Community metrics are not exported from `deepeval.metrics` — import them explicitly from `deepeval.metrics.community` instead.
+:::
+
+:::note
+Where the [`FaithfulnessMetric`](/docs/metrics-faithfulness) and [`HallucinationMetric`](/docs/metrics-hallucination) grade the _content_ of an answer, the `AbstentionMetric` grades the _decision to answer or decline_. A system that confidently answers a question its context cannot support will fail here even if every claim it makes is internally consistent, and a system that needlessly refuses an answerable question (over-refusal) will fail too.
+:::
+
+## Required Arguments
+
+To use the `AbstentionMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
+
+- `input`
+- `actual_output`
+- `retrieval_context`
+
+## Usage
+
+The `AbstentionMetric()` can be used for [end-to-end](/docs/evaluation-end-to-end-llm-evals) evaluation of text-based test cases:
+
+```python
+from deepeval import evaluate
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.community import AbstentionMetric
+
+# Replace this with the actual output from your LLM application.
+# The context does not contain the visitor capacity, and the answer correctly declines.
+actual_output = "The retrieved context doesn't state the Eiffel Tower's daily visitor capacity."
+
+# Replace this with the actual retrieved context from your RAG pipeline
+retrieval_context = [
+    "The Eiffel Tower stands 330 metres tall in Paris.",
+    "The Eiffel Tower was completed in 1889 for the World Fair.",
+]
+
+metric = AbstentionMetric()
+test_case = LLMTestCase(
+    input="What is the Eiffel Tower's daily visitor capacity?",
+    actual_output=actual_output,
+    retrieval_context=retrieval_context,
+)
+
+# To run metric as a standalone
+# metric.measure(test_case)
+# print(metric.score, metric.reason)
+
+evaluate(test_cases=[test_case], metrics=[metric])
+```
+
+In the example above the answer **passes**, because the context genuinely does not contain the visitor capacity and the system correctly abstained. Had the system instead answered with a specific number, it would **fail** — that is an unsupported answer. Conversely, if the context _had_ contained the figure but the system still declined, it would fail as an over-refusal.
+
+There are six optional parameters when creating an `AbstentionMetric`:
+
+- [Optional] `threshold`: a float representing the minimum passing score, defaulted to `0.5`. The score is `1.0` for a correct answer-vs-abstain decision and `0.0` for an incorrect one, so the default requires a correct decision to pass.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, OR [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to `gpt-4.1`.
+- [Optional] `include_reason`: a boolean which when set to `True`, will include a reason for its evaluation score. Defaulted to `True`.
+- [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: `1` for a correct decision, `0` otherwise. It also overrides the current threshold and sets it to `1`. Defaulted to `False`.
+- [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method](/docs/metrics-introduction#measuring-metrics-in-async). Defaulted to `True`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console. Defaulted to `False`.
+
+## How Is It Calculated?
+
+A single LLM judge reads the question, the numbered passages, and the answer, then makes two boolean determinations in one call:
+
+- `context_supports_answer`: whether the passages contain enough information to answer the question.
+- `output_abstained`: whether the answer declined to answer rather than giving a substantive response.
+
+The decision is **correct** (score `1.0`) when `context_supports_answer` equals `not output_abstained` — that is, the system answered a supported question or abstained on an unsupported one. Otherwise the decision is **incorrect** (score `0.0`): either an over-refusal (context supports an answer but the system abstained) or an unsupported answer (context does not support one but the system answered).

--- a/tests/test_metrics/test_abstention_metric.py
+++ b/tests/test_metrics/test_abstention_metric.py
@@ -1,0 +1,156 @@
+"""Tests for AbstentionMetric.
+
+These tests use a fake DeepEvalBaseLLM judge so they run without any API key.
+They cover all four decision quadrants — correct answer, correct abstention,
+over-refusal, and unsupported answer — plus async/sync parity.
+"""
+
+from deepeval.metrics.community import AbstentionMetric
+from deepeval.metrics.community.abstention.schema import AbstentionVerdict
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+
+class FakeJudge(DeepEvalBaseLLM):
+    """Returns a preset verdict, capturing the prompt it was given."""
+
+    def __init__(self, verdict: AbstentionVerdict):
+        self._verdict = verdict
+        self.last_prompt = None
+        super().__init__(model="fake-judge")
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt, *args, schema=None, **kwargs):
+        self.last_prompt = prompt
+        return self._verdict
+
+    async def a_generate(self, prompt, *args, schema=None, **kwargs):
+        self.last_prompt = prompt
+        return self._verdict
+
+    def get_model_name(self, *args, **kwargs):
+        return "fake-judge"
+
+
+QUERY = "What is the Eiffel Tower's daily visitor capacity?"
+# Neither passage covers daily visitor capacity — the question is unanswerable
+# from this context.
+UNSUPPORTED_CONTEXT = [
+    "The Eiffel Tower stands 330 metres tall in Paris.",
+    "The Eiffel Tower was completed in 1889 for the World Fair.",
+]
+
+
+def test_passes_appropriate_abstention():
+    # Context does not support an answer, and the system abstained -> correct.
+    judge = FakeJudge(
+        AbstentionVerdict(
+            context_supports_answer=False,
+            output_abstained=True,
+            reasoning="The passages never mention visitor capacity and the answer declines.",
+        )
+    )
+    metric = AbstentionMetric(model=judge, async_mode=False)
+    test_case = LLMTestCase(
+        input=QUERY,
+        actual_output="The context doesn't state the Eiffel Tower's daily visitor capacity.",
+        retrieval_context=UNSUPPORTED_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+    assert metric.reason is not None
+    # The prompt must number the passages.
+    assert "[1] The Eiffel Tower stands 330 metres tall" in judge.last_prompt
+    assert "[2] The Eiffel Tower was completed in 1889" in judge.last_prompt
+
+
+def test_fails_unsupported_answer():
+    # Context does not support an answer, but the system answered anyway -> wrong.
+    judge = FakeJudge(
+        AbstentionVerdict(
+            context_supports_answer=False,
+            output_abstained=False,
+            reasoning="The passages never mention visitor capacity but the answer states a number.",
+        )
+    )
+    metric = AbstentionMetric(model=judge, async_mode=False)
+    test_case = LLMTestCase(
+        input=QUERY,
+        actual_output="The Eiffel Tower welcomes about 25,000 visitors per day.",
+        retrieval_context=UNSUPPORTED_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 0.0
+    assert metric.is_successful() is False
+
+
+def test_fails_over_refusal():
+    # Context supports an answer, but the system abstained anyway -> over-refusal.
+    judge = FakeJudge(
+        AbstentionVerdict(
+            context_supports_answer=True,
+            output_abstained=True,
+            reasoning="The height is stated in the passages but the answer declines to give it.",
+        )
+    )
+    metric = AbstentionMetric(model=judge, async_mode=False)
+    test_case = LLMTestCase(
+        input="How tall is the Eiffel Tower?",
+        actual_output="I'm not able to find that in the provided context.",
+        retrieval_context=UNSUPPORTED_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 0.0
+    assert metric.is_successful() is False
+
+
+def test_passes_answered_when_supported():
+    # Context supports an answer, and the system answered -> correct.
+    judge = FakeJudge(
+        AbstentionVerdict(
+            context_supports_answer=True,
+            output_abstained=False,
+            reasoning="The height is stated in the passages and the answer gives it.",
+        )
+    )
+    metric = AbstentionMetric(model=judge, async_mode=False)
+    test_case = LLMTestCase(
+        input="How tall is the Eiffel Tower?",
+        actual_output="The Eiffel Tower stands 330 metres tall.",
+        retrieval_context=UNSUPPORTED_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+
+
+def test_async_measure_matches_sync():
+    judge = FakeJudge(
+        AbstentionVerdict(
+            context_supports_answer=False,
+            output_abstained=True,
+            reasoning="unanswerable, correctly declined",
+        )
+    )
+    metric = AbstentionMetric(model=judge, async_mode=True)
+    test_case = LLMTestCase(
+        input=QUERY,
+        actual_output="The context doesn't state the Eiffel Tower's daily visitor capacity.",
+        retrieval_context=UNSUPPORTED_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True


### PR DESCRIPTION
## What

Adds a new **community metric**, `AbstentionMetric`, that grades whether a RAG answer made the correct decision about *whether to answer at all*, given its `retrieval_context`:

| context supports an answer? | model abstained? | verdict |
| --- | --- | --- |
| yes | no  | ✅ correct — answered a supported question |
| no  | yes | ✅ correct — appropriate abstention |
| yes | yes | ❌ over-refusal |
| no  | no  | ❌ unsupported answer |

## Why

`FaithfulnessMetric` and `HallucinationMetric` grade the *content* of an answer, but nothing in `deepeval` grades the *decision to answer or decline*. Over-refusal (needlessly declining an answerable question) and unsupported answers (answering when the context can't support it) are both common, costly RAG failure modes that content-faithfulness metrics don't isolate — a confidently-wrong answer and an unnecessary "I don't know" are exactly what teams want to catch. This measures that decision directly.

## How

- A single LLM-judge call returns two booleans (`context_supports_answer`, `output_abstained`); the decision is correct when `context_supports_answer == not output_abstained` → score `1.0`, else `0.0`. Self-explaining `reason`, plus `strict_mode` and `async_mode` — the same conventions as the existing `CitationFaithfulnessMetric`.
- New metric under `deepeval/metrics/community/abstention/` (mirrors `citation_faithfulness/`), registered in `deepeval/metrics/community/__init__.py`.
- Docs page at `docs/content/docs/(community)/metrics-abstention.mdx`.
- Tests in `tests/test_metrics/test_abstention_metric.py` — a fake judge (no API key) covering all four decision quadrants plus async/sync parity (`5 passed` locally).

```python
from deepeval.metrics.community import AbstentionMetric
```

Follows the community-metric contribution path in `CONTRIBUTING.md`. Happy to adjust naming or wording to fit your conventions.