### PR TITLE
fix(scorer): raise clear ModuleNotFoundError for missing optional deps

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -36,8 +36,10 @@ class Scorer:
         """
         try:
             from rouge_score import rouge_scorer
-        except:
-            pass
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "Please install rouge-score. Command: pip install rouge-score"
+            ) from e
 
         assert score_type in [
             "rouge1",
@@ -72,7 +74,9 @@ class Scorer:
             from nltk.tokenize import word_tokenize
             from nltk.translate.bleu_score import sentence_bleu
         except ModuleNotFoundError as e:
-            print("Please install nltk module. Command: pip install nltk")
+            raise ModuleNotFoundError(
+                "Please install nltk module. Command: pip install nltk"
+            ) from e
 
         assert bleu_type in [
             "bleu1",


### PR DESCRIPTION
**What**

`Scorer.rouge_score` swallowed the `rouge-score` import error with a bare `except: pass`, then died with an opaque `NameError` on `rouge_scorer` when the package wasn't installed. `Scorer.sentence_bleu_score` printed an nltk hint but fell through to the same `NameError` on `word_tokenize`.

**Change**

Both optional-dependency guards now `raise ModuleNotFoundError` with the install hint, so a missing dep surfaces the fix instead of a confusing `NameError`. Narrowing the rouge guard from a bare `except:` also stops it swallowing `KeyboardInterrupt`.

Scoped to `scorer.py`'s optional-dependency guards only.