### PR TITLE
fix: respect write_cache for local test-run state

### DIFF
--- a/deepeval/cli/inspect.py
+++ b/deepeval/cli/inspect.py
@@ -14,7 +14,6 @@ from typing import Optional
 import typer
 from rich import print
 
-
 _INSTALL_HINT = (
     "[bold red]deepeval inspect[/bold red] requires extras that are not "
     "installed.\n"
@@ -105,10 +104,18 @@ def _resolve_target(
             return _find_latest(folder_path)
         return None
 
-    from deepeval.test_run.test_run import LATEST_FULL_TEST_RUN_FILE_PATH
+    from deepeval.test_run.test_run import (
+        LATEST_FULL_TEST_RUN_FILE_PATH,
+        _read_latest_file_owner_token,
+    )
+    from deepeval.utils import is_read_only_env
 
     rolling = Path(LATEST_FULL_TEST_RUN_FILE_PATH)
-    if rolling.is_file():
+    if (
+        not is_read_only_env()
+        and rolling.is_file()
+        and _read_latest_file_owner_token(str(rolling)) is not None
+    ):
         return rolling
 
     legacy = Path("experiments")

--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -56,12 +56,13 @@ from deepeval.utils import (
     convert_keys_to_snake_case,
     get_or_create_event_loop,
     open_browser,
+    get_is_running_deepeval,
 )
 from deepeval.test_run import (
     global_test_run_manager,
 )
+from deepeval.test_run.cache import global_test_run_cache_manager
 
-from deepeval.tracing import trace_manager
 from deepeval.tracing.tracing import EVAL_DUMMY_SPAN_NAME
 
 if TYPE_CHECKING:
@@ -1517,11 +1518,6 @@ class EvaluationDataset:
         async_config: Optional["AsyncConfig"] = None,
         run_otel: Optional[bool] = False,
     ) -> Iterator[Golden]:
-        from deepeval.evaluate.utils import (
-            aggregate_metric_pass_rates,
-            print_test_result,
-            write_test_result_to_file,
-        )
         from deepeval.evaluate.types import EvaluationResult, TestResult
         from deepeval.evaluate.execute import (
             a_execute_agentic_test_cases_from_loop,
@@ -1546,127 +1542,168 @@ class EvaluationDataset:
         if not self.goldens or len(self.goldens) == 0:
             raise ValueError("Unable to evaluate dataset with no goldens.")
         goldens = self.goldens
-        with capture_evaluation_run("traceable evaluate()"):
-            global_test_run_manager.reset()
-            start_time = time.perf_counter()
-            test_results: List[TestResult] = []
+        should_restore_cache_policy = not get_is_running_deepeval()
+        previous_disable_write_cache = (
+            global_test_run_cache_manager.disable_write_cache
+        )
+        previous_write_cache_state = (
+            global_test_run_manager._write_cache_state()
+        )
 
-            # sandwich start trace for OTEL
-            if run_otel:
-                ctx = self._start_otel_test_run()  # ignored span
-                ctx_token = attach(ctx)
-
-            if async_config.run_async:
-                loop = get_or_create_event_loop()
-                for golden in a_execute_agentic_test_cases_from_loop(
-                    goldens=goldens,
-                    identifier=identifier,
-                    loop=loop,
-                    trace_metrics=metrics,
-                    test_results=test_results,
-                    display_config=display_config,
-                    cache_config=cache_config,
-                    error_config=error_config,
-                    async_config=async_config,
-                ):
-                    if run_otel:
-                        _tracer = check_tracer()
-                        with _tracer.start_as_current_span(
-                            name=EVAL_DUMMY_SPAN_NAME,
-                            context=ctx,
-                        ):
-                            yield golden
-                    else:
-                        yield golden
-
-            else:
-                for golden in execute_agentic_test_cases_from_loop(
-                    goldens=goldens,
-                    trace_metrics=metrics,
-                    display_config=display_config,
-                    cache_config=cache_config,
-                    error_config=error_config,
-                    test_results=test_results,
-                    identifier=identifier,
-                ):
-                    if run_otel:
-                        _tracer = check_tracer()
-                        with _tracer.start_as_current_span(
-                            name=EVAL_DUMMY_SPAN_NAME,
-                            context=ctx,
-                        ):
-                            yield golden
-                    else:
-                        yield golden
-
-            end_time = time.perf_counter()
-            run_duration = end_time - start_time
-            if display_config.print_results:
-                console_report = EvaluationConsoleReport(test_results)
-                console_report.render_to_terminal(
-                    truncate_passing_cases=display_config.truncate_passing_cases
+        def restore_cache_policy(preserve_latest_invalidation: bool = False):
+            if preserve_latest_invalidation:
+                global_test_run_manager._invalidate_latest_test_run_cache(
+                    delete_owned_disk_state=True
                 )
-
-                # Handle full, un-truncated file exports
-                if display_config.file_output_dir is not None:
-                    if display_config.file_type == "html":
-                        console_report.export_to_html(
-                            output_dir=display_config.file_output_dir,
-                            evaluation_name=identifier,
-                            theme_mode="dark",
-                        )
-                    elif display_config.file_type == "md":
-                        console_report.export_to_markdown(
-                            output_dir=display_config.file_output_dir,
-                            evaluation_name=identifier,
-                        )
-                    else:
-                        raise ValueError(
-                            f"Invalid file type: {display_config.file_type}"
-                        )
-
-            test_run = global_test_run_manager.get_test_run()
-            if hyperparameters is not None or test_run.hyperparameters is None:
-                test_run.hyperparameters = process_hyperparameters(
-                    hyperparameters
-                )
-                test_run.prompts = process_prompts(hyperparameters)
-
-            global_test_run_manager.configure_local_store(
-                results_folder=display_config.results_folder,
-                results_subfolder=display_config.results_subfolder,
+            global_test_run_cache_manager.disable_write_cache = (
+                previous_disable_write_cache
             )
-            # save test run
-            global_test_run_manager.save_test_run(TEMP_FILE_PATH)
+            global_test_run_manager._restore_write_cache_state(
+                previous_write_cache_state,
+                preserve_latest_invalidation=preserve_latest_invalidation,
+            )
 
-            # sandwich end trace for OTEL
-            if run_otel:
-                self._end_otel_test_run(ctx)
-                detach(ctx_token)
+        completed_normally = False
+        try:
+            with capture_evaluation_run("traceable evaluate()"):
+                global_test_run_manager.reset()
+                start_time = time.perf_counter()
+                test_results: List[TestResult] = []
 
-            else:
-                res = global_test_run_manager.wrap_up_test_run(
-                    run_duration, display_table=False
-                )
-                if isinstance(res, tuple):
-                    confident_link, test_run_id = res
+                # sandwich start trace for OTEL
+                if run_otel:
+                    ctx = self._start_otel_test_run()  # ignored span
+                    ctx_token = attach(ctx)
+
+                if async_config.run_async:
+                    loop = get_or_create_event_loop()
+                    for golden in a_execute_agentic_test_cases_from_loop(
+                        goldens=goldens,
+                        identifier=identifier,
+                        loop=loop,
+                        trace_metrics=metrics,
+                        test_results=test_results,
+                        display_config=display_config,
+                        cache_config=cache_config,
+                        error_config=error_config,
+                        async_config=async_config,
+                    ):
+                        if run_otel:
+                            _tracer = check_tracer()
+                            with _tracer.start_as_current_span(
+                                name=EVAL_DUMMY_SPAN_NAME,
+                                context=ctx,
+                            ):
+                                yield golden
+                        else:
+                            yield golden
+
                 else:
-                    confident_link = test_run_id = None
+                    for golden in execute_agentic_test_cases_from_loop(
+                        goldens=goldens,
+                        trace_metrics=metrics,
+                        display_config=display_config,
+                        cache_config=cache_config,
+                        error_config=error_config,
+                        test_results=test_results,
+                        identifier=identifier,
+                    ):
+                        if run_otel:
+                            _tracer = check_tracer()
+                            with _tracer.start_as_current_span(
+                                name=EVAL_DUMMY_SPAN_NAME,
+                                context=ctx,
+                            ):
+                                yield golden
+                        else:
+                            yield golden
 
-                # Offer the inspect TUI after all other run output has
-                # flushed — mirrors the placement in
-                # ``deepeval/evaluate/evaluate.py``.
-                from deepeval.evaluate.inspect_prompt import (
-                    maybe_offer_inspect_tui,
+                end_time = time.perf_counter()
+                run_duration = end_time - start_time
+                if display_config.print_results:
+                    console_report = EvaluationConsoleReport(test_results)
+                    console_report.render_to_terminal(
+                        truncate_passing_cases=display_config.truncate_passing_cases
+                    )
+
+                    # Handle full, un-truncated file exports
+                    if display_config.file_output_dir is not None:
+                        if display_config.file_type == "html":
+                            console_report.export_to_html(
+                                output_dir=display_config.file_output_dir,
+                                evaluation_name=identifier,
+                                theme_mode="dark",
+                            )
+                        elif display_config.file_type == "md":
+                            console_report.export_to_markdown(
+                                output_dir=display_config.file_output_dir,
+                                evaluation_name=identifier,
+                            )
+                        else:
+                            raise ValueError(
+                                f"Invalid file type: {display_config.file_type}"
+                            )
+
+                test_run = global_test_run_manager.get_test_run()
+                if (
+                    hyperparameters is not None
+                    or test_run.hyperparameters is None
+                ):
+                    test_run.hyperparameters = process_hyperparameters(
+                        hyperparameters
+                    )
+                    test_run.prompts = process_prompts(hyperparameters)
+
+                global_test_run_manager.configure_local_store(
+                    results_folder=display_config.results_folder,
+                    results_subfolder=display_config.results_subfolder,
                 )
+                # save test run
+                global_test_run_manager.save_test_run(TEMP_FILE_PATH)
 
-                maybe_offer_inspect_tui(global_test_run_manager, display_config)
+                # sandwich end trace for OTEL
+                if run_otel:
+                    self._end_otel_test_run(ctx)
+                    detach(ctx_token)
+                    completed_normally = True
 
-                return EvaluationResult(
-                    test_results=test_results,
-                    confident_link=confident_link,
-                    test_run_id=test_run_id,
-                )
+                else:
+                    res = global_test_run_manager.wrap_up_test_run(
+                        run_duration, display_table=False
+                    )
+                    if isinstance(res, tuple):
+                        confident_link, test_run_id = res
+                    else:
+                        confident_link = test_run_id = None
+
+                    # Offer the inspect TUI after all other run output has
+                    # flushed — mirrors the placement in
+                    # ``deepeval/evaluate/evaluate.py``.
+                    from deepeval.evaluate.inspect_prompt import (
+                        maybe_offer_inspect_tui,
+                    )
+
+                    maybe_offer_inspect_tui(
+                        global_test_run_manager, display_config
+                    )
+
+                    completed_normally = True
+                    return EvaluationResult(
+                        test_results=test_results,
+                        confident_link=confident_link,
+                        test_run_id=test_run_id,
+                    )
+        finally:
+            if should_restore_cache_policy:
+                if completed_normally:
+                    global_test_run_cache_manager.disable_write_cache = (
+                        previous_disable_write_cache
+                    )
+                    global_test_run_manager.save_to_disk = (
+                        previous_write_cache_state[0]
+                    )
+                else:
+                    restore_cache_policy(cache_config.write_cache is False)
 
     def evaluate(self, task: Task):
         coerce_to_task(task)

--- a/deepeval/evaluate/evaluate.py
+++ b/deepeval/evaluate/evaluate.py
@@ -1,4 +1,3 @@
-import os
 from typing import (
     List,
     Optional,
@@ -55,6 +54,7 @@ from deepeval.test_run import (
     global_test_run_manager,
     MetricData,
 )
+from deepeval.test_run.cache import global_test_run_cache_manager
 from deepeval.utils import get_is_running_deepeval
 from deepeval.evaluate.types import EvaluationResult
 from deepeval.evaluate.execute import (
@@ -185,6 +185,28 @@ def evaluate(
 
     if metrics:
 
+        should_restore_cache_policy = not get_is_running_deepeval()
+        previous_disable_write_cache = (
+            global_test_run_cache_manager.disable_write_cache
+        )
+        previous_write_cache_state = (
+            global_test_run_manager._write_cache_state()
+        )
+
+        def restore_cache_policy(preserve_latest_invalidation: bool = False):
+            if preserve_latest_invalidation:
+                global_test_run_manager._invalidate_latest_test_run_cache(
+                    delete_owned_disk_state=True
+                )
+            global_test_run_cache_manager.disable_write_cache = (
+                previous_disable_write_cache
+            )
+            global_test_run_manager._restore_write_cache_state(
+                previous_write_cache_state,
+                preserve_latest_invalidation=preserve_latest_invalidation,
+            )
+
+        completed_normally = False
         if not _skip_reset and not get_is_running_deepeval():
             global_test_run_manager.reset()
         set_test_run_official(official)
@@ -199,111 +221,128 @@ def evaluate(
                     )
                 )
 
-        with capture_evaluation_run("evaluate()"):
-            if async_config.run_async:
-                loop = get_or_create_event_loop()
-                test_results = loop.run_until_complete(
-                    a_execute_test_cases(
+        try:
+            with capture_evaluation_run("evaluate()"):
+                if async_config.run_async:
+                    loop = get_or_create_event_loop()
+                    test_results = loop.run_until_complete(
+                        a_execute_test_cases(
+                            test_cases,
+                            metrics,
+                            identifier=identifier,
+                            error_config=error_config,
+                            display_config=display_config,
+                            cache_config=cache_config,
+                            async_config=async_config,
+                        )
+                    )
+                else:
+                    test_results = execute_test_cases(
                         test_cases,
                         metrics,
                         identifier=identifier,
                         error_config=error_config,
                         display_config=display_config,
                         cache_config=cache_config,
-                        async_config=async_config,
                     )
-                )
-            else:
-                test_results = execute_test_cases(
-                    test_cases,
-                    metrics,
-                    identifier=identifier,
-                    error_config=error_config,
-                    display_config=display_config,
-                    cache_config=cache_config,
+
+            end_time = time.perf_counter()
+            run_duration = end_time - start_time
+            if display_config.print_results:
+                console_report = EvaluationConsoleReport(test_results)
+                console_report.render_to_terminal(
+                    truncate_passing_cases=display_config.truncate_passing_cases,
+                    display_option=display_config.display_option,
                 )
 
-        end_time = time.perf_counter()
-        run_duration = end_time - start_time
-        if display_config.print_results:
-            console_report = EvaluationConsoleReport(test_results)
-            console_report.render_to_terminal(
-                truncate_passing_cases=display_config.truncate_passing_cases,
-                display_option=display_config.display_option,
+                # Handle full, un-truncated file exports
+                if display_config.file_output_dir is not None:
+                    if display_config.file_type == "html":
+                        console_report.export_to_html(
+                            output_dir=display_config.file_output_dir,
+                            evaluation_name=identifier,
+                            theme_mode="dark",
+                        )
+                    elif display_config.file_type == "md":
+                        console_report.export_to_markdown(
+                            output_dir=display_config.file_output_dir,
+                            evaluation_name=identifier,
+                        )
+                    else:
+                        raise ValueError(
+                            f"Invalid file type: {display_config.file_type}"
+                        )
+
+            test_run = global_test_run_manager.get_test_run()
+            if hyperparameters is not None or test_run.hyperparameters is None:
+                test_run.hyperparameters = process_hyperparameters(
+                    hyperparameters
+                )
+                test_run.prompts = process_prompts(hyperparameters)
+
+            global_test_run_manager.configure_local_store(
+                results_folder=display_config.results_folder,
+                results_subfolder=display_config.results_subfolder,
             )
 
-            # Handle full, un-truncated file exports
-            if display_config.file_output_dir is not None:
-                if display_config.file_type == "html":
-                    console_report.export_to_html(
-                        output_dir=display_config.file_output_dir,
-                        evaluation_name=identifier,
-                        theme_mode="dark",
+            if _skip_reset:
+                test_run.run_duration += run_duration
+                global_test_run_manager.save_test_run(TEMP_FILE_PATH)
+                completed_normally = True
+                return EvaluationResult(
+                    test_results=test_results,
+                    confident_link=None,
+                    test_run_id=None,
+                )
+
+            global_test_run_manager.save_test_run(TEMP_FILE_PATH)
+
+            # In CLI mode (`deepeval test run`), the CLI owns finalization and will
+            # call `wrap_up_test_run()` once after pytest finishes. Finalizing here
+            # as well would double finalize the run and consequently result in
+            # duplicate uploads / local saves and temp file races, so only
+            # do it when we're NOT in CLI mode.
+            if get_is_running_deepeval():
+                completed_normally = True
+                return EvaluationResult(
+                    test_results=test_results,
+                    confident_link=None,
+                    test_run_id=None,
+                )
+
+            res = global_test_run_manager.wrap_up_test_run(
+                run_duration, display_table=False
+            )
+            if isinstance(res, tuple):
+                confident_link, test_run_id = res
+            else:
+                confident_link = test_run_id = None
+
+            # All other side-effects (saving locally, posting to Confident AI,
+            # rendering the table) have already happened inside wrap_up_test_run.
+            # Offer to open the inspect TUI as the very last thing the user sees,
+            # so it never competes with the run output for attention.
+            from deepeval.evaluate.inspect_prompt import maybe_offer_inspect_tui
+
+            maybe_offer_inspect_tui(global_test_run_manager, display_config)
+
+            completed_normally = True
+            return EvaluationResult(
+                test_results=test_results,
+                confident_link=confident_link,
+                test_run_id=test_run_id,
+            )
+        finally:
+            if should_restore_cache_policy:
+                if completed_normally:
+                    global_test_run_cache_manager.disable_write_cache = (
+                        previous_disable_write_cache
                     )
-                elif display_config.file_type == "md":
-                    console_report.export_to_markdown(
-                        output_dir=display_config.file_output_dir,
-                        evaluation_name=identifier,
+                    global_test_run_manager.save_to_disk = (
+                        previous_write_cache_state[0]
                     )
                 else:
-                    raise ValueError(
-                        f"Invalid file type: {display_config.file_type}"
-                    )
-
-        test_run = global_test_run_manager.get_test_run()
-        if hyperparameters is not None or test_run.hyperparameters is None:
-            test_run.hyperparameters = process_hyperparameters(hyperparameters)
-            test_run.prompts = process_prompts(hyperparameters)
-
-        global_test_run_manager.configure_local_store(
-            results_folder=display_config.results_folder,
-            results_subfolder=display_config.results_subfolder,
-        )
-
-        if _skip_reset:
-            test_run.run_duration += run_duration
-            global_test_run_manager.save_test_run(TEMP_FILE_PATH)
-            return EvaluationResult(
-                test_results=test_results,
-                confident_link=None,
-                test_run_id=None,
-            )
-
-        global_test_run_manager.save_test_run(TEMP_FILE_PATH)
-
-        # In CLI mode (`deepeval test run`), the CLI owns finalization and will
-        # call `wrap_up_test_run()` once after pytest finishes. Finalizing here
-        # as well would double finalize the run and consequently result in
-        # duplicate uploads / local saves and temp file races, so only
-        # do it when we're NOT in CLI mode.
-        if get_is_running_deepeval():
-            return EvaluationResult(
-                test_results=test_results,
-                confident_link=None,
-                test_run_id=None,
-            )
-
-        res = global_test_run_manager.wrap_up_test_run(
-            run_duration, display_table=False
-        )
-        if isinstance(res, tuple):
-            confident_link, test_run_id = res
-        else:
-            confident_link = test_run_id = None
-
-        # All other side-effects (saving locally, posting to Confident AI,
-        # rendering the table) have already happened inside wrap_up_test_run.
-        # Offer to open the inspect TUI as the very last thing the user sees,
-        # so it never competes with the run output for attention.
-        from deepeval.evaluate.inspect_prompt import maybe_offer_inspect_tui
-
-        maybe_offer_inspect_tui(global_test_run_manager, display_config)
-
-        return EvaluationResult(
-            test_results=test_results,
-            confident_link=confident_link,
-            test_run_id=test_run_id,
-        )
+                    restore_cache_policy(cache_config.write_cache is False)
     elif metric_collection:
         api = Api()
         api_evaluate = APIEvaluate(

--- a/deepeval/evaluate/execute/e2e.py
+++ b/deepeval/evaluate/execute/e2e.py
@@ -67,15 +67,14 @@ from deepeval.utils import add_pbar, update_pbar, custom_console
 from deepeval.tracing.types import TestCaseMetricPair
 from deepeval.config.settings import get_settings
 
-logger = logging.getLogger(__name__)
-
-
 from deepeval.evaluate.execute._common import (
     _await_with_outer_deadline,
     _execute_metric,
     _log_gather_timeout,
     _timeout_msg,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def execute_test_cases(
@@ -92,37 +91,61 @@ def execute_test_cases(
     _use_bar_indicator: bool = True,
     _is_assert_test: bool = False,
 ) -> List[TestResult]:
-    global_test_run_cache_manager.disable_write_cache = (
-        cache_config.write_cache is False
-    )
-
     if test_run_manager is None:
         test_run_manager = global_test_run_manager
 
-    test_run_manager.save_to_disk = cache_config.write_cache
-    test_run = test_run_manager.get_test_run(identifier=identifier)
-    if test_run is None:
-        # ensure we have a test_run ( in case it couldn't be loaded from disk )
-        test_run_manager.create_test_run(identifier=identifier)
+    previous_disable_write_cache = (
+        global_test_run_cache_manager.disable_write_cache
+    )
+    previous_write_cache_state = test_run_manager._write_cache_state()
+
+    def restore_cache_policy(preserve_latest_invalidation: bool = False):
+        if preserve_latest_invalidation:
+            test_run_manager._invalidate_latest_test_run_cache(
+                delete_owned_disk_state=True
+            )
+        global_test_run_cache_manager.disable_write_cache = (
+            previous_disable_write_cache
+        )
+        test_run_manager._restore_write_cache_state(
+            previous_write_cache_state,
+            preserve_latest_invalidation=preserve_latest_invalidation,
+        )
+
+    global_test_run_cache_manager.disable_write_cache = (
+        cache_config.write_cache is False
+    )
+    test_run_manager.configure_write_cache(cache_config.write_cache)
+
+    try:
         test_run = test_run_manager.get_test_run(identifier=identifier)
+        if test_run is None:
+            # ensure we have a test_run ( in case it couldn't be loaded from disk )
+            test_run_manager.create_test_run(identifier=identifier)
+            test_run = test_run_manager.get_test_run(identifier=identifier)
 
-    # capture once for inner closures
-    hyperparameters = test_run.hyperparameters if test_run is not None else None
+        # capture once for inner closures
+        hyperparameters = (
+            test_run.hyperparameters if test_run is not None else None
+        )
 
-    if display_config.verbose_mode is not None:
+        if display_config.verbose_mode is not None:
+            for metric in metrics:
+                metric.verbose_mode = display_config.verbose_mode
+
+        conversational_metrics: List[BaseConversationalMetric] = []
+        llm_metrics: List[BaseMetric] = []
         for metric in metrics:
-            metric.verbose_mode = display_config.verbose_mode
+            metric.async_mode = False
+            if isinstance(metric, BaseMetric):
+                llm_metrics.append(metric)
+            elif isinstance(metric, BaseConversationalMetric):
+                conversational_metrics.append(metric)
 
-    conversational_metrics: List[BaseConversationalMetric] = []
-    llm_metrics: List[BaseMetric] = []
-    for metric in metrics:
-        metric.async_mode = False
-        if isinstance(metric, BaseMetric):
-            llm_metrics.append(metric)
-        elif isinstance(metric, BaseConversationalMetric):
-            conversational_metrics.append(metric)
-
-    test_results: List[TestResult] = []
+        test_results: List[TestResult] = []
+    except BaseException:
+        restore_cache_policy(cache_config.write_cache is False)
+        raise
 
     def evaluate_test_cases(
         progress: Optional[Progress] = None, pbar_id: Optional[int] = None
@@ -309,25 +332,29 @@ def execute_test_cases(
                 finally:
                     reset_outer_deadline(deadline_token)
 
-    if display_config.show_indicator and _use_bar_indicator:
-        progress = Progress(
-            TextColumn("{task.description}"),
-            BarColumn(bar_width=60),
-            TaskProgressColumn(),
-            TimeElapsedColumn(),
-            console=custom_console,
-        )
-        with progress:
-            pbar_id = add_pbar(
-                progress,
-                f"Evaluating {len(test_cases)} test case(s) sequentially",
-                total=len(test_cases),
+    try:
+        if display_config.show_indicator and _use_bar_indicator:
+            progress = Progress(
+                TextColumn("{task.description}"),
+                BarColumn(bar_width=60),
+                TaskProgressColumn(),
+                TimeElapsedColumn(),
+                console=custom_console,
             )
-            evaluate_test_cases(progress=progress, pbar_id=pbar_id)
-    else:
-        evaluate_test_cases()
+            with progress:
+                pbar_id = add_pbar(
+                    progress,
+                    f"Evaluating {len(test_cases)} test case(s) sequentially",
+                    total=len(test_cases),
+                )
+                evaluate_test_cases(progress=progress, pbar_id=pbar_id)
+        else:
+            evaluate_test_cases()
 
-    return test_results
+        return test_results
+    except BaseException:
+        restore_cache_policy(cache_config.write_cache is False)
+        raise
 
 
 async def a_execute_test_cases(
@@ -353,54 +380,146 @@ async def a_execute_test_cases(
                 func, *args, timeout=get_per_task_timeout_seconds(), **kwargs
             )
 
-    global_test_run_cache_manager.disable_write_cache = (
-        cache_config.write_cache is False
-    )
     if test_run_manager is None:
         test_run_manager = global_test_run_manager
 
-    test_run_manager.save_to_disk = cache_config.write_cache
-    test_run = test_run_manager.get_test_run(identifier=identifier)
+    previous_disable_write_cache = (
+        global_test_run_cache_manager.disable_write_cache
+    )
+    previous_write_cache_state = test_run_manager._write_cache_state()
 
-    if display_config.verbose_mode is not None:
+    def restore_cache_policy(preserve_latest_invalidation: bool = False):
+        if preserve_latest_invalidation:
+            test_run_manager._invalidate_latest_test_run_cache(
+                delete_owned_disk_state=True
+            )
+        global_test_run_cache_manager.disable_write_cache = (
+            previous_disable_write_cache
+        )
+        test_run_manager._restore_write_cache_state(
+            previous_write_cache_state,
+            preserve_latest_invalidation=preserve_latest_invalidation,
+        )
+
+    global_test_run_cache_manager.disable_write_cache = (
+        cache_config.write_cache is False
+    )
+    test_run_manager.configure_write_cache(cache_config.write_cache)
+
+    try:
+        test_run = test_run_manager.get_test_run(identifier=identifier)
+
+        if display_config.verbose_mode is not None:
+            for metric in metrics:
+                metric.verbose_mode = display_config.verbose_mode
+
+        llm_metrics: List[BaseMetric] = []
+        conversational_metrics: List[BaseConversationalMetric] = []
         for metric in metrics:
-            metric.verbose_mode = display_config.verbose_mode
+            if isinstance(metric, BaseMetric):
+                llm_metrics.append(metric)
+            elif isinstance(metric, BaseConversationalMetric):
+                conversational_metrics.append(metric)
 
-    llm_metrics: List[BaseMetric] = []
-    conversational_metrics: List[BaseConversationalMetric] = []
-    for metric in metrics:
-        if isinstance(metric, BaseMetric):
-            llm_metrics.append(metric)
-        elif isinstance(metric, BaseConversationalMetric):
-            conversational_metrics.append(metric)
+        llm_test_case_counter = -1
+        conversational_test_case_counter = -1
+        test_results: List[Union[TestResult, LLMTestCase]] = []
+        tasks = []
+    except BaseException:
+        restore_cache_policy(cache_config.write_cache is False)
+        raise
 
-    llm_test_case_counter = -1
-    conversational_test_case_counter = -1
-    test_results: List[Union[TestResult, LLMTestCase]] = []
-    tasks = []
+    try:
+        if display_config.show_indicator and _use_bar_indicator:
+            progress = Progress(
+                TextColumn("{task.description}"),
+                BarColumn(bar_width=60),
+                TaskProgressColumn(),
+                TimeElapsedColumn(),
+                console=custom_console,
+            )
+            pbar_id = add_pbar(
+                progress,
+                f"Evaluating {len(test_cases)} test case(s) in parallel",
+                total=len(test_cases),
+            )
+            with progress:
+                for test_case in test_cases:
+                    with capture_evaluation_run("test case"):
+                        if isinstance(test_case, LLMTestCase):
+                            if len(llm_metrics) == 0:
+                                update_pbar(progress, pbar_id)
+                                continue
 
-    if display_config.show_indicator and _use_bar_indicator:
-        progress = Progress(
-            TextColumn("{task.description}"),
-            BarColumn(bar_width=60),
-            TaskProgressColumn(),
-            TimeElapsedColumn(),
-            console=custom_console,
-        )
-        pbar_id = add_pbar(
-            progress,
-            f"Evaluating {len(test_cases)} test case(s) in parallel",
-            total=len(test_cases),
-        )
-        with progress:
+                            llm_test_case_counter += 1
+                            copied_llm_metrics: List[BaseMetric] = copy_metrics(
+                                llm_metrics
+                            )
+                            task = execute_with_semaphore(
+                                func=_a_execute_llm_test_cases,
+                                metrics=copied_llm_metrics,
+                                test_case=test_case,
+                                test_run_manager=test_run_manager,
+                                test_results=test_results,
+                                count=llm_test_case_counter,
+                                test_run=test_run,
+                                ignore_errors=error_config.ignore_errors,
+                                skip_on_missing_params=error_config.skip_on_missing_params,
+                                use_cache=cache_config.use_cache,
+                                show_indicator=display_config.show_indicator,
+                                _use_bar_indicator=_use_bar_indicator,
+                                _is_assert_test=_is_assert_test,
+                                progress=progress,
+                                pbar_id=pbar_id,
+                            )
+                            tasks.append(asyncio.create_task(task))
+
+                        elif isinstance(test_case, ConversationalTestCase):
+                            conversational_test_case_counter += 1
+
+                            task = execute_with_semaphore(
+                                func=_a_execute_conversational_test_cases,
+                                metrics=copy_metrics(conversational_metrics),
+                                test_case=test_case,
+                                test_run_manager=test_run_manager,
+                                test_results=test_results,
+                                count=conversational_test_case_counter,
+                                ignore_errors=error_config.ignore_errors,
+                                skip_on_missing_params=error_config.skip_on_missing_params,
+                                show_indicator=display_config.show_indicator,
+                                _use_bar_indicator=_use_bar_indicator,
+                                _is_assert_test=_is_assert_test,
+                                progress=progress,
+                                pbar_id=pbar_id,
+                            )
+                            tasks.append(asyncio.create_task(task))
+
+                        await asyncio.sleep(async_config.throttle_value)
+
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*tasks),
+                        timeout=get_gather_timeout(),
+                    )
+                except (asyncio.TimeoutError, TimeoutError) as e:
+                    for t in tasks:
+                        if not t.done():
+                            t.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+
+                    _log_gather_timeout(logger, exc=e)
+
+                    if not error_config.ignore_errors:
+                        raise
+
+        else:
             for test_case in test_cases:
                 with capture_evaluation_run("test case"):
                     if isinstance(test_case, LLMTestCase):
                         if len(llm_metrics) == 0:
-                            update_pbar(progress, pbar_id)
                             continue
-
                         llm_test_case_counter += 1
+
                         copied_llm_metrics: List[BaseMetric] = copy_metrics(
                             llm_metrics
                         )
@@ -415,33 +534,34 @@ async def a_execute_test_cases(
                             ignore_errors=error_config.ignore_errors,
                             skip_on_missing_params=error_config.skip_on_missing_params,
                             use_cache=cache_config.use_cache,
-                            show_indicator=display_config.show_indicator,
                             _use_bar_indicator=_use_bar_indicator,
                             _is_assert_test=_is_assert_test,
-                            progress=progress,
-                            pbar_id=pbar_id,
+                            show_indicator=display_config.show_indicator,
                         )
-                        tasks.append(asyncio.create_task(task))
+                        tasks.append(asyncio.create_task((task)))
 
                     elif isinstance(test_case, ConversationalTestCase):
                         conversational_test_case_counter += 1
-
+                        copied_conversational_metrics: List[
+                            BaseConversationalMetric
+                        ] = []
+                        copied_conversational_metrics = copy_metrics(
+                            conversational_metrics
+                        )
                         task = execute_with_semaphore(
                             func=_a_execute_conversational_test_cases,
-                            metrics=copy_metrics(conversational_metrics),
+                            metrics=copied_conversational_metrics,
                             test_case=test_case,
                             test_run_manager=test_run_manager,
                             test_results=test_results,
                             count=conversational_test_case_counter,
                             ignore_errors=error_config.ignore_errors,
                             skip_on_missing_params=error_config.skip_on_missing_params,
-                            show_indicator=display_config.show_indicator,
                             _use_bar_indicator=_use_bar_indicator,
                             _is_assert_test=_is_assert_test,
-                            progress=progress,
-                            pbar_id=pbar_id,
+                            show_indicator=display_config.show_indicator,
                         )
-                        tasks.append(asyncio.create_task(task))
+                        tasks.append(asyncio.create_task((task)))
 
                     await asyncio.sleep(async_config.throttle_value)
 
@@ -451,84 +571,24 @@ async def a_execute_test_cases(
                     timeout=get_gather_timeout(),
                 )
             except (asyncio.TimeoutError, TimeoutError) as e:
+                # Cancel any still-pending tasks and drain them
                 for t in tasks:
                     if not t.done():
                         t.cancel()
                 await asyncio.gather(*tasks, return_exceptions=True)
-
                 _log_gather_timeout(logger, exc=e)
-
                 if not error_config.ignore_errors:
                     raise
 
-    else:
-        for test_case in test_cases:
-            with capture_evaluation_run("test case"):
-                if isinstance(test_case, LLMTestCase):
-                    if len(llm_metrics) == 0:
-                        continue
-                    llm_test_case_counter += 1
-
-                    copied_llm_metrics: List[BaseMetric] = copy_metrics(
-                        llm_metrics
-                    )
-                    task = execute_with_semaphore(
-                        func=_a_execute_llm_test_cases,
-                        metrics=copied_llm_metrics,
-                        test_case=test_case,
-                        test_run_manager=test_run_manager,
-                        test_results=test_results,
-                        count=llm_test_case_counter,
-                        test_run=test_run,
-                        ignore_errors=error_config.ignore_errors,
-                        skip_on_missing_params=error_config.skip_on_missing_params,
-                        use_cache=cache_config.use_cache,
-                        _use_bar_indicator=_use_bar_indicator,
-                        _is_assert_test=_is_assert_test,
-                        show_indicator=display_config.show_indicator,
-                    )
-                    tasks.append(asyncio.create_task((task)))
-
-                elif isinstance(test_case, ConversationalTestCase):
-                    conversational_test_case_counter += 1
-                    copied_conversational_metrics: List[
-                        BaseConversationalMetric
-                    ] = []
-                    copied_conversational_metrics = copy_metrics(
-                        conversational_metrics
-                    )
-                    task = execute_with_semaphore(
-                        func=_a_execute_conversational_test_cases,
-                        metrics=copied_conversational_metrics,
-                        test_case=test_case,
-                        test_run_manager=test_run_manager,
-                        test_results=test_results,
-                        count=conversational_test_case_counter,
-                        ignore_errors=error_config.ignore_errors,
-                        skip_on_missing_params=error_config.skip_on_missing_params,
-                        _use_bar_indicator=_use_bar_indicator,
-                        _is_assert_test=_is_assert_test,
-                        show_indicator=display_config.show_indicator,
-                    )
-                    tasks.append(asyncio.create_task((task)))
-
-                await asyncio.sleep(async_config.throttle_value)
-
-        try:
-            await asyncio.wait_for(
-                asyncio.gather(*tasks),
-                timeout=get_gather_timeout(),
-            )
-        except (asyncio.TimeoutError, TimeoutError):
-            # Cancel any still-pending tasks and drain them
-            for t in tasks:
-                if not t.done():
-                    t.cancel()
+        return test_results
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-            if not error_config.ignore_errors:
-                raise
-
-    return test_results
+        restore_cache_policy(cache_config.write_cache is False)
+        raise
 
 
 async def _a_execute_llm_test_cases(

--- a/deepeval/evaluate/execute/loop.py
+++ b/deepeval/evaluate/execute/loop.py
@@ -60,6 +60,7 @@ from deepeval.test_run import (
     global_test_run_manager,
     TestRunManager,
 )
+from deepeval.test_run.cache import global_test_run_cache_manager
 from deepeval.evaluate.types import TestResult
 from deepeval.evaluate.utils import (
     create_api_trace,
@@ -80,9 +81,6 @@ from deepeval.tracing.types import (
 from deepeval.tracing.api import TraceSpanApiStatus
 from deepeval.config.settings import get_settings
 
-logger = logging.getLogger(__name__)
-
-
 from deepeval.evaluate.execute._common import (
     _await_with_outer_deadline,
     _execute_metric,
@@ -99,6 +97,8 @@ from deepeval.evaluate.execute.agentic import (
     _a_execute_agentic_test_case,
 )
 from deepeval.evaluate.execute.e2e import _evaluate_test_case_pairs
+
+logger = logging.getLogger(__name__)
 
 
 def _span_subtree_has_metrics(span: BaseSpan) -> bool:
@@ -158,11 +158,38 @@ def execute_agentic_test_cases_from_loop(
 ) -> Iterator[TestResult]:
 
     test_run_manager = global_test_run_manager
-    test_run_manager.save_to_disk = cache_config.write_cache
-    test_run_manager.get_test_run(identifier=identifier)
+    previous_disable_write_cache = (
+        global_test_run_cache_manager.disable_write_cache
+    )
+    previous_write_cache_state = test_run_manager._write_cache_state()
 
-    local_trace_manager = trace_manager
-    local_trace_manager.eval_session = EvalSession(mode=EvalMode.ITERATOR_SYNC)
+    def restore_cache_policy(preserve_latest_invalidation: bool = False):
+        if preserve_latest_invalidation:
+            test_run_manager._invalidate_latest_test_run_cache(
+                delete_owned_disk_state=True
+            )
+        global_test_run_cache_manager.disable_write_cache = (
+            previous_disable_write_cache
+        )
+        test_run_manager._restore_write_cache_state(
+            previous_write_cache_state,
+            preserve_latest_invalidation=preserve_latest_invalidation,
+        )
+
+    global_test_run_cache_manager.disable_write_cache = (
+        cache_config.write_cache is False
+    )
+    test_run_manager.configure_write_cache(cache_config.write_cache)
+    try:
+        test_run_manager.get_test_run(identifier=identifier)
+
+        local_trace_manager = trace_manager
+        local_trace_manager.eval_session = EvalSession(
+            mode=EvalMode.ITERATOR_SYNC
+        )
+    except BaseException:
+        restore_cache_policy(cache_config.write_cache is False)
+        raise
 
     def evaluate_test_cases(
         progress: Optional[Progress] = None,
@@ -469,6 +496,7 @@ def execute_agentic_test_cases_from_loop(
         ):
             _raise_no_metrics_error()
 
+    completed_normally = False
     try:
         if display_config.show_indicator and _use_bar_indicator:
             progress = Progress(
@@ -489,6 +517,7 @@ def execute_agentic_test_cases_from_loop(
                 )
         else:
             yield from evaluate_test_cases()
+        completed_normally = True
     except Exception:
         raise
     finally:
@@ -496,6 +525,8 @@ def execute_agentic_test_cases_from_loop(
         # per-run collection in a single assignment, so state can't leak
         # into the next run.
         local_trace_manager.eval_session = EvalSession()
+        if not completed_normally:
+            restore_cache_policy(cache_config.write_cache is False)
 
 
 def a_execute_agentic_test_cases_from_loop(
@@ -516,11 +547,38 @@ def a_execute_agentic_test_cases_from_loop(
     original_create_task = asyncio.create_task
 
     test_run_manager = global_test_run_manager
-    test_run_manager.save_to_disk = cache_config.write_cache
-    test_run = test_run_manager.get_test_run(identifier=identifier)
+    previous_disable_write_cache = (
+        global_test_run_cache_manager.disable_write_cache
+    )
+    previous_write_cache_state = test_run_manager._write_cache_state()
 
-    local_trace_manager = trace_manager
-    local_trace_manager.eval_session = EvalSession(mode=EvalMode.ITERATOR_ASYNC)
+    def restore_cache_policy(preserve_latest_invalidation: bool = False):
+        if preserve_latest_invalidation:
+            test_run_manager._invalidate_latest_test_run_cache(
+                delete_owned_disk_state=True
+            )
+        global_test_run_cache_manager.disable_write_cache = (
+            previous_disable_write_cache
+        )
+        test_run_manager._restore_write_cache_state(
+            previous_write_cache_state,
+            preserve_latest_invalidation=preserve_latest_invalidation,
+        )
+
+    global_test_run_cache_manager.disable_write_cache = (
+        cache_config.write_cache is False
+    )
+    test_run_manager.configure_write_cache(cache_config.write_cache)
+    try:
+        test_run = test_run_manager.get_test_run(identifier=identifier)
+
+        local_trace_manager = trace_manager
+        local_trace_manager.eval_session = EvalSession(
+            mode=EvalMode.ITERATOR_ASYNC
+        )
+    except BaseException:
+        restore_cache_policy(cache_config.write_cache is False)
+        raise
 
     async def execute_callback_with_semaphore(coroutine: Awaitable):
         async with semaphore:
@@ -719,6 +777,7 @@ def a_execute_agentic_test_cases_from_loop(
         # Snapshot tasks that already exist on this loop so we can detect strays
         baseline_tasks = loop.run_until_complete(_snapshot_tasks())
 
+        callbacks_completed = False
         try:
             for index, golden in enumerate(goldens):
                 token = set_current_golden(golden)
@@ -738,8 +797,19 @@ def a_execute_agentic_test_cases_from_loop(
                 if len(created_tasks) == prev_task_length:
                     update_pbar(progress, pbar_callback_id)
                     update_pbar(progress, pbar_id)
+            callbacks_completed = True
         finally:
             asyncio.create_task = original_create_task
+            if not callbacks_completed and created_tasks:
+                for task in created_tasks:
+                    if not task.done():
+                        task.cancel()
+                try:
+                    loop.run_until_complete(
+                        asyncio.gather(*created_tasks, return_exceptions=True)
+                    )
+                except RuntimeError:
+                    pass
 
         if created_tasks:
             # Only await tasks we created on this loop in this run.
@@ -803,53 +873,53 @@ def a_execute_agentic_test_cases_from_loop(
                     asyncio.gather(*created_tasks, return_exceptions=True)
                 )
             finally:
-
-                # if it is already closed, we are done
-                if loop.is_closed():
-                    return
-
-                try:
-                    current_tasks = set()
-                    # Find tasks that were created during this run but we didn’t track
-                    current_tasks = loop.run_until_complete(_snapshot_tasks())
-                except RuntimeError:
-                    # this might happen if the loop is already closing
-                    pass
-
-                leftovers = [
-                    t
-                    for t in current_tasks
-                    if t not in baseline_tasks
-                    and t not in created_tasks
-                    and not t.done()
-                ]
-
-                if get_settings().DEEPEVAL_DEBUG_ASYNC:
-                    if len(leftovers) > 0:
-                        logger.warning(
-                            "[deepeval] %d stray task(s) not tracked; cancelling...",
-                            len(leftovers),
-                        )
-                    for t in leftovers:
-                        meta = task_meta.get(t, {})
-                        name = t.get_name()
-                        logger.warning("  - STRAY %s meta=%s", name, meta)
-
-                if leftovers:
-                    for t in leftovers:
-                        t.cancel()
-
-                    # Drain strays so they don’t leak into the next iteration
+                if not loop.is_closed():
                     try:
-                        loop.run_until_complete(
-                            asyncio.gather(*leftovers, return_exceptions=True)
+                        current_tasks = set()
+                        # Find tasks that were created during this run but we didn’t track
+                        current_tasks = loop.run_until_complete(
+                            _snapshot_tasks()
                         )
                     except RuntimeError:
-                        # If the loop is closing here, just continue
-                        if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                        # this might happen if the loop is already closing
+                        pass
+
+                    leftovers = [
+                        t
+                        for t in current_tasks
+                        if t not in baseline_tasks
+                        and t not in created_tasks
+                        and not t.done()
+                    ]
+
+                    if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                        if len(leftovers) > 0:
                             logger.warning(
-                                "[deepeval] failed to drain stray tasks because loop is closing"
+                                "[deepeval] %d stray task(s) not tracked; cancelling...",
+                                len(leftovers),
                             )
+                        for t in leftovers:
+                            meta = task_meta.get(t, {})
+                            name = t.get_name()
+                            logger.warning("  - STRAY %s meta=%s", name, meta)
+
+                    if leftovers:
+                        for t in leftovers:
+                            t.cancel()
+
+                        # Drain strays so they don’t leak into the next iteration
+                        try:
+                            loop.run_until_complete(
+                                asyncio.gather(
+                                    *leftovers, return_exceptions=True
+                                )
+                            )
+                        except RuntimeError:
+                            # If the loop is closing here, just continue
+                            if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                                logger.warning(
+                                    "[deepeval] failed to drain stray tasks because loop is closing"
+                                )
 
         # Pre-evaluation guard: refuse a run that has no metric source.
         # Lazy check is the only correct option because span-level metrics
@@ -904,6 +974,7 @@ def a_execute_agentic_test_cases_from_loop(
                 )
             )
 
+    completed_normally = False
     try:
         if display_config.show_indicator and _use_bar_indicator:
             progress = Progress(
@@ -931,12 +1002,15 @@ def a_execute_agentic_test_cases_from_loop(
                 )
         else:
             yield from evaluate_test_cases()
+        completed_normally = True
     except Exception:
         raise
     finally:
         # Atomic exit cleanup: replacing the session resets mode + every
         # per-run collection in a single assignment.
         local_trace_manager.eval_session = EvalSession()
+        if not completed_normally:
+            restore_cache_policy(cache_config.write_cache is False)
 
 
 async def _a_evaluate_traces(

--- a/deepeval/evaluate/local_store.py
+++ b/deepeval/evaluate/local_store.py
@@ -79,7 +79,9 @@ def resolve_test_run_path(target_dir: Path) -> Path:
         n += 1
 
 
-def write_rolling_test_run(test_run: TestRun) -> Optional[Path]:
+def write_rolling_test_run(
+    test_run: TestRun, owner_token: Optional[str] = None
+) -> Optional[Path]:
     """Overwrite `.deepeval/.latest_run_full.json` with `test_run`.
 
     Returns `None` (silently) on read-only env or write failure so a failed
@@ -93,7 +95,7 @@ def write_rolling_test_run(test_run: TestRun) -> Optional[Path]:
     path = Path(LATEST_FULL_TEST_RUN_FILE_PATH)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        _dump(test_run, path)
+        _dump(test_run, path, owner_token=owner_token)
         return path
     except Exception as e:
         print(
@@ -130,11 +132,17 @@ def write_test_run(
     return path
 
 
-def _dump(test_run: TestRun, path: Path) -> None:
+def _dump(
+    test_run: TestRun, path: Path, owner_token: Optional[str] = None
+) -> None:
     try:
         body = test_run.model_dump(by_alias=True, exclude_none=True)
     except AttributeError:
         body = test_run.dict(by_alias=True, exclude_none=True)
+    if owner_token is not None:
+        from deepeval.test_run.test_run import LATEST_TEST_RUN_OWNER_TOKEN_KEY
+
+        body[LATEST_TEST_RUN_OWNER_TOKEN_KEY] = owner_token
     with open(path, "w", encoding="utf-8") as f:
         json.dump(body, f, cls=TestRunEncoder)
         f.flush()

--- a/deepeval/test_run/cache.py
+++ b/deepeval/test_run/cache.py
@@ -109,11 +109,19 @@ class TestRunCacheManager:
         self.cache_file_name: str = CACHE_FILE_NAME
         self.temp_cached_test_run: Optional[CachedTestRun] = None
         self.temp_cache_file_name: str = TEMP_CACHE_FILE_NAME
+        self._temp_cache_session_started: bool = False
+
+    def _disk_cache_disabled(self) -> bool:
+        return (
+            self.disable_write_cache
+            or portalocker is None
+            or is_read_only_env()
+        )
 
     def get_cached_test_case(
         self, test_case: LLMTestCase, hyperparameters: Union[Dict, None]
     ) -> Union[CachedTestCase, None]:
-        if self.disable_write_cache or portalocker is None:
+        if self._disk_cache_disabled():
             return None
 
         cached_test_run = self.get_cached_test_run()
@@ -145,8 +153,10 @@ class TestRunCacheManager:
         hyperparameters: Union[Dict, None],
         to_temp: bool = False,
     ):
-        if self.disable_write_cache or portalocker is None:
+        if self._disk_cache_disabled():
             return
+        if to_temp and not self._temp_cache_session_started:
+            self._temp_cache_session_started = True
         cache_dict = {
             SingleTurnParams.INPUT.value: test_case.input,
             SingleTurnParams.ACTUAL_OUTPUT.value: test_case.actual_output,
@@ -172,7 +182,7 @@ class TestRunCacheManager:
     def set_cached_test_run(
         self, cached_test_run: CachedTestRun, temp: bool = False
     ):
-        if self.disable_write_cache or portalocker is None:
+        if self._disk_cache_disabled():
             return
 
         if temp:
@@ -181,7 +191,7 @@ class TestRunCacheManager:
             self.cached_test_run = cached_test_run
 
     def save_cached_test_run(self, to_temp: bool = False):
-        if self.disable_write_cache or portalocker is None:
+        if self._disk_cache_disabled():
             return
 
         if to_temp:
@@ -208,7 +218,7 @@ class TestRunCacheManager:
                 )
 
     def create_cached_test_run(self, temp: bool = False):
-        if self.disable_write_cache or portalocker is None:
+        if self._disk_cache_disabled():
             return
 
         cached_test_run = CachedTestRun()
@@ -218,7 +228,7 @@ class TestRunCacheManager:
     def get_cached_test_run(
         self, from_temp: bool = False
     ) -> Union[CachedTestRun, None]:
-        if self.disable_write_cache or portalocker is None:
+        if self._disk_cache_disabled():
             return
 
         should_create_cached_test_run = False
@@ -283,16 +293,34 @@ class TestRunCacheManager:
             return self.cached_test_run
 
     def wrap_up_cached_test_run(self):
-        if portalocker is None:
+        if self._disk_cache_disabled():
+            self.cached_test_run = None
+            self.temp_cached_test_run = None
+            self._temp_cache_session_started = False
             return
 
-        if self.disable_write_cache:
-            # Clear cache if write cache is disabled
-            delete_file_if_exists(self.cache_file_name)
-            delete_file_if_exists(self.temp_cache_file_name)
+        if not self._temp_cache_session_started:
+            self.temp_cached_test_run = None
             return
 
+        if self.temp_cached_test_run is None and not os.path.exists(
+            self.temp_cache_file_name
+        ):
+            self._temp_cache_session_started = False
+            return
+
+        if os.path.exists(self.temp_cache_file_name):
+            self.temp_cached_test_run = None
         self.get_cached_test_run(from_temp=True)
+        if not (
+            self.temp_cached_test_run
+            and self.temp_cached_test_run.test_cases_lookup_map
+        ):
+            self.temp_cached_test_run = None
+            delete_file_if_exists(self.temp_cache_file_name)
+            self._temp_cache_session_started = False
+            return
+
         try:
             with portalocker.Lock(self.cache_file_name, mode="w") as file:
                 self.temp_cached_test_run = self.temp_cached_test_run.save(file)
@@ -303,6 +331,7 @@ class TestRunCacheManager:
             )
         finally:
             delete_file_if_exists(self.temp_cache_file_name)
+            self._temp_cache_session_started = False
 
 
 global_test_run_cache_manager = TestRunCacheManager()

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import os
 import json
+import uuid
 from pathlib import Path
 from pydantic import BaseModel, Field
 from typing import Any, Optional, List, Dict, Union, Tuple
@@ -63,7 +64,75 @@ LATEST_TEST_RUN_FILE_PATH = f"{HIDDEN_DIR}/.latest_test_run.json"
 LATEST_FULL_TEST_RUN_FILE_PATH = f"{HIDDEN_DIR}/.latest_run_full.json"
 LATEST_TEST_RUN_DATA_KEY = "testRunData"
 LATEST_TEST_RUN_LINK_KEY = "testRunLink"
+LATEST_TEST_RUN_OWNER_TOKEN_KEY = "_deepevalOwnerToken"
 console = Console()
+
+
+def _read_latest_file_owner_token(file_path: str) -> Optional[str]:
+    try:
+        with open(file_path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if isinstance(data, dict):
+        token = data.get(LATEST_TEST_RUN_OWNER_TOKEN_KEY)
+        if isinstance(token, str):
+            return token
+    return None
+
+
+def _delete_latest_file_if_owned(
+    file_path: str, expected_owner_token: Optional[str]
+):
+    if (
+        expected_owner_token is None
+        or portalocker is None
+        or is_read_only_env()
+    ):
+        return
+
+    try:
+        stat_result = os.lstat(file_path)
+    except FileNotFoundError:
+        return
+    except OSError as e:
+        print(f"An error occurred: {e}")
+        return
+
+    if not os.path.isfile(file_path) or os.path.islink(file_path):
+        return
+
+    try:
+        with portalocker.Lock(file_path, mode="r+") as file:
+            try:
+                data = json.load(file)
+            except json.JSONDecodeError:
+                return
+            if not isinstance(data, dict):
+                return
+            if (
+                data.get(LATEST_TEST_RUN_OWNER_TOKEN_KEY)
+                != expected_owner_token
+            ):
+                return
+            current_stat = os.fstat(file.fileno())
+            if (
+                current_stat.st_dev != stat_result.st_dev
+                or current_stat.st_ino != stat_result.st_ino
+            ):
+                return
+            file.seek(0)
+            json.dump({"_deepevalInvalidated": True}, file)
+            file.truncate()
+            file.flush()
+            os.fsync(file.fileno())
+            try:
+                os.unlink(file_path)
+            except OSError:
+                return
+    except (OSError, portalocker.exceptions.LockException) as e:
+        print(f"An error occurred: {e}")
 
 
 class TestRunResultDisplay(Enum):
@@ -469,6 +538,77 @@ class TestRunManager:
         # Timestamped export if one was written, else rolling snapshot.
         # Consumed by the post-run inspect prompt.
         self.last_saved_path: Optional[Path] = None
+        self._latest_test_run_cache_valid = True
+        self._temp_test_run_cache_valid = True
+        self._latest_test_run_owner_token = uuid.uuid4().hex
+        self._latest_test_run_snapshot_owner_tokens = {}
+
+    def _can_write_local_state(self) -> bool:
+        return portalocker is not None and not is_read_only_env()
+
+    def _can_use_disk(self) -> bool:
+        return self._can_write_local_state() and self.save_to_disk
+
+    def configure_write_cache(self, write_cache: bool):
+        self.save_to_disk = write_cache
+        if write_cache is False:
+            self._latest_test_run_snapshot_owner_tokens = (
+                self._snapshot_latest_test_run_owner_tokens()
+            )
+            self._invalidate_latest_test_run_cache(
+                delete_owned_disk_state=False
+            )
+            self._temp_test_run_cache_valid = False
+        else:
+            self._latest_test_run_snapshot_owner_tokens = {}
+
+    def _snapshot_latest_test_run_owner_tokens(self):
+        if is_read_only_env():
+            return {}
+        return {
+            LATEST_TEST_RUN_FILE_PATH: _read_latest_file_owner_token(
+                LATEST_TEST_RUN_FILE_PATH
+            ),
+            LATEST_FULL_TEST_RUN_FILE_PATH: _read_latest_file_owner_token(
+                LATEST_FULL_TEST_RUN_FILE_PATH
+            ),
+        }
+
+    def _invalidate_latest_test_run_cache(
+        self, delete_owned_disk_state: bool = False
+    ):
+        self._latest_test_run_cache_valid = False
+        if delete_owned_disk_state and self._can_write_local_state():
+            snapshot_tokens = self._latest_test_run_snapshot_owner_tokens
+            _delete_latest_file_if_owned(
+                LATEST_TEST_RUN_FILE_PATH,
+                snapshot_tokens.get(LATEST_TEST_RUN_FILE_PATH),
+            )
+            _delete_latest_file_if_owned(
+                LATEST_FULL_TEST_RUN_FILE_PATH,
+                snapshot_tokens.get(LATEST_FULL_TEST_RUN_FILE_PATH),
+            )
+            self._latest_test_run_snapshot_owner_tokens = {}
+
+    def _write_cache_state(self):
+        return (
+            self.save_to_disk,
+            self._latest_test_run_cache_valid,
+            self._temp_test_run_cache_valid,
+            self._latest_test_run_snapshot_owner_tokens,
+        )
+
+    def _restore_write_cache_state(
+        self, state, preserve_latest_invalidation: bool = False
+    ):
+        (
+            self.save_to_disk,
+            self._latest_test_run_cache_valid,
+            self._temp_test_run_cache_valid,
+            self._latest_test_run_snapshot_owner_tokens,
+        ) = state
+        if preserve_latest_invalidation:
+            self._latest_test_run_cache_valid = False
 
     def reset(self):
         self.test_run = None
@@ -478,6 +618,9 @@ class TestRunManager:
         self.results_folder = None
         self.results_subfolder = None
         self.last_saved_path = None
+        self._latest_test_run_cache_valid = True
+        self._temp_test_run_cache_valid = True
+        self._latest_test_run_snapshot_owner_tokens = {}
 
     def configure_local_store(
         self,
@@ -518,14 +661,17 @@ class TestRunManager:
         )
         self.set_test_run(test_run)
 
-        if self.save_to_disk:
+        if self._can_use_disk():
             self.save_test_run(self.temp_file_path)
+            self._temp_test_run_cache_valid = True
+        else:
+            self._temp_test_run_cache_valid = False
 
     def get_test_run(self, identifier: Optional[str] = None):
         if self.test_run is None:
             self.create_test_run(identifier=identifier)
 
-        if portalocker and self.save_to_disk:
+        if self._can_use_disk() and self._temp_test_run_cache_valid:
             try:
                 with portalocker.Lock(
                     self.temp_file_path,
@@ -548,7 +694,7 @@ class TestRunManager:
         return self.test_run
 
     def save_test_run(self, path: str, save_under_key: Optional[str] = None):
-        if portalocker and self.save_to_disk:
+        if self._can_use_disk():
             try:
                 # ensure parent directory exists
                 parent = os.path.dirname(path)
@@ -567,24 +713,53 @@ class TestRunManager:
                                 by_alias=True, exclude_none=True
                             )
                         wrapper_data = {save_under_key: test_run_data}
+                        if path == LATEST_TEST_RUN_FILE_PATH:
+                            wrapper_data[LATEST_TEST_RUN_OWNER_TOKEN_KEY] = (
+                                uuid.uuid4().hex
+                            )
                         json.dump(wrapper_data, file, cls=TestRunEncoder)
                         file.flush()
                         os.fsync(file.fileno())
                     else:
-                        self.test_run.save(file)
+                        if path == LATEST_TEST_RUN_FILE_PATH:
+                            try:
+                                body = self.test_run.model_dump(
+                                    by_alias=True, exclude_none=True
+                                )
+                            except AttributeError:
+                                body = self.test_run.dict(
+                                    by_alias=True, exclude_none=True
+                                )
+                            body[LATEST_TEST_RUN_OWNER_TOKEN_KEY] = (
+                                uuid.uuid4().hex
+                            )
+                            json.dump(body, file, cls=TestRunEncoder)
+                            file.flush()
+                            os.fsync(file.fileno())
+                        else:
+                            self.test_run.save(file)
+                if path == LATEST_TEST_RUN_FILE_PATH:
+                    self._latest_test_run_cache_valid = True
             except portalocker.exceptions.LockException:
                 pass
 
-    def save_final_test_run_link(self, link: str):
-        if portalocker:
+    def save_final_test_run_link(self, link: str, persist_link: bool = True):
+        if self._can_write_local_state() and persist_link:
             try:
                 with portalocker.Lock(
                     LATEST_TEST_RUN_FILE_PATH, mode="w"
                 ) as file:
-                    json.dump({LATEST_TEST_RUN_LINK_KEY: link}, file)
+                    json.dump(
+                        {
+                            LATEST_TEST_RUN_LINK_KEY: link,
+                            LATEST_TEST_RUN_OWNER_TOKEN_KEY: uuid.uuid4().hex,
+                        },
+                        file,
+                    )
                     file.flush()
                     os.fsync(file.fileno())
-            except portalocker.exceptions.LockException:
+                self._latest_test_run_cache_valid = True
+            except (OSError, portalocker.exceptions.LockException):
                 pass
 
     def update_test_run(
@@ -599,7 +774,10 @@ class TestRunManager:
         ):
             return
 
-        if portalocker and self.save_to_disk:
+        if self._can_use_disk():
+            if not self._temp_test_run_cache_valid:
+                self.save_test_run(self.temp_file_path)
+                self._temp_test_run_cache_valid = True
             try:
                 with portalocker.Lock(
                     self.temp_file_path,
@@ -860,7 +1038,9 @@ class TestRunManager:
         )
         print(table)
 
-    def post_test_run(self, test_run: TestRun) -> Optional[Tuple[str, str]]:
+    def post_test_run(
+        self, test_run: TestRun, persist_link: bool = True
+    ) -> Optional[Tuple[str, str]]:
         if (
             len(test_run.test_cases) == 0
             and len(test_run.conversational_test_cases) == 0
@@ -990,14 +1170,15 @@ class TestRunManager:
             "[rgb(5,245,141)]✓[/rgb(5,245,141)] Done 🎉! View results on "
             f"[link={link}]{link}[/link]"
         )
-        self.save_final_test_run_link(link)
+        self.save_final_test_run_link(link, persist_link=persist_link)
         open_browser(link)
         return link, res.id
 
-    def save_test_run_locally(self):
+    def save_test_run_locally(self, write_rolling_snapshot: bool = True):
         """Persist the current TestRun to disk.
 
-        Always writes a rolling snapshot to `.deepeval/.latest_run_full.json`.
+        Writes a rolling snapshot to `.deepeval/.latest_run_full.json` when
+        implicit cache writes are enabled.
         Additionally writes a timestamped `test_run_<YYYYMMDD_HHMMSS>.json` to
         `results_folder` (or `DEEPEVAL_RESULTS_FOLDER`) when set.
         """
@@ -1010,9 +1191,12 @@ class TestRunManager:
             write_test_run,
         )
 
-        rolling_path = write_rolling_test_run(self.test_run)
-        if rolling_path is not None:
-            self.last_saved_path = rolling_path
+        if write_rolling_snapshot and not is_read_only_env():
+            rolling_path = write_rolling_test_run(
+                self.test_run, owner_token=uuid.uuid4().hex
+            )
+            if rolling_path is not None:
+                self.last_saved_path = rolling_path
 
         target_dir = resolve_target_dir(
             results_folder=self.results_folder,
@@ -1047,14 +1231,16 @@ class TestRunManager:
         test_run = self.get_test_run()
         if test_run is None:
             print("Test Run is empty, please try again.")
-            delete_file_if_exists(self.temp_file_path)
+            if self._can_use_disk():
+                delete_file_if_exists(self.temp_file_path)
             return
         elif (
             len(test_run.test_cases) == 0
             and len(test_run.conversational_test_cases) == 0
         ):
             print("No test cases found, please try again.")
-            delete_file_if_exists(self.temp_file_path)
+            if self._can_use_disk():
+                delete_file_if_exists(self.temp_file_path)
             return
 
         # Mark the run as the official if requested via the `--official` CLI flag or `evaluate(official=True)`.
@@ -1105,35 +1291,66 @@ class TestRunManager:
                 console.print("\n[bold green]✓ Prompts Logged[/bold green]\n")
                 self._render_prompts_panels(prompts=test_run.prompts)
 
-        self.save_test_run_locally()
-        delete_file_if_exists(self.temp_file_path)
+        should_write_to_disk = self._can_use_disk()
+        if not should_write_to_disk:
+            self._invalidate_latest_test_run_cache(delete_owned_disk_state=True)
+            self._temp_test_run_cache_valid = False
+        has_local_export_target = bool(
+            self.results_folder or os.getenv("DEEPEVAL_RESULTS_FOLDER")
+        )
+        if should_write_to_disk or has_local_export_target:
+            self.save_test_run_locally(
+                write_rolling_snapshot=should_write_to_disk
+            )
+        else:
+            self.last_saved_path = None
+        if should_write_to_disk:
+            delete_file_if_exists(self.temp_file_path)
         confident_enabled = is_confident()
         if confident_enabled and self.disable_request is False:
-            return self.post_test_run(test_run)
-        else:
-            self.save_test_run(
-                LATEST_TEST_RUN_FILE_PATH,
-                save_under_key=LATEST_TEST_RUN_DATA_KEY,
+            return self.post_test_run(
+                test_run, persist_link=should_write_to_disk
             )
+        else:
+            if should_write_to_disk:
+                self.save_test_run(
+                    LATEST_TEST_RUN_FILE_PATH,
+                    save_under_key=LATEST_TEST_RUN_DATA_KEY,
+                )
             token_cost = (
                 f"{test_run.evaluation_cost} USD"
                 if test_run.evaluation_cost
                 else "None"
             )
+            if should_write_to_disk:
+                follow_up_message = "  » Run [bold]'deepeval view'[/bold] to analyze and save testing results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n"
+            elif is_read_only_env():
+                follow_up_message = "  » Local result persistence is disabled because [bold]DEEPEVAL_FILE_SYSTEM=READ_ONLY[/bold]. Upload to Confident AI to inspect this run outside the current process.\n\n"
+            else:
+                follow_up_message = "  » Enable [bold]CacheConfig(write_cache=True)[/bold] or set [bold]DisplayConfig(results_folder=...)[/bold] to save local results for later inspection.\n\n"
             console.print(
                 f"\n\n[rgb(5,245,141)]✓[/rgb(5,245,141)] Evaluation completed 🎉! (time taken: {round(runDuration, 2)}s | token cost: {token_cost})\n"
                 f"» Test Results ({test_run.test_passed + test_run.test_failed} total tests):\n",
                 f"  » Pass Rate: {round((test_run.test_passed / (test_run.test_passed + test_run.test_failed)) * 100, 2)}% | Passed: [bold green]{test_run.test_passed}[/bold green] | Failed: [bold red]{test_run.test_failed}[/bold red]\n\n",
                 "=" * 80,
                 "\n\n» Want to share evals with your team, or a place for your test cases to live? ❤️ 🏡\n"
-                "  » Run [bold]'deepeval view'[/bold] to analyze and save testing results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n",
+                + follow_up_message,
             )
 
     def get_latest_test_run_data(self) -> Optional[TestRun]:
+        if is_read_only_env():
+            return None
+        if not self._latest_test_run_cache_valid:
+            return None
+
         try:
             if os.path.exists(LATEST_TEST_RUN_FILE_PATH):
                 with open(LATEST_TEST_RUN_FILE_PATH, "r") as file:
                     data = json.load(file)
+                    if not isinstance(
+                        data.get(LATEST_TEST_RUN_OWNER_TOKEN_KEY), str
+                    ):
+                        return None
                     return TestRun.model_validate(
                         data[LATEST_TEST_RUN_DATA_KEY]
                     )
@@ -1142,10 +1359,19 @@ class TestRunManager:
         return None
 
     def get_latest_test_run_link(self) -> Optional[str]:
+        if is_read_only_env():
+            return None
+        if not self._latest_test_run_cache_valid:
+            return None
+
         try:
             if os.path.exists(LATEST_TEST_RUN_FILE_PATH):
                 with open(LATEST_TEST_RUN_FILE_PATH, "r") as file:
                     data = json.load(file)
+                    if not isinstance(
+                        data.get(LATEST_TEST_RUN_OWNER_TOKEN_KEY), str
+                    ):
+                        return None
                     return data[LATEST_TEST_RUN_LINK_KEY]
         except (FileNotFoundError, json.JSONDecodeError, Exception):
             pass

--- a/docs/content/docs/command-line-interface.mdx
+++ b/docs/content/docs/command-line-interface.mdx
@@ -185,6 +185,8 @@ This allows you to inspect traces and spans locally on your machine:
 
 Resolution order when no path is passed: `--folder` → `DEEPEVAL_RESULTS_FOLDER` → `.deepeval/.latest_run_full.json` → `./experiments` (legacy fallback).
 
+For safety, the zero-arg hidden rolling fallback only opens latest-run snapshots written by versions that mark the file as deepeval-owned. If you need to inspect an older tokenless snapshot, pass the file path explicitly.
+
 The TUI needs an optional extras bundle (Textual + clipboard support):
 
 ```bash

--- a/docs/content/docs/environment-variables.mdx
+++ b/docs/content/docs/environment-variables.mdx
@@ -37,8 +37,8 @@ These are the core settings for controlling `deepeval`'s behavior, file paths, a
 | `APP_ENV`                         | `string` / unset        | When set, loads `.env.{APP_ENV}` between `.env` and `.env.local`.                                                                  |
 | `DEEPEVAL_DISABLE_LEGACY_KEYFILE` | `1` / `0` / `unset`             | Disable reading legacy `.deepeval/.deepeval` JSON keystore into env.                                                               |
 | `DEEPEVAL_DEFAULT_SAVE`           | `dotenv[:path]` / unset | Default persistence target for `deepeval set-* --save` when `--save` is omitted.                                                   |
-| `DEEPEVAL_FILE_SYSTEM`            | `READ_ONLY` / unset     | Restrict file writes in constrained environments.                                                                                  |
-| `DEEPEVAL_RESULTS_FOLDER`         | `path` / unset          | Export a timestamped JSON of the latest test run into this directory (created if needed).                                          |
+| `DEEPEVAL_FILE_SYSTEM`            | `READ_ONLY` / unset     | Disable DeepEval implicit hidden local test-run/cache persistence and hidden latest-run reads in constrained environments.         |
+| `DEEPEVAL_RESULTS_FOLDER`         | `path` / unset          | Export a timestamped JSON of the latest test run into this directory (created if needed). Explicit exports still require a writable target path. |
 | `DEEPEVAL_NO_INSPECT_PROMPT`      | `1` / `0` / `unset`     | Disable the post-run prompt that offers to open the latest `evals_iterator()` run in [`deepeval inspect`](/docs/command-line-interface#inspect). Useful in CI or non-interactive scripts. |
 | `DEEPEVAL_IDENTIFIER`             | `string` / unset        | Default identifier for runs (same idea as `deepeval test run -id ...`).                                                            |
 

--- a/docs/content/docs/evaluation-flags-and-configs.mdx
+++ b/docs/content/docs/evaluation-flags-and-configs.mdx
@@ -136,9 +136,9 @@ evaluate(cache_config=CacheConfig(), ...)
 There are **TWO** optional parameters when creating an `CacheConfig`:
 
 - [Optional] `use_cache`: a boolean which when set to `True`, uses cached test run results instead. Defaulted to `False`.
-- [Optional] `write_cache`: a boolean which when set to `True`, uses writes test run results to **DISK**. Defaulted to `True`.
+- [Optional] `write_cache`: a boolean which when set to `True`, writes DeepEval's hidden local cache and test-run state to **DISK**. Defaulted to `True`.
 
-The `write_cache` parameter writes to disk and so you should disable it if that is causing any errors in your environment.
+Set `write_cache=False` to avoid DeepEval's implicit hidden cache and test-run files. This does not disable explicit exports configured through `DisplayConfig(results_folder=...)`. If your runtime cannot use DeepEval's hidden local state (for example serverless environments with read-only working directories), set `DEEPEVAL_FILE_SYSTEM=READ_ONLY`; explicit exports still require their configured target path to be writable.
 
 ## Flags for `deepeval test run`:
 

--- a/tests/test_core/test_evaluation/test_local_store.py
+++ b/tests/test_core/test_evaluation/test_local_store.py
@@ -6,8 +6,7 @@ import threading
 from pathlib import Path
 from typing import Optional
 
-import pytest
-
+from deepeval.config.settings import reset_settings
 from deepeval.evaluate.configs import DisplayConfig
 from deepeval.evaluate.local_store import (
     resolve_target_dir,
@@ -18,7 +17,6 @@ from deepeval.test_run.test_run import (
     TestRun as _TestRun,
     TestRunManager as _TestRunManager,
 )
-
 
 FILENAME_RE = re.compile(r"^test_run_\d{8}_\d{6}(?:_(\d+))?\.json$")
 
@@ -161,6 +159,21 @@ class TestWriteTestRun:
             p for p in tmp_path.iterdir() if p.name.startswith("test_run_")
         )
         assert len(files) == n
+
+    def test_read_only_env_allows_explicit_write(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+        reset_settings(reload_dotenv=False)
+
+        try:
+            path = write_test_run(tmp_path / "exports", _make_test_run())
+        finally:
+            monkeypatch.delenv("DEEPEVAL_FILE_SYSTEM", raising=False)
+            reset_settings(reload_dotenv=False)
+
+        assert path.exists()
+        assert path.parent == tmp_path / "exports"
 
 
 class TestDisplayConfigFields:

--- a/tests/test_core/test_run/test_run_manager.py
+++ b/tests/test_core/test_run/test_run_manager.py
@@ -1,14 +1,912 @@
+import asyncio
+import importlib
+import json
 import os
 import portalocker
 
+import pytest
+
+import deepeval.cli.utils as cli_utils
+
+import deepeval.test_run.cache as cache_mod
 import deepeval.test_run.test_run as tr_mod
 
+from pathlib import Path
 from types import SimpleNamespace
 
+from deepeval.config.settings import reset_settings
+from deepeval.dataset import EvaluationDataset, Golden
+from deepeval.evaluate.console_report import EvaluationConsoleReport
+from deepeval.evaluate import evaluate
+from deepeval.evaluate.configs import (
+    AsyncConfig,
+    CacheConfig,
+    DisplayConfig,
+    ErrorConfig,
+)
+from deepeval.metrics import BaseMetric
 from deepeval.test_case import LLMTestCase
-from deepeval.test_run.test_run import TestRunManager, LLMApiTestCase
+from deepeval.test_run.test_run import TestRun, TestRunManager, LLMApiTestCase
 from tests.test_core.helpers import _make_fake_portalocker
 from tests.test_core.stubs import RecordingPortalockerLock
+
+eval_e2e_mod = importlib.import_module("deepeval.evaluate.execute.e2e")
+eval_loop_mod = importlib.import_module("deepeval.evaluate.execute.loop")
+evaluate_mod = importlib.import_module("deepeval.evaluate.evaluate")
+execute_common_mod = importlib.import_module(
+    "deepeval.evaluate.execute._common"
+)
+trace_scope_mod = importlib.import_module(
+    "deepeval.evaluate.execute.trace_scope"
+)
+hyperparameters_mod = importlib.import_module(
+    "deepeval.test_run.hyperparameters"
+)
+test_run_pkg_mod = importlib.import_module("deepeval.test_run")
+cli_inspect_mod = importlib.import_module("deepeval.cli.inspect")
+
+
+class _AlwaysPassMetric(BaseMetric):
+    def __init__(self):
+        self.threshold = 0.5
+        self.strict_mode = False
+        self.score = None
+        self.reason = None
+        self.success = False
+        self.error = None
+        self.evaluation_model = None
+        self.evaluation_cost = None
+        self.input_tokens = None
+        self.output_tokens = None
+        self.verbose_logs = None
+
+    @property
+    def __name__(self):
+        return "AlwaysPass"
+
+    def measure(self, test_case, *args, **kwargs):
+        self.score = 1.0
+        self.success = True
+        return self.score
+
+    async def a_measure(self, test_case, *args, **kwargs):
+        return self.measure(test_case, *args, **kwargs)
+
+    def is_successful(self) -> bool:
+        return self.success
+
+
+def _reset_test_run_singletons():
+    tr_mod.global_test_run_manager.reset()
+    tr_mod.global_test_run_cache_manager.disable_write_cache = None
+    tr_mod.global_test_run_cache_manager.cached_test_run = None
+    tr_mod.global_test_run_cache_manager.temp_cached_test_run = None
+    tr_mod.global_test_run_cache_manager._temp_cache_session_started = False
+
+
+@pytest.fixture
+def isolated_test_run_singletons():
+    _reset_test_run_singletons()
+    yield
+    _reset_test_run_singletons()
+
+
+@pytest.fixture(autouse=True)
+def isolated_hidden_artifact_paths(monkeypatch, tmp_path):
+    hidden_dir = tmp_path / ".deepeval"
+    temp_file = hidden_dir / ".temp_test_run_data.json"
+    latest_file = hidden_dir / ".latest_test_run.json"
+    latest_full_file = hidden_dir / ".latest_run_full.json"
+    cache_file = hidden_dir / ".deepeval-cache.json"
+    temp_cache_file = hidden_dir / ".temp-deepeval-cache.json"
+
+    # Several modules import these path constants by value. Patch each import
+    # site used by this test file so filesystem assertions stay tmp_path-local.
+    monkeypatch.setattr(tr_mod, "TEMP_FILE_PATH", str(temp_file))
+    monkeypatch.setattr(test_run_pkg_mod, "TEMP_FILE_PATH", str(temp_file))
+    monkeypatch.setattr(evaluate_mod, "TEMP_FILE_PATH", str(temp_file))
+    monkeypatch.setattr(execute_common_mod, "TEMP_FILE_PATH", str(temp_file))
+    monkeypatch.setattr(trace_scope_mod, "TEMP_FILE_PATH", str(temp_file))
+    monkeypatch.setattr(hyperparameters_mod, "TEMP_FILE_PATH", str(temp_file))
+    monkeypatch.setattr(tr_mod, "LATEST_TEST_RUN_FILE_PATH", str(latest_file))
+    monkeypatch.setattr(
+        test_run_pkg_mod, "LATEST_TEST_RUN_FILE_PATH", str(latest_file)
+    )
+    monkeypatch.setattr(
+        tr_mod, "LATEST_FULL_TEST_RUN_FILE_PATH", str(latest_full_file)
+    )
+    monkeypatch.setattr(cache_mod, "CACHE_FILE_NAME", str(cache_file))
+    monkeypatch.setattr(cache_mod, "TEMP_CACHE_FILE_NAME", str(temp_cache_file))
+    monkeypatch.setattr(
+        tr_mod.global_test_run_manager, "temp_file_path", str(temp_file)
+    )
+    monkeypatch.setattr(
+        tr_mod.global_test_run_cache_manager,
+        "cache_file_name",
+        str(cache_file),
+    )
+    monkeypatch.setattr(
+        tr_mod.global_test_run_cache_manager,
+        "temp_cache_file_name",
+        str(temp_cache_file),
+    )
+
+
+def _implicit_test_run_payload_paths():
+    return [
+        Path(tr_mod.TEMP_FILE_PATH),
+        Path(tr_mod.LATEST_TEST_RUN_FILE_PATH),
+        Path(tr_mod.LATEST_FULL_TEST_RUN_FILE_PATH),
+    ]
+
+
+def _cache_artifact_paths():
+    return [
+        Path(cache_mod.CACHE_FILE_NAME),
+        Path(cache_mod.TEMP_CACHE_FILE_NAME),
+    ]
+
+
+def _assert_no_implicit_test_run_payloads():
+    for path in _implicit_test_run_payload_paths():
+        assert not path.exists(), f"{path} should not exist"
+
+
+def _assert_no_cache_artifacts():
+    for path in _cache_artifact_paths():
+        assert not path.exists(), f"{path} should not exist"
+
+
+def _write_stale_hidden_artifacts():
+    for path, content in [
+        (Path(tr_mod.TEMP_FILE_PATH), "stale temp run"),
+        (Path(tr_mod.LATEST_TEST_RUN_FILE_PATH), "stale latest run"),
+        (Path(tr_mod.LATEST_FULL_TEST_RUN_FILE_PATH), "stale rolling snapshot"),
+        (Path(cache_mod.CACHE_FILE_NAME), "stale cache"),
+        (Path(cache_mod.TEMP_CACHE_FILE_NAME), "stale temp cache"),
+    ]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def _assert_stale_hidden_artifacts_handled_after_no_cache():
+    assert (
+        Path(tr_mod.TEMP_FILE_PATH).read_text(encoding="utf-8")
+        == "stale temp run"
+    )
+    assert (
+        Path(tr_mod.LATEST_TEST_RUN_FILE_PATH).read_text(encoding="utf-8")
+        == "stale latest run"
+    )
+    assert (
+        Path(tr_mod.LATEST_FULL_TEST_RUN_FILE_PATH).read_text(encoding="utf-8")
+        == "stale rolling snapshot"
+    )
+    assert (
+        Path(cache_mod.CACHE_FILE_NAME).read_text(encoding="utf-8")
+        == "stale cache"
+    )
+    assert (
+        Path(cache_mod.TEMP_CACHE_FILE_NAME).read_text(encoding="utf-8")
+        == "stale temp cache"
+    )
+
+
+def _latest_test_run_wrapper(identifier="stale-hidden", owner_token=None):
+    payload = {
+        tr_mod.LATEST_TEST_RUN_DATA_KEY: TestRun(
+            identifier=identifier
+        ).model_dump(by_alias=True, exclude_none=True)
+    }
+    if owner_token is not None:
+        payload[tr_mod.LATEST_TEST_RUN_OWNER_TOKEN_KEY] = owner_token
+    return payload
+
+
+def _run_no_cache_evaluate(monkeypatch, **display_kwargs):
+    monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+    monkeypatch.setattr(tr_mod.console, "print", lambda *args, **kwargs: None)
+    return evaluate(
+        test_cases=[LLMTestCase(input="in", actual_output="out")],
+        metrics=[_AlwaysPassMetric()],
+        async_config=AsyncConfig(run_async=False),
+        cache_config=CacheConfig(write_cache=False, use_cache=False),
+        display_config=DisplayConfig(
+            show_indicator=False,
+            print_results=False,
+            inspect_after_run=False,
+            **display_kwargs,
+        ),
+    )
+
+
+def _run_quiet_evaluate(monkeypatch, *, cache_config=None, **display_kwargs):
+    monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+    monkeypatch.setattr(tr_mod.console, "print", lambda *args, **kwargs: None)
+    return evaluate(
+        test_cases=[LLMTestCase(input="in", actual_output="out")],
+        metrics=[_AlwaysPassMetric()],
+        async_config=AsyncConfig(run_async=False),
+        cache_config=cache_config
+        or CacheConfig(write_cache=True, use_cache=False),
+        display_config=DisplayConfig(
+            show_indicator=False,
+            print_results=False,
+            inspect_after_run=False,
+            **display_kwargs,
+        ),
+    )
+
+
+def _assert_exported_test_run(path: Path):
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["testPassed"] == 1
+    assert payload["testFailed"] == 0
+    test_cases = payload["testCases"]
+    assert len(test_cases) == 1
+    assert test_cases[0]["input"] == "in"
+    assert test_cases[0]["actualOutput"] == "out"
+    assert test_cases[0]["success"] is True
+
+
+def test_evaluate_write_cache_false_skips_implicit_hidden_writes(
+    isolated_test_run_singletons, monkeypatch
+):
+    _run_no_cache_evaluate(monkeypatch)
+
+    _assert_no_implicit_test_run_payloads()
+    _assert_no_cache_artifacts()
+    assert tr_mod.global_test_run_manager.last_saved_path is None
+
+
+def test_evaluate_default_async_write_cache_false_skips_hidden_writes(
+    isolated_test_run_singletons, monkeypatch
+):
+    monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+    monkeypatch.setattr(tr_mod.console, "print", lambda *args, **kwargs: None)
+
+    evaluate(
+        test_cases=[LLMTestCase(input="in", actual_output="out")],
+        metrics=[_AlwaysPassMetric()],
+        cache_config=CacheConfig(write_cache=False, use_cache=False),
+        display_config=DisplayConfig(
+            show_indicator=False,
+            print_results=False,
+            inspect_after_run=False,
+        ),
+    )
+
+    _assert_no_implicit_test_run_payloads()
+    _assert_no_cache_artifacts()
+    assert tr_mod.global_test_run_manager.last_saved_path is None
+
+
+def test_evaluate_write_cache_false_invalidates_stale_latest_files(
+    isolated_test_run_singletons, monkeypatch
+):
+    _write_stale_hidden_artifacts()
+
+    _run_no_cache_evaluate(monkeypatch)
+
+    _assert_stale_hidden_artifacts_handled_after_no_cache()
+    assert tr_mod.global_test_run_manager.get_latest_test_run_data() is None
+    assert TestRunManager().get_latest_test_run_data() is None
+
+
+def test_evaluate_write_cache_true_does_not_leave_temp_metric_cache(
+    isolated_test_run_singletons, monkeypatch
+):
+    monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+    monkeypatch.setattr(tr_mod.console, "print", lambda *args, **kwargs: None)
+
+    evaluate(
+        test_cases=[LLMTestCase(input="in", actual_output="out")],
+        metrics=[_AlwaysPassMetric()],
+        async_config=AsyncConfig(run_async=False),
+        cache_config=CacheConfig(write_cache=True, use_cache=False),
+        display_config=DisplayConfig(
+            show_indicator=False,
+            print_results=False,
+            inspect_after_run=False,
+        ),
+    )
+
+    assert not Path(cache_mod.TEMP_CACHE_FILE_NAME).exists()
+
+
+def test_evaluate_successful_write_cache_keeps_latest_run_readable(
+    isolated_test_run_singletons, monkeypatch
+):
+    tr_mod.global_test_run_manager._latest_test_run_cache_valid = False
+
+    _run_quiet_evaluate(
+        monkeypatch,
+        cache_config=CacheConfig(write_cache=True, use_cache=False),
+    )
+
+    latest_run = tr_mod.global_test_run_manager.get_latest_test_run_data()
+    assert latest_run is not None
+    assert latest_run.test_passed == 1
+    assert latest_run.test_failed == 0
+
+
+def test_evaluate_write_cache_false_still_allows_explicit_results_export(
+    isolated_test_run_singletons, monkeypatch, tmp_path
+):
+    results_folder = tmp_path / "exports"
+
+    _run_no_cache_evaluate(monkeypatch, results_folder=str(results_folder))
+
+    exported_files = list(results_folder.glob("test_run_*.json"))
+    assert len(exported_files) == 1
+    assert tr_mod.global_test_run_manager.last_saved_path == exported_files[0]
+    _assert_exported_test_run(exported_files[0])
+    _assert_no_implicit_test_run_payloads()
+    _assert_no_cache_artifacts()
+
+
+def test_evaluate_read_only_allows_explicit_results_export(
+    isolated_test_run_singletons, monkeypatch, tmp_path
+):
+    results_folder = tmp_path / "read-only-exports"
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+    reset_settings(reload_dotenv=False)
+
+    try:
+        _run_quiet_evaluate(
+            monkeypatch,
+            cache_config=CacheConfig(write_cache=True, use_cache=False),
+            results_folder=str(results_folder),
+        )
+    finally:
+        monkeypatch.delenv("DEEPEVAL_FILE_SYSTEM", raising=False)
+        reset_settings(reload_dotenv=False)
+
+    exported_files = list(results_folder.glob("test_run_*.json"))
+    assert len(exported_files) == 1
+    assert tr_mod.global_test_run_manager.last_saved_path == exported_files[0]
+    _assert_exported_test_run(exported_files[0])
+    _assert_no_implicit_test_run_payloads()
+    _assert_no_cache_artifacts()
+
+
+def test_evaluate_read_only_allows_explicit_console_report_export(
+    isolated_test_run_singletons, monkeypatch, tmp_path
+):
+    output_dir = tmp_path / "console-report"
+    export_calls = []
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+    reset_settings(reload_dotenv=False)
+
+    try:
+        monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+        monkeypatch.setattr(
+            tr_mod.console, "print", lambda *args, **kwargs: None
+        )
+        monkeypatch.setattr(
+            EvaluationConsoleReport,
+            "export_to_markdown",
+            lambda *args, **kwargs: export_calls.append((args, kwargs)),
+        )
+        evaluate(
+            test_cases=[LLMTestCase(input="in", actual_output="out")],
+            metrics=[_AlwaysPassMetric()],
+            async_config=AsyncConfig(run_async=False),
+            cache_config=CacheConfig(write_cache=True, use_cache=False),
+            display_config=DisplayConfig(
+                show_indicator=False,
+                print_results=True,
+                inspect_after_run=False,
+                file_output_dir=str(output_dir),
+                file_type="md",
+            ),
+        )
+    finally:
+        monkeypatch.delenv("DEEPEVAL_FILE_SYSTEM", raising=False)
+        reset_settings(reload_dotenv=False)
+
+    assert len(export_calls) == 1
+    assert export_calls[0][1]["output_dir"] == str(output_dir)
+    _assert_no_implicit_test_run_payloads()
+    _assert_no_cache_artifacts()
+
+
+def test_dataset_read_only_allows_explicit_console_report_export(
+    isolated_test_run_singletons, monkeypatch, tmp_path
+):
+    output_dir = tmp_path / "dataset-console-report"
+    export_calls = []
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+    reset_settings(reload_dotenv=False)
+
+    try:
+        monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+        monkeypatch.setattr(
+            tr_mod.console, "print", lambda *args, **kwargs: None
+        )
+        monkeypatch.setattr(
+            EvaluationConsoleReport,
+            "export_to_markdown",
+            lambda *args, **kwargs: export_calls.append((args, kwargs)),
+        )
+
+        dataset = EvaluationDataset(goldens=[Golden(input="in")])
+        for golden in dataset.evals_iterator(
+            metrics=[_AlwaysPassMetric()],
+            async_config=AsyncConfig(run_async=False),
+            cache_config=CacheConfig(write_cache=True, use_cache=False),
+            display_config=DisplayConfig(
+                show_indicator=False,
+                print_results=True,
+                inspect_after_run=False,
+                file_output_dir=str(output_dir),
+                file_type="md",
+            ),
+        ):
+            assert golden.input == "in"
+    finally:
+        monkeypatch.delenv("DEEPEVAL_FILE_SYSTEM", raising=False)
+        reset_settings(reload_dotenv=False)
+
+    assert len(export_calls) == 1
+    assert export_calls[0][1]["output_dir"] == str(output_dir)
+    _assert_no_implicit_test_run_payloads()
+    _assert_no_cache_artifacts()
+
+
+def test_dataset_evals_iterator_restores_cache_policy_on_success(
+    isolated_test_run_singletons, monkeypatch
+):
+    tr_mod.global_test_run_manager.save_to_disk = True
+    tr_mod.global_test_run_cache_manager.disable_write_cache = False
+    monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+    monkeypatch.setattr(tr_mod.console, "print", lambda *args, **kwargs: None)
+
+    dataset = EvaluationDataset(goldens=[Golden(input="in")])
+    for golden in dataset.evals_iterator(
+        metrics=[_AlwaysPassMetric()],
+        async_config=AsyncConfig(run_async=False),
+        cache_config=CacheConfig(write_cache=False, use_cache=False),
+        display_config=DisplayConfig(
+            show_indicator=False,
+            print_results=False,
+            inspect_after_run=False,
+        ),
+    ):
+        assert golden.input == "in"
+
+    assert tr_mod.global_test_run_manager.save_to_disk is True
+    assert tr_mod.global_test_run_cache_manager.disable_write_cache is False
+
+
+def test_no_cache_run_does_not_upload_stale_latest_in_current_process(
+    isolated_test_run_singletons, monkeypatch
+):
+    latest_path = Path(tr_mod.LATEST_TEST_RUN_FILE_PATH)
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper()),
+        encoding="utf-8",
+    )
+
+    _run_no_cache_evaluate(monkeypatch)
+
+    post_calls = []
+    monkeypatch.setattr(
+        tr_mod.global_test_run_manager,
+        "post_test_run",
+        lambda *args, **kwargs: post_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(cli_utils, "print", lambda *args, **kwargs: None)
+
+    cli_utils.upload_and_open_link()
+
+    assert latest_path.exists()
+    assert tr_mod.global_test_run_manager.get_latest_test_run_data() is None
+    assert TestRunManager().get_latest_test_run_data() is None
+    assert post_calls == []
+
+
+def test_read_only_fresh_manager_ignores_stale_latest_run(
+    isolated_test_run_singletons, monkeypatch
+):
+    latest_path = Path(tr_mod.LATEST_TEST_RUN_FILE_PATH)
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper()),
+        encoding="utf-8",
+    )
+
+    fresh_manager = TestRunManager()
+    post_calls = []
+    monkeypatch.setattr(
+        fresh_manager,
+        "post_test_run",
+        lambda *args, **kwargs: post_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(cli_utils, "global_test_run_manager", fresh_manager)
+    monkeypatch.setattr(cli_utils, "print", lambda *args, **kwargs: None)
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+    reset_settings(reload_dotenv=False)
+
+    try:
+        assert fresh_manager.get_latest_test_run_data() is None
+        cli_utils.upload_and_open_link()
+    finally:
+        monkeypatch.delenv("DEEPEVAL_FILE_SYSTEM", raising=False)
+        reset_settings(reload_dotenv=False)
+
+    assert post_calls == []
+
+
+def test_read_only_configure_write_cache_false_does_not_read_hidden_latest(
+    isolated_test_run_singletons, monkeypatch
+):
+    def fail_if_latest_file_is_read(file_path):
+        raise AssertionError(f"unexpected hidden latest read: {file_path}")
+
+    manager = TestRunManager()
+    monkeypatch.setattr(
+        tr_mod, "_read_latest_file_owner_token", fail_if_latest_file_is_read
+    )
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+    reset_settings(reload_dotenv=False)
+
+    try:
+        manager.configure_write_cache(False)
+    finally:
+        monkeypatch.delenv("DEEPEVAL_FILE_SYSTEM", raising=False)
+        reset_settings(reload_dotenv=False)
+
+    assert manager._latest_test_run_snapshot_owner_tokens == {}
+    assert manager._latest_test_run_cache_valid is False
+    assert manager._temp_test_run_cache_valid is False
+
+
+def test_read_only_inspect_default_ignores_stale_rolling_snapshot(
+    isolated_test_run_singletons, monkeypatch, tmp_path
+):
+    rolling_path = Path(tr_mod.LATEST_FULL_TEST_RUN_FILE_PATH)
+    rolling_path.parent.mkdir(parents=True, exist_ok=True)
+    rolling_path.write_text("stale rolling snapshot", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DEEPEVAL_RESULTS_FOLDER", raising=False)
+    monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+    reset_settings(reload_dotenv=False)
+
+    try:
+        assert cli_inspect_mod._resolve_target(None, None) is None
+    finally:
+        monkeypatch.delenv("DEEPEVAL_FILE_SYSTEM", raising=False)
+        reset_settings(reload_dotenv=False)
+
+
+def test_inspect_default_ignores_unowned_rolling_snapshot(
+    isolated_test_run_singletons, monkeypatch, tmp_path
+):
+    rolling_path = Path(tr_mod.LATEST_FULL_TEST_RUN_FILE_PATH)
+    rolling_path.parent.mkdir(parents=True, exist_ok=True)
+    rolling_path.write_text("stale rolling snapshot", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DEEPEVAL_RESULTS_FOLDER", raising=False)
+
+    assert cli_inspect_mod._resolve_target(None, None) is None
+
+
+def test_latest_reader_ignores_unowned_stale_file(
+    isolated_test_run_singletons,
+):
+    latest_path = Path(tr_mod.LATEST_TEST_RUN_FILE_PATH)
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper()),
+        encoding="utf-8",
+    )
+
+    assert TestRunManager().get_latest_test_run_data() is None
+
+
+def test_no_cache_latest_invalidation_deletes_same_owner_snapshot(
+    isolated_test_run_singletons,
+):
+    manager = TestRunManager()
+    latest_path = Path(tr_mod.LATEST_TEST_RUN_FILE_PATH)
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper(owner_token="owned-token")),
+        encoding="utf-8",
+    )
+
+    manager.configure_write_cache(False)
+    manager._invalidate_latest_test_run_cache(delete_owned_disk_state=True)
+
+    assert not latest_path.exists()
+
+
+def test_no_cache_latest_invalidation_tombstones_when_delete_fails(
+    isolated_test_run_singletons, monkeypatch
+):
+    manager = TestRunManager()
+    latest_path = Path(tr_mod.LATEST_TEST_RUN_FILE_PATH)
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper(owner_token="owned-token")),
+        encoding="utf-8",
+    )
+    real_unlink = os.unlink
+
+    def raise_permission_error(path):
+        if path == str(latest_path):
+            raise PermissionError("simulated locked file")
+        real_unlink(path)
+
+    monkeypatch.setattr(tr_mod.os, "unlink", raise_permission_error)
+
+    manager.configure_write_cache(False)
+    manager._invalidate_latest_test_run_cache(delete_owned_disk_state=True)
+
+    assert latest_path.exists()
+    payload = json.loads(latest_path.read_text(encoding="utf-8"))
+    assert tr_mod.LATEST_TEST_RUN_OWNER_TOKEN_KEY not in payload
+    assert TestRunManager().get_latest_test_run_data() is None
+
+
+def test_no_cache_latest_invalidation_preserves_new_owner_replacement(
+    isolated_test_run_singletons,
+):
+    manager = TestRunManager()
+    latest_path = Path(tr_mod.LATEST_TEST_RUN_FILE_PATH)
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper(owner_token="old-token")),
+        encoding="utf-8",
+    )
+
+    manager.configure_write_cache(False)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper(owner_token="new-token")),
+        encoding="utf-8",
+    )
+    manager._invalidate_latest_test_run_cache(delete_owned_disk_state=True)
+
+    payload = json.loads(latest_path.read_text(encoding="utf-8"))
+    assert payload[tr_mod.LATEST_TEST_RUN_OWNER_TOKEN_KEY] == "new-token"
+
+
+def test_execute_test_cases_restores_cache_policy_on_base_exception(
+    isolated_test_run_singletons, monkeypatch
+):
+    tr_mod.global_test_run_manager.save_to_disk = True
+    tr_mod.global_test_run_cache_manager.disable_write_cache = False
+
+    def raise_keyboard_interrupt(*args, **kwargs):
+        raise KeyboardInterrupt("interrupt metric")
+
+    monkeypatch.setattr(
+        eval_e2e_mod, "_execute_metric", raise_keyboard_interrupt
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="interrupt metric"):
+        eval_e2e_mod.execute_test_cases(
+            test_cases=[LLMTestCase(input="in", actual_output="out")],
+            metrics=[_AlwaysPassMetric()],
+            error_config=ErrorConfig(ignore_errors=False),
+            display_config=DisplayConfig(show_indicator=False),
+            cache_config=CacheConfig(write_cache=False, use_cache=False),
+        )
+
+    assert tr_mod.global_test_run_manager.save_to_disk is True
+    assert tr_mod.global_test_run_cache_manager.disable_write_cache is False
+
+
+def test_evaluate_restores_cache_policy_after_post_execution_error(
+    isolated_test_run_singletons, monkeypatch, tmp_path
+):
+    tr_mod.global_test_run_manager.save_to_disk = True
+    tr_mod.global_test_run_cache_manager.disable_write_cache = False
+    latest_path = Path(tr_mod.LATEST_TEST_RUN_FILE_PATH)
+    latest_path.parent.mkdir(parents=True, exist_ok=True)
+    latest_path.write_text(
+        json.dumps(_latest_test_run_wrapper(owner_token="owned-token")),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(tr_mod, "is_confident", lambda: False)
+    monkeypatch.setattr(tr_mod.console, "print", lambda *args, **kwargs: None)
+
+    with pytest.raises(ValueError, match="Invalid file type"):
+        evaluate(
+            test_cases=[LLMTestCase(input="in", actual_output="out")],
+            metrics=[_AlwaysPassMetric()],
+            async_config=AsyncConfig(run_async=False),
+            cache_config=CacheConfig(write_cache=False, use_cache=False),
+            display_config=DisplayConfig(
+                show_indicator=False,
+                print_results=True,
+                inspect_after_run=False,
+                file_output_dir=str(tmp_path / "console-report"),
+                file_type=None,
+            ),
+        )
+
+    assert tr_mod.global_test_run_manager.save_to_disk is True
+    assert tr_mod.global_test_run_cache_manager.disable_write_cache is False
+    assert tr_mod.global_test_run_manager.get_latest_test_run_data() is None
+    assert TestRunManager().get_latest_test_run_data() is None
+    assert not latest_path.exists()
+
+
+def test_async_execute_test_cases_restores_cache_policy_on_cancel(
+    isolated_test_run_singletons, monkeypatch
+):
+    tr_mod.global_test_run_manager.save_to_disk = True
+    tr_mod.global_test_run_cache_manager.disable_write_cache = False
+
+    async def scenario():
+        started = asyncio.Event()
+        blocker = asyncio.Event()
+
+        async def wait_forever(*args, **kwargs):
+            started.set()
+            await blocker.wait()
+
+        monkeypatch.setattr(
+            eval_e2e_mod, "_a_execute_llm_test_cases", wait_forever
+        )
+
+        task = asyncio.create_task(
+            eval_e2e_mod.a_execute_test_cases(
+                test_cases=[LLMTestCase(input="in", actual_output="out")],
+                metrics=[_AlwaysPassMetric()],
+                error_config=ErrorConfig(ignore_errors=False),
+                display_config=DisplayConfig(show_indicator=False),
+                cache_config=CacheConfig(write_cache=False, use_cache=False),
+                async_config=AsyncConfig(run_async=True),
+            )
+        )
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())
+
+    assert tr_mod.global_test_run_manager.save_to_disk is True
+    assert tr_mod.global_test_run_cache_manager.disable_write_cache is False
+
+
+def test_temp_cache_session_preserves_existing_temp_cache_entries(
+    isolated_test_run_singletons,
+):
+    first = cache_mod.TestRunCacheManager()
+    second = cache_mod.TestRunCacheManager()
+    for manager in (first, second):
+        manager.cache_file_name = cache_mod.CACHE_FILE_NAME
+        manager.temp_cache_file_name = cache_mod.TEMP_CACHE_FILE_NAME
+
+    first.cache_test_case(
+        LLMTestCase(input="first", actual_output="out"),
+        cache_mod.CachedTestCase(),
+        hyperparameters=None,
+        to_temp=True,
+    )
+    second.cache_test_case(
+        LLMTestCase(input="second", actual_output="out"),
+        cache_mod.CachedTestCase(),
+        hyperparameters=None,
+        to_temp=True,
+    )
+
+    payload = json.loads(
+        Path(cache_mod.TEMP_CACHE_FILE_NAME).read_text(encoding="utf-8")
+    )
+
+    assert len(payload["test_cases_lookup_map"]) == 2
+
+
+def test_temp_cache_wrap_up_merges_existing_temp_entries(
+    isolated_test_run_singletons,
+):
+    first = cache_mod.TestRunCacheManager()
+    second = cache_mod.TestRunCacheManager()
+    for manager in (first, second):
+        manager.cache_file_name = cache_mod.CACHE_FILE_NAME
+        manager.temp_cache_file_name = cache_mod.TEMP_CACHE_FILE_NAME
+
+    first.cache_test_case(
+        LLMTestCase(input="first", actual_output="out"),
+        cache_mod.CachedTestCase(),
+        hyperparameters=None,
+        to_temp=True,
+    )
+    second.cache_test_case(
+        LLMTestCase(input="second", actual_output="out"),
+        cache_mod.CachedTestCase(),
+        hyperparameters=None,
+        to_temp=True,
+    )
+
+    first.wrap_up_cached_test_run()
+
+    payload = json.loads(
+        Path(cache_mod.CACHE_FILE_NAME).read_text(encoding="utf-8")
+    )
+    assert len(payload["test_cases_lookup_map"]) == 2
+    assert not Path(cache_mod.TEMP_CACHE_FILE_NAME).exists()
+    assert first._temp_cache_session_started is False
+
+
+def test_agentic_loop_restores_cache_policy_on_early_close(
+    isolated_test_run_singletons,
+):
+    tr_mod.global_test_run_manager.save_to_disk = True
+    tr_mod.global_test_run_cache_manager.disable_write_cache = False
+
+    iterator = eval_loop_mod.execute_agentic_test_cases_from_loop(
+        goldens=[Golden(input="in")],
+        trace_metrics=[_AlwaysPassMetric()],
+        test_results=[],
+        display_config=DisplayConfig(show_indicator=False),
+        cache_config=CacheConfig(write_cache=False, use_cache=False),
+        error_config=ErrorConfig(ignore_errors=False),
+    )
+
+    assert next(iterator).input == "in"
+    iterator.close()
+
+    assert tr_mod.global_test_run_manager.save_to_disk is True
+    assert tr_mod.global_test_run_cache_manager.disable_write_cache is False
+
+
+def test_async_agentic_loop_cancels_created_tasks_on_early_close(
+    isolated_test_run_singletons,
+):
+    tr_mod.global_test_run_manager.save_to_disk = True
+    tr_mod.global_test_run_cache_manager.disable_write_cache = False
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        blocker = asyncio.Event()
+        iterator = eval_loop_mod.a_execute_agentic_test_cases_from_loop(
+            goldens=[Golden(input="in")],
+            trace_metrics=[_AlwaysPassMetric()],
+            test_results=[],
+            loop=loop,
+            display_config=DisplayConfig(show_indicator=False),
+            cache_config=CacheConfig(write_cache=False, use_cache=False),
+            error_config=ErrorConfig(ignore_errors=False),
+            async_config=AsyncConfig(run_async=True),
+        )
+
+        assert next(iterator).input == "in"
+        created_task = asyncio.create_task(blocker.wait())
+        loop.run_until_complete(asyncio.sleep(0))
+        iterator.close()
+
+        assert created_task.cancelled()
+        assert tr_mod.global_test_run_manager.save_to_disk is True
+        assert tr_mod.global_test_run_cache_manager.disable_write_cache is False
+    finally:
+        pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(
+                asyncio.gather(*pending, return_exceptions=True)
+            )
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+def test_save_final_link_can_skip_hidden_persistence(
+    isolated_test_run_singletons,
+):
+    trm = TestRunManager()
+
+    trm.save_final_test_run_link(
+        "https://example.com/test-runs/123", persist_link=False
+    )
+
+    assert not Path(tr_mod.LATEST_TEST_RUN_FILE_PATH).exists()
 
 
 def test_get_test_run_preserves_valid_instance_on_read_lock(tmp_path):
@@ -128,6 +1026,7 @@ def test_save_test_run_with_save_under_key_flushes_and_syncs(
     dummy_manager = SimpleNamespace(
         save_to_disk=True,
         test_run=dummy_test_run,
+        _can_use_disk=lambda: True,
     )
 
     path = tmp_path / "run.json"


### PR DESCRIPTION
## Summary

Fixes #1413 by making `CacheConfig(write_cache=False)` and `DEEPEVAL_FILE_SYSTEM=READ_ONLY` consistently avoid DeepEval's implicit hidden local state writes/reads across `evaluate()`, `evals_iterator()`, cache finalization, latest-run upload/view state, and the rolling `deepeval inspect` fallback.

The change keeps explicit user-requested exports separate from hidden cache state: `DisplayConfig(results_folder=...)`, `DEEPEVAL_RESULTS_FOLDER`, and `DisplayConfig(file_output_dir=...)` still write when their configured target path is writable.

## Changes

- Route evaluation/cache executors through scoped write-cache configuration so disabled-cache runs do not write hidden temp/latest/cache/rolling files.
- Preserve and restore process-global cache/test-run manager policy after sync, async, iterator, early-close, and exception paths.
- Add owner-token metadata for hidden latest/rolling snapshots so no-cache invalidation only tombstones/deletes snapshots written by the same owner and does not blindly remove concurrent or legacy files.
- Make read-only mode skip hidden latest/cache reads as well as hidden writes, including bare `deepeval inspect` rolling fallback.
- Preserve explicit local exports while documenting the distinction between hidden cache state and user-configured export paths.
- Add regression tests covering disabled-cache, read-only, explicit export, stale latest, owner-token invalidation, temp-cache merge, async/default evaluation, dataset iterator, and error-restoration behavior.

## Why this matters

`write_cache=False` is the expected escape hatch for serverless/read-only environments. Before this change, disabled-cache evaluations could still touch hidden local files during finalization, cache wrap-up, latest-run persistence, or inspect/view state, which can fail in environments such as Azure Functions or AWS Lambda.

This PR narrows the filesystem behavior so hidden DeepEval state respects disabled-cache/read-only modes without taking away explicit artifact exports that users intentionally configure.

## Tests

Commands run:

- `.agent-notes/venv312/bin/python -m pytest tests/test_core/test_run/test_run_manager.py tests/test_core/test_evaluation/test_local_store.py tests/test_core/test_evaluation/test_end_to_end/test_skip_reset.py -q` — passed (`69 passed, 3 warnings`)
- `.agent-notes/venv312/bin/python -m black --check deepeval/evaluate/execute/e2e.py deepeval/evaluate/execute/loop.py deepeval/evaluate/evaluate.py deepeval/dataset/dataset.py deepeval/evaluate/local_store.py deepeval/test_run/cache.py deepeval/test_run/test_run.py deepeval/cli/inspect.py tests/test_core/test_run/test_run_manager.py tests/test_core/test_evaluation/test_local_store.py` — passed
- `.agent-notes/venv312/bin/python -m ruff check deepeval/evaluate/execute/e2e.py deepeval/evaluate/execute/loop.py deepeval/evaluate/evaluate.py deepeval/dataset/dataset.py deepeval/evaluate/local_store.py deepeval/test_run/cache.py deepeval/test_run/test_run.py deepeval/cli/inspect.py tests/test_core/test_run/test_run_manager.py tests/test_core/test_evaluation/test_local_store.py` — passed
- `.agent-notes/venv312/bin/python -m py_compile deepeval/evaluate/execute/e2e.py deepeval/evaluate/execute/loop.py deepeval/evaluate/evaluate.py deepeval/dataset/dataset.py deepeval/evaluate/local_store.py deepeval/test_run/cache.py deepeval/test_run/test_run.py deepeval/cli/inspect.py tests/test_core/test_run/test_run_manager.py tests/test_core/test_evaluation/test_local_store.py` — passed
- `git diff --check` — passed

Independent review passes completed:

- Maintainer review — approved, no findings.
- Correctness/edge-case review — approved, no findings.
- Test quality review — approved, no findings.
- Security/reliability review — approved, no findings.
- Product/DX/docs review — approved, no findings after adding the inspect compatibility note.

## Risk

Risk level: medium.

This touches shared evaluation/test-run/cache lifecycle code and process-global manager state. The change is intentionally scoped to local hidden state handling and does not change metric scoring behavior or explicit export schemas.

Compatibility notes:

- New hidden latest/rolling files include owner-token metadata so disabled-cache invalidation can safely ignore files it does not own.
- Bare `deepeval inspect` now only auto-opens hidden rolling snapshots written with deepeval ownership metadata. Older tokenless snapshots can still be inspected by passing the file path explicitly.
- Explicit exports still depend on the target path being writable.

Rollback is straightforward by reverting this commit, but that would restore the issue where disabled-cache/read-only runs can still touch implicit local files.

## Issue

Fixes #1413.

## Notes for maintainers

Not tested locally:

- Full repository test suite.
- Live Confident AI upload/view flow.
- A real Azure Functions/AWS Lambda filesystem mount.
