### PR TITLE
fix: run async arena compare when progress is hidden

### DIFF
--- a/deepeval/evaluate/compare.py
+++ b/deepeval/evaluate/compare.py
@@ -13,7 +13,7 @@ import json
 
 from deepeval.errors import MissingTestCaseParamsError
 from deepeval.evaluate.configs import AsyncConfig, DisplayConfig, ErrorConfig
-from deepeval.test_case import ArenaTestCase, Contestant
+from deepeval.test_case import ArenaTestCase, Contestant  # noqa: F401
 from deepeval.test_case.api import create_api_test_case
 from deepeval.metrics import ArenaGEval
 from deepeval.utils import (
@@ -192,7 +192,73 @@ async def a_execute_arena_test_cases(
             run_duration=run_duration,
         )
 
-    # Create tasks for all test cases
+    async def execute_test_cases(
+        progress: Optional[Progress] = None,
+        pbar_id: Optional[int] = None,
+    ):
+        tasks = []
+
+        def raise_first_task_error():
+            for task in tasks:
+                if not task.done():
+                    continue
+                if task.cancelled():
+                    raise asyncio.CancelledError()
+                exception = task.exception()
+                if exception is not None:
+                    raise exception
+
+        async def wait_for_throttle_or_failure():
+            if throttle_value <= 0:
+                await asyncio.sleep(0)
+                raise_first_task_error()
+                return
+
+            raise_first_task_error()
+            active_tasks = [task for task in tasks if not task.done()]
+            if not active_tasks:
+                await asyncio.sleep(throttle_value)
+                raise_first_task_error()
+                return
+
+            start_time = time.perf_counter()
+            await asyncio.wait(
+                active_tasks,
+                timeout=throttle_value,
+                return_when=asyncio.FIRST_EXCEPTION,
+            )
+            raise_first_task_error()
+
+            remaining_throttle = throttle_value - (
+                time.perf_counter() - start_time
+            )
+            if remaining_throttle > 0 and all(
+                task.done() for task in active_tasks
+            ):
+                await asyncio.sleep(remaining_throttle)
+                raise_first_task_error()
+
+        try:
+            for i, test_case in enumerate(test_cases):
+                task = execute_with_semaphore(
+                    func=evaluate_single_test_case,
+                    test_case=test_case,
+                    progress=progress,
+                    pbar_id=pbar_id,
+                    index=i,
+                )
+                tasks.append(asyncio.create_task(task))
+                await wait_for_throttle_or_failure()
+
+            await asyncio.gather(*tasks)
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+
     if show_indicator:
         progress = Progress(
             TextColumn("{task.description}"),
@@ -207,19 +273,9 @@ async def a_execute_arena_test_cases(
                 f"🆚 Comparing {len(test_cases)} contestants concurrently",
                 total=len(test_cases),
             )
-            tasks = []
-            for i, test_case in enumerate(test_cases):
-                task = execute_with_semaphore(
-                    func=evaluate_single_test_case,
-                    test_case=test_case,
-                    progress=progress,
-                    pbar_id=pbar_id,
-                    index=i,
-                )
-                tasks.append(asyncio.create_task(task))
-                await asyncio.sleep(throttle_value)
-
-            await asyncio.gather(*tasks)
+            await execute_test_cases(progress=progress, pbar_id=pbar_id)
+    else:
+        await execute_test_cases()
 
     return winners
 

--- a/tests/test_core/test_evaluation/test_arena_compare.py
+++ b/tests/test_core/test_evaluation/test_arena_compare.py
@@ -1,0 +1,259 @@
+from contextlib import nullcontext
+import asyncio
+import importlib
+import time
+
+import pytest
+
+from deepeval.evaluate.configs import AsyncConfig, DisplayConfig
+from deepeval.metrics import ArenaGEval
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import (
+    ArenaTestCase,
+    Contestant,
+    LLMTestCase,
+    SingleTurnParams,
+)
+from deepeval.test_run.test_run import MetricScores, TestRun as DeepEvalTestRun
+
+
+class DummyLLM(DeepEvalBaseLLM):
+    def load_model(self, *args, **kwargs):
+        return self
+
+    def generate(self, *args, **kwargs) -> str:
+        return '{"winner": "Version 2", "reason": "deterministic"}'
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        return '{"winner": "Version 2", "reason": "deterministic"}'
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "dummy"
+
+
+def build_arena_test_case(case_id: str) -> ArenaTestCase:
+    return ArenaTestCase(
+        contestants=[
+            Contestant(
+                name="Version 1",
+                test_case=LLMTestCase(
+                    input=case_id,
+                    actual_output="Hey! how are you?",
+                ),
+            ),
+            Contestant(
+                name="Version 2",
+                test_case=LLMTestCase(
+                    input=case_id,
+                    actual_output="Hello.",
+                ),
+            ),
+        ]
+    )
+
+
+def build_arena_metric() -> ArenaGEval:
+    return ArenaGEval(
+        name="Friendly",
+        criteria="Choose the more accurate contestant.",
+        evaluation_params=[
+            SingleTurnParams.INPUT,
+            SingleTurnParams.ACTUAL_OUTPUT,
+        ],
+        model=DummyLLM(),
+    )
+
+
+def build_test_run_map(metric_name: str):
+    test_run_map = {}
+    for contestant_name in ("Version 1", "Version 2"):
+        test_run = DeepEvalTestRun(
+            identifier=contestant_name,
+            test_passed=0,
+            test_failed=0,
+        )
+        test_run.metrics_scores = [
+            MetricScores(
+                metric=metric_name,
+                scores=[],
+                passes=0,
+                fails=0,
+                errors=0,
+            )
+        ]
+        test_run_map[contestant_name] = test_run
+    return test_run_map
+
+
+def test_compare_async_without_indicator_executes_arena_tests(monkeypatch):
+    compare_module = importlib.import_module("deepeval.evaluate.compare")
+    measure_calls = []
+    wrap_up_payload = {}
+
+    async def fake_a_measure(
+        self,
+        test_case,
+        _show_indicator=True,
+        _progress=None,
+        _pbar_id=None,
+    ):
+        measure_calls.append(test_case)
+        self.winner = "Version 2"
+        self.reason = "deterministic winner"
+        self.success = True
+        self.evaluation_cost = 0
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.verbose_logs = None
+        return self.winner
+
+    def fake_wrap_up_experiment(**kwargs):
+        wrap_up_payload.update(kwargs)
+
+    monkeypatch.setattr(
+        compare_module,
+        "capture_evaluation_run",
+        lambda *args, **kwargs: nullcontext(),
+    )
+    monkeypatch.setattr(
+        compare_module.ArenaGEval,
+        "a_measure",
+        fake_a_measure,
+    )
+    monkeypatch.setattr(
+        compare_module,
+        "wrap_up_experiment",
+        fake_wrap_up_experiment,
+    )
+
+    test_case = build_arena_test_case("Say hello.")
+    metric = build_arena_metric()
+
+    result = compare_module.compare(
+        test_cases=[test_case],
+        metric=metric,
+        async_config=AsyncConfig(run_async=True, throttle_value=0),
+        display_config=DisplayConfig(show_indicator=False),
+    )
+
+    assert result == {"Version 2": 1}
+    assert measure_calls == [test_case]
+    assert dict(wrap_up_payload["winner_counts"]) == {"Version 2": 1}
+    assert {run.identifier for run in wrap_up_payload["test_runs"]} == {
+        "Version 1",
+        "Version 2",
+    }
+    assert all(len(run.test_cases) == 1 for run in wrap_up_payload["test_runs"])
+
+
+@pytest.mark.asyncio
+async def test_compare_async_without_indicator_cancels_pending_tasks_on_error(
+    monkeypatch,
+):
+    compare_module = importlib.import_module("deepeval.evaluate.compare")
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    slow_completed = False
+
+    async def fake_a_measure(
+        self,
+        test_case,
+        _show_indicator=True,
+        _progress=None,
+        _pbar_id=None,
+    ):
+        nonlocal slow_completed
+        case_input = test_case.contestants[0].test_case.input
+        if case_input == "fail":
+            await slow_started.wait()
+            raise RuntimeError("arena failure")
+
+        slow_started.set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+        slow_completed = True
+        return "Version 2"
+
+    monkeypatch.setattr(
+        compare_module.ArenaGEval,
+        "a_measure",
+        fake_a_measure,
+    )
+
+    metric = build_arena_metric()
+
+    with pytest.raises(RuntimeError, match="arena failure"):
+        await compare_module.a_execute_arena_test_cases(
+            test_cases=[
+                build_arena_test_case("fail"),
+                build_arena_test_case("slow"),
+            ],
+            metric=metric,
+            ignore_errors=False,
+            verbose_mode=False,
+            show_indicator=False,
+            throttle_value=0,
+            skip_on_missing_params=False,
+            max_concurrent=2,
+            test_run_map=build_test_run_map(metric.name),
+        )
+
+    assert slow_cancelled.is_set()
+    assert slow_completed is False
+
+
+@pytest.mark.asyncio
+async def test_compare_async_without_indicator_stops_scheduling_after_error(
+    monkeypatch,
+):
+    compare_module = importlib.import_module("deepeval.evaluate.compare")
+    started_cases = []
+
+    async def fake_a_measure(
+        self,
+        test_case,
+        _show_indicator=True,
+        _progress=None,
+        _pbar_id=None,
+    ):
+        case_input = test_case.contestants[0].test_case.input
+        started_cases.append(case_input)
+        if case_input == "fail":
+            raise RuntimeError("arena failure")
+
+        await asyncio.sleep(3600)
+        return "Version 2"
+
+    monkeypatch.setattr(
+        compare_module.ArenaGEval,
+        "a_measure",
+        fake_a_measure,
+    )
+
+    metric = build_arena_metric()
+
+    start_time = time.perf_counter()
+    with pytest.raises(RuntimeError, match="arena failure"):
+        await compare_module.a_execute_arena_test_cases(
+            test_cases=[
+                build_arena_test_case("fail"),
+                build_arena_test_case("slow-1"),
+                build_arena_test_case("slow-2"),
+                build_arena_test_case("slow-3"),
+            ],
+            metric=metric,
+            ignore_errors=False,
+            verbose_mode=False,
+            show_indicator=False,
+            throttle_value=1,
+            skip_on_missing_params=False,
+            max_concurrent=4,
+            test_run_map=build_test_run_map(metric.name),
+        )
+    elapsed = time.perf_counter() - start_time
+
+    assert started_cases == ["fail"]
+    assert elapsed < 0.9


### PR DESCRIPTION
## Summary

`compare()` currently skips async arena evaluation entirely when progress output is disabled with `DisplayConfig(show_indicator=False)`. The async path only scheduled `ArenaGEval` tasks inside the Rich progress-bar branch, so quiet CI/notebook/server usage returned `{}` without evaluating any test cases.

This PR moves async arena task scheduling into a shared helper so both visible and quiet progress modes execute the same measurement path. It also adds a deterministic no-network regression test that verifies quiet async compare invokes `ArenaGEval.a_measure`, returns the expected winner counts, populates test-run data, stops scheduling queued work after the first observed failure, and cancels unfinished tasks on failure.

## Changes

- Reuse the same async arena task scheduling path for `show_indicator=True` and `show_indicator=False`.
- Stop scheduling further async arena tasks after the first observed failure, then cancel and drain unfinished in-flight tasks so quiet mode does not leave background work running or launch avoidable follow-up work.
- Preserve existing throttling, concurrency, metric-copy creation, winner aggregation, and test-run map updates.
- Preserve the existing module-level `Contestant` import surface while marking it as an intentional compatibility re-export.
- Add `tests/test_core/test_evaluation/test_arena_compare.py` regression coverage using a dummy LLM and monkeypatched arena measurement, so the test does not require provider API keys.

## Why this matters

Disabling progress indicators should only suppress console UI. It should not change evaluation semantics or silently skip all comparisons. This matters for CI, notebooks, and log-sensitive environments where users commonly disable Rich progress output.

## Tests

Commands run:

- `python -m pytest tests/test_core/test_evaluation/test_arena_compare.py -q` — passed (`3 passed`, `1 warning` for existing event-loop deprecation in `deepeval.utils`).
- `python -m pytest --collect-only tests/test_core/test_evaluation/test_arena_compare.py tests/test_confident/test_compare.py -q` — passed (`5 tests collected`).
- `python -m black --check deepeval/evaluate/compare.py tests/test_core/test_evaluation/test_arena_compare.py` — passed.
- `python -m ruff check deepeval/evaluate/compare.py tests/test_core/test_evaluation/test_arena_compare.py` — passed.
- `python -m py_compile deepeval/evaluate/compare.py tests/test_core/test_evaluation/test_arena_compare.py` — passed.
- `git diff --check` — passed.

Not run:

- Full repository test suite — out of scope for this narrow compare-path fix.
- Live provider-backed arena comparison — regression test uses a deterministic dummy LLM to avoid API-key/network dependence.

## Risk

Risk level: low to medium.

The production change is limited to async arena task scheduling in `deepeval/evaluate/compare.py`. The visible progress path continues to use Rich progress, throttling, and concurrency as before; the quiet path now calls the same scheduling helper without progress objects. The helper now observes failures during throttled scheduling, stops launching queued cases after the first observed failure, cancels and drains unfinished in-flight tasks, and then re-raises the original error. Rollback is simple: revert this PR.

## Issue

No existing issue found. This was discovered during repository analysis.

Related context: open PR #2711 also touches `compare()` for return-details support, but does not address quiet async execution being skipped.

## Notes for maintainers

This PR intentionally does not change result-detail APIs, sync compare behavior, or provider/model logic. It only separates display suppression from async execution.
