### PR TITLE
fix: preserve CLI-saved dotenv value round-trips

### DIFF
--- a/deepeval/cli/dotenv_handler.py
+++ b/deepeval/cli/dotenv_handler.py
@@ -1,71 +1,240 @@
 from __future__ import annotations
-from pathlib import Path
+
 import os
 import re
 import stat
-from typing import Dict, Iterable
+import tempfile
+from io import StringIO
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
 
-_LINE_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$")
+from dotenv.parser import parse_stream
+
+_KEY_LINE_RE = re.compile(
+    r"^\s*(?:export\s+)?(?:'(?P<quoted>[^']+)'|(?P<key>[^=\#\s]+))\s*="
+)
+_BARE_VALUE_RE = re.compile(r"^[^\s#'\"\r\n]*$")
+_ALLOWED_PLATFORM_SYMLINKS = {
+    Path("/tmp"): Path("/private/tmp"),
+    Path("/var"): Path("/private/var"),
+}
+
+
+class DotenvTargetError(ValueError):
+    """Failure for unsafe dotenv save targets."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        super().__init__(
+            f"Refusing to write to symlinked dotenv path: {path}. "
+            "Point the configured save target, such as save= or "
+            "DEEPEVAL_DEFAULT_SAVE, at the real dotenv file instead."
+        )
+
+    def cli_message(self) -> str:
+        message = (
+            f"Refusing to write to symlinked dotenv path: {self.path}. "
+            "Point --save / DEEPEVAL_DEFAULT_SAVE at the real dotenv file "
+            "instead."
+        )
+        return message
 
 
 class DotenvHandler:
     def __init__(self, path: str | Path = ".env.local"):
         self.path = Path(path)
 
-    def _quote_if_needed(self, val: str) -> str:
-        # keep existing quoting if present; add quotes for spaces/#
-        if (val.startswith('"') and val.endswith('"')) or (
-            val.startswith("'") and val.endswith("'")
-        ):
-            return val
-        return f'"{val}"' if any(c in val for c in " #\t") else val
-
     def upsert(self, updates: Dict[str, str]) -> None:
         """
         Idempotently set/replace keys in a dotenv file. Preserves comments/order.
         Creates file if missing. Sets file mode to 0600 when possible.
         """
-        lines = self.path.read_text().splitlines() if self.path.exists() else []
-        seen = set()
-
-        # replace existing keys in-place
-        for i, line in enumerate(lines):
-            m = _LINE_RE.match(line)
-            if not m:
-                continue
-            key = m.group(1)
-            if key in updates and key not in seen:
-                lines[i] = f"{key}={self._quote_if_needed(updates[key])}"
-                seen.add(key)
-
-        # append missing keys at end (after a blank line)
-        to_append = []
-        for k, v in updates.items():
-            if k in seen:
-                continue
-            to_append.append(f"{k}={self._quote_if_needed(v)}")
-        if to_append:
-            if lines and lines[-1].strip():
-                lines.append("")
-            lines.extend(to_append)
-
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text("\n".join(lines) + ("\n" if lines else ""))
-        try:
-            self.path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
-        except Exception:
-            pass
+        self.update(updates=updates)
 
     def unset(self, keys: Iterable[str]) -> None:
         """Remove keys from dotenv file, but leave comments and other lines untouched."""
-        if not self.path.exists():
+        self.update(removals=keys)
+
+    def update(
+        self,
+        *,
+        updates: Mapping[str, str] | None = None,
+        removals: Iterable[str] = (),
+    ) -> None:
+        """
+        Apply updates and removals in one atomic rewrite.
+
+        This is used by settings/provider persistence paths where one logical
+        operation can both write and clear keys.
+        """
+        updates = dict(updates or {})
+        removals = set(removals)
+        if not updates and not removals:
             return
-        lines = self.path.read_text().splitlines()
-        out = []
-        keys = set(keys)
-        for line in lines:
-            m = _LINE_RE.match(line)
-            if m and m.group(1) in keys:
+        write_path = self.validate_target()
+        if not updates and not write_path.exists():
+            return
+        self._rewrite(
+            write_path=write_path,
+            updates=updates,
+            removals=removals,
+            create=bool(updates),
+        )
+
+    def validate_target(self) -> Path:
+        """Validate and return the path this handler is allowed to mutate."""
+        return self._write_path()
+
+    def _write_path(self) -> Path:
+        """
+        Return the path to mutate, refusing symlinked secret stores.
+
+        Check the target file and its lexical parent chain so a configured save
+        target cannot redirect persisted secrets through a symlinked path
+        component. Known macOS system aliases are allowed because they are
+        stable platform paths rather than project-controlled redirects.
+        """
+        for candidate in (self.path, *self.path.parents):
+            if candidate.is_symlink() and not self._is_platform_alias(
+                candidate
+            ):
+                raise DotenvTargetError(self.path)
+        return self.path
+
+    def _is_platform_alias(self, path: Path) -> bool:
+        target = _ALLOWED_PLATFORM_SYMLINKS.get(path)
+        if target is None:
+            return False
+        try:
+            return path.resolve(strict=False) == target
+        except OSError:
+            return False
+
+    def _rewrite(
+        self,
+        *,
+        write_path: Path,
+        updates: Mapping[str, str],
+        removals: set[str],
+        create: bool,
+    ) -> None:
+        if not create and not write_path.exists():
+            return
+
+        write_path.parent.mkdir(parents=True, exist_ok=True)
+        original = (
+            write_path.read_text(encoding="utf-8")
+            if write_path.exists()
+            else ""
+        )
+        content = self._render_updated_dotenv(original, updates, removals)
+        self._atomic_write(write_path, content)
+
+    def _render_updated_dotenv(
+        self,
+        original: str,
+        updates: Mapping[str, str],
+        removals: set[str],
+    ) -> str:
+        rendered: list[str] = []
+        replaced: set[str] = set()
+
+        for binding in parse_stream(StringIO(original)):
+            original_line = binding.original.string
+            key = binding.key or self._raw_assignment_key(original_line)
+            if key is None:
+                rendered.append(original_line)
                 continue
-            out.append(line)
-        self.path.write_text("\n".join(out) + ("\n" if out else ""))
+
+            if binding.key is None and binding.error:
+                _, separator, remainder = original_line.partition("\n")
+                if separator and remainder:
+                    if key in removals:
+                        rendered.append(remainder)
+                        continue
+                    if key in updates:
+                        if key not in replaced:
+                            rendered.append(
+                                self._format_line(key, updates[key])
+                            )
+                            replaced.add(key)
+                        rendered.append(remainder)
+                        continue
+
+            if key in removals:
+                continue
+            if key in updates:
+                if key not in replaced:
+                    rendered.append(self._format_line(key, updates[key]))
+                    replaced.add(key)
+                continue
+            rendered.append(original_line)
+
+        for key, value in updates.items():
+            if key in replaced:
+                continue
+            if rendered and not rendered[-1].endswith("\n"):
+                rendered[-1] = f"{rendered[-1]}\n"
+            rendered.append(self._format_line(key, value))
+
+        return "".join(rendered)
+
+    def _raw_assignment_key(self, line: str) -> str | None:
+        match = _KEY_LINE_RE.match(line)
+        if not match:
+            return None
+        return match.group("quoted") or match.group("key")
+
+    def _format_line(self, key: str, value: str) -> str:
+        value = self._escape_interpolation(value)
+        # Keep shell-safe values bare for cross-tool compatibility, and quote
+        # only when dotenv syntax requires escaping. Prefer single quotes
+        # because they preserve backslash sequences such as JSON "\\n"; use
+        # double quotes only when a quoted value ends with a backslash because
+        # that would otherwise escape the closing single quote.
+        if _BARE_VALUE_RE.fullmatch(value):
+            value_out = value
+        elif value.endswith("\\"):
+            value_out = '"{}"'.format(
+                value.replace("\\", "\\\\").replace('"', '\\"')
+            )
+        else:
+            value_out = "'{}'".format(value.replace("'", "\\'"))
+        return f"{key}={value_out}\n"
+
+    def _escape_interpolation(self, value: str) -> str:
+        # python-dotenv resolves ${VAR} after parsing regardless of quote style.
+        # Encoding the literal "$" through an empty-name default preserves the
+        # original value when DeepEval reads the file with interpolation enabled.
+        return value.replace("${", "${:-$}{")
+
+    def _atomic_write(
+        self,
+        path: Path,
+        content: str,
+    ) -> None:
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                delete=False,
+                prefix=".tmp_",
+                dir=str(path.parent),
+            ) as temp_file:
+                temp_path = Path(temp_file.name)
+                temp_file.write(content)
+            temp_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            os.replace(temp_path, path)
+            try:
+                path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                # The replacement file was already hardened before os.replace.
+                # Treat a post-replace chmod failure as best-effort so callers
+                # do not roll back runtime state while the new dotenv content
+                # has already been committed to disk.
+                pass
+        except BaseException:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+            raise

--- a/deepeval/cli/main.py
+++ b/deepeval/cli/main.py
@@ -19,6 +19,7 @@ import os
 import typer
 import importlib.metadata
 from typing import List, Optional
+from typer.core import TyperGroup
 from rich import print
 from rich.markup import escape
 from rich.console import Console
@@ -51,6 +52,7 @@ from deepeval.cli.utils import (
     resolve_field_names,
     upload_and_open_link,
 )
+from deepeval.cli.dotenv_handler import DotenvTargetError
 from deepeval.confident.api import (
     is_confident,
     Api,
@@ -58,7 +60,23 @@ from deepeval.confident.api import (
     HttpMethods,
 )
 
-app = typer.Typer(name="deepeval", no_args_is_help=True)
+
+class DeepevalTyperGroup(TyperGroup):
+    def invoke(self, ctx):
+        try:
+            return super().invoke(ctx)
+        except DotenvTargetError as exc:
+            raise typer.BadParameter(
+                exc.cli_message(),
+                param_hint="--save",
+            ) from exc
+
+
+app = typer.Typer(
+    name="deepeval",
+    no_args_is_help=True,
+    cls=DeepevalTyperGroup,
+)
 app.add_typer(test_app, name="test")
 app.command(name="generate")(generate_command)
 app.command(name="inspect")(inspect_command)

--- a/deepeval/cli/utils.py
+++ b/deepeval/cli/utils.py
@@ -25,6 +25,7 @@ from typing import (
 from opentelemetry.trace import Span
 
 from deepeval.config.settings import Settings, get_settings
+from deepeval import key_handler as key_handler_mod
 from deepeval.key_handler import (
     KEY_FILE_HANDLER,
     ModelKeyValues,
@@ -252,7 +253,7 @@ def save_environ_to_store(
     Returns (handled, path).
     """
     ok, path = _parse_save_option(save_opt)
-    if not ok:
+    if not ok or path is None:
         return False, None
     if updates:
         DotenvHandler(path).upsert(_normalize_kv(updates))
@@ -267,11 +268,33 @@ def unset_environ_in_store(
     Returns (handled, path).
     """
     ok, path = _parse_save_option(save_opt)
-    if not ok:
+    if not ok or path is None:
         return False, None
     norm = _normalize_keys(keys)
     if norm:
         DotenvHandler(path).unset(norm)
+    return True, path
+
+
+def update_environ_store(
+    updates: Dict[StrOrEnum, str],
+    keys_to_unset: Iterable[StrOrEnum],
+    save_opt: Optional[str] = None,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Apply dotenv updates and removals as one logical store mutation.
+    Returns (handled, path).
+    """
+    ok, path = _parse_save_option(save_opt)
+    if not ok or path is None:
+        return False, None
+    norm_updates = _normalize_kv(updates)
+    norm_unset = _normalize_keys(keys_to_unset)
+    if norm_updates or norm_unset:
+        DotenvHandler(path).update(
+            updates=norm_updates,
+            removals=norm_unset,
+        )
     return True, path
 
 
@@ -283,6 +306,23 @@ def _as_legacy_use_key(
     if k in EmbeddingKeyValues.__members__:
         return EmbeddingKeyValues[k]
     return None
+
+
+def _snapshot_file(path: Path):
+    if not path.exists():
+        return path, False, None, None
+    return path, True, path.read_bytes(), path.stat().st_mode
+
+
+def _restore_file(snapshot) -> None:
+    path, existed, content, mode = snapshot
+    if existed:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        if mode is not None:
+            path.chmod(mode)
+    else:
+        path.unlink(missing_ok=True)
 
 
 def switch_model_provider(
@@ -303,21 +343,45 @@ def switch_model_provider(
     if target_key not in keys_to_clear:
         raise ValueError(f"{target} is not a recognized USE_* model key")
 
-    # Clear legacy JSON store entries
-    for k in keys_to_clear:
-        legacy = _as_legacy_use_key(k)
-        if legacy is not None:
-            KEY_FILE_HANDLER.remove_key(legacy)
+    dotenv_result: Tuple[bool, Optional[str]] = (True, None)
+    dotenv_snapshot = None
+    if save:
+        ok, path = _parse_save_option(save)
+        if not ok or path is None:
+            return False, None
+        handler = DotenvHandler(path)
+        write_path = handler.validate_target()
+        dotenv_snapshot = _snapshot_file(write_path)
+        handler.update(
+            updates=_normalize_kv({target: "true"}),
+            removals=_normalize_keys(
+                key for key in keys_to_clear if key != target_key
+            ),
+        )
+        dotenv_result = (True, path)
 
-    KEY_FILE_HANDLER.write_key(target, "YES")
+    legacy_snapshot = _snapshot_file(
+        Path(key_handler_mod.HIDDEN_DIR) / key_handler_mod.KEY_FILE
+    )
+
+    try:
+        # Clear legacy JSON store entries
+        for k in keys_to_clear:
+            legacy = _as_legacy_use_key(k)
+            if legacy is not None:
+                KEY_FILE_HANDLER.remove_key(legacy)
+
+        KEY_FILE_HANDLER.write_key(target, "YES")
+    except BaseException:
+        _restore_file(legacy_snapshot)
+        if dotenv_snapshot is not None:
+            _restore_file(dotenv_snapshot)
+        raise
 
     if not save:
         return True, None
 
-    handled, path = unset_environ_in_store(keys_to_clear, save)
-    if not handled:
-        return False, None
-    return save_environ_to_store({target: "true"}, save)
+    return dotenv_result
 
 
 def coerce_blank_to_none(value: Optional[str]) -> Optional[str]:

--- a/deepeval/config/settings.py
+++ b/deepeval/config/settings.py
@@ -48,6 +48,7 @@ from deepeval.config.utils import (
     dedupe_preserve_order,
     parse_bool,
     read_dotenv_file,
+    read_dotenv_file_silent,
 )
 from deepeval.constants import SUPPORTED_PROVIDER_SLUGS, slugify
 
@@ -1369,9 +1370,11 @@ class Settings(BaseSettings):
                     _normalize_for_env,
                     _resolve_save_path,
                 )
+                from deepeval.cli.dotenv_handler import DotenvHandler
 
                 # lazy import legacy JSON store deps
                 from deepeval.key_handler import KEY_FILE_HANDLER
+                from deepeval import key_handler as key_handler_mod
 
                 model_fields = type(self._s).model_fields
                 # Exclude computed fields from persistence
@@ -1396,41 +1399,134 @@ class Settings(BaseSettings):
                 persist_dotenv = self._persist is not False
                 ok, resolved_path = _resolve_save_path(self._save)
 
-                existing_dotenv = {}
-                if persist_dotenv and ok and resolved_path is not None:
-                    existing_dotenv = read_dotenv_file(resolved_path)
-
                 candidate_keys_for_dotenv = (
                     changed_keys | touched_keys
                 ) - self.COMPUTED_FIELDS
+                keys_to_restore = changed_keys | candidate_keys_for_dotenv
 
-                keys_for_dotenv: set[str] = set()
-                for key in candidate_keys_for_dotenv:
-                    desired = after_norm.get(key)  # normalized string or None
-                    if desired is None:
-                        # only need to unset if it's actually present in dotenv
-                        # if key in existing_dotenv:
-                        #     keys_for_dotenv.add(key)
-                        keys_for_dotenv.add(key)
+                def restore_settings_snapshot() -> None:
+                    for key in keys_to_restore:
+                        if key in self._before:
+                            setattr(self._s, key, self._before[key])
+                    if "LOG_LEVEL" in keys_to_restore:
+                        from deepeval.config.logging import (
+                            apply_deepeval_log_level,
+                        )
+
+                        apply_deepeval_log_level()
+
+                legacy_snapshot = None
+                if self._persist is not False:
+                    legacy_path = (
+                        Path(key_handler_mod.HIDDEN_DIR)
+                        / key_handler_mod.KEY_FILE
+                    )
+                    legacy_snapshot = (
+                        legacy_path,
+                        legacy_path.exists(),
+                        (
+                            legacy_path.read_bytes()
+                            if legacy_path.exists()
+                            else None
+                        ),
+                    )
+
+                def restore_legacy_snapshot() -> None:
+                    if legacy_snapshot is None:
+                        return
+                    legacy_path, existed, content = legacy_snapshot
+                    if existed:
+                        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+                        legacy_path.write_bytes(content)
                     else:
-                        if existing_dotenv.get(key) != desired:
-                            keys_for_dotenv.add(key)
+                        legacy_path.unlink(missing_ok=True)
 
-                updates_for_dotenv = {
-                    key: after[key] for key in keys_for_dotenv
-                }
-
-                if not changed_keys and not updates_for_dotenv:
-                    if self._persist is False:
-                        # we report handled so that the cli does not mistakenly report invalid save option
-                        self.result = PersistResult(True, None, {})
+                try:
+                    if persist_dotenv and not ok:
+                        restore_settings_snapshot()
+                        self.result = PersistResult(False, None, {})
                         return False
 
-                    ok, resolved_path = _resolve_save_path(self._save)
-                    self.result = PersistResult(ok, resolved_path, {})
-                    return False
+                    existing_dotenv = {}
+                    if persist_dotenv and resolved_path is not None:
+                        DotenvHandler(resolved_path).validate_target()
+                        existing_dotenv = read_dotenv_file_silent(resolved_path)
 
-                updates = {k: after[k] for k in changed_keys}
+                    keys_for_dotenv: set[str] = set()
+                    for key in candidate_keys_for_dotenv:
+                        desired = after_norm.get(
+                            key
+                        )  # normalized string or None
+                        if desired is None:
+                            # only need to unset if it's actually present in dotenv
+                            # if key in existing_dotenv:
+                            #     keys_for_dotenv.add(key)
+                            keys_for_dotenv.add(key)
+                        else:
+                            if existing_dotenv.get(key) != desired:
+                                keys_for_dotenv.add(key)
+
+                    updates_for_dotenv = {
+                        key: after[key] for key in keys_for_dotenv
+                    }
+
+                    if not changed_keys and not updates_for_dotenv:
+                        if self._persist is False:
+                            # we report handled so that the cli does not mistakenly report invalid save option
+                            self.result = PersistResult(True, None, {})
+                            return False
+
+                        ok, resolved_path = _resolve_save_path(self._save)
+                        self.result = PersistResult(ok, resolved_path, {})
+                        return False
+
+                    updates = {k: after[k] for k in changed_keys}
+
+                    #
+                    # .deepeval JSON support
+                    #
+
+                    if self._persist is not False:
+                        for k in changed_keys:
+                            legacy_member = _find_legacy_enum(k)
+                            if legacy_member is None:
+                                continue  # skip if not a defined as legacy field
+
+                            val = updates[k]
+                            # Remove from JSON if unset
+                            if val is None:
+                                KEY_FILE_HANDLER.remove_key(legacy_member)
+                                continue
+
+                            # Never store secrets in the JSON keystore
+                            if _is_secret_key(k):
+                                continue
+
+                            # For booleans, the legacy store expects "YES"/"NO"
+                            if isinstance(val, bool):
+                                KEY_FILE_HANDLER.write_key(
+                                    legacy_member, "YES" if val else "NO"
+                                )
+                            else:
+                                # store as string
+                                KEY_FILE_HANDLER.write_key(
+                                    legacy_member, str(val)
+                                )
+
+                    #
+                    # dotenv store
+                    #
+
+                    # defer import to avoid cyclics
+                    handled, path = update_settings_and_persist(
+                        updates_for_dotenv,
+                        save=self._save,
+                        persist_dotenv=persist_dotenv,
+                    )
+                except BaseException:
+                    restore_settings_snapshot()
+                    restore_legacy_snapshot()
+                    raise
 
                 if "LOG_LEVEL" in updates:
                     from deepeval.config.logging import (
@@ -1439,45 +1535,6 @@ class Settings(BaseSettings):
 
                     apply_deepeval_log_level()
 
-                #
-                # .deepeval JSON support
-                #
-
-                if self._persist is not False:
-                    for k in changed_keys:
-                        legacy_member = _find_legacy_enum(k)
-                        if legacy_member is None:
-                            continue  # skip if not a defined as legacy field
-
-                        val = updates[k]
-                        # Remove from JSON if unset
-                        if val is None:
-                            KEY_FILE_HANDLER.remove_key(legacy_member)
-                            continue
-
-                        # Never store secrets in the JSON keystore
-                        if _is_secret_key(k):
-                            continue
-
-                        # For booleans, the legacy store expects "YES"/"NO"
-                        if isinstance(val, bool):
-                            KEY_FILE_HANDLER.write_key(
-                                legacy_member, "YES" if val else "NO"
-                            )
-                        else:
-                            # store as string
-                            KEY_FILE_HANDLER.write_key(legacy_member, str(val))
-
-                #
-                # dotenv store
-                #
-
-                # defer import to avoid cyclics
-                handled, path = update_settings_and_persist(
-                    updates_for_dotenv,
-                    save=self._save,
-                    persist_dotenv=persist_dotenv,
-                )
                 self.result = PersistResult(handled, path, updates_for_dotenv)
                 return False
             finally:
@@ -1488,8 +1545,6 @@ class Settings(BaseSettings):
             """
             Flip USE_* settings within the target's provider family (LLM vs embeddings).
             """
-            from deepeval.key_handler import KEY_FILE_HANDLER
-
             target_key = getattr(target, "value", str(target))
 
             def _is_embedding_flag(k: str) -> bool:

--- a/deepeval/config/settings_manager.py
+++ b/deepeval/config/settings_manager.py
@@ -77,31 +77,53 @@ def update_settings_and_persist(
     """
     settings = get_settings()
 
-    # validate + assign into settings.
-    # validation is handled in Settings as long as validate_assignment=True
-    typed: Dict[str, Any] = {}
-    for key, value in updates.items():
-        k = _env_key(key)
-        if k not in type(settings).model_fields:
-            suggestion = get_close_matches(
-                k, type(settings).model_fields.keys(), n=1
-            )
-            if suggestion:
-                logger.warning(
-                    "Unknown settings field '%s'; did you mean '%s'? Ignoring.",
-                    k,
-                    suggestion[0],
-                    stacklevel=2,
-                )
-            else:
-                logger.warning(
-                    "Unknown settings field '%s'; ignoring.", k, stacklevel=2
-                )
-            continue
+    # Resolve the persistence target before mutating live settings/env so an
+    # invalid save option cannot leave runtime state dirty.
+    dotenv_handler: DotenvHandler | None = None
+    if persist_dotenv:
+        ok, path = _resolve_save_path(save)
+        if not ok:
+            return False, None  # unsupported --save
+        if path:
+            dotenv_handler = DotenvHandler(path)
+    else:
+        path = None
 
-        setattr(settings, k, value)
-        # coercion is handled in Settings
-        typed[k] = getattr(settings, k)
+    settings_snapshot: Dict[str, Any] = {}
+    typed: Dict[str, Any] = {}
+    try:
+        # validate + assign into settings.
+        # validation is handled in Settings as long as validate_assignment=True
+        for key, value in updates.items():
+            k = _env_key(key)
+            if k not in type(settings).model_fields:
+                suggestion = get_close_matches(
+                    k, type(settings).model_fields.keys(), n=1
+                )
+                if suggestion:
+                    logger.warning(
+                        "Unknown settings field '%s'; did you mean '%s'? Ignoring.",
+                        k,
+                        suggestion[0],
+                        stacklevel=2,
+                    )
+                else:
+                    logger.warning(
+                        "Unknown settings field '%s'; ignoring.",
+                        k,
+                        stacklevel=2,
+                    )
+                continue
+
+            if k not in settings_snapshot:
+                settings_snapshot[k] = getattr(settings, k)
+            setattr(settings, k, value)
+            # coercion is handled in Settings
+            typed[k] = getattr(settings, k)
+    except BaseException:
+        for k, v in settings_snapshot.items():
+            setattr(settings, k, v)
+        raise
 
     # build env maps
     to_write: Dict[str, str] = {}
@@ -114,24 +136,43 @@ def update_settings_and_persist(
         else:
             to_write[k] = env_val
 
-    # update process env so that it is effective immediately
-    for k, v in to_write.items():
-        os.environ[k] = v
-    for k in to_unset:
-        os.environ.pop(k, None)
+    env_keys = set(to_write) | to_unset
+    env_snapshot: Dict[str, Optional[str]] = {
+        k: os.environ.get(k) for k in env_keys
+    }
 
-    if not persist_dotenv:
-        return True, None
+    try:
+        if dotenv_handler and (to_write or to_unset):
+            dotenv_handler.validate_target()
 
-    # persist to dotenv if save is ok
-    ok, path = _resolve_save_path(save)
-    if not ok:
-        return False, None  # unsupported --save
-    if path:
-        h = DotenvHandler(path)
-        if to_write:
-            h.upsert(to_write)
-        if to_unset:
-            h.unset(to_unset)
+        # update process env so that it is effective immediately
+        for k, v in to_write.items():
+            os.environ[k] = v
+        for k in to_unset:
+            os.environ.pop(k, None)
+
+        if dotenv_handler and (to_write or to_unset):
+            # Preserve existing "unset wins" behavior if a caller supplies
+            # the same key in both maps, but commit the logical settings
+            # change to dotenv in a single rewrite.
+            dotenv_handler.update(
+                updates={
+                    key: value
+                    for key, value in to_write.items()
+                    if key not in to_unset
+                },
+                removals=to_unset,
+            )
+    except BaseException:
+        for k, v in env_snapshot.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        for k, v in settings_snapshot.items():
+            setattr(settings, k, v)
+        raise
+
+    if persist_dotenv and path:
         return True, path
     return True, None

--- a/deepeval/config/utils.py
+++ b/deepeval/config/utils.py
@@ -2,6 +2,8 @@ import json
 import os
 import re
 from dotenv import dotenv_values
+from dotenv.main import resolve_variables
+from dotenv.parser import parse_stream
 from pathlib import Path
 from typing import Any, Iterable, List, Optional
 
@@ -148,4 +150,19 @@ def read_dotenv_file(path: Path) -> dict[str, str]:
     if not path.exists():
         return {}
     values = dotenv_values(path)
+    return {key: value for key, value in values.items() if value is not None}
+
+
+def read_dotenv_file_silent(path: Path) -> dict[str, str]:
+    """Read valid dotenv bindings without emitting parser warnings."""
+    if not path.exists():
+        return {}
+
+    raw_values: list[tuple[str, str | None]] = []
+    with path.open(encoding="utf-8") as stream:
+        for binding in parse_stream(stream):
+            if binding.key is not None and binding.value is not None:
+                raw_values.append((binding.key, binding.value))
+
+    values = resolve_variables(raw_values, override=True)
     return {key: value for key, value in values.items() if value is not None}

--- a/tests/test_core/test_cli/test_cli.py
+++ b/tests/test_core/test_cli/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import pytest
+from dotenv import dotenv_values
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, Tuple
 from typer.testing import CliRunner
@@ -167,6 +168,33 @@ def test_settings_set_coerces_and_persists_dotenv(
     assert "No changes to save" in out2
     assert _count_key_occurrences(env_path, "LOG_LEVEL") == 1
     assert _count_key_occurrences(env_path, "TEMPERATURE") == 1
+
+
+def test_settings_set_symlinked_dotenv_save_reports_guided_error(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    target_path = tmp_path / "target.env"
+    target_path.write_text("LOG_LEVEL=20\n", encoding="utf-8")
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "settings",
+            "-u",
+            "log-level=error",
+            "--save",
+            f"dotenv:{link_path}",
+        ],
+    )
+
+    assert result.exit_code != 0
+    output = _normalize_cli_output(result.output)
+    assert "Refusing to write to symlinked dotenv path" in output
+    assert "--save / DEEPEVAL_DEFAULT_SAVE" in output
+    assert "real dotenv file" in output
+    assert _read_dotenv(target_path).get("LOG_LEVEL") == "20"
 
 
 def test_settings_unset_removes_key_from_dotenv(
@@ -687,8 +715,10 @@ def test_set_unset_gemini_service_account_file_roundtrip_dotenv_only(
 
     env = _read_dotenv(env_path)
 
-    # Service account key should be persisted to dotenv as a single line.
+    # Service account key should be persisted to dotenv as a single line that
+    # also round-trips through the real python-dotenv parser.
     assert env.get("GOOGLE_SERVICE_ACCOUNT_KEY") == expected_sa
+    assert dotenv_values(env_path)["GOOGLE_SERVICE_ACCOUNT_KEY"] == expected_sa
 
     # Because project/location/service-account-file set and no api_key, Vertex mode should be enabled.
     assert parse_bool(env.get("GOOGLE_GENAI_USE_VERTEXAI")) is True

--- a/tests/test_core/test_config/test_cli_dotenv_handler.py
+++ b/tests/test_core/test_config/test_cli_dotenv_handler.py
@@ -1,0 +1,686 @@
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from dotenv import dotenv_values
+from typer import BadParameter
+
+from deepeval.cli.dotenv_handler import DotenvHandler, DotenvTargetError
+
+
+@pytest.fixture
+def reset_settings_after_test():
+    yield
+    from deepeval.config.settings import reset_settings
+
+    reset_settings(reload_dotenv=False)
+
+
+def _count_key_occurrences(content: str, key: str) -> int:
+    return sum(1 for line in content.splitlines() if line.startswith(f"{key}="))
+
+
+def test_upsert_round_trips_values_that_need_dotenv_escaping(tmp_path):
+    dotenv_path = tmp_path / "nested" / ".env.local"
+    values = {
+        "SIMPLE": "ERROR",
+        "SPACE_HASH": "hello # world",
+        "DOUBLE_QUOTE": 'token with " quote',
+        "SINGLE_QUOTE": "token with ' quote",
+        "NEWLINE": "line1\nline2",
+        "BACKSLASH": r"C:\tmp\value with space",
+        "TRAILING_BACKSLASH": "C:\\models\\",
+        "TRAILING_BACKSLASH_WITH_SPACE": "C:\\model dir\\",
+        "UNC_TRAILING_BACKSLASH": "\\\\server\\share\\",
+    }
+
+    DotenvHandler(dotenv_path).upsert(values)
+
+    assert dict(dotenv_values(dotenv_path)) == values
+    assert stat.S_IMODE(dotenv_path.stat().st_mode) == 0o600
+
+
+def test_upsert_keeps_shell_safe_values_bare_for_compatibility(tmp_path):
+    dotenv_path = tmp_path / ".env.local"
+    values = {
+        "OPENAI_API_KEY": "sk-proj_abc-123",
+        "SERVICE_ACCOUNT_PATH": "/tmp/key-file.json",
+        "EMPTY": "",
+    }
+
+    DotenvHandler(dotenv_path).upsert(values)
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    assert "OPENAI_API_KEY=sk-proj_abc-123\n" in content
+    assert "SERVICE_ACCOUNT_PATH=/tmp/key-file.json\n" in content
+    assert "EMPTY=\n" in content
+    assert dict(dotenv_values(dotenv_path)) == values
+
+
+def test_upsert_round_trips_literal_interpolation_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", "/expanded-home")
+    monkeypatch.setenv("TOKEN", "expanded-token")
+    dotenv_path = tmp_path / ".env.local"
+    values = {
+        "HOME_TEMPLATE": "${HOME}",
+        "PREFIXED_TEMPLATE": "prefix-${TOKEN}-suffix",
+        "DEFAULT_TEMPLATE": "${MISSING:-fallback}",
+        "SPACED_TEMPLATE": "hello ${HOME}",
+    }
+
+    DotenvHandler(dotenv_path).upsert(values)
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    assert "${:-$}{HOME}" in content
+    assert "${:-$}{TOKEN}" in content
+    assert dict(dotenv_values(dotenv_path)) == values
+
+
+def test_upsert_preserves_comments_and_updates_without_duplicates(tmp_path):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        "# model settings\n" "EXISTING=old\n" "KEEP=unchanged\n",
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).upsert(
+        {
+            "EXISTING": "updated # with comment marker",
+            "ADDED": r"C:\tmp\added value",
+        }
+    )
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    parsed = dotenv_values(dotenv_path)
+
+    assert content.startswith("# model settings\n")
+    assert "KEEP=unchanged\n" in content
+    assert _count_key_occurrences(content, "EXISTING") == 1
+    assert parsed["EXISTING"] == "updated # with comment marker"
+    assert parsed["ADDED"] == r"C:\tmp\added value"
+    assert parsed["KEEP"] == "unchanged"
+
+
+def test_unset_removes_keys_while_leaving_other_lines_intact(tmp_path):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        "# keep this comment\n" "REMOVE=secret\n" "KEEP=value\n",
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).unset(["REMOVE", "MISSING"])
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    assert content.startswith("# keep this comment\n")
+    assert "REMOVE=" not in content
+    assert "KEEP=value\n" in content
+    assert dotenv_values(dotenv_path)["KEEP"] == "value"
+
+
+def test_unset_only_missing_regular_dotenv_stays_silent(tmp_path):
+    dotenv_path = tmp_path / ".env.local"
+
+    DotenvHandler(dotenv_path).unset(["MISSING"])
+
+    assert not dotenv_path.exists()
+
+
+def test_upsert_replaces_legacy_malformed_assignment_without_duplicate(
+    tmp_path,
+):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        'BROKEN="token with " quote"\n' "KEEP=unchanged\n",
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).upsert({"BROKEN": 'fixed " value'})
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    parsed = dotenv_values(dotenv_path)
+
+    assert _count_key_occurrences(content, "BROKEN") == 1
+    assert parsed["BROKEN"] == 'fixed " value'
+    assert parsed["KEEP"] == "unchanged"
+
+
+@pytest.mark.parametrize("key", ["FOO.BAR", "A-B", "1A"])
+def test_upsert_replaces_malformed_assignments_for_dotenv_key_grammar(
+    tmp_path,
+    key,
+):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        f'{key}="token with " quote"\nKEEP=unchanged\n',
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).upsert({key: "fixed"})
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    parsed = dotenv_values(dotenv_path)
+
+    assert _count_key_occurrences(content, key) == 1
+    assert parsed[key] == "fixed"
+    assert parsed["KEEP"] == "unchanged"
+
+
+def test_unset_removes_legacy_malformed_assignment_silently(tmp_path, caplog):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        'BROKEN="token with " quote"\n' "KEEP=unchanged\n",
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).unset(["BROKEN", "MISSING"])
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    assert "BROKEN=" not in content
+    assert "KEEP=unchanged\n" in content
+    assert not [
+        record for record in caplog.records if record.name.startswith("dotenv")
+    ]
+
+
+def test_unset_removes_malformed_assignment_for_dotenv_key_grammar(tmp_path):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        'FOO.BAR="token with " quote"\nKEEP=unchanged\n',
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).unset(["FOO.BAR"])
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    assert "FOO.BAR=" not in content
+    assert "KEEP=unchanged\n" in content
+
+
+def test_update_repairs_multiline_malformed_assignment_without_dropping_following_keys(
+    tmp_path,
+):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        "BROKEN='unterminated\nKEEP='value'\n",
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).upsert({"BROKEN": "fixed"})
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    parsed = dotenv_values(dotenv_path)
+    assert "KEEP='value'\n" in content
+    assert _count_key_occurrences(content, "BROKEN") == 1
+    assert parsed["BROKEN"] == "fixed"
+    assert parsed["KEEP"] == "value"
+
+
+def test_unset_multiline_malformed_assignment_preserves_following_keys(
+    tmp_path,
+):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        "BROKEN='unterminated\nKEEP='value'\n",
+        encoding="utf-8",
+    )
+
+    DotenvHandler(dotenv_path).unset(["BROKEN"])
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    assert "BROKEN=" not in content
+    assert "KEEP='value'\n" in content
+    assert dotenv_values(dotenv_path)["KEEP"] == "value"
+
+
+def test_update_applies_writes_and_removals_in_single_hardened_rewrite(
+    tmp_path, monkeypatch
+):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        "REMOVE=old\nKEEP=unchanged\n",
+        encoding="utf-8",
+    )
+    dotenv_path.chmod(0o644)
+    atomic_writes = []
+    original_atomic_write = DotenvHandler._atomic_write
+
+    def spy_atomic_write(self, path, content):
+        atomic_writes.append(content)
+        return original_atomic_write(self, path, content)
+
+    monkeypatch.setattr(DotenvHandler, "_atomic_write", spy_atomic_write)
+
+    DotenvHandler(dotenv_path).update(
+        updates={"ADD": "value with spaces"},
+        removals=["REMOVE", "MISSING"],
+    )
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    parsed = dotenv_values(dotenv_path)
+
+    assert len(atomic_writes) == 1
+    assert "REMOVE=" not in content
+    assert parsed["ADD"] == "value with spaces"
+    assert parsed["KEEP"] == "unchanged"
+    assert stat.S_IMODE(dotenv_path.stat().st_mode) == 0o600
+
+
+def test_update_settings_persistence_batches_dotenv_writes_and_unsets(
+    tmp_path, monkeypatch
+):
+    from deepeval.config.settings_manager import update_settings_and_persist
+
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        "GRPC_VERBOSITY=INFO\nLOG_LEVEL=20\n",
+        encoding="utf-8",
+    )
+    atomic_writes = []
+    original_atomic_write = DotenvHandler._atomic_write
+
+    def spy_atomic_write(self, path, content):
+        atomic_writes.append(content)
+        return original_atomic_write(self, path, content)
+
+    monkeypatch.setattr(DotenvHandler, "_atomic_write", spy_atomic_write)
+
+    handled, path = update_settings_and_persist(
+        {"LOG_LEVEL": 40},
+        save=f"dotenv:{dotenv_path}",
+        unset=["GRPC_VERBOSITY"],
+    )
+
+    parsed = dotenv_values(dotenv_path)
+
+    assert handled is True
+    assert path == dotenv_path
+    assert len(atomic_writes) == 1
+    assert parsed["LOG_LEVEL"] == "40"
+    assert "GRPC_VERBOSITY" not in parsed
+
+
+def test_unset_only_hardens_existing_dotenv_mode(tmp_path):
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        "REMOVE=old\nKEEP=unchanged\n",
+        encoding="utf-8",
+    )
+    dotenv_path.chmod(0o644)
+
+    DotenvHandler(dotenv_path).unset(["REMOVE"])
+
+    content = dotenv_path.read_text(encoding="utf-8")
+    assert "REMOVE=" not in content
+    assert "KEEP=unchanged\n" in content
+    assert stat.S_IMODE(dotenv_path.stat().st_mode) == 0o600
+
+
+def test_settings_edit_repairs_malformed_dotenv_without_dotenv_warning(
+    tmp_path, caplog, reset_settings_after_test
+):
+    from pydantic import SecretStr
+
+    from deepeval.config.settings import reset_settings
+
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text(
+        'OPENAI_API_KEY="token with " quote"\nKEEP=unchanged\n',
+        encoding="utf-8",
+    )
+
+    settings = reset_settings(reload_dotenv=False)
+    with settings.edit(save=f"dotenv:{dotenv_path}"):
+        settings.OPENAI_API_KEY = SecretStr('fixed " value')
+
+    parsed = dotenv_values(dotenv_path)
+    assert parsed["OPENAI_API_KEY"] == 'fixed " value'
+    assert parsed["KEEP"] == "unchanged"
+    assert not [
+        record for record in caplog.records if record.name.startswith("dotenv")
+    ]
+
+
+def test_update_rejects_existing_symlinked_dotenv_path(tmp_path):
+    target_path = tmp_path / "target.env"
+    target_path.write_text("EXISTING=old\n", encoding="utf-8")
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv") as exc:
+        DotenvHandler(link_path).upsert({"EXISTING": "updated"})
+
+    assert isinstance(exc.value, ValueError)
+    assert not isinstance(exc.value, BadParameter)
+    assert "--save" not in str(exc.value)
+    assert link_path.is_symlink()
+    assert dotenv_values(target_path)["EXISTING"] == "old"
+
+
+def test_update_rejects_symlinked_dotenv_parent_directory(tmp_path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link_dir = tmp_path / "linked"
+    link_dir.symlink_to(real_dir, target_is_directory=True)
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        DotenvHandler(link_dir / ".env.local").upsert({"EXISTING": "updated"})
+
+    assert not (real_dir / ".env.local").exists()
+
+
+def test_update_rejects_symlinked_dotenv_ancestor(tmp_path):
+    real_root = tmp_path / "real-root"
+    real_parent = real_root / "settings"
+    real_parent.mkdir(parents=True)
+    link_root = tmp_path / "linked-root"
+    link_root.symlink_to(real_root, target_is_directory=True)
+    dotenv_path = link_root / "settings" / ".env.local"
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        DotenvHandler(dotenv_path).upsert({"EXISTING": "updated"})
+
+    assert not (real_parent / ".env.local").exists()
+
+
+def test_validate_allows_known_macos_platform_alias(monkeypatch):
+    path = Path("/var/folders/deepeval/.env.local")
+    original_is_symlink = Path.is_symlink
+    original_resolve = Path.resolve
+
+    def fake_is_symlink(self):
+        if self == Path("/var"):
+            return True
+        return original_is_symlink(self)
+
+    def fake_resolve(self, strict=False):
+        if self == Path("/var"):
+            return Path("/private/var")
+        return original_resolve(self, strict=strict)
+
+    monkeypatch.setattr(Path, "is_symlink", fake_is_symlink)
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+    assert DotenvHandler(path).validate_target() == path
+
+
+def test_unset_rejects_broken_symlinked_dotenv_path(tmp_path):
+    target_path = tmp_path / "missing.env"
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    assert link_path.is_symlink()
+    assert not link_path.exists()
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        DotenvHandler(link_path).unset(["EXISTING"])
+
+
+def test_settings_edit_rejects_symlink_before_dotenv_pre_read(
+    tmp_path, monkeypatch, reset_settings_after_test
+):
+    import deepeval.config.settings as settings_mod
+    from deepeval.config.settings import reset_settings
+
+    settings = reset_settings(reload_dotenv=False)
+    previous_log_level = settings.LOG_LEVEL
+    target_path = tmp_path / "target.env"
+    target_path.write_text("LOG_LEVEL=20\n", encoding="utf-8")
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    def fail_if_read(path):
+        raise AssertionError("symlinked dotenv target should not be read")
+
+    monkeypatch.setattr(settings_mod, "read_dotenv_file_silent", fail_if_read)
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        with settings.edit(save=f"dotenv:{link_path}"):
+            settings.LOG_LEVEL = 40
+
+    assert settings.LOG_LEVEL == previous_log_level
+
+
+def test_settings_edit_rolls_back_when_dotenv_pre_read_fails(
+    tmp_path, monkeypatch, reset_settings_after_test
+):
+    from deepeval.config.settings import reset_settings
+
+    settings = reset_settings(reload_dotenv=False)
+    previous_log_level = settings.LOG_LEVEL
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+
+    with pytest.raises(IsADirectoryError):
+        with settings.edit(save=f"dotenv:{tmp_path}"):
+            settings.LOG_LEVEL = 40
+
+    assert settings.LOG_LEVEL == previous_log_level
+    assert "LOG_LEVEL" not in os.environ
+
+
+def test_update_settings_rolls_back_runtime_env_when_dotenv_persist_fails(
+    tmp_path, monkeypatch, reset_settings_after_test
+):
+    from deepeval.config.settings import reset_settings
+    from deepeval.config.settings_manager import update_settings_and_persist
+
+    settings = reset_settings(reload_dotenv=False)
+    previous_log_level = settings.LOG_LEVEL
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+
+    target_path = tmp_path / "target.env"
+    target_path.write_text("LOG_LEVEL=20\n", encoding="utf-8")
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        update_settings_and_persist(
+            {"LOG_LEVEL": 40},
+            save=f"dotenv:{link_path}",
+        )
+
+    assert settings.LOG_LEVEL == previous_log_level
+    assert "LOG_LEVEL" not in os.environ
+
+
+def test_settings_edit_rolls_back_runtime_when_dotenv_persist_fails(
+    tmp_path, monkeypatch, reset_settings_after_test
+):
+    from deepeval.config.settings import reset_settings
+
+    settings = reset_settings(reload_dotenv=False)
+    previous_log_level = settings.LOG_LEVEL
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+
+    target_path = tmp_path / "target.env"
+    target_path.write_text("LOG_LEVEL=20\n", encoding="utf-8")
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        with settings.edit(save=f"dotenv:{link_path}"):
+            settings.LOG_LEVEL = 40
+
+    assert settings.LOG_LEVEL == previous_log_level
+    assert "LOG_LEVEL" not in os.environ
+
+
+def test_update_settings_rolls_back_after_atomic_write_failure(
+    tmp_path, monkeypatch, reset_settings_after_test
+):
+    from deepeval.config.settings import reset_settings
+    from deepeval.config.settings_manager import update_settings_and_persist
+
+    settings = reset_settings(reload_dotenv=False)
+    previous_log_level = settings.LOG_LEVEL
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text("LOG_LEVEL=20\n", encoding="utf-8")
+
+    def fail_atomic_write(self, path, content):
+        raise OSError("simulated dotenv write failure")
+
+    monkeypatch.setattr(DotenvHandler, "_atomic_write", fail_atomic_write)
+
+    with pytest.raises(OSError, match="simulated dotenv write failure"):
+        update_settings_and_persist(
+            {"LOG_LEVEL": 40},
+            save=f"dotenv:{dotenv_path}",
+        )
+
+    assert settings.LOG_LEVEL == previous_log_level
+    assert "LOG_LEVEL" not in os.environ
+    assert dotenv_values(dotenv_path)["LOG_LEVEL"] == "20"
+
+
+def test_settings_edit_restores_legacy_store_after_atomic_write_failure(
+    tmp_path, monkeypatch, reset_settings_after_test
+):
+    from deepeval import key_handler as key_handler_mod
+    from deepeval.config.settings import reset_settings
+
+    hidden_store_dir = tmp_path / "hidden-store"
+    hidden_store_dir.mkdir()
+    keyfile_path = hidden_store_dir / key_handler_mod.KEY_FILE
+    original_keyfile = {"TEMPERATURE": "0.5"}
+    keyfile_path.write_text(json.dumps(original_keyfile), encoding="utf-8")
+    monkeypatch.setattr(
+        key_handler_mod, "HIDDEN_DIR", str(hidden_store_dir), raising=False
+    )
+    monkeypatch.delenv("TEMPERATURE", raising=False)
+
+    dotenv_path = tmp_path / ".env.local"
+    dotenv_path.write_text("TEMPERATURE=0.5\n", encoding="utf-8")
+    settings = reset_settings(reload_dotenv=False)
+    previous_temperature = settings.TEMPERATURE
+
+    def fail_atomic_write(self, path, content):
+        raise OSError("simulated dotenv write failure")
+
+    monkeypatch.setattr(DotenvHandler, "_atomic_write", fail_atomic_write)
+
+    with pytest.raises(OSError, match="simulated dotenv write failure"):
+        with settings.edit(save=f"dotenv:{dotenv_path}"):
+            settings.TEMPERATURE = 0.7
+
+    assert settings.TEMPERATURE == previous_temperature
+    assert "TEMPERATURE" not in os.environ
+    assert (
+        json.loads(keyfile_path.read_text(encoding="utf-8")) == original_keyfile
+    )
+    assert dotenv_values(dotenv_path)["TEMPERATURE"] == "0.5"
+
+
+def test_settings_provider_switch_rolls_back_legacy_store_on_dotenv_failure(
+    tmp_path, monkeypatch, reset_settings_after_test
+):
+    from deepeval import key_handler as key_handler_mod
+    from deepeval.config.settings import reset_settings
+    from deepeval.key_handler import ModelKeyValues
+
+    hidden_store_dir = tmp_path / "hidden-store"
+    hidden_store_dir.mkdir()
+    keyfile_path = hidden_store_dir / key_handler_mod.KEY_FILE
+    original_keyfile = {"USE_OPENAI_MODEL": "YES"}
+    keyfile_path.write_text(json.dumps(original_keyfile), encoding="utf-8")
+    monkeypatch.setattr(
+        key_handler_mod, "HIDDEN_DIR", str(hidden_store_dir), raising=False
+    )
+
+    settings = reset_settings(reload_dotenv=False)
+    previous_openai = settings.USE_OPENAI_MODEL
+    previous_local = settings.USE_LOCAL_MODEL
+    target_path = tmp_path / "target.env"
+    target_path.write_text("USE_OPENAI_MODEL=1\n", encoding="utf-8")
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        settings.set_model_provider(
+            ModelKeyValues.USE_LOCAL_MODEL,
+            save=f"dotenv:{link_path}",
+        )
+
+    assert settings.USE_OPENAI_MODEL is previous_openai
+    assert settings.USE_LOCAL_MODEL is previous_local
+    assert (
+        json.loads(keyfile_path.read_text(encoding="utf-8")) == original_keyfile
+    )
+    assert dotenv_values(target_path)["USE_OPENAI_MODEL"] == "1"
+
+
+def test_cli_utils_provider_switch_leaves_legacy_store_on_dotenv_failure(
+    tmp_path, monkeypatch
+):
+    from deepeval import key_handler as key_handler_mod
+    from deepeval.cli import utils as cli_utils
+    from deepeval.key_handler import ModelKeyValues
+
+    hidden_store_dir = tmp_path / "hidden-store"
+    hidden_store_dir.mkdir()
+    keyfile_path = hidden_store_dir / key_handler_mod.KEY_FILE
+    original_keyfile = {"USE_OPENAI_MODEL": "YES"}
+    keyfile_path.write_text(json.dumps(original_keyfile), encoding="utf-8")
+    monkeypatch.setattr(
+        key_handler_mod, "HIDDEN_DIR", str(hidden_store_dir), raising=False
+    )
+
+    target_path = tmp_path / "target.env"
+    target_path.write_text("USE_OPENAI_MODEL=1\n", encoding="utf-8")
+    link_path = tmp_path / ".env.local"
+    link_path.symlink_to(target_path)
+
+    with pytest.raises(DotenvTargetError, match="symlinked dotenv"):
+        cli_utils.switch_model_provider(
+            ModelKeyValues.USE_LOCAL_MODEL,
+            save=f"dotenv:{link_path}",
+        )
+
+    assert (
+        json.loads(keyfile_path.read_text(encoding="utf-8")) == original_keyfile
+    )
+    assert dotenv_values(target_path)["USE_OPENAI_MODEL"] == "1"
+
+
+def test_cli_utils_provider_switch_restores_dotenv_when_legacy_write_fails(
+    tmp_path, monkeypatch
+):
+    from deepeval import key_handler as key_handler_mod
+    from deepeval.cli import utils as cli_utils
+    from deepeval.key_handler import ModelKeyValues
+
+    hidden_store_dir = tmp_path / "hidden-store"
+    hidden_store_dir.mkdir()
+    keyfile_path = hidden_store_dir / key_handler_mod.KEY_FILE
+    original_keyfile = {"USE_OPENAI_MODEL": "YES"}
+    keyfile_path.write_text(json.dumps(original_keyfile), encoding="utf-8")
+    monkeypatch.setattr(
+        key_handler_mod, "HIDDEN_DIR", str(hidden_store_dir), raising=False
+    )
+
+    dotenv_path = tmp_path / ".env.local"
+    original_dotenv = "USE_OPENAI_MODEL=true\nKEEP=unchanged\n"
+    dotenv_path.write_text(original_dotenv, encoding="utf-8")
+    dotenv_path.chmod(0o644)
+
+    def fail_write_key(key, value):
+        raise OSError("simulated legacy write failure")
+
+    monkeypatch.setattr(
+        cli_utils.KEY_FILE_HANDLER,
+        "write_key",
+        fail_write_key,
+    )
+
+    with pytest.raises(OSError, match="simulated legacy write failure"):
+        cli_utils.switch_model_provider(
+            ModelKeyValues.USE_LOCAL_MODEL,
+            save=f"dotenv:{dotenv_path}",
+        )
+
+    assert dotenv_path.read_text(encoding="utf-8") == original_dotenv
+    assert stat.S_IMODE(dotenv_path.stat().st_mode) == 0o644
+    assert (
+        json.loads(keyfile_path.read_text(encoding="utf-8")) == original_keyfile
+    )


### PR DESCRIPTION
## Summary

CLI/settings dotenv persistence currently assembles `KEY=value` lines by hand. That breaks valid values containing embedded double quotes, newlines, or backslash escapes: an executable repro on `main` showed values parsing back as `None`, truncated, or with changed characters through `python-dotenv`.

This PR rewrites CLI dotenv persistence around `python-dotenv` parsing and parser-compatible escaping, matching the loader semantics already used by DeepEval while preserving atomic updates, 0600 chmod hardening, and fail-closed behavior for unsafe dotenv targets.

## Changes

- Replace the fragile CLI dotenv quote/update/remove logic with a single-pass rewrite that uses `python-dotenv` parsing, keeps shell-safe values bare, and quotes only values that need dotenv escaping.
- Add a combined dotenv update API and wire settings/provider persistence paths through it so one logical save can write and remove keys in one atomic rewrite.
- Preserve parent-directory creation, refuse configured dotenv save paths containing any symlinked component for secret-store safety, and enforce 0600 file mode hardening before replacement.
- Return a guided CLI error for symlinked dotenv save targets, including remediation for `--save` / `DEEPEVAL_DEFAULT_SAVE`.
- Roll back live `Settings`, `os.environ`, and legacy `.deepeval` keyfile state when a settings edit cannot be persisted to the requested dotenv file.
- Add a warning-free dotenv reader for settings pre-diff checks so malformed legacy rows can be repaired without temporarily muting the process-global `dotenv.main` logger.
- Add focused regression tests for round-tripping spaces, `#`, embedded quotes, newlines, trailing backslashes, literal `${...}` interpolation tokens, and service-account JSON backslash sequences.
- Add coverage that comments/neighboring keys remain intact, updates do not duplicate keys, broader dotenv key grammar is handled for malformed legacy rows, `unset()` keeps unrelated lines, missing-key unsets stay silent, settings edits repair malformed dotenv rows without parse-warning noise, symlinked dotenv paths fail closed before reads/writes, broken symlink unsets are rejected, failed persistence rolls back runtime/dotenv/legacy state, and CLI users see an actionable symlink-save error.

## Why this matters

`--save=dotenv` and `DEEPEVAL_DEFAULT_SAVE=dotenv:<path>` are used to persist model/provider/auth settings. Those values may legitimately contain quotes, escaped key material, or other dotenv-sensitive characters. Persisting them as invalid dotenv syntax can make later CLI runs lose or corrupt configuration, which is especially risky for secrets and provider setup.

The rollback coverage also keeps a failed save from making the running process believe a setting changed when the configured persistence target rejected the write.

## Tests

Commands run:

- `python -m pytest tests/test_core/test_config/test_cli_dotenv_handler.py tests/test_core/test_config/test_settings.py tests/test_core/test_cli/test_cli.py -q` — passed (`118 passed`)
- `python -m black --check deepeval/cli/dotenv_handler.py deepeval/cli/main.py deepeval/cli/utils.py deepeval/config/settings.py deepeval/config/settings_manager.py deepeval/config/utils.py tests/test_core/test_config/test_cli_dotenv_handler.py tests/test_core/test_config/test_settings.py tests/test_core/test_cli/test_cli.py` — passed
- `python -m ruff check deepeval/cli/dotenv_handler.py deepeval/cli/main.py deepeval/cli/utils.py deepeval/config/settings.py deepeval/config/settings_manager.py deepeval/config/utils.py tests/test_core/test_config/test_cli_dotenv_handler.py tests/test_core/test_config/test_settings.py tests/test_core/test_cli/test_cli.py` — passed
- `python -m py_compile deepeval/cli/dotenv_handler.py deepeval/cli/main.py deepeval/cli/utils.py deepeval/config/settings.py deepeval/config/settings_manager.py deepeval/config/utils.py tests/test_core/test_config/test_cli_dotenv_handler.py tests/test_core/test_config/test_settings.py tests/test_core/test_cli/test_cli.py` — passed
- `git diff --check` — passed

Not run:

- Full repository test suite — targeted CLI/settings dotenv persistence suites were run for this focused change.

## Risk

Risk level: low/medium

The change is focused and uses `python-dotenv` parsing semantics, which the repo already depends on for dotenv reads. Shell-safe values, including common API keys with hyphens/underscores and simple file paths, remain bare to preserve broad dotenv-file usability where possible. Values containing dotenv-sensitive syntax such as whitespace, `#`, quotes, newlines, literal interpolation tokens, or quoted trailing backslashes are rewritten in parser-compatible quoted form so DeepEval’s `python-dotenv` loader can parse them back correctly; broader non-python dotenv consumer compatibility is best-effort.

For secret-store safety, configured dotenv save paths containing symlinked components now fail closed rather than redirecting reads or writes through a symlink target, with narrow allowance for stable macOS platform aliases such as `/var` resolving to `/private/var`. Saved dotenv files are hardened to 0600 before replacement. If persistence fails, settings/env/dotenv/legacy state is restored to the pre-edit snapshot. Rollback is straightforward by reverting this commit.

## Issue

No exact existing issue found. This was discovered during repository analysis.

Related but not fixed by this PR: #1221 discusses broader policy/security concerns around storing sensitive information in dotenv files. This PR does not change what gets stored; it only ensures values that are explicitly saved remain valid and round-trip correctly.

## Notes for maintainers

I intentionally kept this scoped to the CLI dotenv helper and the settings paths that call it. There is a separate `deepeval.config.dotenv_handler`; this PR does not merge the two helpers to avoid broadening the diff beyond the serialization bug and compatibility hardening.
