### PR TITLE
fix(synthesizer): avoid UnboundLocalError when a document yields 0 chunks

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -923,9 +923,15 @@ class ContextGenerator:
             # Build the error message with suggestions.
             error_lines = [
                 f"Impossible to generate {min_contexts_per_source_file} contexts from a document with {num_chunks} chunks.",
-                "You have the following options:",
             ]
             suggestion_num = 1
+            # Initialize both flags so the combined-suggestion check below is
+            # always safe. When a document produces 0 chunks none of the
+            # suggestion branches run, and without these defaults the final
+            # `adjust_chunk_size or adjust_overlap` check raised an
+            # UnboundLocalError instead of the intended ValueError.
+            adjust_chunk_size = False
+            adjust_overlap = False
 
             # 1. Suggest adjusting the number of contexts if applicable.
             if num_chunks > 0:
@@ -973,6 +979,11 @@ class ContextGenerator:
                 error_lines.append(
                     f"{suggestion_num}. Adjust both the `chunk_size` and `chunk_overlap` to generate more chunks."
                 )
+            # Only surface the "options" header when we actually have at least
+            # one suggestion (e.g. a 0-chunk document has none), so the message
+            # never dangles.
+            if len(error_lines) > 1:
+                error_lines.insert(1, "You have the following options:")
             error_message = "\n".join(error_lines)
             raise ValueError(error_message)
 

--- a/tests/test_core/test_synthesizer/test_context_generator.py
+++ b/tests/test_core/test_synthesizer/test_context_generator.py
@@ -5,6 +5,7 @@ from itertools import chain
 from types import SimpleNamespace
 
 from deepeval.synthesizer.chunking.context_generator import ContextGenerator
+from deepeval.models.base_model import DeepEvalBaseLLM
 from deepeval.models.embedding_models.openai_embedding_model import (
     OpenAIEmbeddingModel,
 )
@@ -68,6 +69,38 @@ def _make_stub_embedder():
             return [0.0, 0.0, 0.0, 0.0]
 
     return _Stub()
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal non-native LLM so ContextGenerator can be constructed without
+    any provider API key (it is never actually called by these tests)."""
+
+    def __init__(self):
+        # Intentionally skip the base __init__, which eagerly calls
+        # load_model(); nothing here needs a real model.
+        pass
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        return ""
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        return ""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+class _FakeCountCollection:
+    """A stand-in Chroma collection that only exposes ``count()``."""
+
+    def __init__(self, count_value):
+        self._count_value = count_value
+
+    def count(self):
+        return self._count_value
 
 
 class _CapturingCollection:
@@ -342,6 +375,89 @@ async def test_async_many_docs_uses_single_chroma_client(monkeypatch, tmp_path):
 ##############
 # Validation #
 ##############
+
+
+def _make_generator_for_validation(chunk_size=1024, chunk_overlap=0):
+    # A stub LLM avoids any provider API key; validate_chunk_size only reads
+    # self.chunk_size / self.chunk_overlap, so no model or embedding call runs.
+    return ContextGenerator(
+        document_paths=["dummy.txt"],
+        embedder=_make_stub_embedder(),
+        model=_StubLLM(),
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+
+
+def test_validate_chunk_size_zero_chunks_raises_value_error():
+    """
+    A document that produces 0 chunks must raise the intended, informative
+    ValueError rather than an UnboundLocalError. Regression test: previously
+    the combined-suggestion check referenced `adjust_chunk_size` /
+    `adjust_overlap`, which were never assigned when num_chunks == 0.
+    """
+    generator = _make_generator_for_validation()
+
+    with pytest.raises(ValueError) as exc_info:
+        generator.validate_chunk_size(
+            min_contexts_per_source_file=1,
+            collection=_FakeCountCollection(0),
+        )
+
+    message = str(exc_info.value)
+    assert "0 chunks" in message
+    # No dangling "options" header when there is nothing to suggest.
+    assert "You have the following options:" not in message
+
+
+def test_validate_chunk_size_zero_chunks_with_overlap_raises_value_error():
+    """
+    The other 0-chunk branch: with min_contexts > 1 and a non-zero overlap the
+    overlap suggestion is produced, but `adjust_chunk_size` is still unset.
+    This also previously raised UnboundLocalError.
+    """
+    generator = _make_generator_for_validation(chunk_size=1024, chunk_overlap=5)
+
+    with pytest.raises(ValueError) as exc_info:
+        generator.validate_chunk_size(
+            min_contexts_per_source_file=3,
+            collection=_FakeCountCollection(0),
+        )
+
+    message = str(exc_info.value)
+    assert "0 chunks" in message
+    assert "You have the following options:" in message
+    assert "chunk_overlap" in message
+
+
+def test_validate_chunk_size_insufficient_chunks_still_lists_options():
+    """
+    The normal shortfall path (num_chunks > 0 but below the requested number of
+    contexts) keeps raising a ValueError with the full suggestion list.
+    """
+    generator = _make_generator_for_validation()
+
+    with pytest.raises(ValueError) as exc_info:
+        generator.validate_chunk_size(
+            min_contexts_per_source_file=5,
+            collection=_FakeCountCollection(2),
+        )
+
+    message = str(exc_info.value)
+    assert "with 2 chunks" in message
+    assert "You have the following options:" in message
+    assert "chunk_size" in message
+
+
+def test_validate_chunk_size_passes_when_enough_chunks():
+    """When there are enough chunks, validation is a no-op (no exception)."""
+    generator = _make_generator_for_validation()
+
+    # Should not raise.
+    generator.validate_chunk_size(
+        min_contexts_per_source_file=2,
+        collection=_FakeCountCollection(10),
+    )
 
 
 @requires_openai_key


### PR DESCRIPTION
## Summary

`ContextGenerator.validate_chunk_size` is meant to raise an **informative `ValueError`** when a source document produces fewer chunks than the requested number of contexts. Instead, when a document yields **0 chunks** (e.g. an empty / whitespace-only / unparseable file), it raises a confusing `UnboundLocalError`, hiding the real cause from the user.

## Reproduction

```python
from deepeval.synthesizer.chunking.context_generator import ContextGenerator

class FakeCollection:          # stand-in Chroma collection
    def count(self): return 0  # document produced 0 chunks

class StubEmbedder:
    def embed_text(self, x): return [0.0]
    async def a_embed_text(self, x): return [0.0]
    def embed_texts(self, xs): return [[0.0] for _ in xs]
    async def a_embed_texts(self, xs): return [[0.0] for _ in xs]

gen = ContextGenerator(document_paths=["doc.txt"], embedder=StubEmbedder(), model=<any model>)
gen.validate_chunk_size(min_contexts_per_source_file=1, collection=FakeCollection())
```

On `main` this raises:

```
UnboundLocalError: cannot access local variable 'adjust_chunk_size' where it is not associated with a value
```

instead of the intended `ValueError` describing the 0-chunk problem.

## Root cause

In `validate_chunk_size`, `adjust_chunk_size` and `adjust_overlap` are only assigned inside the `num_chunks > 0` and `min_contexts_per_source_file > 1 and self.chunk_overlap > 0` branches, but the final combined-suggestion check evaluates them unconditionally:

```python
if adjust_chunk_size or adjust_overlap:   # both unbound when num_chunks == 0
```

When a document yields 0 chunks, none of those branches run, so the names are never bound and Python raises `UnboundLocalError`.

## Fix

- Initialize `adjust_chunk_size = False` and `adjust_overlap = False` before the suggestion branches, so the combined check is always safe.
- Only emit the `"You have the following options:"` header when there is at least one concrete suggestion, so the 0-chunk message no longer dangles with an empty options list.

After the fix, a 0-chunk document produces a clean, actionable error:

```
Impossible to generate 1 contexts from a document with 0 chunks.
```

and the existing multi-suggestion messages are unchanged for the normal shortfall cases.

## Tests

Adds four regression tests in `tests/test_core/test_synthesizer/test_context_generator.py` (no API key required — a stub LLM is injected so `ContextGenerator` constructs offline):

- `test_validate_chunk_size_zero_chunks_raises_value_error` — 0 chunks, `min_contexts=1`
- `test_validate_chunk_size_zero_chunks_with_overlap_raises_value_error` — 0 chunks, `min_contexts>1`, non-zero overlap
- `test_validate_chunk_size_insufficient_chunks_still_lists_options` — normal shortfall path keeps the full suggestion list
- `test_validate_chunk_size_passes_when_enough_chunks` — no error when there are enough chunks

The two zero-chunk tests fail on `main` with `UnboundLocalError` and pass with this change.

## Notes

- Scope is intentionally minimal and does not touch the `min_contexts_per_document` wording that #2759 corrects (that is a separate line), so there is no conflict.
- Formatted with `black`.


