### PR TITLE
Fix dotted access to deepeval.evaluate.configs

### DIFF
--- a/deepeval/__init__.py
+++ b/deepeval/__init__.py
@@ -20,6 +20,7 @@ def _expose_public_api() -> None:
     global instrument
 
     from ._version import __version__ as _version
+    import deepeval.evaluate as _evaluate_module
     from deepeval.evaluate import (
         evaluate as _evaluate,
         assert_test as _assert_test,
@@ -34,6 +35,12 @@ def _expose_public_api() -> None:
 
     __version__ = _version
     evaluate = _evaluate
+    # `evaluate` is reassigned above from the `deepeval.evaluate` subpackage to
+    # the `evaluate` function it exports, so `deepeval.evaluate` no longer
+    # resolves to that subpackage. Re-attach its `configs` submodule to the
+    # function so `deepeval.evaluate.configs` keeps working after this module
+    # has finished importing (see issue #2216).
+    evaluate.configs = _evaluate_module.configs
     assert_test = _assert_test
     compare = _compare
     on_test_run_end = _on_end

--- a/tests/test_core/test_imports.py
+++ b/tests/test_core/test_imports.py
@@ -375,3 +375,19 @@ def test_tracing_imports():
     assert evaluate_thread is not None
     assert evaluate_trace is not None
     assert evaluate_span is not None
+
+
+def test_evaluate_configs_submodule_accessible_via_dotted_import():
+    """`deepeval.evaluate` is reassigned to the `evaluate` callable, so
+    `deepeval.evaluate.configs` must still resolve to the configs submodule
+    for `import deepeval.evaluate.configs` to keep working (see #2216)."""
+    import deepeval
+    import deepeval.evaluate.configs
+
+    assert deepeval.evaluate.configs.AsyncConfig() is not None
+    assert deepeval.evaluate.configs.DisplayConfig() is not None
+    assert deepeval.evaluate.configs.CacheConfig() is not None
+    assert deepeval.evaluate.configs.ErrorConfig() is not None
+
+    # The primary calling convention must keep working too.
+    assert callable(deepeval.evaluate)


### PR DESCRIPTION
## What

deepeval/__init__.py imports the evaluate function from the deepeval.evaluate subpackage and assigns it to the top-level name evaluate, so that deepeval.evaluate(...) works as the main entry point. That assignment also overwrites the deepeval.evaluate attribute on the package itself, which until then pointed at the subpackage. As a result, code that relies on plain dotted access, such as:

    import deepeval.evaluate.configs
    deepeval.evaluate.configs.AsyncConfig()

failed with AttributeError: 'function' object has no attribute 'configs', even though the equivalent from-import (from deepeval.evaluate.configs import AsyncConfig) worked fine.

## Fix

Re-attach the configs submodule to the evaluate function right after the reassignment, since functions can hold arbitrary attributes in Python. This keeps deepeval.evaluate callable while restoring dotted access to its configs submodule, without touching the public API.

## Testing

- Reproduced the original AttributeError against main, confirmed the fix resolves it.
- Added a regression test covering the dotted-import path for all four config classes (AsyncConfig, DisplayConfig, CacheConfig, ErrorConfig), plus a check that deepeval.evaluate is still callable.
- Full tests/test_core/test_imports.py suite passes (12 tests).
- black --check and ruff check pass on both changed files.

Fixes #2216