### PR TITLE
fix(g-eval): add score_mode to control silent logprob-score fallback

### DIFF
--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -28,7 +28,8 @@ from deepeval.metrics.g_eval.utils import (
     construct_test_case_string,
     format_rubrics,
     no_log_prob_support,
-    calculate_weighted_summed_score,
+    resolve_weighted_score,
+    G_EVAL_SCORE_MODES,
     validate_and_sort_rubrics,
     validate_criteria_and_evaluation_steps,
     number_evaluation_steps,
@@ -40,6 +41,7 @@ from deepeval.metrics.g_eval.utils import (
 )
 from deepeval.config.settings import get_settings
 from deepeval.confident.api import Api, Endpoints, HttpMethods
+from deepeval.errors import DeepEvalError
 
 
 class GEval(BaseMetric):
@@ -53,6 +55,7 @@ class GEval(BaseMetric):
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
         threshold: float = 0.5,
         top_logprobs: int = 20,
+        score_mode: str = "auto",
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
@@ -63,6 +66,12 @@ class GEval(BaseMetric):
 
         if criteria is not None or evaluation_steps is not None:
             validate_criteria_and_evaluation_steps(criteria, evaluation_steps)
+
+        if score_mode not in G_EVAL_SCORE_MODES:
+            raise ValueError(
+                f"score_mode must be one of {G_EVAL_SCORE_MODES}, "
+                f"received {score_mode!r}."
+            )
 
         self.name = name
         self.evaluation_params = evaluation_params
@@ -79,6 +88,7 @@ class GEval(BaseMetric):
         )
         self.threshold = 1 if strict_mode else threshold
         self.top_logprobs = top_logprobs
+        self.score_mode = score_mode
         self.strict_mode = strict_mode
         self.async_mode = async_mode
         self.verbose_mode = verbose_mode
@@ -198,9 +208,9 @@ class GEval(BaseMetric):
             _show_indicator=_show_indicator,
             _in_component=_in_component,
         ):
-            self.evaluation_steps: List[str] = (
-                await self._a_generate_evaluation_steps(multimodal)
-            )
+            self.evaluation_steps: List[
+                str
+            ] = await self._a_generate_evaluation_steps(multimodal)
             g_score, reason = await self._a_evaluate(
                 test_case,
                 _additional_context=_additional_context,
@@ -246,6 +256,15 @@ class GEval(BaseMetric):
             extract_schema=lambda s: s.steps,
             extract_json=lambda d: d["steps"],
         )
+
+    def _raise_if_logprobs_required(self) -> None:
+        if self.score_mode == "logprobs_weighted":
+            raise DeepEvalError(
+                "score_mode='logprobs_weighted' requires an evaluator model "
+                f"that exposes logprobs, and '{self.evaluation_model}' does "
+                "not. Use score_mode='top_token' or 'auto' to score without "
+                "logprobs."
+            )
 
     def _generate_evaluation_steps(self, multimodal: bool) -> List[str]:
         if self.evaluation_steps:
@@ -322,15 +341,13 @@ class GEval(BaseMetric):
             if self.strict_mode:
                 return score, reason
 
-            try:
-                weighted_summed_score = calculate_weighted_summed_score(
-                    score, res
-                )
-                return weighted_summed_score, reason
-            except (KeyError, AttributeError, TypeError, ValueError):
-                return score, reason
+            return (
+                resolve_weighted_score(score, res, self.score_mode),
+                reason,
+            )
         except AttributeError:
             # This catches the case where a_generate_raw_response doesn't exist.
+            self._raise_if_logprobs_required()
             return await a_generate_with_schema_and_extract(
                 metric=self,
                 prompt=prompt,
@@ -391,15 +408,13 @@ class GEval(BaseMetric):
             if self.strict_mode:
                 return score, reason
 
-            try:
-                weighted_summed_score = calculate_weighted_summed_score(
-                    score, res
-                )
-                return weighted_summed_score, reason
-            except (KeyError, AttributeError, TypeError, ValueError):
-                return score, reason
+            return (
+                resolve_weighted_score(score, res, self.score_mode),
+                reason,
+            )
         except AttributeError:
             # This catches the case where a_generate_raw_response doesn't exist.
+            self._raise_if_logprobs_required()
             return generate_with_schema_and_extract(
                 metric=self,
                 prompt=prompt,

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -208,9 +208,9 @@ class GEval(BaseMetric):
             _show_indicator=_show_indicator,
             _in_component=_in_component,
         ):
-            self.evaluation_steps: List[
-                str
-            ] = await self._a_generate_evaluation_steps(multimodal)
+            self.evaluation_steps: List[str] = (
+                await self._a_generate_evaluation_steps(multimodal)
+            )
             g_score, reason = await self._a_evaluate(
                 test_case,
                 _additional_context=_additional_context,

--- a/deepeval/metrics/g_eval/utils.py
+++ b/deepeval/metrics/g_eval/utils.py
@@ -1,7 +1,9 @@
 from typing import List, Optional, Union, Tuple, Dict
 from openai.types.chat.chat_completion import ChatCompletion
 import math
+import warnings
 
+from deepeval.errors import DeepEvalError
 from deepeval.models import DeepEvalBaseLLM, GPTModel, AzureOpenAIModel
 from deepeval.test_case import (
     SingleTurnParams,
@@ -15,8 +17,7 @@ from deepeval.models.llms.constants import OPENAI_MODELS_DATA
 from deepeval.test_case.conversational_test_case import ConversationalTestCase
 
 
-from pydantic import BaseModel, Field
-from typing import Optional, List, Tuple
+from pydantic import Field
 
 
 class APIRubric(BaseModel):
@@ -381,6 +382,36 @@ def calculate_weighted_summed_score(
         return weighted_summed_score
     except Exception:
         raise
+
+
+G_EVAL_SCORE_MODES = ("auto", "logprobs_weighted", "top_token")
+
+
+def resolve_weighted_score(
+    raw_score: int,
+    raw_response: ChatCompletion,
+    score_mode: str,
+) -> Union[int, float]:
+    if score_mode == "top_token":
+        return raw_score
+    try:
+        return calculate_weighted_summed_score(raw_score, raw_response)
+    except (KeyError, AttributeError, TypeError, ValueError) as e:
+        if score_mode == "logprobs_weighted":
+            raise DeepEvalError(
+                "Unable to compute the logprobs-weighted G-Eval score because "
+                "the evaluator model's response did not include usable "
+                f"logprobs ({type(e).__name__}: {e}). Set "
+                "score_mode='top_token' to score without logprobs."
+            ) from e
+        warnings.warn(
+            "G-Eval could not compute the logprobs-weighted score "
+            f"({type(e).__name__}: {e}); falling back to the raw top token "
+            "score. Set score_mode='logprobs_weighted' to raise instead, or "
+            "score_mode='top_token' to silence this warning.",
+            UserWarning,
+        )
+        return raw_score
 
 
 def number_evaluation_steps(evaluation_steps: List[str]) -> str:

--- a/tests/test_metrics/test_g_eval_score_mode.py
+++ b/tests/test_metrics/test_g_eval_score_mode.py
@@ -1,0 +1,107 @@
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from deepeval.errors import DeepEvalError
+from deepeval.metrics import GEval
+from deepeval.metrics.g_eval.utils import resolve_weighted_score
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+
+class StubModel(DeepEvalBaseLLM):
+    """Custom model without generate_raw_response / logprob support."""
+
+    def __init__(self):
+        super().__init__(model="stub-model")
+
+    def load_model(self):
+        return self
+
+    def generate(self, *args, **kwargs) -> str:
+        return '{"score": 8, "reason": "stub"}'
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        return '{"score": 8, "reason": "stub"}'
+
+    def get_model_name(self):
+        return "stub-model"
+
+
+def make_response_without_logprobs():
+    message = SimpleNamespace(content='{"score": 8, "reason": "ok"}')
+    return SimpleNamespace(
+        choices=[SimpleNamespace(logprobs=None, message=message)]
+    )
+
+
+def make_response_with_logprobs(score_token, top_logprobs):
+    message = SimpleNamespace(content='{"score": 8, "reason": "ok"}')
+    logprobs = SimpleNamespace(
+        content=[SimpleNamespace(token=score_token, top_logprobs=top_logprobs)]
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(logprobs=logprobs, message=message)]
+    )
+
+
+class TestResolveWeightedScore:
+    def test_top_token_mode_returns_raw_score_without_touching_logprobs(self):
+        response = make_response_without_logprobs()
+        assert resolve_weighted_score(8, response, "top_token") == 8
+
+    def test_logprobs_weighted_mode_raises_when_logprobs_missing(self):
+        response = make_response_without_logprobs()
+        with pytest.raises(DeepEvalError, match="top_token"):
+            resolve_weighted_score(8, response, "logprobs_weighted")
+
+    def test_auto_mode_falls_back_to_raw_score_with_warning(self):
+        response = make_response_without_logprobs()
+        with pytest.warns(UserWarning, match="top token"):
+            score = resolve_weighted_score(8, response, "auto")
+        assert score == 8
+
+    def test_logprobs_weighted_mode_computes_weighted_score(self):
+        response = make_response_with_logprobs(
+            "8",
+            [
+                SimpleNamespace(token="8", logprob=math.log(0.6)),
+                SimpleNamespace(token="9", logprob=math.log(0.4)),
+            ],
+        )
+        score = resolve_weighted_score(8, response, "logprobs_weighted")
+        assert score == pytest.approx(8.4)
+
+
+class TestGEvalScoreMode:
+    def make_test_case(self):
+        return LLMTestCase(input="question", actual_output="answer")
+
+    def make_metric(self, score_mode):
+        return GEval(
+            name="score mode test",
+            evaluation_params=[
+                SingleTurnParams.INPUT,
+                SingleTurnParams.ACTUAL_OUTPUT,
+            ],
+            evaluation_steps=["Check the answer addresses the question."],
+            model=StubModel(),
+            async_mode=False,
+            score_mode=score_mode,
+        )
+
+    def test_rejects_invalid_score_mode(self):
+        with pytest.raises(ValueError, match="score_mode"):
+            self.make_metric("bogus")
+
+    def test_logprobs_weighted_mode_raises_for_model_without_raw_response(
+        self,
+    ):
+        metric = self.make_metric("logprobs_weighted")
+        with pytest.raises(DeepEvalError, match="logprob"):
+            metric.measure(
+                self.make_test_case(),
+                _show_indicator=False,
+                _log_metric_to_confident=False,
+            )


### PR DESCRIPTION
Fixes #1029.

`GEval` silently falls back to the raw top-token score whenever the logprobs-weighted computation fails: both the sync and async paths catch `(KeyError, AttributeError, TypeError, ValueError)` around `calculate_weighted_summed_score` and return `score` as-is, so a logprob parse failure changes score semantics with no signal to the user.

This adds a `score_mode` parameter to `GEval`, following the modes proposed in the issue:

- `"auto"` (default): current behavior preserved, but the fallback now emits a `UserWarning` explaining what happened and how to escalate or silence it.
- `"logprobs_weighted"`: raises a clear `DeepEvalError` when logprobs are unavailable or unparseable (including evaluator models with no raw-response support), pointing the user at `top_token`.
- `"top_token"`: skips logprob weighting explicitly.

I kept the default on `auto` so no existing scores change; the silent part just becomes visible. Happy to flip the default to the loud error instead if you'd rather (per my question on the issue).

Tests: `tests/test_metrics/test_g_eval_score_mode.py` covers the weighted computation, all three modes' failure behavior, constructor validation, and the unsupported-model path, all offline. `pytest tests/test_metrics/` passes (103 passed, 265 skipped, the usual key-gated skips).
