### PR TITLE
fix(synthesizer): run async pipeline without nest_asyncio re-entrancy

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -15,7 +15,7 @@ import csv
 import os
 from contextlib import nullcontext
 
-from deepeval.utils import get_or_create_event_loop
+from deepeval.utils import run_async
 from deepeval.synthesizer.chunking.context_generator import ContextGenerator
 from deepeval.metrics.utils import (
     is_native_model,
@@ -437,8 +437,7 @@ class Synthesizer:
             context_construction_config.critic_model = self.model
 
         if self.async_mode:
-            loop = get_or_create_event_loop()
-            goldens = loop.run_until_complete(
+            goldens = run_async(
                 self.a_generate_goldens_from_docs(
                     document_paths=document_paths,
                     include_expected_output=include_expected_output,
@@ -689,9 +688,8 @@ class Synthesizer:
         goldens: List[Golden] = []
 
         if self.async_mode:
-            loop = get_or_create_event_loop()
             goldens.extend(
-                loop.run_until_complete(
+                run_async(
                     self.a_generate_goldens_from_contexts(
                         contexts=contexts,
                         include_expected_output=include_expected_output,
@@ -1289,9 +1287,8 @@ class Synthesizer:
         )
         goldens: List[Golden] = []
         if self.async_mode:
-            loop = get_or_create_event_loop()
             goldens.extend(
-                loop.run_until_complete(
+                run_async(
                     self.a_generate_goldens_from_scratch(
                         num_goldens=num_goldens,
                     )
@@ -1384,8 +1381,7 @@ class Synthesizer:
     ) -> List[Golden]:
         self.synthetic_goldens = []
         if self.async_mode:
-            loop = get_or_create_event_loop()
-            result = loop.run_until_complete(
+            result = run_async(
                 self.a_generate_goldens_from_goldens(
                     goldens=goldens,
                     max_goldens_per_golden=max_goldens_per_golden,
@@ -2070,8 +2066,7 @@ class Synthesizer:
             context_construction_config.critic_model = self.model
 
         if self.async_mode:
-            loop = get_or_create_event_loop()
-            goldens = loop.run_until_complete(
+            goldens = run_async(
                 self.a_generate_conversational_goldens_from_docs(
                     document_paths=document_paths,
                     include_expected_outcome=include_expected_outcome,
@@ -2318,9 +2313,8 @@ class Synthesizer:
         goldens: List[ConversationalGolden] = []
 
         if self.async_mode:
-            loop = get_or_create_event_loop()
             goldens.extend(
-                loop.run_until_complete(
+                run_async(
                     self.a_generate_conversational_goldens_from_contexts(
                         contexts=contexts,
                         include_expected_outcome=include_expected_outcome,
@@ -2900,9 +2894,8 @@ class Synthesizer:
         )
         goldens: List[ConversationalGolden] = []
         if self.async_mode:
-            loop = get_or_create_event_loop()
             goldens.extend(
-                loop.run_until_complete(
+                run_async(
                     self.a_generate_conversational_goldens_from_scratch(
                         num_goldens=num_goldens,
                     )
@@ -3181,8 +3174,7 @@ class Synthesizer:
     ) -> List[ConversationalGolden]:
         self.synthetic_conversational_goldens = []
         if self.async_mode:
-            loop = get_or_create_event_loop()
-            result = loop.run_until_complete(
+            result = run_async(
                 self.a_generate_conversational_goldens_from_goldens(
                     goldens=goldens,
                     max_goldens_per_golden=max_goldens_per_golden,

--- a/deepeval/utils.py
+++ b/deepeval/utils.py
@@ -12,10 +12,20 @@ import uuid
 import math
 import logging
 
-from contextvars import ContextVar
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar, copy_context
 from enum import Enum
 from importlib import import_module
-from typing import Any, Dict, List, Optional, Protocol, Sequence, Union
+from typing import (
+    Any,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Union,
+)
 from collections.abc import Iterable
 from dataclasses import asdict, is_dataclass
 from pydantic import BaseModel
@@ -218,6 +228,43 @@ def get_or_create_event_loop() -> asyncio.AbstractEventLoop:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     return loop
+
+
+def run_async(coro: Coroutine) -> Any:
+    """Drive ``coro`` to completion and return its result without depending on
+    ``nest_asyncio`` or re-entering an already-running event loop.
+
+    - When called from a synchronous context (no running loop), the coroutine
+      runs on a fresh event loop via :func:`asyncio.run`, which cancels leftover
+      tasks and closes the loop on exit. This avoids reusing a stale/shared loop
+      returned by the deprecated ``asyncio.get_event_loop()``.
+    - When called from within a running event loop (Jupyter/IPython, an async
+      web server, or any ``async def``), the coroutine runs on a dedicated worker
+      thread with its own fresh event loop. This replaces the fragile pattern of
+      calling ``loop.run_until_complete`` re-entrantly after monkeypatching the
+      running loop with ``nest_asyncio.apply()`` — a known source of scheduling
+      deadlocks on Python 3.12.
+
+    The public behaviour is identical to the old
+    ``get_or_create_event_loop().run_until_complete(coro)`` for synchronous
+    callers, but it never mutates the caller's event loop.
+    """
+    try:
+        asyncio.get_running_loop()
+        loop_already_running = True
+    except RuntimeError:
+        loop_already_running = False
+
+    if not loop_already_running:
+        return asyncio.run(coro)
+
+    # A loop is already running in this thread: execute the coroutine on a
+    # separate thread with its own event loop so we never re-enter the caller's
+    # loop. copy_context() preserves any contextvars set by the caller.
+    ctx = copy_context()
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(ctx.run, asyncio.run, coro)
+        return future.result()
 
 
 def get_or_create_general_event_loop() -> asyncio.AbstractEventLoop:

--- a/tests/test_core/test_synthesizer/test_async_event_loop.py
+++ b/tests/test_core/test_synthesizer/test_async_event_loop.py
@@ -1,0 +1,198 @@
+"""Regression tests for the ``Synthesizer(async_mode=True)`` event-loop handling.
+
+Background
+----------
+The synchronous ``generate_*`` wrappers used to drive their ``async`` pipeline
+with::
+
+    loop = get_or_create_event_loop()
+    loop.run_until_complete(self.a_generate_...(...))
+
+``get_or_create_event_loop`` calls ``nest_asyncio.apply()`` whenever it is
+invoked while an event loop is *already running* (Jupyter/IPython, an async web
+server, or any ``async def``). ``nest_asyncio`` monkeypatches the running loop so
+that ``run_until_complete`` can be called re-entrantly on it. That global patch
+of asyncio's scheduler is a well-known source of scheduling deadlocks on
+Python 3.12 and is entirely avoidable.
+
+The fix routes every synchronous wrapper through :func:`deepeval.utils.run_async`,
+which uses a fresh ``asyncio.run`` loop from a sync context and a dedicated
+worker thread (with its own fresh loop) when a loop is already running — so it
+never re-enters the caller's loop and never applies ``nest_asyncio``.
+
+These tests assert:
+  * ``async_mode=True`` completes from a plain synchronous caller, and
+  * ``async_mode=True`` completes when called from *within* a running event loop
+    **without** monkeypatching asyncio via ``nest_asyncio.apply()``.
+
+The second test fails on the pre-fix code (``nest_asyncio.apply`` is called) and
+passes after the fix. Both run under a hard timeout so a regression surfaces as a
+failure rather than a hung test run.
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from unittest.mock import patch
+
+import pytest
+
+import deepeval.utils as deepeval_utils
+from deepeval.dataset import Golden
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.synthesizer import Evolution, Synthesizer
+from deepeval.synthesizer.config import (
+    EvolutionConfig,
+    FiltrationConfig,
+    StylingConfig,
+)
+from deepeval.synthesizer.schema import (
+    InputFeedback,
+    PromptStyling,
+    Response,
+    RewrittenInput,
+    SyntheticData,
+    SyntheticDataList,
+)
+
+_TIMEOUT_SECONDS = 60
+
+
+class _FakeLLM(DeepEvalBaseLLM):
+    """A minimal custom (non-native) model that returns canned structured
+    objects, so the full synthesizer pipeline runs without any network I/O."""
+
+    def __init__(self):
+        self.name = "fake-async-model"
+
+    def load_model(self, *args, **kwargs):
+        return self
+
+    def get_model_name(self, *args, **kwargs):
+        return self.name
+
+    def _answer(self, schema):
+        if schema is None:
+            return "canned response"
+        if schema is SyntheticDataList:
+            return SyntheticDataList(
+                data=[
+                    SyntheticData(input="synthetic input", used_source_files=[])
+                ]
+            )
+        if schema is SyntheticData:
+            return SyntheticData(input="styled input", used_source_files=[])
+        if schema is InputFeedback:
+            return InputFeedback(score=1.0, feedback="great")
+        if schema is RewrittenInput:
+            return RewrittenInput(rewritten_input="rewritten")
+        if schema is Response:
+            return Response(response="expected output")
+        if schema is PromptStyling:
+            return PromptStyling(scenario="s", task="t", input_format="f")
+        return schema()
+
+    def generate(self, prompt, schema=None, *args, **kwargs):
+        return self._answer(schema)
+
+    async def a_generate(self, prompt, schema=None, *args, **kwargs):
+        # Force interleaving between concurrent tasks.
+        await asyncio.sleep(0)
+        return self._answer(schema)
+
+
+def _make_synthesizer(max_concurrent=2):
+    model = _FakeLLM()
+    return Synthesizer(
+        model=model,
+        styling_config=StylingConfig(
+            input_format="question",
+            expected_output_format="answer",
+            task="qa",
+            scenario="user asks a question",
+        ),
+        evolution_config=EvolutionConfig(
+            evolutions={Evolution.CONSTRAINED: 1.0}, num_evolutions=1
+        ),
+        filtration_config=FiltrationConfig(
+            synthetic_input_quality_threshold=0.7,
+            max_quality_retries=1,
+            critic_model=model,
+        ),
+        async_mode=True,
+        max_concurrent=max_concurrent,
+        cost_tracking=False,
+    )
+
+
+def _build_goldens(n):
+    return [
+        Golden(
+            input=f"question {i}",
+            expected_output=f"answer {i}",
+            context=[f"supporting quote {i}"],
+            retrieval_context=[f"supporting quote {i}"],
+        )
+        for i in range(n)
+    ]
+
+
+def _run_with_timeout(fn, timeout=_TIMEOUT_SECONDS):
+    """Run ``fn`` on a worker thread, failing (rather than hanging) on deadlock."""
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(fn)
+        try:
+            return future.result(timeout=timeout)
+        except FutureTimeout:
+            pytest.fail(
+                f"generate_goldens_from_goldens(async_mode=True) hung for "
+                f">{timeout}s (event-loop deadlock)"
+            )
+
+
+def test_generate_goldens_async_mode_completes_from_plain_sync_caller():
+    """The default async path completes from an ordinary synchronous caller."""
+    synth = _make_synthesizer()
+    goldens = _build_goldens(4)
+
+    result = _run_with_timeout(
+        lambda: synth.generate_goldens_from_goldens(
+            goldens=goldens,
+            max_goldens_per_golden=1,
+            include_expected_output=True,
+        )
+    )
+
+    assert len(result) == 4
+    assert all(isinstance(g, Golden) for g in result)
+
+
+def test_generate_goldens_async_mode_completes_inside_running_loop_without_nest_asyncio():
+    """Calling the sync wrapper from within a running event loop must complete
+    and must NOT globally monkeypatch asyncio via ``nest_asyncio.apply()``.
+
+    Pre-fix, ``get_or_create_event_loop`` calls ``nest_asyncio.apply()`` on the
+    running loop and re-enters it with ``run_until_complete``; this assertion
+    fails there. After the fix the pipeline runs on an isolated worker-thread
+    loop and ``nest_asyncio.apply`` is never called.
+    """
+    synth = _make_synthesizer()
+    goldens = _build_goldens(4)
+
+    async def _driver():
+        # We are inside a running event loop here; calling the *synchronous*
+        # wrapper exercises run_async's "loop already running" branch.
+        return synth.generate_goldens_from_goldens(
+            goldens=goldens,
+            max_goldens_per_golden=1,
+            include_expected_output=True,
+        )
+
+    real_apply = deepeval_utils.nest_asyncio.apply
+    with patch.object(
+        deepeval_utils.nest_asyncio, "apply", wraps=real_apply
+    ) as apply_spy:
+        result = _run_with_timeout(lambda: asyncio.run(_driver()))
+
+    apply_spy.assert_not_called()
+    assert len(result) == 4
+    assert all(isinstance(g, Golden) for g in result)


### PR DESCRIPTION
## Summary

`Synthesizer`'s synchronous `generate_*` methods drive their async pipeline (when `async_mode=True`, the default) with:

```python
loop = get_or_create_event_loop()
loop.run_until_complete(self.a_generate_...(...))
```

`get_or_create_event_loop` (in `deepeval/utils.py`) calls **`nest_asyncio.apply()` whenever it runs while an event loop is already running** — Jupyter/IPython, an async web server, or any `async def`. `nest_asyncio` monkeypatches the running loop's scheduler so `run_until_complete` can be re-entered on it. That global patch of asyncio internals is a well-documented source of scheduling deadlocks on Python 3.12, and it silently mutates the caller's event loop for the rest of the process (see also #821). Separately, `asyncio.get_event_loop()` is deprecated on 3.12 when no loop is running and can hand back a stale/shared loop.

This PR routes every synchronous `Synthesizer` wrapper through a new `deepeval.utils.run_async` helper that never re-enters or monkeypatches the caller's loop:

- **No running loop (plain script):** run the coroutine on a fresh loop via `asyncio.run(...)`, which also cancels leftover tasks and closes the loop on exit.
- **A loop is already running:** run the coroutine on a dedicated worker thread with its own fresh event loop.

This is the standard, non-fragile replacement for `nest_asyncio`.

## Scope

- Migrated all 8 synchronous `Synthesizer` wrappers (`generate_goldens_from_docs / _from_contexts / _from_scratch / _from_goldens`, plus the 4 `conversational` variants).
- **Public API and defaults are unchanged.** `async_mode=True` stays the default; `async_mode=False` is untouched.
- `get_or_create_event_loop` is left in place (still used by metrics/evaluate/simulator). Migrating those call sites to `run_async` is a good follow-up but is out of scope here to keep the change focused and reviewable.

## Regression test

`tests/test_core/test_synthesizer/test_async_event_loop.py` (fake model, no network) asserts `generate_goldens_from_goldens(async_mode=True)`:

1. completes from a plain synchronous caller, and
2. completes when called from **within a running event loop** *and* never calls `nest_asyncio.apply()`.

Test (2) **fails on the current code** (`nest_asyncio.apply` is invoked once) and **passes after this change**. Both run under a hard timeout so a future regression surfaces as a failure rather than a hung CI run.

## What was and wasn't confirmed

I want to be transparent about the diagnosis:

- **Confirmed:** the `Synthesizer` async orchestration itself does **not** re-enter a synchronous `run_until_complete`; from a plain synchronous caller `nest_asyncio.apply()` fires **0 times** and the pipeline completes across a wide range of workloads. The `nest_asyncio` re-entrancy is triggered specifically when the sync wrapper is invoked **from an already-running loop**.
- **Not reproduced locally:** I created a Streamlit app to A/B a RAG pipeline we have in production. When I use the synthesizer with the golden dataset, I experience an indefinite hang with `async_mode=True` on Azure OpenAI reasoning models (Python 3.12.11, nest-asyncio 1.6.0, openai 2.x). I could not reproduce a hard deadlock in a matching environment with fake models, real `httpx.AsyncClient`, or anyio task groups. This change removes the fragile event-loop handling that is the most plausible contributor and makes the async path robust from both sync and running-loop contexts, but I don't claim it as a proven fix for that specific environment — it would be great if the original reporter can confirm against their setup.

## Environment

Verified on Python 3.12.11, nest-asyncio 1.6.0, openai 2.44.0, httpx 0.28.1, anyio 4.14.1.
