### PR TITLE
fix: #2859

### DIFF
--- a/deepeval/metrics/task_completion/task_completion.py
+++ b/deepeval/metrics/task_completion/task_completion.py
@@ -7,6 +7,7 @@ from deepeval.metrics.utils import (
     initialize_model,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
+    print_tools_called,
 )
 from deepeval.test_case import (
     LLMTestCase,
@@ -193,7 +194,9 @@ class TaskCompletionMetric(BaseMetric):
                 "extract_goal_and_outcome",
                 input=test_case.input,
                 actual_output=test_case.actual_output,
-                tools_called=test_case.tools_called,
+                tools_called_formatted=print_tools_called(
+                    test_case.tools_called or []
+                ),
             )
         return await a_generate_with_schema_and_extract(
             metric=self,
@@ -219,7 +222,9 @@ class TaskCompletionMetric(BaseMetric):
                 "extract_goal_and_outcome",
                 input=test_case.input,
                 actual_output=test_case.actual_output,
-                tools_called=test_case.tools_called,
+                tools_called_formatted=print_tools_called(
+                    test_case.tools_called or []
+                ),
             )
         return generate_with_schema_and_extract(
             metric=self,

--- a/tests/test_metrics/test_task_completion_metric_tools_called_template.py
+++ b/tests/test_metrics/test_task_completion_metric_tools_called_template.py
@@ -1,0 +1,87 @@
+"""Regression tests for TaskCompletionMetric tool-call prompt rendering.
+
+These tests exercise the legacy no-trace fallback path directly and do not
+require an API key.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+from deepeval.metrics import TaskCompletionMetric
+from deepeval.test_case import LLMTestCase, ToolCall
+from tests.test_core.stubs import DummyModel
+
+
+def make_metric(*, async_mode: bool = False) -> TaskCompletionMetric:
+    with patch(
+        "deepeval.metrics.task_completion.task_completion.initialize_model"
+    ) as mock_init:
+        mock_init.return_value = (DummyModel(), True)
+        return TaskCompletionMetric(async_mode=async_mode)
+
+
+def make_test_case() -> LLMTestCase:
+    return LLMTestCase(
+        input="Find a flight from NYC to Berlin on March 15.",
+        actual_output="I found matching flights from NYC to Berlin.",
+        tools_called=[
+            ToolCall(
+                name="search_flights",
+                input_parameters={
+                    "origin": "NYC",
+                    "destination": "Berlin",
+                    "date": "2025-03-15",
+                },
+            )
+        ],
+    )
+
+
+def test_task_completion_no_trace_formats_tools_called_sync():
+    metric = make_metric(async_mode=False)
+    test_case = make_test_case()
+    captured = {}
+
+    def fake_generate_with_schema_and_extract(**kwargs):
+        captured["prompt"] = kwargs["prompt"]
+        return "Book travel", "The agent searched for flights."
+
+    assert test_case._trace_dict is None
+
+    with patch(
+        "deepeval.metrics.task_completion.task_completion.generate_with_schema_and_extract",
+        side_effect=fake_generate_with_schema_and_extract,
+    ):
+        task, outcome = metric._extract_task_and_outcome(test_case)
+
+    assert task == "Book travel"
+    assert outcome == "The agent searched for flights."
+    assert "search_flights" in captured["prompt"]
+    assert '"origin": "NYC"' in captured["prompt"]
+
+
+def test_task_completion_no_trace_formats_tools_called_async():
+    asyncio.run(_run_async_extract_task_and_outcome_test())
+
+
+async def _run_async_extract_task_and_outcome_test():
+    metric = make_metric(async_mode=True)
+    test_case = make_test_case()
+    captured = {}
+
+    async def fake_a_generate_with_schema_and_extract(**kwargs):
+        captured["prompt"] = kwargs["prompt"]
+        return "Book travel", "The agent searched for flights."
+
+    assert test_case._trace_dict is None
+
+    with patch(
+        "deepeval.metrics.task_completion.task_completion.a_generate_with_schema_and_extract",
+        side_effect=fake_a_generate_with_schema_and_extract,
+    ):
+        task, outcome = await metric._a_extract_task_and_outcome(test_case)
+
+    assert task == "Book travel"
+    assert outcome == "The agent searched for flights."
+    assert "search_flights" in captured["prompt"]
+    assert '"origin": "NYC"' in captured["prompt"]


### PR DESCRIPTION
Fixes `TaskCompletionMetric` crashing in the no-trace fallback path with:

`MetricTemplateInterpolationError: Missing variable during template render: 'tools_called_formatted' is undefined`

The Python implementation was passing raw `tools_called` into the `extract_goal_and_outcome` template, while the template expects `tools_called_formatted`. This PR formats tool calls with `print_tools_called()` before rendering, matching the existing TypeScript implementation.

## Changes

- Import and use `print_tools_called` in `TaskCompletionMetric`.
- Pass `tools_called_formatted` in both sync and async no-trace extraction paths.
- Add regression tests covering sync and async fallback behavior with `ToolCall` objects.
- Ensure the tests do not require an API key or real LLM call.

## Test Plan

```bash
poetry run pytest -vv tests/test_templates/test_metric_templates.py \
  tests/test_metrics/test_task_completion_metric_tools_called_template.py