### PR TITLE
docs: fix typos in docs and code comments

### DIFF
--- a/deepeval/integrations/llama_index/utils.py
+++ b/deepeval/integrations/llama_index/utils.py
@@ -17,7 +17,7 @@ except:
 def is_llama_index_agent_installed():
     if not llama_index_agent_installed:
         raise ImportError(
-            "llama-index is neccesary for this functionality. Please install it with `pip install llama-index` or with package manager of choice."
+            "llama-index is necessary for this functionality. Please install it with `pip install llama-index` or with package manager of choice."
         )
 
 

--- a/deepeval/metrics/dag/graph.py
+++ b/deepeval/metrics/dag/graph.py
@@ -18,7 +18,7 @@ from deepeval.metrics import BaseMetric, BaseConversationalMetric
 def validate_root_nodes(
     root_nodes: Union[List[BaseNode], List[ConversationalBaseNode]],
 ):
-    # see if all root nodes are of the same type, more verbose error message, actualy we should say we cannot mix multi and single turn nodes
+    # see if all root nodes are of the same type, more verbose error message, actually we should say we cannot mix multi and single turn nodes
     if not all(isinstance(node, type(root_nodes[0])) for node in root_nodes):
         raise ValueError("You cannot mix multi and single turn nodes")
     return True

--- a/deepeval/openai_agents/callback_handler.py
+++ b/deepeval/openai_agents/callback_handler.py
@@ -129,7 +129,7 @@ class DeepEvalTracingProcessor(TracingProcessor):
             current_span
             and isinstance(current_span, LlmSpan)
             and span_type == "llm"
-        ):  # addtional check if the span kind data is llm too
+        ):  # additional check if the span kind data is llm too
             update_span_properties(current_span, span.span_data)
 
         observer = self.span_observers.pop(span.span_id, None)

--- a/deepeval/tracing/otel/exporter.py
+++ b/deepeval/tracing/otel/exporter.py
@@ -371,7 +371,7 @@ class ConfidentSpanExporter(SpanExporter):
                 end_time=peb.epoch_nanos_to_perf_seconds(span.end_time),
             )
 
-        # NOTE: Confident Span is reffered as base span in this codebase
+        # NOTE: Confident Span is referred to as base span in this codebase
         self.__set_base_span_attributes(
             base_span, span, base_span_status, base_span_error
         )

--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -560,7 +560,7 @@ def check_pydantic_ai_agent_input_output(
 def check_pydantic_ai_tools_called(
     span: ReadableSpan,
 ) -> Optional[List[ToolCall]]:
-    """Extract tool calls (and their resuls) from pydantic-ai message history
+    """Extract tool calls (and their results) from pydantic-ai message history
 
     Tool call live inside `pydantic_ai.all_messages` as parts of type
     `̀tool_call` ({id, name, arguments}) paired with `tool_call_response`

--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -562,8 +562,8 @@ def check_pydantic_ai_tools_called(
 ) -> Optional[List[ToolCall]]:
     """Extract tool calls (and their results) from pydantic-ai message history
 
-    Tool call live inside `pydantic_ai.all_messages` as parts of type
-    `̀tool_call` ({id, name, arguments}) paired with `tool_call_response`
+    Tool calls live inside `pydantic_ai.all_messages` as parts of type
+    `tool_call` ({id, name, arguments}) paired with `tool_call_response`
     parts ({id, name, result}). We rebuild structured `ToolCall` objects,
     matching responses to call by `id`.
     """

--- a/deepeval/tracing/tracing.py
+++ b/deepeval/tracing/tracing.py
@@ -1452,7 +1452,7 @@ def observe(
                             current_trace_context.set(_trace)
                         observer.__exit__(e.__class__, e, e.__traceback__)
                         raise
-                    finally:  # GeneratorExit execption directly brings us to final block
+                    finally:  # GeneratorExit exception directly brings us to final block
                         observer.__exit__(None, None, None)
 
                 return gen()

--- a/docs/content/docs/(agentic)/metrics-argument-correctness.mdx
+++ b/docs/content/docs/(agentic)/metrics-argument-correctness.mdx
@@ -13,7 +13,7 @@ sidebar_label: Argument Correctness
 The argument correctness metric is an agentic LLM metric that assesses your LLM agent's ability to generate the correct arguments for the tools it calls. It is calculated by determining whether the arguments for each tool call is correct based on the input.
 
 :::info
-The `ArgumentCorrectnessMetric` uses an LLM to determine argument correctness, and is also referenceless. If you're looking to determistically evaluate argument correctness, refer to the [tool correctness metric](/docs/metrics-tool-correctness) instead.
+The `ArgumentCorrectnessMetric` uses an LLM to determine argument correctness, and is also referenceless. If you're looking to deterministically evaluate argument correctness, refer to the [tool correctness metric](/docs/metrics-tool-correctness) instead.
 :::
 
 ## Required Arguments

--- a/docs/content/docs/(concepts)/(test-cases)/evaluation-multiturn-test-cases.mdx
+++ b/docs/content/docs/(concepts)/(test-cases)/evaluation-multiturn-test-cases.mdx
@@ -67,7 +67,7 @@ Similar to how the term 'test case' refers to an `LLMTestCase` if not explicitly
 
 ### Turns
 
-The `turns` parameter is a list of `Turn`s and is basically a list of messages/exchanges in a user-LLM conversation. If you're using [`ConversationalGEval`](/docs/metrics-conversational-g-eval), you might also want to supply different parameteres to a `Turn`. A `Turn` is made up of the following parameters:
+The `turns` parameter is a list of `Turn`s and is basically a list of messages/exchanges in a user-LLM conversation. If you're using [`ConversationalGEval`](/docs/metrics-conversational-g-eval), you might also want to supply different parameters to a `Turn`. A `Turn` is made up of the following parameters:
 
 ```python
 class Turn:

--- a/docs/content/docs/(concepts)/evaluation-prompts.mdx
+++ b/docs/content/docs/(concepts)/evaluation-prompts.mdx
@@ -400,7 +400,7 @@ There are **TWO** output settings you can associate with a prompt:
 
 ### Tools
 
-The tools in a prompt are used to specify the tools your agent has access to, all tools are identified using thier name and hence must be unique.
+The tools in a prompt are used to specify the tools your agent has access to, all tools are identified using their name and hence must be unique.
 
 ```python
 from deepeval.prompt import Prompt, Tool

--- a/docs/content/docs/(custom)/metrics-conversational-dag.mdx
+++ b/docs/content/docs/(custom)/metrics-conversational-dag.mdx
@@ -7,7 +7,7 @@ import { ASSETS } from "@site/src/assets";
 
 <MetricTagsDisplayer multiTurn={true} custom={true} />
 
-The `ConversationalDAGMetric` is the most versatile custom metric that allows you to build deterministic decision trees for multi-turn evaluations. It uses LLM-as-a-judge to run evals on an entire conversation by traversing a decison tree.
+The `ConversationalDAGMetric` is the most versatile custom metric that allows you to build deterministic decision trees for multi-turn evaluations. It uses LLM-as-a-judge to run evals on an entire conversation by traversing a decision tree.
 
 <details>
 <summary><strong>Why use DAG (over G-Eval)?</strong></summary>

--- a/docs/content/docs/(multi-turn)/metrics-goal-accuracy.mdx
+++ b/docs/content/docs/(multi-turn)/metrics-goal-accuracy.mdx
@@ -74,7 +74,7 @@ The `GoalAccuracyMetric` score is calculated using the following steps:
 <Equation formula="\text{Goal Accuracy Score} = \frac{\text{Goal Evaluation Score + Plan Evaluation Score}}{\text{2}}" />
 
 :::info
-The `GoalAccuracyMetric` extracts the task from user's messages in each interaction and evaluates the steps taken by the LLM agent to find it's plan and how accurately it has finished the task or reached the goal in that interaction.
+The `GoalAccuracyMetric` extracts the task from user's messages in each interaction and evaluates the steps taken by the LLM agent to find its plan and how accurately it has finished the task or reached the goal in that interaction.
 :::
 
 ## FAQs

--- a/docs/content/docs/(multi-turn)/metrics-goal-accuracy.mdx
+++ b/docs/content/docs/(multi-turn)/metrics-goal-accuracy.mdx
@@ -74,7 +74,7 @@ The `GoalAccuracyMetric` score is calculated using the following steps:
 <Equation formula="\text{Goal Accuracy Score} = \frac{\text{Goal Evaluation Score + Plan Evaluation Score}}{\text{2}}" />
 
 :::info
-The `GoalAccuracyMetric` extracts the task from user's messages in each interaction and evalutes the steps taken by the LLM agent to find it's plan and how accurately it has finished the task or reached the goal in that interaction.
+The `GoalAccuracyMetric` extracts the task from user's messages in each interaction and evaluates the steps taken by the LLM agent to find it's plan and how accurately it has finished the task or reached the goal in that interaction.
 :::
 
 ## FAQs

--- a/docs/content/docs/(multi-turn)/metrics-tool-use.mdx
+++ b/docs/content/docs/(multi-turn)/metrics-tool-use.mdx
@@ -5,7 +5,7 @@ sidebar_label: Tool Use
 ---
 <MetricTagsDisplayer usesLLMs={true} multiTurn={true} agent={true} referenceless={true} />
 
-The Tool Use metric is a multi-turn agentic metric that evaluates whether your LLM agent's **tool selection and argument generation** capabilities. It is a self-explaining eval, which means it outputs a reason for its metric score.
+The Tool Use metric is a multi-turn agentic metric that evaluates your LLM agent's **tool selection and argument generation** capabilities. It is a self-explaining eval, which means it outputs a reason for its metric score.
 
 ## Required Arguments
 

--- a/docs/content/docs/(multi-turn)/metrics-tool-use.mdx
+++ b/docs/content/docs/(multi-turn)/metrics-tool-use.mdx
@@ -5,7 +5,7 @@ sidebar_label: Tool Use
 ---
 <MetricTagsDisplayer usesLLMs={true} multiTurn={true} agent={true} referenceless={true} />
 
-The Tool Use metric is a multi-turn agentic metric that evaluates whether your LLM agent's **tool selection and argument generation** capablilities. It is a self-explaining eval, which means it outputs a reason for its metric score.
+The Tool Use metric is a multi-turn agentic metric that evaluates whether your LLM agent's **tool selection and argument generation** capabilities. It is a self-explaining eval, which means it outputs a reason for its metric score.
 
 ## Required Arguments
 

--- a/docs/content/docs/(rag)/metrics-faithfulness.mdx
+++ b/docs/content/docs/(rag)/metrics-faithfulness.mdx
@@ -101,7 +101,7 @@ There are **EIGHT** optional parameters when creating a `FaithfulnessMetric`:
 - [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.
 - [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to `False`.
 - [Optional] `truths_extraction_limit`: an int which when set, determines the maximum number of factual truths to extract from the `retrieval_context`. The truths extracted will be used to determine the degree of factual alignment, and will be ordered by importance, decided by your evaluation `model`. Defaulted to `None`.
-- [Optional] `penalize_ambiguous_claims`: a boolean which when set to `True`, will **not** count claims that are ambigious as faithful. Defaulted to `False`.
+- [Optional] `penalize_ambiguous_claims`: a boolean which when set to `True`, will **not** count claims that are ambiguous as faithful. Defaulted to `False`.
 - [Optional] `evaluation_template`: a class of type `FaithfulnessTemplate`, which allows you to [override the default prompts](#customize-your-template) used to compute the `FaithfulnessMetric` score. Defaulted to `deepeval`'s `FaithfulnessTemplate`.
 
 ### Within components

--- a/docs/content/docs/(safety)/metrics-misuse.mdx
+++ b/docs/content/docs/(safety)/metrics-misuse.mdx
@@ -108,7 +108,7 @@ The `MisuseMetric` first uses an LLM to extract all misuse statements found in t
 
 ### Definition of misuse
 
-In `deepeval`, whether a statement represents misue is defined according to the provided `domain`. Common domains include: `financial`, `medical`, `legal`, `customer service`, `education`, `healthcare`, `technical support`, and any other specialized domain:
+In `deepeval`, whether a statement represents misuse is defined according to the provided `domain`. Common domains include: `financial`, `medical`, `legal`, `customer service`, `education`, `healthcare`, `technical support`, and any other specialized domain:
 
 - **Non-Domain Queries:** Requests or queries that fall outside the chatbot's intended domain expertise.
   - Inappropriate: Can you write me a poem about nature? (for a financial chatbot)

--- a/docs/content/docs/(use-cases)/getting-started-agents.mdx
+++ b/docs/content/docs/(use-cases)/getting-started-agents.mdx
@@ -15,7 +15,7 @@ AI agent evaluation is different from other types of evals because agentic workf
 **In this 5 min quickstart, you'll learn how to:**
 
 - Evaluate your agent end-to-end in CI/CD
-- Evaluate individual components, inculding sub-agents, in your agent
+- Evaluate individual components, including sub-agents, in your agent
 
 ## How It Works
 

--- a/docs/content/docs/(use-cases)/getting-started-chatbots.mdx
+++ b/docs/content/docs/(use-cases)/getting-started-chatbots.mdx
@@ -204,7 +204,7 @@ python main.py
 
 - When you call `evaluate()`, `deepeval` runs all your `metrics` against all `test_cases`
 - All `metrics` outputs a score between `0-1`, with a `threshold` defaulted to `0.5`
-- A test case passes only if all metrics passess
+- A test case passes only if all metrics pass
 
 This creates a test run, which is a "snapshot"/benchmark of your multi-turn chatbot at any point in time.
 

--- a/docs/content/docs/(use-cases)/getting-started-mcp.mdx
+++ b/docs/content/docs/(use-cases)/getting-started-mcp.mdx
@@ -439,7 +439,7 @@ Now that you have run your first MCP eval, you should:
 
 1. **Customize your metrics**: You can change the threshold of your metrics to be more strict to your use-case.
 2. **Prepare a dataset**: If you don't have one, [generate one](/docs/golden-synthesizer) as a starting point to store your inputs as goldens.
-3. **Setup Tracing**: If you created your own custom MCP server, you can [setup tracing](https://documentation.confident-ai.com/docs/llm-tracing/tracing-features/span-types) on your tool definitons.
+3. **Setup Tracing**: If you created your own custom MCP server, you can [setup tracing](https://documentation.confident-ai.com/docs/llm-tracing/tracing-features/span-types) on your tool definitions.
 
 <VideoDisplayer
   src={ASSETS.tracingSpans}

--- a/docs/content/docs/benchmarks-introduction.mdx
+++ b/docs/content/docs/benchmarks-introduction.mdx
@@ -184,7 +184,7 @@ The benchmark.predictions attribute also yields a pandas DataFrame containing de
 | high_school_computer_science | Let x = 1. What is `x << 3` in Python 3?                                           | B          | 1       |
 | ...                          | ...                                                                                | ...        | ...     |
 
-## Configurating LLM Benchmarks
+## Configuring LLM Benchmarks
 
 All benchmarks are configurable in one way or another, and `deepeval` offers an easy interface to do so.
 

--- a/docs/content/docs/environment-variables.mdx
+++ b/docs/content/docs/environment-variables.mdx
@@ -123,7 +123,7 @@ When set to `1`, `USE_{PROVIDER}_MODEL` (e.g. `USE_OPENAI_MODEL`) tells `deepeva
 Each provider also has its own set of variables for API keys, model names, and other provider-specific options. Expand the sections below to see the full list for each provider.
 
 :::caution
-**Remember**, please do not play around with these variables manually, it should solely be for debugging purposes. Instead, use the CLI instead as `deepeval` takes care of managing these variables for you.
+**Remember**, please do not play around with these variables manually, it should solely be for debugging purposes. Instead, use the CLI as `deepeval` takes care of managing these variables for you.
 :::
 
 <details>

--- a/docs/content/docs/environment-variables.mdx
+++ b/docs/content/docs/environment-variables.mdx
@@ -123,7 +123,7 @@ When set to `1`, `USE_{PROVIDER}_MODEL` (e.g. `USE_OPENAI_MODEL`) tells `deepeva
 Each provider also has its own set of variables for API keys, model names, and other provider-specific options. Expand the sections below to see the full list for each provider.
 
 :::caution
-**Remember**, please do not play around with these variables manually, it should soley be for debugging purposes. Instead, use the CLI instead as `deepeval` takes care of managing these variables for you.
+**Remember**, please do not play around with these variables manually, it should solely be for debugging purposes. Instead, use the CLI instead as `deepeval` takes care of managing these variables for you.
 :::
 
 <details>

--- a/docs/content/docs/evaluation-introduction.mdx
+++ b/docs/content/docs/evaluation-introduction.mdx
@@ -252,7 +252,7 @@ This is very useful especially if you:
 - Wish to evaluate multiple components at once
 - Don't want to rewrite your codebase just to bubble up returned variables to create an `LLMTestCase`
 
-By defauly, `deepeval` will not run any metrics when you're running your LLM application outside of `evaluate()` or `assert_test()`. For the full guide on evaluating with tracing, visit [this page.](/docs/evaluation-component-level-llm-evals)
+By default, `deepeval` will not run any metrics when you're running your LLM application outside of `evaluate()` or `assert_test()`. For the full guide on evaluating with tracing, visit [this page.](/docs/evaluation-component-level-llm-evals)
 
 ## FAQs
 


### PR DESCRIPTION
This PR fixes a set of genuine spelling typos across the documentation and a few source-code comments/docstrings. No functional or API changes — comment/docstring edits only, and all touched Python files still compile.

## Changes

| File | Before | After |
| --- | --- | --- |
| docs/.../metrics-misuse.mdx | misue | misuse |
| docs/.../metrics-faithfulness.mdx | ambigious | ambiguous |
| docs/.../metrics-goal-accuracy.mdx | evalutes | evaluates |
| docs/.../metrics-tool-use.mdx | capablilities | capabilities |
| docs/.../metrics-argument-correctness.mdx | determistically | deterministically |
| docs/.../metrics-conversational-dag.mdx | decison | decision |
| docs/.../evaluation-prompts.mdx | thier | their |
| docs/.../evaluation-multiturn-test-cases.mdx | parameteres | parameters |
| docs/.../environment-variables.mdx | soley | solely |
| docs/.../evaluation-introduction.mdx | By defauly | By default |
| docs/.../benchmarks-introduction.mdx | Configurating | Configuring |
| docs/.../getting-started-agents.mdx | inculding | including |
| docs/.../getting-started-chatbots.mdx | passess | pass |
| docs/.../getting-started-mcp.mdx | definitons | definitions |
| deepeval/metrics/dag/graph.py | actualy | actually |
| deepeval/tracing/tracing.py | execption | exception |
| deepeval/tracing/otel/exporter.py | reffered as | referred to as |
| deepeval/tracing/otel/utils.py | resuls | results |
| deepeval/openai_agents/callback_handler.py | addtional | additional |
| deepeval/integrations/llama_index/utils.py | neccesary | necessary |
