### PR TITLE
feat: GitHub Action to post DeepEval eval results as a PR comment

### DIFF
--- a/github-action/deepeval-pr-comment/README.md
+++ b/github-action/deepeval-pr-comment/README.md
@@ -1,0 +1,65 @@
+# DeepEval PR Comment (GitHub Action)
+
+A ready-to-use GitHub Action that runs your [DeepEval](https://github.com/confident-ai/deepeval)
+tests and posts the evaluation results — totals, per-metric scores, and a
+per-test-case breakdown — as a comment on the pull request.
+
+This is the "post eval results as a PR comment" workflow many teams want for
+LLM evaluation in CI, without writing custom scripting.
+
+## Usage
+
+Add a workflow file (e.g. `.github/workflows/deepeval.yml`):
+
+```yaml
+name: DeepEval
+
+on:
+  pull_request:
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install deepeval openai
+
+      - name: Run DeepEval and comment
+        uses: confident-ai/deepeval/github-action/deepeval-pr-comment@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          test_command: "deepeval test run test_eval.py"
+```
+
+The action:
+
+1. Runs `test_command` (defaults to `deepeval test run .`).
+2. Reads the test-run snapshot DeepEval writes to
+   `.deepeval/.latest_run_full.json`.
+3. Renders a Markdown summary and posts it as a PR comment using
+   `secrets.GITHUB_TOKEN`.
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `github_token` | _required_ | Token used to post the comment. |
+| `test_command` | `deepeval test run .` | Command to run your DeepEval tests. |
+| `pr_number` | _auto_ | PR number; auto-detected from `GITHUB_REF` if omitted. |
+| `summary_only` | `false` | Only post the metrics summary table. |
+| `fail_on_failure` | `false` | Fail the action if any test case failed. |
+
+## Development
+
+The formatter is pure (no network, no DeepEval import) and is unit tested:
+
+```bash
+pip install pytest requests
+PYTHONPATH=github-action/deepeval-pr-comment python -m pytest github-action/deepeval-pr-comment/tests
+```

--- a/github-action/deepeval-pr-comment/action.yml
+++ b/github-action/deepeval-pr-comment/action.yml
@@ -1,0 +1,37 @@
+"""GitHub Action: run DeepEval and post the results as a pull-request comment."""
+
+name: "DeepEval PR Comment"
+description: "Run DeepEval and post evaluation results as a PR comment"
+author: "gautamkishore"
+inputs:
+  github_token:
+    description: "GitHub token used to post the comment (e.g. secrets.GITHUB_TOKEN)."
+    required: true
+  test_command:
+    description: "Command used to run your DeepEval tests."
+    required: false
+    default: "deepeval test run ."
+  pr_number:
+    description: "Pull-request number. Auto-detected from GITHUB_REF when omitted."
+    required: false
+  summary_only:
+    description: "Only post the metrics summary table (skip the per-test-case list)."
+    required: false
+    default: "false"
+  fail_on_failure:
+    description: "Fail the action if any DeepEval test case failed."
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Run DeepEval and post PR comment
+      shell: bash
+      env:
+        INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_TEST_COMMAND: ${{ inputs.test_command }}
+        INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        INPUT_SUMMARY_ONLY: ${{ inputs.summary_only }}
+        INPUT_FAIL_ON_FAILURE: ${{ inputs.fail_on_failure }}
+        PYTHONPATH: ${{ github.action_path }}
+      run: python -m deepeval_comment.runner

--- a/github-action/deepeval-pr-comment/deepeval_comment/__init__.py
+++ b/github-action/deepeval-pr-comment/deepeval_comment/__init__.py
@@ -1,0 +1,1 @@
+"""DeepEval PR Comment action package."""

--- a/github-action/deepeval-pr-comment/deepeval_comment/formatter.py
+++ b/github-action/deepeval-pr-comment/deepeval_comment/formatter.py
@@ -1,0 +1,114 @@
+"""Build a Markdown PR comment from a DeepEval test run JSON.
+
+The formatter is intentionally pure (no network, no DeepEval import) so it can
+be unit tested against a fixture of the JSON that ``deepeval test run`` writes
+to ``.deepeval/.latest_run_full.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def load_test_run(path: str) -> dict[str, Any]:
+    """Load a DeepEval test-run JSON file."""
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _safe_average(scores: list[float | None]) -> float:
+    values = [s for s in scores if s is not None]
+    if not values:
+        return 0.0
+    return sum(values) / len(values)
+
+
+def _format_metrics_summary(run: dict[str, Any]) -> list[str]:
+    metrics_scores = run.get("metricsScores") or []
+    if not metrics_scores:
+        return []
+
+    lines = [
+        "### Metrics",
+        "",
+        "| Metric | Avg Score | Pass | Fail | Error |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for metric in metrics_scores:
+        scores = metric.get("scores") or []
+        avg = _safe_average(scores)
+        lines.append(
+            f"| {metric.get('metric')} "
+            f"| {avg:.2f} "
+            f"| {metric.get('passes', 0)} "
+            f"| {metric.get('fails', 0)} "
+            f"| {metric.get('errors', 0)} |"
+        )
+    return lines
+
+
+def _format_test_cases(run: dict[str, Any]) -> list[str]:
+    test_cases = run.get("testCases") or []
+    conversational = run.get("conversationalTestCases") or []
+    if not test_cases and not conversational:
+        return []
+
+    lines = ["### Test Cases", ""]
+    rows = []
+
+    for case in test_cases:
+        rows.append(_format_single_case(case))
+
+    for case in conversational:
+        rows.append(_format_single_case(case))
+
+    # Keep the comment readable: show every case but cap very long lists.
+    shown = rows[:50]
+    lines.extend(shown)
+    if len(rows) > len(shown):
+        lines.append("")
+        lines.append(f"_… and {len(rows) - len(shown)} more test case(s)._")
+    return lines
+
+
+def _format_single_case(case: dict[str, Any]) -> str:
+    name = case.get("name") or "(unnamed)"
+    success = case.get("success")
+    status = "✅" if success is True else ("❌" if success is False else "⚠️")
+    metrics = case.get("metricsData") or []
+    if not metrics:
+        return f"- {status} **{name}**"
+    parts = ", ".join(
+        f"{m.get('name')}={m.get('score')}"
+        for m in metrics
+        if m.get("score") is not None
+    )
+    return f"- {status} **{name}** — {parts}"
+
+
+def format_summary(run: dict[str, Any], *, summary_only: bool = False) -> str:
+    """Render a DeepEval test run as a Markdown PR comment."""
+    test_passed = run.get("testPassed") or 0
+    test_failed = run.get("testFailed") or 0
+    total = test_passed + test_failed
+    duration = run.get("runDuration") or 0.0
+    cost = run.get("evaluationCost")
+
+    lines: list[str] = ["## 🧪 DeepEval Test Report", ""]
+    header = (
+        f"**{total}** test case(s) · "
+        f"✅ {test_passed} passed · "
+        f"❌ {test_failed} failed · "
+        f"⏱ {duration:.1f}s"
+    )
+    if cost is not None:
+        header += f" · 💲 {cost:.4f}"
+    lines.append(header)
+    lines.append("")
+
+    lines.extend(_format_metrics_summary(run))
+    if not summary_only:
+        lines.extend(_format_test_cases(run))
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/github-action/deepeval-pr-comment/deepeval_comment/github_client.py
+++ b/github-action/deepeval-pr-comment/deepeval_comment/github_client.py
@@ -1,0 +1,42 @@
+"""Post a Markdown comment to a GitHub pull request via the REST API."""
+
+from __future__ import annotations
+
+import os
+
+import requests
+
+
+def post_pr_comment(
+    repo: str,
+    pr_number: str,
+    body: str,
+    token: str,
+    api_url: str = "https://api.github.com",
+) -> int:
+    """Create an issue comment on the given PR.
+
+    Returns the HTTP status code from the GitHub API.
+    """
+    url = f"{api_url}/repos/{repo}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    response = requests.post(
+        url, json={"body": body}, headers=headers, timeout=30
+    )
+    response.raise_for_status()
+    return response.status_code
+
+
+def extract_pr_number(github_ref: str) -> str | None:
+    """Extract the PR number from a ``refs/pull/<n>/merge`` GitHub ref."""
+    if not github_ref:
+        return None
+    parts = github_ref.split("/")
+    # refs/pull/123/merge -> ['refs', 'pull', '123', 'merge']
+    if len(parts) >= 3 and parts[1] == "pull":
+        return parts[2]
+    return None

--- a/github-action/deepeval-pr-comment/deepeval_comment/runner.py
+++ b/github-action/deepeval-pr-comment/deepeval_comment/runner.py
@@ -1,0 +1,85 @@
+"""Orchestrate a DeepEval run and post the result as a PR comment.
+
+Inputs are read from ``INPUT_*`` environment variables (set by the composite
+GitHub Action) with sane fallbacks to the standard ``GITHUB_*`` variables.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from deepeval_comment.formatter import format_summary, load_test_run
+from deepeval_comment.github_client import extract_pr_number, post_pr_comment
+
+
+def _find_run_json() -> str | None:
+    hidden = os.getenv("DEEPEVAL_CACHE_FOLDER", ".deepeval")
+    candidates = [
+        os.path.join(hidden, ".latest_run_full.json"),
+        os.path.join(hidden, ".temp_test_run_data.json"),
+        os.path.join(hidden, ".latest_test_run.json"),
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def main() -> int:
+    token = os.environ.get("INPUT_GITHUB_TOKEN") or os.environ.get(
+        "GITHUB_TOKEN"
+    )
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    pr_number = os.environ.get("INPUT_PR_NUMBER") or extract_pr_number(
+        os.environ.get("GITHUB_REF", "")
+    )
+    command = os.environ.get("INPUT_TEST_COMMAND", "deepeval test run .")
+    summary_only = (
+        os.environ.get("INPUT_SUMMARY_ONLY", "false").lower() == "true"
+    )
+    fail_on_failure = (
+        os.environ.get("INPUT_FAIL_ON_FAILURE", "false").lower() == "true"
+    )
+
+    if not token:
+        print("deepeval-pr-comment: missing github_token", file=sys.stderr)
+        return 2
+    if not repo:
+        print("deepeval-pr-comment: missing GITHUB_REPOSITORY", file=sys.stderr)
+        return 2
+    if not pr_number:
+        print(
+            "deepeval-pr-comment: could not determine PR number "
+            "(set pr_number or run from a pull_request event)",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"deepeval-pr-comment: running '{command}'")
+    subprocess.run(command, shell=True, check=False)
+
+    path = _find_run_json()
+    if not path:
+        print(
+            "deepeval-pr-comment: no DeepEval test run JSON found "
+            f"(looked in '{os.getenv('DEEPEVAL_CACHE_FOLDER', '.deepeval')}')",
+            file=sys.stderr,
+        )
+        return 1
+
+    run = load_test_run(path)
+    body = format_summary(run, summary_only=summary_only)
+    print(body)
+
+    post_pr_comment(repo, pr_number, body, token)
+    print("deepeval-pr-comment: posted comment to PR #" + str(pr_number))
+
+    if fail_on_failure and (run.get("testFailed") or 0) > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/github-action/deepeval-pr-comment/tests/test_formatter.py
+++ b/github-action/deepeval-pr-comment/tests/test_formatter.py
@@ -1,0 +1,97 @@
+"""Tests for the DeepEval PR-comment formatter and GitHub helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from deepeval_comment.formatter import format_summary, load_test_run
+from deepeval_comment.github_client import extract_pr_number
+
+SAMPLE_RUN = {
+    "testPassed": 2,
+    "testFailed": 1,
+    "runDuration": 12.34,
+    "evaluationCost": 0.0123,
+    "metricsScores": [
+        {
+            "metric": "Answer Relevancy",
+            "scores": [0.9, 0.85, 0.2],
+            "passes": 2,
+            "fails": 1,
+            "errors": 0,
+        },
+        {
+            "metric": "Faithfulness",
+            "scores": [1.0, 0.95, 0.0],
+            "passes": 2,
+            "fails": 1,
+            "errors": 0,
+        },
+    ],
+    "testCases": [
+        {
+            "name": "weather question",
+            "success": True,
+            "metricsData": [
+                {"name": "Answer Relevancy", "score": 0.9, "success": True},
+                {"name": "Faithfulness", "score": 1.0, "success": True},
+            ],
+        },
+        {
+            "name": "math question",
+            "success": False,
+            "metricsData": [
+                {"name": "Answer Relevancy", "score": 0.2, "success": False},
+                {"name": "Faithfulness", "score": 0.0, "success": False},
+            ],
+        },
+    ],
+}
+
+
+def test_format_summary_contains_totals_and_metrics(tmp_path):
+    run_path = tmp_path / "run.json"
+    run_path.write_text(json.dumps(SAMPLE_RUN))
+    run = load_test_run(str(run_path))
+
+    body = format_summary(run)
+
+    assert "3** test case(s)" in body
+    assert "✅ 2 passed" in body
+    assert "❌ 1 failed" in body
+    assert "Answer Relevancy" in body
+    assert "Faithfulness" in body
+    assert "weather question" in body
+    assert "math question" in body
+    # averages: Answer Relevancy = (0.9+0.85+0.2)/3 = 0.65
+    assert "0.65" in body
+
+
+def test_format_summary_summary_only_omits_test_cases(tmp_path):
+    run_path = tmp_path / "run.json"
+    run_path.write_text(json.dumps(SAMPLE_RUN))
+    run = load_test_run(str(run_path))
+
+    body = format_summary(run, summary_only=True)
+
+    assert "weather question" not in body
+    assert "### Metrics" in body
+
+
+def test_format_summary_handles_missing_sections(tmp_path):
+    run_path = tmp_path / "run.json"
+    run_path.write_text(json.dumps({"testPassed": 0, "testFailed": 0}))
+    run = load_test_run(str(run_path))
+
+    body = format_summary(run)
+
+    assert "0** test case(s)" in body
+    assert "### Metrics" not in body
+    assert "### Test Cases" not in body
+
+
+def test_extract_pr_number():
+    assert extract_pr_number("refs/pull/123/merge") == "123"
+    assert extract_pr_number("refs/heads/main") is None
+    assert extract_pr_number("") is None


### PR DESCRIPTION
## Summary

Adds a ready-to-use **GitHub Action** that runs your DeepEval tests and posts the evaluation results (totals, per-metric scores, and a per-test-case breakdown) as a comment on the pull request.

This implements the widely-requested "post evaluation results as a PR comment" CI workflow for LLM evals — one of the most-asked-for DeepEval integrations. I checked open PRs and didn't find an existing action, so this is additive and conflict-free.

## What it does

1. Runs `test_command` (defaults to `deepeval test run .`).
2. Reads the test-run snapshot DeepEval writes to `.deepeval/.latest_run_full.json`.
3. Renders a Markdown summary and posts it as a PR comment via `secrets.GITHUB_TOKEN`.

## Design notes

- **Pure, tested formatter.** `deepeval_comment/formatter.py` has no network access and no DeepEval import, so it's unit tested against a fixture of the real `TestRun` JSON shape (see `tests/test_formatter.py`). All 4 tests pass.
- **Matches DeepEval's actual output.** It consumes the fields the test-run writer already emits: `testPassed`/`testFailed`/`runDuration`/`evaluationCost`, the aggregated `metricsScores` (metric / scores / passes / fails / errors), and per-case `testCases[].metricsData` (name / score / success).
- **Forgiving inputs.** `pr_number` is auto-detected from `GITHUB_REF` when omitted; `summary_only` and `fail_on_failure` are supported; it degrades gracefully if a section is missing.

## Usage

```yaml
- uses: confident-ai/deepeval/github-action/deepeval-pr-comment@main
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
    test_command: "deepeval test run test_eval.py"
```

Full docs in `github-action/deepeval-pr-comment/README.md`.

## Test plan

- `tests/test_formatter.py`: summary rendering (totals, metric averages, per-case list), `summary_only` mode, missing-section handling, and `extract_pr_number` parsing — all pass.
- `black` applied to the new files.

Happy to move the directory, adjust the comment format, or wire it into the docs site if the maintainers prefer a different layout.