### PR TITLE
fix(langchain): import integration cleanly when langchain is missing (was NameError)

### DIFF
--- a/deepeval/integrations/langchain/callback.py
+++ b/deepeval/integrations/langchain/callback.py
@@ -66,6 +66,18 @@ try:
 except ImportError:
     langchain_installed = False
 
+    # Import-time fallbacks so this module can still be imported when LangChain
+    # is not installed. Without them, `class CallbackHandler(BaseCallbackHandler)`
+    # (and the `LLMResult` method annotation / the `tool` re-export) reference
+    # undefined names and raise a cryptic `NameError` at import time — which makes
+    # the `is_langchain_installed()` guard below unreachable dead code. With the
+    # fallbacks, importing succeeds and any real use raises the helpful ImportError.
+    BaseCallbackHandler = object
+    LLMResult = object
+
+    def tool(*args, **kwargs):
+        is_langchain_installed()
+
 
 def is_langchain_installed():
     if not langchain_installed:

--- a/tests/test_core/test_integration_import_guards.py
+++ b/tests/test_core/test_integration_import_guards.py
@@ -1,0 +1,67 @@
+"""
+Regression tests: optional integration modules must import cleanly even when
+their optional third-party dependency is missing, and only raise a *helpful*
+ImportError when actually used.
+
+The dependency's absence is simulated via an import blocker so these run
+deterministically regardless of whether the dependency happens to be installed
+in the test environment.
+"""
+
+import sys
+import importlib
+
+import pytest
+
+
+class _BlockModules:
+    """A meta_path finder that makes the given top-level packages look absent."""
+
+    def __init__(self, *blocked):
+        self._blocked = blocked
+
+    def find_spec(self, name, path=None, target=None):
+        if name in self._blocked or name.startswith(
+            tuple(p + "." for p in self._blocked)
+        ):
+            raise ModuleNotFoundError(f"blocked for test: {name}")
+        return None
+
+
+def test_langchain_integration_imports_without_langchain():
+    """`import deepeval.integrations.langchain` must not raise NameError when
+    langchain is not installed; using the integration raises a helpful
+    ImportError instead.
+
+    Previously the module referenced ``BaseCallbackHandler`` as a base class at
+    class-definition time, so importing without langchain crashed with
+    ``NameError: name 'BaseCallbackHandler' is not defined`` — which made the
+    ``is_langchain_installed()`` guard unreachable dead code.
+    """
+    module_name = "deepeval.integrations.langchain"
+    watch = ("langchain", module_name)
+
+    # Snapshot and clear anything cached so the import runs fresh under the block.
+    saved = {k: v for k, v in sys.modules.items() if k.startswith(watch)}
+    for key in list(sys.modules):
+        if key.startswith(watch):
+            del sys.modules[key]
+
+    finder = _BlockModules("langchain")
+    sys.meta_path.insert(0, finder)
+    try:
+        lc = importlib.import_module(module_name)
+        assert hasattr(lc, "CallbackHandler")
+        assert hasattr(lc, "tool")
+
+        # Actually using the integration surfaces the intended, helpful error.
+        with pytest.raises(ImportError, match="LangChain is not installed"):
+            lc.CallbackHandler()
+        with pytest.raises(ImportError, match="LangChain is not installed"):
+            lc.tool()
+    finally:
+        sys.meta_path.remove(finder)
+        for key in list(sys.modules):
+            if key.startswith(watch):
+                del sys.modules[key]
+        sys.modules.update(saved)

--- a/tests/test_core/test_integration_import_guards.py
+++ b/tests/test_core/test_integration_import_guards.py
@@ -30,27 +30,44 @@ class _BlockModules:
 
 def test_langchain_integration_imports_without_langchain():
     """`import deepeval.integrations.langchain` must not raise NameError when
-    langchain is not installed; using the integration raises a helpful
+    LangChain is not installed; using the integration raises a helpful
     ImportError instead.
 
     Previously the module referenced ``BaseCallbackHandler`` as a base class at
-    class-definition time, so importing without langchain crashed with
-    ``NameError: name 'BaseCallbackHandler' is not defined`` — which made the
+    class-definition time, so importing without LangChain crashed with
+    ``NameError: name 'BaseCallbackHandler' is not defined`` -- which made the
     ``is_langchain_installed()`` guard unreachable dead code.
     """
     module_name = "deepeval.integrations.langchain"
-    watch = ("langchain", module_name)
+    # The integration imports from `langchain_core`, not from `langchain`, so
+    # blocking only the latter leaves the dependency importable and the test
+    # would silently exercise the installed-LangChain path instead.
+    blocked = ("langchain", "langchain_core")
+    prefixes = blocked + (module_name,)
 
-    # Snapshot and clear anything cached so the import runs fresh under the block.
-    saved = {k: v for k, v in sys.modules.items() if k.startswith(watch)}
-    for key in list(sys.modules):
-        if key.startswith(watch):
-            del sys.modules[key]
+    def _matches(key):
+        return key in prefixes or key.startswith(
+            tuple(p + "." for p in prefixes)
+        )
 
-    finder = _BlockModules("langchain")
+    # Snapshot and clear anything cached so the import runs fresh under the
+    # block -- a cached module is served without ever reaching the finder.
+    saved = {k: v for k, v in sys.modules.items() if _matches(k)}
+    for key in saved:
+        del sys.modules[key]
+
+    finder = _BlockModules(*blocked)
     sys.meta_path.insert(0, finder)
     try:
         lc = importlib.import_module(module_name)
+
+        # Guard the simulation itself: if the integration ever starts importing
+        # a package not listed in `blocked`, fail loudly here rather than
+        # quietly asserting against the installed-LangChain path.
+        assert (
+            lc.callback.langchain_installed is False
+        ), "LangChain still importable under the block -- update `blocked`"
+
         assert hasattr(lc, "CallbackHandler")
         assert hasattr(lc, "tool")
 
@@ -62,6 +79,6 @@ def test_langchain_integration_imports_without_langchain():
     finally:
         sys.meta_path.remove(finder)
         for key in list(sys.modules):
-            if key.startswith(watch):
+            if _matches(key):
                 del sys.modules[key]
         sys.modules.update(saved)


### PR DESCRIPTION
## Summary

The LangChain integration is meant to degrade gracefully when `langchain` isn't installed: `deepeval/integrations/langchain/callback.py` guards its langchain imports in a `try/except ImportError`, sets `langchain_installed = False`, and defines `is_langchain_installed()` to raise a helpful message — and `CallbackHandler.__init__` calls that guard first. (This mirrors how the `llama_index` integration fails with a clean error.)

But that graceful path is **currently dead code**: the `except ImportError` branch leaves the names that are referenced at *import time* undefined, so the module raises a cryptic `NameError` before the guard can ever run.

## Reproduction (without `langchain` installed)

```python
import deepeval.integrations.langchain
```
```
NameError: name 'BaseCallbackHandler' is not defined
```
raised at `class CallbackHandler(BaseCallbackHandler):` — the user never sees the intended `"LangChain is not installed. Please install it with pip install langchain"`.

## Root cause

In the `except ImportError` branch, three names remain undefined but are needed at import time:

- `BaseCallbackHandler` — used as the base class `class CallbackHandler(BaseCallbackHandler)` (evaluated when the class is defined).
- `LLMResult` — used as a method parameter annotation (`def on_llm_end(self, response: LLMResult, ...)`); with no `from __future__ import annotations`, annotations are evaluated at class-definition time.
- `tool` — imported from `.patch` inside the `try` and re-exported by `__init__.py` (`from .callback import CallbackHandler, tool`).

So `import deepeval.integrations.langchain` crashes at import, and `is_langchain_installed()` (only reachable via `CallbackHandler.__init__`) is never executed.

## Fix

Add import-time fallbacks in the `except ImportError` branch so the module imports cleanly, and any real use raises the intended helpful `ImportError`:

```python
except ImportError:
    langchain_installed = False
    BaseCallbackHandler = object
    LLMResult = object

    def tool(*args, **kwargs):
        is_langchain_installed()
```

After this, importing the module succeeds without langchain, and constructing `CallbackHandler()` or calling `tool()` raises `ImportError: LangChain is not installed...` — the behavior the existing code was clearly written for.

## Tests

Adds `tests/test_core/test_integration_import_guards.py`, which simulates langchain being absent with an import blocker (so it runs deterministically whether or not langchain is installed) and asserts:
- `import deepeval.integrations.langchain` succeeds (no `NameError`),
- `CallbackHandler()` and `tool()` raise `ImportError` matching `"LangChain is not installed"`.

The test fails on `main` (`NameError`) and passes with this change. Formatted with `black`.

## Note

`deepeval/integrations/crewai/handler.py` has the same class-base pattern (`class CrewAIEventsListener(BaseEventListener)`), but its package `__init__` also hard-imports `.subs`/`.tool`, so a clean fix there is larger — I've kept this PR focused on LangChain. Happy to follow up on crewai if you'd like.

