### PR TITLE
fix(crewai): import integration cleanly when crewai is missing (was NameError; dead guard)

### DIFF
--- a/deepeval/integrations/crewai/handler.py
+++ b/deepeval/integrations/crewai/handler.py
@@ -51,6 +51,11 @@ except ImportError as e:
             )
 
     crewai_installed = False
+    # Fallback base class so `class CrewAIEventsListener(BaseEventListener)`
+    # below can still be defined when crewai is absent. Without it, importing
+    # this module raises a cryptic NameError before is_crewai_installed() can
+    # surface the helpful error on use.
+    BaseEventListener = object
 
 # GLOBAL STATE to prevent duplicate listeners
 IS_WRAPPED_ALL = False

--- a/deepeval/integrations/crewai/subs.py
+++ b/deepeval/integrations/crewai/subs.py
@@ -6,13 +6,23 @@ from deepeval.metrics.base_metric import BaseMetric
 try:
     from crewai import Crew, Agent, LLM
 
-    is_crewai_installed = True
+    crewai_installed = True
 except ImportError:
-    is_crewai_installed = False
+    crewai_installed = False
+    # Fallbacks so the factory calls at the bottom of this module do not raise a
+    # NameError at import time when crewai is absent. `Crew`/`Agent` are used as
+    # base classes (must be classes); `LLM` is only invoked lazily inside the
+    # factory wrapper, after the is_crewai_installed() guard has run.
+    Crew = Agent = object
+    LLM = None
 
 
 def is_crewai_installed():
-    if not is_crewai_installed:
+    # NOTE: this must check the `crewai_installed` flag, not a name that shadows
+    # this function. Previously the flag was also named `is_crewai_installed`,
+    # so `not is_crewai_installed` tested this function object (always truthy)
+    # and the ImportError was never raised.
+    if not crewai_installed:
         raise ImportError(
             "CrewAI is not installed. Please install it with `pip install crewai`."
         )

--- a/deepeval/integrations/crewai/tool.py
+++ b/deepeval/integrations/crewai/tool.py
@@ -1,9 +1,16 @@
 import functools
 from typing import Callable
-from crewai.tools import tool as crewai_tool
 
 from deepeval.tracing.context import current_span_context
 from deepeval.tracing.types import ToolSpan
+
+try:
+    from crewai.tools import tool as crewai_tool
+
+    crewai_installed = True
+except ImportError:
+    crewai_installed = False
+    crewai_tool = None
 
 
 def tool(*args, metric=None, metric_collection=None, **kwargs) -> Callable:
@@ -13,6 +20,10 @@ def tool(*args, metric=None, metric_collection=None, **kwargs) -> Callable:
       - accepts additional parameters: metric and metric_collection
       - remains backward compatible with CrewAI's decorator usage patterns
     """
+    if not crewai_installed:
+        raise ImportError(
+            "CrewAI is not installed. Please install it with `pip install crewai`."
+        )
     crewai_kwargs = kwargs
 
     # Case 1: @tool (function passed directly)

--- a/tests/test_core/test_crewai_import_guard.py
+++ b/tests/test_core/test_crewai_import_guard.py
@@ -1,0 +1,79 @@
+"""
+Regression test: the crewai integration must import cleanly even when crewai is
+not installed, and every public entry point must raise a *helpful* ImportError
+when actually used.
+
+crewai's absence is simulated via an import blocker so this runs deterministically
+regardless of whether crewai happens to be installed in the test environment.
+"""
+
+import sys
+import importlib
+from contextlib import contextmanager
+
+import pytest
+
+
+class _BlockModules:
+    """A meta_path finder that makes the given top-level packages look absent."""
+
+    def __init__(self, *blocked):
+        self._blocked = blocked
+
+    def find_spec(self, name, path=None, target=None):
+        if name in self._blocked or name.startswith(
+            tuple(p + "." for p in self._blocked)
+        ):
+            raise ModuleNotFoundError(f"blocked for test: {name}")
+        return None
+
+
+@contextmanager
+def dependency_absent(dep_prefix, integration_module):
+    """Run a block with ``dep_prefix`` forced unavailable, clearing and then
+    restoring cached ``dep_prefix``/``integration_module`` modules so the
+    integration re-imports fresh and later tests are unaffected."""
+    watch = (dep_prefix, integration_module)
+    saved = {k: v for k, v in sys.modules.items() if k.startswith(watch)}
+    for key in list(sys.modules):
+        if key.startswith(watch):
+            del sys.modules[key]
+
+    finder = _BlockModules(dep_prefix)
+    sys.meta_path.insert(0, finder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+        for key in list(sys.modules):
+            if key.startswith(watch):
+                del sys.modules[key]
+        sys.modules.update(saved)
+
+
+def test_crewai_integration_imports_without_crewai():
+    """`import deepeval.integrations.crewai` must not raise NameError when crewai
+    is not installed; every public entry point raises a helpful ImportError.
+
+    Previously the module crashed at import (``NameError: name
+    'BaseEventListener'`` in handler.py, and undefined ``Crew``/``Agent``/``LLM``
+    at the bottom of subs.py), and the ``is_crewai_installed()`` guard in subs.py
+    was shadowed by a same-named flag, so it could never raise.
+    """
+    with dependency_absent("crewai", "deepeval.integrations.crewai"):
+        ci = importlib.import_module("deepeval.integrations.crewai")
+        for attr in ("Crew", "Agent", "LLM", "tool", "instrument_crewai"):
+            assert hasattr(ci, attr)
+
+        with pytest.raises(ImportError, match="CrewAI is not installed"):
+            ci.Crew()
+        with pytest.raises(ImportError, match="CrewAI is not installed"):
+            ci.tool()
+        with pytest.raises(ImportError, match="CrewAI is not installed"):
+            ci.instrument_crewai()
+
+        # The previously-shadowed guard must now actually raise.
+        from deepeval.integrations.crewai.subs import is_crewai_installed
+
+        with pytest.raises(ImportError, match="CrewAI is not installed"):
+            is_crewai_installed()


### PR DESCRIPTION
## Summary

The crewai integration is written to **degrade gracefully** when `crewai` isn't installed: `handler.py` keeps a `crewai_installed` flag and defines `is_crewai_installed()` (called first in `CrewAIEventsListener.__init__`), mirroring how the llama_index integration fails with a clean message. But that path is broken in several ways, so `import deepeval.integrations.crewai` crashes at import time when crewai is absent — and one of the guards can never fire at all.

## Reproduction (without `crewai` installed)

```python
import deepeval.integrations.crewai
```
```
NameError: name 'BaseEventListener' is not defined
```

## Root causes

1. **handler.py** — `class CrewAIEventsListener(BaseEventListener)` references a base class that is undefined in the `except ImportError` branch → `NameError` at import.
2. **subs.py** — the module-scope factory calls `create_deepeval_class(Crew, ...)`, `create_deepeval_class(Agent, ...)`, `create_deepeval_llm(LLM)` reference `Crew`/`Agent`/`LLM`, which are undefined when the import failed → `NameError` at import.
3. **subs.py** — name collision: the flag `is_crewai_installed = True/False` and the function `def is_crewai_installed():` share a name. The function ends up shadowing the flag, so its check `if not is_crewai_installed:` tests the **function object** (always truthy) and the `ImportError` is **never raised**. The guard is dead.
4. **tool.py** — `from crewai.tools import tool as crewai_tool` is a hard top-level import → `ModuleNotFoundError` at import.

## Fix

- **handler.py**: add `BaseEventListener = object` fallback in the except branch.
- **subs.py**: rename the flag to `crewai_installed` (fixing the shadow), and add `Crew = Agent = object` / `LLM = None` fallbacks so the module-scope factories don't `NameError`.
- **tool.py**: guard the `crewai_tool` import and raise the helpful `ImportError` at the top of `tool()`.

After this, `import deepeval.integrations.crewai` succeeds without crewai, and every public entry point — `Crew()`, `Agent()`, `LLM()`, `tool()`, `instrument_crewai()`, and the now-working `is_crewai_installed()` — raises `ImportError: CrewAI is not installed...`.

## Tests

Adds `tests/test_core/test_crewai_import_guard.py`, which simulates crewai being absent via an import blocker (so it runs regardless of whether crewai is installed) and asserts the module imports and each entry point raises the helpful `ImportError`. Fails on `main` (`NameError`), passes with this change. Formatted with `black`.

## Note

This is the crewai counterpart to the LangChain fix in #2872 (same "graceful degradation is broken at import" theme). The two PRs touch disjoint files and can be reviewed/merged independently.
