### PR TITLE
docs: add community health files (CODE_OF_CONDUCT.md, CHANGELOG.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Future features will be listed here
+
+### Changed
+- Ongoing updates
+
+### Fixed
+- Bug fixes
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+- Harassment of any kind
+- Trolling, insulting or derogatory comments
+- Public or private harassment
+- Publishing others' private information without permission
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -609,3 +609,7 @@ Built by the founders of Confident AI. Contact jeffreyip@confident-ai.com for al
 # License
 
 DeepEval is licensed under Apache 2.0 - see the [LICENSE.md](https://github.com/confident-ai/deepeval/blob/main/LICENSE.md) file for details.
+
+---
+
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Summary

Adds missing open-source community health files:

- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **CHANGELOG.md** — Keep a Changelog format, Semantic Versioning
- **README.md** — contributor profile link

### Why
These files help contributors understand how to participate and set community expectations.

---
*[Mukller](https://github.com/Mukller)*