### PR TITLE
fix(dataset): serialize ToolCall type enum as JSON in save_as

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -1269,7 +1269,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            mode="json",
+                                            by_alias=True,
+                                            exclude_none=True,
                                         )
                                     )
                                 elif hasattr(t, "dict"):
@@ -1395,7 +1397,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            mode="json",
+                                            by_alias=True,
+                                            exclude_none=True,
                                         )
                                     )
                                 elif hasattr(t, "dict"):
@@ -1476,7 +1480,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            mode="json",
+                                            by_alias=True,
+                                            exclude_none=True,
                                         )
                                     )
                                 elif hasattr(t, "dict"):

--- a/deepeval/dataset/utils.py
+++ b/deepeval/dataset/utils.py
@@ -187,7 +187,9 @@ def format_turns(turns: List[Turn]) -> str:
             for m in models:
                 if hasattr(m, "model_dump"):
                     dumped.append(
-                        m.model_dump(by_alias=True, exclude_none=True)
+                        m.model_dump(
+                            mode="json", by_alias=True, exclude_none=True
+                        )
                     )
                 elif hasattr(m, "dict"):
                     dumped.append(m.dict(exclude_none=True))

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -10,6 +10,7 @@ from deepeval.test_case import (
     LLMTestCase,
     ConversationalTestCase,
     ToolCall,
+    ToolCallType,
     RetrievedContextData,
 )
 
@@ -239,6 +240,82 @@ class TestSaveAndLoad:
                 if vals[custom_idx]:
                     custom_obj = json.loads(vals[custom_idx])
                     assert custom_obj["col"] == "val"
+
+    def test_save_as_serializes_tool_call_type_as_json_string(self):
+        """Regression: a Golden carrying a ToolCall must serialize the
+        ToolCallType enum as its string value ("FUNCTION"), not as a bare
+        Enum member. mode="json" is required on the ToolCall.model_dump in
+        save_as; without it, json.dump/json.dumps raise
+        `TypeError: Object of type ToolCallType is not JSON serializable`
+        for every json/jsonl/csv export of a tool-use dataset."""
+        dataset = EvaluationDataset(
+            [
+                Golden(
+                    input="hi",
+                    actual_output="ok",
+                    tools_called=[
+                        ToolCall(
+                            name="search",
+                            input_parameters={"q": "foo"},
+                            output={"ok": True},
+                        )
+                    ],
+                    expected_tools=[ToolCall(name="finalize")],
+                )
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # save_as must not raise for any of the three formats
+            json_path = dataset.save_as(
+                "json", directory=tmpdir, file_name="tc_json"
+            )
+            jsonl_path = dataset.save_as(
+                "jsonl", directory=tmpdir, file_name="tc_jsonl"
+            )
+            csv_path = dataset.save_as(
+                "csv", directory=tmpdir, file_name="tc_csv"
+            )
+
+            # Raw JSON: the enum is emitted as the string "FUNCTION", and no
+            # bare Enum repr (e.g. "<ToolCallType.FUNCTION>") leaks to disk.
+            with open(json_path, "r", encoding="utf-8") as f:
+                raw_json = f.read()
+            assert "ToolCallType" not in raw_json
+            row = json.loads(raw_json)[0]
+            assert row["tools_called"][0]["type"] == "FUNCTION"
+            assert row["expected_tools"][0]["type"] == "FUNCTION"
+
+            # Raw JSONL: one JSON object per line, same serialization.
+            with open(jsonl_path, "r", encoding="utf-8") as f:
+                raw_jsonl = f.read()
+            assert "ToolCallType" not in raw_jsonl
+            row = json.loads(raw_jsonl.splitlines()[0])
+            assert row["tools_called"][0]["type"] == "FUNCTION"
+            assert row["expected_tools"][0]["type"] == "FUNCTION"
+
+            # Raw CSV: the tools column holds a JSON string with type
+            # "FUNCTION".
+            with open(csv_path, "r", encoding="utf-8") as f:
+                raw_csv = f.read()
+            assert "ToolCallType" not in raw_csv
+            rows = list(csv.reader(raw_csv.splitlines()))
+            header, vals = rows[0], rows[1]
+            tools = json.loads(vals[header.index("tools_called")])
+            assert tools[0]["type"] == "FUNCTION"
+
+            # Round-trip: each loader rebuilds the ToolCall from the string,
+            # coercing "FUNCTION" back to the ToolCallType enum.
+            for loader, path in (
+                ("add_goldens_from_json_file", json_path),
+                ("add_goldens_from_jsonl_file", jsonl_path),
+                ("add_goldens_from_csv_file", csv_path),
+            ):
+                reloaded = EvaluationDataset()
+                getattr(reloaded, loader)(path)
+                tool = reloaded.goldens[0].tools_called[0]
+                assert tool.name == "search"
+                assert tool.type == ToolCallType.FUNCTION
 
     def test_save_as_round_trips_retrieval_context_data(self):
         """save_as serializes a RetrievedContextData (a type-allowed member of


### PR DESCRIPTION
### Who hits this

Anyone calling `EvaluationDataset.save_as("json" | "jsonl" | "csv", ...)` on a dataset where any `Golden` (or, for multi-turn, any `Turn`) has a non-empty `tools_called` or `expected_tools`. Since tool calls are central to evaluating agent/tool-use, and exporting a dataset to disk is a primary workflow, this makes dataset export a hard crash (no file written) for every tool-use dataset across all three formats.

### Symptom

```
TypeError: Object of type ToolCallType is not JSON serializable
```

### Root cause

In `save_as` (and in `utils.format_turns` for multi-turn), each `ToolCall` is serialized with `t.model_dump(by_alias=True, exclude_none=True)`. That uses Pydantic v2's default `mode="python"`, which leaves the field `type: ToolCallType = ToolCallType.FUNCTION` as a bare `Enum` member. `ToolCallType` is a plain `Enum` (not `str, Enum`), and `type` is never `None`, so `exclude_none` does not drop it. The resulting dict is handed to `json.dump` / `json.dumps`, which cannot serialize a bare Enum.

### Fix

Add `mode="json"` to the `ToolCall.model_dump(...)` at all four serialization sites (single-turn json/jsonl/csv in `deepeval/dataset/dataset.py`; multi-turn `format_turns` in `deepeval/dataset/utils.py`). Pydantic then emits the enum's string value, e.g. `{"name": "x", "type": "FUNCTION"}`. This is the localized, low-risk fix; it has no effect on tool-call-free data.

### Before / after

```python
from deepeval.dataset import EvaluationDataset, Golden
from deepeval.test_case import ToolCall
import tempfile

d = EvaluationDataset()
d.add_golden(Golden(input="hi", tools_called=[ToolCall(name="search")]))
d.save_as("json", tempfile.mkdtemp(), file_name="x")

# Before: TypeError: Object of type ToolCallType is not JSON serializable
# After:  writes x.json with "tools_called": [{"name": "search", "type": "FUNCTION"}]
```

### Tests

Adds `TestSaveAndLoad::test_save_as_serializes_tool_call_type_as_json_string`, which saves a tool-call golden to json, jsonl and csv, asserts no exception, asserts the on-disk `type` is the string `"FUNCTION"` (no bare-enum repr), and round-trips through each loader. The three single-turn export paths are covered directly; the multi-turn `format_turns` path receives the same one-line fix for parity.
