### PR TITLE
feat(benchmarks): add PubMedQA benchmark

### DIFF
--- a/deepeval/benchmarks/__init__.py
+++ b/deepeval/benchmarks/__init__.py
@@ -15,6 +15,7 @@ from .lambada.lambada import LAMBADA
 from .winogrande.winogrande import Winogrande
 from .equity_med_qa.equity_med_qa import EquityMedQA
 from .ifeval.ifeval import IFEval
+from .pub_med_qa.pub_med_qa import PubMedQA
 
 __all__ = [
     "BigBenchHard",
@@ -34,4 +35,5 @@ __all__ = [
     "Winogrande",
     "EquityMedQA",
     "IFEval",
+    "PubMedQA",
 ]

--- a/deepeval/benchmarks/pub_med_qa/__init__.py
+++ b/deepeval/benchmarks/pub_med_qa/__init__.py
@@ -1,0 +1,3 @@
+from .pub_med_qa import PubMedQA
+
+__all__ = ["PubMedQA"]

--- a/deepeval/benchmarks/pub_med_qa/pub_med_qa.py
+++ b/deepeval/benchmarks/pub_med_qa/pub_med_qa.py
@@ -46,9 +46,13 @@ class PubMedQA(DeepEvalBaseBenchmark):
             correct_predictions = 0
             predictions_row = []
             goldens = self.load_benchmark_dataset()[: self.n_problems]
+            if not goldens:
+                raise ValueError(
+                    "PubMedQA dataset must contain at least one problem."
+                )
 
             for idx, golden in enumerate(
-                tqdm(goldens, desc=f"Processing {self.n_problems} problems")
+                tqdm(goldens, desc=f"Processing {len(goldens)} problems")
             ):
                 result = self.predict(model, golden)
                 prediction = result["prediction"]
@@ -66,7 +70,7 @@ class PubMedQA(DeepEvalBaseBenchmark):
                         score,
                     )
 
-            overall_accuracy = correct_predictions / self.n_problems
+            overall_accuracy = correct_predictions / len(goldens)
             print(f"Overall PubMedQA Accuracy: {overall_accuracy}")
 
             self.predictions = pd.DataFrame(

--- a/deepeval/benchmarks/pub_med_qa/pub_med_qa.py
+++ b/deepeval/benchmarks/pub_med_qa/pub_med_qa.py
@@ -1,0 +1,140 @@
+from typing import Dict, List, Optional
+
+from tqdm import tqdm
+
+from deepeval.benchmarks.base_benchmark import (
+    DeepEvalBaseBenchmark,
+    DeepEvalBaseBenchmarkResult,
+)
+from deepeval.benchmarks.pub_med_qa.template import PubMedQATemplate
+from deepeval.benchmarks.schema import PubMedQASchema
+from deepeval.dataset import Golden
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.telemetry import capture_benchmark_run
+
+
+class PubMedQA(DeepEvalBaseBenchmark):
+    def __init__(
+        self,
+        n_problems: int = 1000,
+        verbose_mode: bool = False,
+        confinement_instructions: Optional[str] = None,
+        **kwargs,
+    ):
+        from deepeval.scorer import Scorer
+        import pandas as pd
+
+        assert (
+            0 < n_problems <= 1000
+        ), "PubMedQA only supports 1 to 1000 problems"
+        super().__init__(**kwargs)
+        self.scorer = Scorer()
+        self.n_problems = n_problems
+        self.predictions: Optional[pd.DataFrame] = None
+        self.overall_score: Optional[float] = None
+        self.verbose_mode = verbose_mode
+        self.confinement_instructions = confinement_instructions or (
+            "Output only 'yes', 'no', or 'maybe'."
+        )
+
+    def evaluate(
+        self, model: DeepEvalBaseLLM, *args, **kwargs
+    ) -> DeepEvalBaseBenchmarkResult:
+        import pandas as pd
+
+        with capture_benchmark_run("PubMedQA", self.n_problems):
+            correct_predictions = 0
+            predictions_row = []
+            goldens = self.load_benchmark_dataset()[: self.n_problems]
+
+            for idx, golden in enumerate(
+                tqdm(goldens, desc=f"Processing {self.n_problems} problems")
+            ):
+                result = self.predict(model, golden)
+                prediction = result["prediction"]
+                score = result["score"]
+                correct_predictions += score
+                predictions_row.append(
+                    (golden.input, prediction, golden.expected_output, score)
+                )
+                if self.verbose_mode:
+                    self.print_verbose_logs(
+                        idx,
+                        golden.input,
+                        golden.expected_output,
+                        prediction,
+                        score,
+                    )
+
+            overall_accuracy = correct_predictions / self.n_problems
+            print(f"Overall PubMedQA Accuracy: {overall_accuracy}")
+
+            self.predictions = pd.DataFrame(
+                predictions_row,
+                columns=["Input", "Prediction", "Expected Output", "Correct"],
+            )
+            self.overall_score = overall_accuracy
+            return DeepEvalBaseBenchmarkResult(
+                overall_accuracy=overall_accuracy
+            )
+
+    def predict(self, model: DeepEvalBaseLLM, golden: Golden) -> Dict:
+        prompt = PubMedQATemplate.generate_output(golden.input)
+        structured_prompt = (
+            f'{prompt}\nReturn a JSON object with an "answer" field.'
+        )
+
+        try:
+            res = model.generate(
+                prompt=structured_prompt, schema=PubMedQASchema
+            )
+            if isinstance(res, tuple):
+                res = res[0]
+            prediction = res.answer
+        except TypeError:
+            prompt += f"\n\n{self.confinement_instructions}"
+            prediction = model.generate(prompt)
+
+        if isinstance(prediction, tuple):
+            prediction = prediction[0]
+
+        prediction = str(prediction).strip().lower()
+        score = self.scorer.exact_match_score(
+            golden.expected_output, prediction
+        )
+        return {"prediction": prediction, "score": score}
+
+    def load_benchmark_dataset(self) -> List[Golden]:
+        from datasets import load_dataset
+
+        if self.dataset is None:
+            self.dataset = load_dataset("qiaojin/PubMedQA", "pqa_labeled")
+
+        return [
+            Golden(
+                input=PubMedQATemplate.format_question(data),
+                expected_output=PubMedQATemplate.format_answer(data),
+            )
+            for data in self.dataset["train"]
+        ]
+
+    def print_verbose_logs(
+        self,
+        idx: int,
+        input: str,
+        expected_output: str,
+        prediction: str,
+        score: int,
+    ) -> str:
+        verbose_logs = (
+            f"Input:\n{input}\n \n"
+            f"Score: {score}\nPrediction: {prediction}\n"
+            f"Expected Output: {expected_output}"
+        )
+        if self.verbose_mode:
+            print("*" * 50)
+            print(f"Problem {idx + 1}")
+            print("*" * 50)
+            print(f"\n{verbose_logs}\n")
+            print("=" * 70)
+        return verbose_logs

--- a/deepeval/benchmarks/pub_med_qa/template.py
+++ b/deepeval/benchmarks/pub_med_qa/template.py
@@ -1,0 +1,31 @@
+from typing import Dict, List
+
+
+class PubMedQATemplate:
+    @staticmethod
+    def generate_output(input: str) -> str:
+        return input
+
+    @staticmethod
+    def format_question(data: Dict) -> str:
+        context = data["context"]
+        passages: List[str] = context["contexts"]
+        labels: List[str] = context.get("labels", [])
+
+        formatted_passages = []
+        for index, passage in enumerate(passages):
+            if index < len(labels) and labels[index]:
+                formatted_passages.append(f"{labels[index]}: {passage}")
+            else:
+                formatted_passages.append(passage)
+
+        abstract = "\n".join(formatted_passages)
+        return (
+            f"Question: {data['question']}\n"
+            f"Abstract:\n{abstract}\n"
+            "Answer (yes, no, or maybe): "
+        )
+
+    @staticmethod
+    def format_answer(data: Dict) -> str:
+        return data["final_decision"].lower()

--- a/deepeval/benchmarks/schema.py
+++ b/deepeval/benchmarks/schema.py
@@ -69,6 +69,10 @@ class AffirmationLowerSchema(BaseModel):
     answer: Literal["no", "yes"]
 
 
+class PubMedQASchema(BaseModel):
+    answer: Literal["yes", "no", "maybe"]
+
+
 class BooleanSchema(BaseModel):
     answer: Literal["True", "False"]
 

--- a/docs/content/docs/(benchmarks)/benchmarks-pub-med-qa.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-pub-med-qa.mdx
@@ -1,0 +1,34 @@
+---
+id: benchmarks-pub-med-qa
+title: PubMedQA
+sidebar_label: PubMedQA
+---
+
+**PubMedQA** evaluates biomedical question answering using questions derived from PubMed abstracts. DeepEval uses the 1,000 expert-labeled examples in **PQA-L**, where each answer is `yes`, `no`, or `maybe`.
+
+:::info
+To learn more about the dataset and its construction, read the [original PubMedQA paper](https://arxiv.org/abs/1909.06146) or view the [dataset on Hugging Face](https://huggingface.co/datasets/qiaojin/PubMedQA).
+:::
+
+## Arguments
+
+There are **TWO** optional arguments when using the `PubMedQA` benchmark:
+
+- [Optional] `n_problems`: the number of problems to evaluate. It defaults to 1,000 (all expert-labeled problems).
+- [Optional] `verbose_mode`: whether to print the prompt, prediction, expected output, and score for each problem. It defaults to `False`.
+
+## Usage
+
+The code below evaluates a custom model on 10 PubMedQA problems.
+
+```python
+from deepeval.benchmarks import PubMedQA
+
+benchmark = PubMedQA(n_problems=10)
+
+# Replace 'mistral_7b' with your own custom model
+benchmark.evaluate(model=mistral_7b)
+print(benchmark.overall_score)
+```
+
+The `overall_score` ranges from 0 to 1 and is the proportion of questions for which the model's `yes`, `no`, or `maybe` answer exactly matches the expert label. Predictions are normalized to lowercase and stripped of surrounding whitespace before scoring.

--- a/docs/content/docs/(benchmarks)/meta.json
+++ b/docs/content/docs/(benchmarks)/meta.json
@@ -13,6 +13,7 @@
     "benchmarks-math-qa",
     "benchmarks-logi-qa",
     "benchmarks-bool-q",
+    "benchmarks-pub-med-qa",
     "benchmarks-arc",
     "benchmarks-bbq",
     "benchmarks-lambada",

--- a/tests/test_benchmarks/test_pub_med_qa.py
+++ b/tests/test_benchmarks/test_pub_med_qa.py
@@ -1,0 +1,112 @@
+import pytest
+
+from deepeval.benchmarks import PubMedQA
+from deepeval.benchmarks.pub_med_qa.template import PubMedQATemplate
+from deepeval.dataset import Golden
+
+
+class StructuredModel:
+    def __init__(self, return_cost=False):
+        self.return_cost = return_cost
+
+    def generate(self, prompt, schema):
+        assert "JSON object" in prompt
+        answer = "yes" if "treatment" in prompt else "maybe"
+        response = schema(answer=answer)
+        return (response, 0.0) if self.return_cost else response
+
+
+class UnstructuredModel:
+    def __init__(self):
+        self.prompt = None
+
+    def generate(self, prompt):
+        self.prompt = prompt
+        return " YES \n"
+
+
+def test_format_question_preserves_abstract_sections():
+    data = {
+        "question": "Does the treatment work?",
+        "context": {
+            "contexts": ["Study objective.", "The treatment helped."],
+            "labels": ["BACKGROUND", "RESULTS"],
+        },
+        "final_decision": "yes",
+    }
+
+    prompt = PubMedQATemplate.format_question(data)
+
+    assert "Question: Does the treatment work?" in prompt
+    assert "BACKGROUND: Study objective." in prompt
+    assert "RESULTS: The treatment helped." in prompt
+    assert prompt.endswith("Answer (yes, no, or maybe): ")
+    assert PubMedQATemplate.format_answer(data) == "yes"
+
+
+def test_format_question_handles_missing_section_labels():
+    data = {
+        "question": "Is the evidence conclusive?",
+        "context": {"contexts": ["More research is needed."], "labels": []},
+        "final_decision": "MAYBE",
+    }
+
+    prompt = PubMedQATemplate.format_question(data)
+
+    assert "More research is needed." in prompt
+    assert PubMedQATemplate.format_answer(data) == "maybe"
+
+
+def test_predict_supports_structured_and_unstructured_models():
+    benchmark = PubMedQA(n_problems=1, dataset={"train": []})
+    golden = Golden(input="Does the treatment work?", expected_output="yes")
+
+    structured_result = benchmark.predict(StructuredModel(), golden)
+    fallback_model = UnstructuredModel()
+    fallback_result = benchmark.predict(fallback_model, golden)
+
+    assert structured_result == {"prediction": "yes", "score": 1}
+    assert fallback_result == {"prediction": "yes", "score": 1}
+    assert fallback_model.prompt.endswith(
+        "Output only 'yes', 'no', or 'maybe'."
+    )
+    assert "JSON object" not in fallback_model.prompt
+
+
+def test_predict_handles_native_model_cost_tuple():
+    benchmark = PubMedQA(n_problems=1, dataset={"train": []})
+    golden = Golden(input="Does the treatment work?", expected_output="yes")
+
+    result = benchmark.predict(StructuredModel(return_cost=True), golden)
+
+    assert result == {"prediction": "yes", "score": 1}
+
+
+def test_evaluate_runs_end_to_end_with_in_memory_dataset():
+    dataset = {
+        "train": [
+            {
+                "question": "Does the treatment work?",
+                "context": {
+                    "contexts": ["The treatment helped."],
+                    "labels": ["RESULTS"],
+                },
+                "final_decision": "yes",
+            },
+            {
+                "question": "Is the evidence conclusive?",
+                "context": {
+                    "contexts": ["More research is needed."],
+                    "labels": ["CONCLUSIONS"],
+                },
+                "final_decision": "maybe",
+            },
+        ]
+    }
+    benchmark = PubMedQA(n_problems=2, dataset=dataset)
+
+    result = benchmark.evaluate(StructuredModel())
+
+    assert result.overall_accuracy == pytest.approx(1.0)
+    assert benchmark.overall_score == pytest.approx(1.0)
+    assert benchmark.predictions["Correct"].tolist() == [1, 1]

--- a/tests/test_benchmarks/test_pub_med_qa.py
+++ b/tests/test_benchmarks/test_pub_med_qa.py
@@ -11,7 +11,12 @@ class StructuredModel:
 
     def generate(self, prompt, schema):
         assert "JSON object" in prompt
-        answer = "yes" if "treatment" in prompt else "maybe"
+        if "treatment" in prompt:
+            answer = "yes"
+        elif "no benefit" in prompt:
+            answer = "no"
+        else:
+            answer = "maybe"
         response = schema(answer=answer)
         return (response, 0.0) if self.return_cost else response
 
@@ -101,12 +106,25 @@ def test_evaluate_runs_end_to_end_with_in_memory_dataset():
                 },
                 "final_decision": "maybe",
             },
+            {
+                "question": "Was there no benefit?",
+                "context": {
+                    "contexts": ["The intervention did not improve outcomes."],
+                    "labels": ["RESULTS"],
+                },
+                "final_decision": "no",
+            },
         ]
     }
-    benchmark = PubMedQA(n_problems=2, dataset=dataset)
+    benchmark = PubMedQA(n_problems=3, dataset=dataset)
 
     result = benchmark.evaluate(StructuredModel())
 
     assert result.overall_accuracy == pytest.approx(1.0)
     assert benchmark.overall_score == pytest.approx(1.0)
-    assert benchmark.predictions["Correct"].tolist() == [1, 1]
+    assert benchmark.predictions["Expected Output"].tolist() == [
+        "yes",
+        "maybe",
+        "no",
+    ]
+    assert benchmark.predictions["Correct"].tolist() == [1, 1, 1]

--- a/tests/test_benchmarks/test_pub_med_qa.py
+++ b/tests/test_benchmarks/test_pub_med_qa.py
@@ -87,7 +87,7 @@ def test_predict_handles_native_model_cost_tuple():
     assert result == {"prediction": "yes", "score": 1}
 
 
-def test_evaluate_runs_end_to_end_with_in_memory_dataset():
+def test_evaluate_uses_available_goldens_for_accuracy():
     dataset = {
         "train": [
             {
@@ -116,7 +116,7 @@ def test_evaluate_runs_end_to_end_with_in_memory_dataset():
             },
         ]
     }
-    benchmark = PubMedQA(n_problems=3, dataset=dataset)
+    benchmark = PubMedQA(n_problems=10, dataset=dataset)
 
     result = benchmark.evaluate(StructuredModel())
 
@@ -128,3 +128,10 @@ def test_evaluate_runs_end_to_end_with_in_memory_dataset():
         "no",
     ]
     assert benchmark.predictions["Correct"].tolist() == [1, 1, 1]
+
+
+def test_evaluate_rejects_empty_dataset():
+    benchmark = PubMedQA(n_problems=10, dataset={"train": []})
+
+    with pytest.raises(ValueError, match="at least one problem"):
+        benchmark.evaluate(StructuredModel())


### PR DESCRIPTION
## What

Adds a `PubMedQA` benchmark backed by the 1,000 expert-labeled examples in the PQA-L subset.

The benchmark presents each biomedical question together with its labeled PubMed abstract sections and evaluates the model's `yes`, `no`, or `maybe` answer using exact-match accuracy.

## Changes

- Add `PubMedQA` with configurable `n_problems`, verbose output, and custom confinement instructions.
- Load the `pqa_labeled` configuration from `qiaojin/PubMedQA`.
- Preserve abstract section labels such as `BACKGROUND`, `METHODS`, and `RESULTS` when formatting prompts.
- Add a `PubMedQASchema` that restricts structured responses to `yes`, `no`, or `maybe`.
- Support both direct schema responses and native model `(response, cost)` tuples.
- Fall back to confined plain-text generation when a model does not support schemas.
- Normalize predictions to lowercase and strip surrounding whitespace before exact-match scoring.
- Export `PubMedQA` from `deepeval.benchmarks`.
- Add a benchmark documentation page and navigation entry.

## Usage

```python
from deepeval.benchmarks import PubMedQA

benchmark = PubMedQA(n_problems=10)
benchmark.evaluate(model=my_model)

print(benchmark.overall_score)
```

## Testing

- `pytest -q tests/test_benchmarks/test_pub_med_qa.py` → **5 passed**
- Unit coverage includes:
  - abstract-section prompt formatting
  - missing section labels
  - all three answer labels (`yes`, `no`, and `maybe`)
  - structured and plain-text generation
  - native `(response, cost)` tuples
  - end-to-end evaluation with an in-memory dataset
- Black formatting check passes.
- Loaded and converted all 1,000 PQA-L examples:
  - 552 `yes`
  - 338 `no`
  - 110 `maybe`
- Smoke-tested the live `deepseek-chat` API on one example from each gold-label category (`yes`, `no`, and `maybe`); all three requests completed successfully and produced schema-valid predictions.

The live API smoke test validates provider integration and structured response parsing only; it is not intended to measure model quality.

## References

- Dataset: https://huggingface.co/datasets/qiaojin/PubMedQA
- Paper: https://arxiv.org/abs/1909.06146