### PR TITLE
fix(synthesizer): don't drop context-generation cost when synthesis_cost is 0

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -486,7 +486,7 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
-                if self.synthesis_cost:
+                if self.synthesis_cost is not None:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
                     SynthesizerStatus.SUCCESS,
@@ -605,7 +605,7 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
-            if self.synthesis_cost:
+            if self.synthesis_cost is not None:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(
                 SynthesizerStatus.SUCCESS,
@@ -2119,7 +2119,7 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
-                if self.synthesis_cost:
+                if self.synthesis_cost is not None:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
                     SynthesizerStatus.SUCCESS,
@@ -2236,7 +2236,7 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
-            if self.synthesis_cost:
+            if self.synthesis_cost is not None:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(
                 SynthesizerStatus.SUCCESS,

--- a/tests/test_core/test_synthesizer/test_synthesizer.py
+++ b/tests/test_core/test_synthesizer/test_synthesizer.py
@@ -2,6 +2,7 @@ import asyncio
 import pytest
 import os
 
+from contextlib import contextmanager
 from typing import List
 
 from deepeval.synthesizer.synthesizer import Synthesizer
@@ -477,3 +478,133 @@ async def test_a_generate_conversational_goldens_from_contexts_no_deadlock_when_
         ),
         timeout=0.5,
     )
+
+
+class _CmDummyProgress(DummyProgress):
+    """DummyProgress that also supports the context-manager protocol, needed
+    for the top-level ``with synthesizer_progress_context(...) as (progress,
+    pbar_id), progress:`` double-with pattern in generate/a_generate_goldens_from_docs.
+    """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+@contextmanager
+def _stub_progress_context_with_cm(**kwargs):
+    yield _CmDummyProgress(), None
+
+
+def test_generate_goldens_from_docs_accrues_context_generation_cost(
+    monkeypatch,
+):
+    """Regression: synthesis_cost starts at 0 (not None) for native models, and
+    ``if self.synthesis_cost:`` treats that initial 0 as falsy, so the very
+    first cost accrual from context generation was silently dropped. Assert
+    the accrued cost survives instead of staying at 0.
+    """
+    s = Synthesizer.__new__(Synthesizer)
+    s.async_mode = False
+    s.max_concurrent = 1
+    s.model = DummyModel()
+    s.evolution_config = DummyEvolutionConfig()
+    s.synthetic_goldens = []
+    s.cost_tracking = False
+    s.using_native_model = True  # triggers synthesis_cost = 0 (not None) below
+
+    # ContextConstructionConfig eagerly resolves a default critic model/embedder
+    # in __post_init__; a fake key satisfies that construction-time check. No
+    # real network call happens: ContextGenerator and golden generation are
+    # both mocked out below.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-key-not-real")
+
+    monkeypatch.setattr(
+        synth_mod,
+        "synthesizer_progress_context",
+        _stub_progress_context_with_cm,
+    )
+
+    class FakeContextGenerator:
+        def __init__(self, **kwargs):
+            self.total_cost = 2.5
+            self.total_chunks = 1
+            self.pbar_generate_contexts_id = None
+            self.pbar_chunk_docs_id = None
+            self.pbar_load_docs_id = None
+
+        def generate_contexts(self, **kwargs):
+            return [["chunk1"]], ["doc.txt"], [1.0]
+
+    monkeypatch.setattr(synth_mod, "ContextGenerator", FakeContextGenerator)
+    monkeypatch.setattr(
+        s,
+        "generate_goldens_from_contexts",
+        lambda **kwargs: [Golden(input="q")],
+    )
+
+    s.generate_goldens_from_docs(
+        document_paths=["fake.txt"],
+        context_construction_config=ContextConstructionConfig(
+            allow_cross_file_contexts=False
+        ),
+        _send_data=False,
+    )
+
+    assert s.synthesis_cost == 2.5
+
+
+@pytest.mark.asyncio
+async def test_a_generate_goldens_from_docs_accrues_context_generation_cost(
+    monkeypatch,
+):
+    """Async counterpart of test_generate_goldens_from_docs_accrues_context_generation_cost."""
+    s = Synthesizer.__new__(Synthesizer)
+    s.async_mode = True
+    s.max_concurrent = 1
+    s.model = DummyModel()
+    s.evolution_config = DummyEvolutionConfig()
+    s.synthetic_goldens = []
+    s.cost_tracking = False
+    s.using_native_model = True
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-key-not-real")
+
+    monkeypatch.setattr(
+        synth_mod,
+        "synthesizer_progress_context",
+        _stub_progress_context_with_cm,
+    )
+
+    class FakeContextGenerator:
+        def __init__(self, **kwargs):
+            self.total_cost = 3.5
+            self.total_chunks = 1
+            self.pbar_generate_contexts_id = None
+            self.pbar_chunk_docs_id = None
+            self.pbar_load_docs_id = None
+
+        async def a_generate_contexts(self, **kwargs):
+            return [["chunk1"]], ["doc.txt"], [1.0]
+
+    monkeypatch.setattr(synth_mod, "ContextGenerator", FakeContextGenerator)
+
+    async def fake_a_generate_goldens_from_contexts(**kwargs):
+        return [Golden(input="q")]
+
+    monkeypatch.setattr(
+        s,
+        "a_generate_goldens_from_contexts",
+        fake_a_generate_goldens_from_contexts,
+    )
+
+    await s.a_generate_goldens_from_docs(
+        document_paths=["fake.txt"],
+        context_construction_config=ContextConstructionConfig(
+            allow_cross_file_contexts=False
+        ),
+    )
+
+    assert s.synthesis_cost == 3.5


### PR DESCRIPTION
Closes #2881

## What

`Synthesizer.synthesis_cost` resets to `0` (not `None`) whenever a native model is used, but 4 cost-accrual sites checked `if self.synthesis_cost:` before adding the context generator's cost. `0` is falsy in Python, so the very first accrual was silently dropped every time `generate_goldens_from_docs`/`a_generate_goldens_from_docs`/`generate_conversational_goldens_from_docs`/`a_generate_conversational_goldens_from_docs` ran with a native model — real context-generation cost (LLM calls used to score candidate contexts) vanished from `synthesis_cost` unreported.

The same file already has the correct pattern at 4 other cost-accrual sites (`if self.synthesis_cost is not None:`), so this was a clear copy/refactor slip rather than an intentional check, isolated to these 4 sites.

## How

Change all 4 sites to `if self.synthesis_cost is not None:`, matching the existing correct pattern used elsewhere in the same file. No other behavior changes.

## Tests

Added two regression tests in `tests/test_core/test_synthesizer/test_synthesizer.py`:
- `test_generate_goldens_from_docs_accrues_context_generation_cost` (sync)
- `test_a_generate_goldens_from_docs_accrues_context_generation_cost` (async)

Both build a `Synthesizer` via `Synthesizer.__new__` (no API key needed, following the existing pattern used by the nearby deadlock-regression tests), mock out `ContextGenerator` and the golden-generation step (the only two things that would make real network calls), and assert the mocked context-generation cost survives into `synthesis_cost`.

I verified both tests **fail on `main`** with `assert 0 == 2.5` / `assert 0 == 3.5` (i.e. they reproduce the exact silent-drop) and **pass** with this fix.

Full local verification: `pytest tests/test_core/test_synthesizer/` — 21 passed, 21 skipped (pre-existing `@requires_openai_key`-gated integration tests, unaffected). `black --check` clean on the changed source file; the one docstring-wrapping tweak `black` requested in my new test code is included.

## Type of change

- [x] Bug fix
