### PR TITLE
fix: handle tuple return from custom DeepEvalBaseLLM in Synthesizer

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -841,14 +841,18 @@ class ContextGenerator:
             return (res.clarity + res.depth + res.structure + res.relevance) / 4
         else:
             try:
-                res: ContextScore = self.model.generate(
+                res = self.model.generate(
                     prompt, schema=ContextScore
                 )
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 return (
                     res.clarity + res.depth + res.structure + res.relevance
                 ) / 4
             except TypeError:
                 res = self.model.generate(prompt)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 data = trimAndLoadJson(res, self)
                 score = (
                     data["clarity"]
@@ -867,14 +871,18 @@ class ContextGenerator:
         else:
 
             try:
-                res: ContextScore = await self.model.a_generate(
+                res = await self.model.a_generate(
                     prompt, schema=ContextScore
                 )
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 return (
                     res.clarity + res.depth + res.structure + res.relevance
                 ) / 4
             except TypeError:
-                res: ContextScore = await self.model.a_generate(prompt)
+                res = await self.model.a_generate(prompt)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 data = trimAndLoadJson(res, self)
                 score = (
                     data["clarity"]

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -1692,9 +1692,13 @@ class Synthesizer:
         else:
             try:
                 res = model.generate(prompt, schema=schema)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 return res
             except TypeError:
                 res = model.generate(prompt)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 data = trimAndLoadJson(res, self)
                 # `SyntheticDataList` is nested, so must be manually processed
                 # if custom model doesn't support schema
@@ -1718,9 +1722,13 @@ class Synthesizer:
         else:
             try:
                 res = await model.a_generate(prompt, schema=schema)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 return res
             except TypeError:
                 res = await model.a_generate(prompt)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 data = trimAndLoadJson(res, self)
                 # `SyntheticDataList` is nested, so must be manually processed
                 # if custom model doesn't support schema
@@ -1738,10 +1746,14 @@ class Synthesizer:
             return res
         else:
             try:
-                res: Response = self.model.generate(prompt, schema=Response)
-                return res.response
+                res = self.model.generate(prompt, schema=Response)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
+                return res.response if isinstance(res, Response) else res
             except TypeError:
                 res = self.model.generate(prompt)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 return res
 
     async def _a_generate(self, prompt: str) -> str:
@@ -1752,12 +1764,16 @@ class Synthesizer:
             return res
         else:
             try:
-                res: Response = await self.model.a_generate(
+                res = await self.model.a_generate(
                     prompt, schema=Response
                 )
-                return res.response
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
+                return res.response if isinstance(res, Response) else res
             except TypeError:
                 res = await self.model.a_generate(prompt)
+                if isinstance(res, tuple) and len(res) == 2:
+                    res, _ = res
                 return res
 
     #############################################################


### PR DESCRIPTION
## Summary

Fix `Synthesizer` silently returning 0 goldens when custom `DeepEvalBaseLLM` subclasses are used as `critic_model`.

## Problem

The abstract `DeepEvalBaseLLM.generate()` signature says `-> str`, but all native implementations return `Tuple[Union[str, BaseModel], float]`. Custom subclasses that return tuples (matching native behavior) hit non-native code paths that assume single-value returns:

```
_generate_schema: res = model.generate(prompt, schema=schema)  # returns tuple
                  caller: res.input → AttributeError on tuple → silently dropped
_generate:        res = self.model.generate(prompt, schema=Response)  # tuple
                  res.response → AttributeError → silently dropped
evaluate_chunk:   same pattern
```

## Fix (2 files)

| File | Change |
|---|---|
| `deepeval/synthesizer/chunking/context_generator.py` | Destructure tuple return in `evaluate_chunk` / `a_evaluate_chunk` non-native paths |
| `deepeval/synthesizer/synthesizer.py` | Destructure tuple return in `_generate_schema`, `_a_generate_schema`, `_generate`, `_a_generate` non-native paths |

All 6 non-native code paths now check `isinstance(res, tuple) and len(res) == 2` and destructure before using the result.

Backward compatible — neither the abstract contract nor any native model behavior is changed.

Closes #2885