### PR TITLE
fix(mmlu): improve custom model response handling

### DIFF
--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -162,6 +162,18 @@ class MMLU(DeepEvalBaseBenchmark):
             return DeepEvalBaseBenchmarkResult(
                 overall_accuracy=overall_accuracy
             )
+        
+    def _normalize_prediction(self, prediction: object) -> str:
+        if isinstance(prediction, tuple):
+            prediction = prediction[0]
+
+        raw_prediction = str(prediction)
+        extracted_answer = MMLUTemplate.extract_answer(raw_prediction)
+
+        if extracted_answer is not None:
+            return extracted_answer
+        
+        return raw_prediction.strip()
 
     def predict(
         self, model: DeepEvalBaseLLM, task: MMLUTask, golden: Golden
@@ -190,10 +202,8 @@ class MMLU(DeepEvalBaseBenchmark):
             prompt += f"\n\n{self.confinement_instructions}"
             prediction = model.generate(prompt)
 
-        # For native models, shouldn't happen but just in case
-        if isinstance(prediction, tuple):
-            prediction = prediction[0]
-        prediction = str(prediction)
+        
+        prediction = self._normalize_prediction(prediction)
 
         # Define Metric
         score = self.scorer.exact_match_score(
@@ -233,20 +243,20 @@ class MMLU(DeepEvalBaseBenchmark):
         except TypeError:
             prompts = [
                 prompt
-                + "\n\nOutput 'A', 'B', 'C', or 'D'. Full answer not needed."
+                + f"\n\n{self.confinement_instructions}"
                 for prompt in prompts
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )
 
         res = []
-        for i in range(len(predictions)):
-            prediction = predictions[i]
-            golden = goldens[i]
+        for golden, raw_prediction in zip(goldens, predictions):
+            prediction = self._normalize_prediction(raw_prediction)
+
             # Define Metric
             score = self.scorer.exact_match_score(
                 golden.expected_output, prediction

--- a/deepeval/benchmarks/mmlu/template.py
+++ b/deepeval/benchmarks/mmlu/template.py
@@ -1,5 +1,6 @@
 from deepeval.benchmarks.mmlu.task import MMLUTask
 
+import re
 
 class MMLUTemplate:
 
@@ -37,3 +38,32 @@ class MMLUTemplate:
         for entry in l:
             s += " " + entry
         return s
+
+    @staticmethod
+    def extract_answer(response: object) -> str | None:
+        if response is None:
+            return None
+        
+        text = str(response).strip()
+
+        match = re.fullmatch(
+            r"""
+            (?ix)
+            \s*
+            (?:
+                (?:final\s+)?answer
+                \s*(?:is|:|-)?\s*
+            )?
+            [\(\[]?
+            ([A-D])
+            [\)\]]?
+            [.!]?
+            \s*
+            """,
+            text,
+        )
+
+        if match is None:
+            return None
+        
+        return match.group(1).upper()

--- a/docs/content/docs/benchmarks-introduction.mdx
+++ b/docs/content/docs/benchmarks-introduction.mdx
@@ -79,7 +79,13 @@ class Mistral7B(DeepEvalBaseLLM):
         model.to(device)
 
         generated_ids = model.generate(**model_inputs, max_new_tokens=100, do_sample=True)
-        return self.tokenizer.batch_decode(generated_ids)[0]
+        input_width = model_inputs["input_ids"].shape[1]
+        completion_ids = generated_ids[:, input_width:]
+
+        return self.tokenizer.batch_decode(
+            completion_ids,
+            skip_special_token=True,
+        )[0].strip()
 
     async def a_generate(self, prompt: str) -> str:
         return self.generate(prompt)
@@ -93,7 +99,15 @@ class Mistral7B(DeepEvalBaseLLM):
         model.to(device)
 
         generated_ids = model.generate(**model_inputs, max_new_tokens=100, do_sample=True)
-        return self.tokenizer.batch_decode(generated_ids)
+        input_width = model_inputs["input_ids"].shape[1]
+        completion_ids = generated_ids[:, input_width:]
+
+        return [
+            response.strip()
+            for response in self.tokenizer.batch_decode(
+                completion_ids, skip_special_tokens=True
+            )
+        ]
 
     def get_model_name(self):
         return "Mistral 7B"


### PR DESCRIPTION
## Summary

Improves MMLU evaluation for custom language models that do not support structured output.

The documented Hugging Face custom model [example](https://deepeval.com/docs/benchmarks-introduction#create-a-custom-llm) currently decodes the full sequence returned by decoder-only models. That sequence contains both the input prompt and the newly generated continuation. When the wrapper is later
passed to `MMLU.evaluate()`, the full prompt can become part of the prediction and fail exact-match scoring even when the generated continuation contains the correct choice.

MMLU's non-schema fallback also currently scores the raw response directly, so common unambiguous outputs such as `Answer: C` or `C.` are treated as incorrect.

## Changes

- Update the documented Hugging Face custom model example to decode only newly generated tokens.
- Use `skip_special_tokens=True` when decoding responses.
- Apply completion-only decoding in both `generate()` and `batch_generate()`.
- Add conservative MMLU answer extraction for common response formats.
- Apply the same normalization in single and batch evaluation paths.
- Respect custom `confinement_instructions` during batch fallback generation.
- Fix the batch prediction length comparison to use value inequality.
- Add tests for accepted, invalid, and ambiguous response formats.

## Supported response formats

Examples normalized to a single choice include:

- `C`
- `c`
- `C.`
- `(C)`
- `Answer: C`
- `The answer is C.`
- `Final answer: C`

Long or ambiguous responses containing multiple possible choices are not parsed.

## Why this matters

For decoder-only Hugging Face models, `model.generate()` returns the input token IDs followed by newly generated token IDs. Decoding the complete sequence causes the evaluation prompt to be returned as part of the prediction.

MMLU compares predictions against `A`, `B`, `C`, or `D`. This change prevents valid generated choices from being marked incorrect solely because of prompt echo or harmless answer formatting.


## Validation

- Manually reproduced the documented Hugging Face prompt-echo behavior with a local decoder-only model.
- Verified that decoding only newly generated tokens removes the input prompt from the returned response.
- Reviewed single and batch MMLU fallback paths to ensure the same normalization logic is applied.

## Related

Related to #914  
Related to #819  
Follow-up to #918