### PR TITLE
feat(evaluate): recalculate pass rates against new thresholds without re-running

### DIFF
--- a/deepeval/evaluate/types.py
+++ b/deepeval/evaluate/types.py
@@ -1,5 +1,5 @@
 from typing import Optional, List, Union, Dict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pydantic import BaseModel
 
 from deepeval.test_run.api import MetricData, TurnApi
@@ -27,10 +27,100 @@ class TestResult:
     metadata: Optional[Dict] = None
 
 
+def _recalculate_metric_success(
+    metric_data: MetricData, threshold: float
+) -> bool:
+    """Recompute a single metric's pass/fail against a new threshold.
+
+    Mirrors the pass/fail semantics used during evaluation: a metric that
+    errored or has no score fails, otherwise it passes when its score meets
+    the threshold.
+    """
+    if metric_data.error is not None:
+        return False
+    if metric_data.score is None:
+        return False
+    return metric_data.score >= threshold
+
+
+def _recalculate_test_result(
+    test_result: TestResult, thresholds: Dict[str, float]
+) -> TestResult:
+    """Return a copy of ``test_result`` with statuses recomputed.
+
+    Metrics whose name is absent from ``thresholds`` keep their original
+    threshold and status. The original ``test_result`` is not mutated.
+    """
+    if not test_result.metrics_data:
+        return replace(test_result)
+
+    recalculated_metrics_data: List[MetricData] = []
+    for metric_data in test_result.metrics_data:
+        if metric_data.name in thresholds:
+            new_threshold = thresholds[metric_data.name]
+            recalculated_metrics_data.append(
+                metric_data.model_copy(
+                    update={
+                        "threshold": new_threshold,
+                        "success": _recalculate_metric_success(
+                            metric_data, new_threshold
+                        ),
+                    }
+                )
+            )
+        else:
+            recalculated_metrics_data.append(metric_data.model_copy())
+
+    success = all(
+        metric_data.success for metric_data in recalculated_metrics_data
+    )
+    return replace(
+        test_result,
+        metrics_data=recalculated_metrics_data,
+        success=success,
+    )
+
+
 class EvaluationResult(BaseModel):
     test_results: List[TestResult]
     confident_link: Optional[str]
     test_run_id: Optional[str]
+
+    def recalculate_results(
+        self,
+        thresholds: Dict[str, float],
+        print_results: bool = True,
+    ) -> "EvaluationResult":
+        """Recompute pass/fail statuses and pass rates using new thresholds.
+
+        Reuses the scores already produced by ``evaluate`` to recompute each
+        metric's pass/fail status and the overall pass/fail of every test case
+        against new per-metric thresholds. No LLM evaluations are re-run, and
+        the original ``EvaluationResult`` (and its scores and reasons) is left
+        untouched: a new ``EvaluationResult`` carrying the recalculated
+        statuses is returned.
+
+        :param thresholds: Mapping of metric name to the new threshold to
+            apply. Metrics whose name is not present keep their original
+            threshold and status.
+        :param print_results: When ``True`` (default), print the recalculated
+            overall metric pass rates.
+        :return: A new ``EvaluationResult`` with recomputed statuses.
+        """
+        recalculated = EvaluationResult(
+            test_results=[
+                _recalculate_test_result(test_result, thresholds)
+                for test_result in self.test_results
+            ],
+            confident_link=self.confident_link,
+            test_run_id=self.test_run_id,
+        )
+        if print_results:
+            # Imported lazily to avoid a circular import at module load time.
+            from deepeval.evaluate.utils import aggregate_metric_pass_rates
+
+            aggregate_metric_pass_rates(recalculated.test_results)
+        return recalculated
 
 
 class PostExperimentRequest(BaseModel):

--- a/tests/test_core/test_evaluation/test_recalculate_results.py
+++ b/tests/test_core/test_evaluation/test_recalculate_results.py
@@ -1,0 +1,139 @@
+"""Tests for ``EvaluationResult.recalculate_results``.
+
+The recalculation replays the scores already produced by ``evaluate`` against
+new thresholds, so these tests run fully offline (no models involved).
+"""
+
+from deepeval.evaluate.types import EvaluationResult, TestResult
+from deepeval.test_run.api import MetricData
+
+
+def _metric(
+    name: str, score, threshold: float, error: str = None
+) -> MetricData:
+    return MetricData(
+        name=name,
+        threshold=threshold,
+        success=(error is None and score is not None and score >= threshold),
+        score=score,
+        reason="because",
+        error=error,
+    )
+
+
+def _evaluation_result() -> EvaluationResult:
+    # Faithfulness fails at 0.9 (score 0.6); Relevancy passes at 0.5.
+    test_result_1 = TestResult(
+        name="tc_1",
+        success=False,
+        metrics_data=[
+            _metric("Faithfulness", 0.6, 0.9),
+            _metric("Relevancy", 0.8, 0.5),
+        ],
+        conversational=False,
+    )
+    # Faithfulness passes at 0.9 (score 0.95); Relevancy passes at 0.5.
+    test_result_2 = TestResult(
+        name="tc_2",
+        success=True,
+        metrics_data=[
+            _metric("Faithfulness", 0.95, 0.9),
+            _metric("Relevancy", 0.7, 0.5),
+        ],
+        conversational=False,
+    )
+    return EvaluationResult(
+        test_results=[test_result_1, test_result_2],
+        confident_link=None,
+        test_run_id="run-123",
+    )
+
+
+def test_lowering_threshold_flips_metric_and_case_to_pass():
+    result = _evaluation_result()
+    recalculated = result.recalculate_results(
+        {"Faithfulness": 0.5}, print_results=False
+    )
+
+    # tc_1's Faithfulness (0.6) now passes against the lowered 0.5 threshold,
+    # so the whole test case passes too.
+    tc_1 = recalculated.test_results[0]
+    assert tc_1.metrics_data[0].name == "Faithfulness"
+    assert tc_1.metrics_data[0].threshold == 0.5
+    assert tc_1.metrics_data[0].success is True
+    assert tc_1.success is True
+
+
+def test_raising_threshold_flips_metric_and_case_to_fail():
+    result = _evaluation_result()
+    recalculated = result.recalculate_results(
+        {"Relevancy": 0.85}, print_results=False
+    )
+
+    # tc_2's Relevancy (0.7) now fails against the raised 0.85 threshold.
+    tc_2 = recalculated.test_results[1]
+    relevancy = next(m for m in tc_2.metrics_data if m.name == "Relevancy")
+    assert relevancy.threshold == 0.85
+    assert relevancy.success is False
+    assert tc_2.success is False
+
+
+def test_original_result_is_not_mutated():
+    result = _evaluation_result()
+    result.recalculate_results({"Faithfulness": 0.5}, print_results=False)
+
+    original_faithfulness = result.test_results[0].metrics_data[0]
+    assert original_faithfulness.threshold == 0.9
+    assert original_faithfulness.success is False
+    assert result.test_results[0].success is False
+    # Metadata is carried over onto the returned result, not lost.
+    assert result.test_run_id == "run-123"
+
+
+def test_metrics_absent_from_thresholds_are_unchanged():
+    result = _evaluation_result()
+    recalculated = result.recalculate_results(
+        {"Faithfulness": 0.5}, print_results=False
+    )
+
+    relevancy = recalculated.test_results[0].metrics_data[1]
+    assert relevancy.name == "Relevancy"
+    assert relevancy.threshold == 0.5
+    assert relevancy.success is True
+
+
+def test_errored_metric_stays_failed_regardless_of_threshold():
+    test_result = TestResult(
+        name="tc_error",
+        success=False,
+        metrics_data=[_metric("Faithfulness", None, 0.9, error="boom")],
+        conversational=False,
+    )
+    result = EvaluationResult(
+        test_results=[test_result], confident_link=None, test_run_id=None
+    )
+
+    recalculated = result.recalculate_results(
+        {"Faithfulness": 0.0}, print_results=False
+    )
+    metric = recalculated.test_results[0].metrics_data[0]
+    assert metric.success is False
+    assert recalculated.test_results[0].success is False
+
+
+def test_test_case_without_metrics_data_is_preserved():
+    test_result = TestResult(
+        name="tc_none",
+        success=True,
+        metrics_data=None,
+        conversational=False,
+    )
+    result = EvaluationResult(
+        test_results=[test_result], confident_link=None, test_run_id=None
+    )
+
+    recalculated = result.recalculate_results(
+        {"Faithfulness": 0.5}, print_results=False
+    )
+    assert recalculated.test_results[0].success is True
+    assert recalculated.test_results[0].metrics_data is None


### PR DESCRIPTION
Closes #1996.

### Problem

After an `evaluate()` run, the only way to see how different thresholds would affect pass/fail is to re-run the whole evaluation — paying the LLM cost again — even though the per-metric scores are already computed and stored. There was no way to replay those scores against new thresholds.

### Change

Add `EvaluationResult.recalculate_results(thresholds, print_results=True)`:

- Recomputes each metric's pass/fail and each test case's overall pass/fail against new per-metric thresholds, reusing the scores already produced by `evaluate()`. **No LLM evaluations are re-run.**
- Non-destructive: returns a **new** `EvaluationResult`; the original result (including its scores and reasons) is left untouched, so nothing is duplicated or lost.
- Metrics whose name is not in `thresholds` keep their original threshold and status.
- Pass/fail semantics match evaluation exactly (errored or score-less metrics fail; otherwise pass when `score >= threshold`).
- When `print_results=True`, prints the recalculated overall pass rates via the existing `aggregate_metric_pass_rates`.

```python
results = evaluate(test_cases, metrics=[faithfulness, relevancy])

# Explore a lower Faithfulness bar without spending anything on the LLM again
what_if = results.recalculate_results({"Faithfulness": 0.5})
```

### Tests

`tests/test_core/test_evaluation/test_recalculate_results.py` covers lowering/raising thresholds (pass↔fail flips at both metric and test-case level), untouched originals, metrics absent from the map, errored metrics, and cases without metric data. All run fully offline.
