### PR TITLE
docs: fix small typo in evaluation-datasets.mdx

### DIFF
--- a/docs/content/docs/(concepts)/evaluation-datasets.mdx
+++ b/docs/content/docs/(concepts)/evaluation-datasets.mdx
@@ -15,7 +15,7 @@ There are two approaches to running evals using datasets in `deepeval`:
 1. Using `deepeval test run`
 2. Using `evaluate`
 
-Depending on the type of goldens you supply, datasets are either **single-turn** or **mult-turn**. Evaluating a dataset means exactly the same as evaluating your LLM system, because by definition a dataset contains all the information produced by your LLM needed for evaluation.
+Depending on the type of goldens you supply, datasets are either **single-turn** or **multi-turn**. Evaluating a dataset means exactly the same as evaluating your LLM system, because by definition a dataset contains all the information produced by your LLM needed for evaluation.
 
 <details>
 


### PR DESCRIPTION
Fix small typo (`mult-turn` -> `multi-turn`) in evaluation-datasets.mdx