### PR TITLE
feat: add TokenBudgetMetric — deterministic token/cost budget gate for agent traces

### DIFF
--- a/deepeval/metrics/__init__.py
+++ b/deepeval/metrics/__init__.py
@@ -37,6 +37,7 @@ from .tool_use.tool_use import ToolUseMetric
 from .goal_accuracy.goal_accuracy import GoalAccuracyMetric
 from .argument_correctness.argument_correctness import ArgumentCorrectnessMetric
 from .agent_loop_detection.agent_loop_detection import AgentLoopDetectionMetric
+from .token_budget.token_budget import TokenBudgetMetric
 from .mcp.mcp_task_completion import MCPTaskCompletionMetric
 from .mcp.multi_turn_mcp_use_metric import MultiTurnMCPUseMetric
 from .mcp_use_metric.mcp_use_metric import MCPUseMetric
@@ -120,6 +121,7 @@ __all__ = [
     "ToolUseMetric",
     "GoalAccuracyMetric",
     "AgentLoopDetectionMetric",
+    "TokenBudgetMetric",
     # Conversational metrics
     "TurnRelevancyMetric",
     "ConversationCompletenessMetric",

--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,9 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from ..token_budget.token_budget import TokenBudgetMetric
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "TokenBudgetMetric",
 ]

--- a/deepeval/metrics/token_budget/__init__.py
+++ b/deepeval/metrics/token_budget/__init__.py
@@ -1,0 +1,1 @@
+from .token_budget import TokenBudgetMetric

--- a/deepeval/metrics/token_budget/token_budget.py
+++ b/deepeval/metrics/token_budget/token_budget.py
@@ -1,0 +1,416 @@
+from typing import Optional, List, Dict, Tuple
+
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.metrics import BaseMetric
+from deepeval.metrics.utils import (
+    construct_verbose_logs,
+    check_llm_test_case_params,
+)
+from deepeval.metrics.indicator import metric_progress_indicator
+
+
+class TokenBudgetMetric(BaseMetric):
+    """Gates an agent run against token and/or cost budgets.
+
+    Walks the agent's execution trace, sums token usage and cost across every
+    LLM span, and checks the totals against the budgets you set.  This is a
+    fully **deterministic** metric — no LLM, no API key — so it is cheap and
+    reliable to run as a CI gate or in production to catch runs that blow past
+    their expected token / cost envelope.
+
+    You enable a budget simply by setting it (any budget left ``None`` is
+    disabled):
+
+    - ``max_total_tokens`` — cap on ``input + output`` tokens across all LLM spans.
+    - ``max_input_tokens`` — cap on input (prompt) tokens only.
+    - ``max_output_tokens`` — cap on output (completion) tokens only.
+    - ``max_cost`` — cap on total dollar cost across all LLM spans.
+
+    At least one budget must be provided.
+
+    Scoring
+    ~~~~~~~
+    The score is a **graded ratio**, not a simple pass/fail.  For each enabled
+    budget the metric computes ``spent / limit``:
+
+    - If the run is under the budget, that budget's sub-score is ``1.0``.
+    - If it is over, the sub-score degrades as ``limit / spent`` — so being
+      twice over budget scores ``0.5``, three times over scores ``0.33``, etc.
+
+    The overall score is the **minimum** across all enabled budgets: the run is
+    only as good as its worst-breached budget.  This makes the metric a strict
+    gate — a single breached budget fails the run.  Under ``strict_mode`` the
+    score collapses to a binary ``1.0`` (all budgets respected) or ``0.0`` (any
+    budget breached).
+
+    Cost accounting
+    ~~~~~~~~~~~~~~~
+    The trace dict exposes ``cost_per_input_token`` and ``cost_per_output_token``
+    as *per-token rates* (not totals), so a span's cost is computed as::
+
+        input_token_count  * cost_per_input_token
+      + output_token_count * cost_per_output_token
+
+    A span only contributes to the cost total when both the token count *and*
+    its per-token rate are present.  Spans that report tokens but no per-token
+    rate are counted as ``unpriced`` and surfaced in the reason so a
+    cheap-looking run is never silently trusted.
+
+    Design decisions
+    ~~~~~~~~~~~~~~~~
+    * **Fully deterministic** — no ``model`` parameter.  Every value is read
+      straight from the trace and summed; an LLM would add nothing.  This keeps
+      the metric zero-cost and safe to run on every request in production.
+    * **Graded, not binary (by default)** — a graded ratio tells you *how far*
+      over budget a run went, which is far more actionable than a bare
+      pass/fail.  ``strict_mode`` is available when a binary gate is preferred.
+    * **Missing token data is reported, not guessed** — spans without token
+      counts contribute ``0`` but are counted separately and reported, so the
+      score is never silently based on partial data.
+
+    Limitations
+    ~~~~~~~~~~~
+    * **No latency / duration budget.**  ``create_nested_spans_dict`` strips
+      ``start_time`` and ``end_time`` (along with ``uuid`` and ``status``) from
+      the trace dict, so span timing is simply unavailable to this metric.  It
+      can gate tokens and cost but *cannot* gate wall-clock latency.
+    * **Cost requires per-token rates.**  Integrations that record token counts
+      but not ``cost_per_*_token`` will produce a token total but no cost for
+      those spans.  The ``max_cost`` budget is only meaningful when your
+      integration populates per-token pricing.
+    * **Token counts are provider-reported** and are only as accurate as the
+      integration that recorded them.
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        max_total_tokens: Optional[float] = None,
+        max_input_tokens: Optional[float] = None,
+        max_output_tokens: Optional[float] = None,
+        max_cost: Optional[float] = None,
+        threshold: float = 1.0,
+        include_reason: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+    ):
+        if (
+            max_total_tokens is None
+            and max_input_tokens is None
+            and max_output_tokens is None
+            and max_cost is None
+        ):
+            raise ValueError(
+                "TokenBudgetMetric requires at least one budget: set one or "
+                "more of `max_total_tokens`, `max_input_tokens`, "
+                "`max_output_tokens`, or `max_cost`."
+            )
+
+        self.max_total_tokens = max_total_tokens
+        self.max_input_tokens = max_input_tokens
+        self.max_output_tokens = max_output_tokens
+        self.max_cost = max_cost
+
+        self.threshold = 1.0 if strict_mode else threshold
+        self.include_reason = include_reason
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+
+        # Deterministic metric: no evaluation model is used.
+        self.model = None
+        self.using_native_model = False
+        self.evaluation_model = None
+        self.async_mode = False
+        self.requires_trace = True
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+        _log_metric_to_confident: bool = True,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            test_case.multimodal,
+        )
+
+        self.evaluation_cost = 0
+
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            self._calculate_metric(test_case)
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+        _log_metric_to_confident: bool = True,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            test_case.multimodal,
+        )
+
+        self.evaluation_cost = 0
+
+        with metric_progress_indicator(
+            self,
+            async_mode=True,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        ):
+            self._calculate_metric(test_case)
+            return self.score
+
+    def _calculate_metric(self, test_case: LLMTestCase):
+        if test_case._trace_dict is None:
+            self.score = 0.0
+            self.success = False
+            self.reason = (
+                "No trace data found. This metric requires trace "
+                "data from @observe."
+            )
+            self.verbose_logs = ""
+            return
+
+        all_spans = self._extract_all_spans(test_case._trace_dict)
+        llm_spans = [s for s in all_spans if s.get("type") == "llm"]
+
+        usage = self._aggregate_usage(llm_spans)
+
+        sub_scores: Dict[str, float] = {}
+        breakdown: Dict[str, Dict] = {}
+        breach_reasons: List[str] = []
+
+        budgets = [
+            ("total_tokens", self.max_total_tokens, usage["total_tokens"]),
+            ("input_tokens", self.max_input_tokens, usage["input_tokens"]),
+            ("output_tokens", self.max_output_tokens, usage["output_tokens"]),
+            ("cost", self.max_cost, usage["cost"]),
+        ]
+
+        for name, limit, spent in budgets:
+            if limit is None:
+                continue
+            sub_score, ratio = self._budget_sub_score(spent, limit)
+            sub_scores[name] = sub_score
+            breakdown[name] = {
+                "spent": spent,
+                "limit": limit,
+                "ratio": ratio,
+                "sub_score": sub_score,
+            }
+            if sub_score < 1.0:
+                breach_reasons.append(
+                    self._format_breach(name, spent, limit, ratio)
+                )
+
+        # sub_scores is guaranteed non-empty: __init__ requires >= 1 budget.
+        raw_score = min(sub_scores.values())
+
+        if self.strict_mode:
+            self.score = 1.0 if raw_score >= 1.0 else 0.0
+        else:
+            self.score = raw_score
+
+        breakdown["most_expensive_span"] = usage["most_expensive_span"]
+        breakdown["llm_span_count"] = usage["llm_span_count"]
+        breakdown["untokened_spans"] = usage["untokened_spans"]
+        breakdown["unpriced_spans"] = usage["unpriced_spans"]
+        self.score_breakdown = breakdown
+
+        self.success = self.score >= self.threshold
+        self.reason = self._build_reason(usage, breach_reasons)
+
+        self.verbose_logs = construct_verbose_logs(
+            self,
+            steps=[
+                f"LLM spans: {usage['llm_span_count']} "
+                f"(untokened: {usage['untokened_spans']}, "
+                f"unpriced: {usage['unpriced_spans']})",
+                f"Total tokens: {usage['total_tokens']} "
+                f"(input: {usage['input_tokens']}, "
+                f"output: {usage['output_tokens']})",
+                f"Total cost: {usage['cost']}",
+                f"Budget sub-scores: {sub_scores}",
+                f"Score: {self.score}",
+                f"Reason: {self.reason}",
+            ],
+        )
+
+    def _extract_all_spans(self, trace_dict: Optional[Dict]) -> List[Dict]:
+        if not trace_dict:
+            return []
+
+        spans: List[Dict] = []
+
+        def traverse(span: Dict):
+            if span:
+                spans.append(span)
+                for child in span.get("children", []):
+                    traverse(child)
+
+        traverse(trace_dict)
+        return spans
+
+    def _aggregate_usage(self, llm_spans: List[Dict]) -> Dict:
+        """Sum tokens and cost across LLM spans, tracking data gaps.
+
+        Token counts and per-token rates are ``Optional[float]`` on the trace
+        span, so every access is null-guarded.  A span contributes to the cost
+        total only when both its token count and the matching per-token rate
+        are present; spans missing token data or pricing are counted so the
+        reason can flag partial coverage.
+        """
+        total_input = 0.0
+        total_output = 0.0
+        total_cost = 0.0
+        untokened_spans = 0
+        unpriced_spans = 0
+        most_expensive_span: Optional[Dict] = None
+
+        for span in llm_spans:
+            in_count = span.get("input_token_count")
+            out_count = span.get("output_token_count")
+            in_rate = span.get("cost_per_input_token")
+            out_rate = span.get("cost_per_output_token")
+
+            if in_count is None and out_count is None:
+                untokened_spans += 1
+
+            if in_count is not None:
+                total_input += in_count
+            if out_count is not None:
+                total_output += out_count
+
+            span_cost = 0.0
+            span_priced = False
+            if in_count is not None and in_rate is not None:
+                span_cost += in_count * in_rate
+                span_priced = True
+            if out_count is not None and out_rate is not None:
+                span_cost += out_count * out_rate
+                span_priced = True
+
+            has_tokens = in_count is not None or out_count is not None
+            if has_tokens and not span_priced:
+                unpriced_spans += 1
+
+            if span_priced:
+                total_cost += span_cost
+                if (
+                    most_expensive_span is None
+                    or span_cost > most_expensive_span["cost"]
+                ):
+                    most_expensive_span = {
+                        "name": span.get("name", "unnamed"),
+                        "cost": span_cost,
+                    }
+
+        return {
+            "input_tokens": total_input,
+            "output_tokens": total_output,
+            "total_tokens": total_input + total_output,
+            "cost": total_cost,
+            "llm_span_count": len(llm_spans),
+            "untokened_spans": untokened_spans,
+            "unpriced_spans": unpriced_spans,
+            "most_expensive_span": most_expensive_span,
+        }
+
+    @staticmethod
+    def _budget_sub_score(
+        spent: float, limit: float
+    ) -> Tuple[float, Optional[float]]:
+        """Return ``(sub_score, ratio)`` for one budget.
+
+        ``ratio`` is ``spent / limit``.  A run under budget scores ``1.0``; a
+        run over budget degrades as ``limit / spent`` (2x over -> 0.5).  A
+        ``limit`` of ``0`` is a degenerate budget: any spend breaches it (0.0),
+        no spend respects it (1.0).
+        """
+        if limit <= 0:
+            if spent <= 0:
+                return 1.0, 0.0 if limit == 0 else None
+            return 0.0, None
+        ratio = spent / limit
+        if ratio <= 1.0:
+            return 1.0, ratio
+        return limit / spent, ratio
+
+    @staticmethod
+    def _format_breach(
+        name: str, spent: float, limit: float, ratio: Optional[float]
+    ) -> str:
+        label = name.replace("_", " ")
+        if name == "cost":
+            spent_str = f"${spent:.6f}"
+            limit_str = f"${limit:.6f}"
+        else:
+            spent_str = f"{spent:g}"
+            limit_str = f"{limit:g}"
+        over = f" ({ratio:.2f}x budget)" if ratio is not None else ""
+        return f"{label} {spent_str} exceeded budget {limit_str}{over}."
+
+    def _build_reason(self, usage: Dict, breach_reasons: List[str]) -> str:
+        if not self.include_reason:
+            return ""
+
+        parts: List[str] = []
+        if breach_reasons:
+            parts.append(" ".join(breach_reasons))
+        elif usage["llm_span_count"] == 0:
+            # No LLM spans at all — the budget could not be measured, so we
+            # must not claim it was "respected". The score stays 1.0 (an agent
+            # legitimately may make no LLM calls) but the reason says so plainly.
+            parts.append(
+                "No LLM spans found in the trace; token/cost budgets could "
+                "not be measured."
+            )
+        else:
+            parts.append("All token and cost budgets respected.")
+
+        if usage["untokened_spans"]:
+            parts.append(
+                f"{usage['untokened_spans']} of {usage['llm_span_count']} "
+                f"LLM spans had no token data."
+            )
+        if usage["unpriced_spans"]:
+            parts.append(
+                f"{usage['unpriced_spans']} of {usage['llm_span_count']} "
+                f"LLM spans had tokens but no per-token pricing "
+                f"(excluded from cost)."
+            )
+        return " ".join(parts)
+
+    def is_successful(self) -> bool:
+        if self.error is not None:
+            self.success = False
+        else:
+            try:
+                self.success = self.score >= self.threshold
+            except TypeError:
+                self.success = False
+        return self.success
+
+    @property
+    def __name__(self):
+        return "Token Budget"

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -4,6 +4,7 @@
     "community-metrics-overview",
     "metrics-citation-faithfulness",
     "metrics-agent-loop-detection",
-    "metrics-tool-permission"
+    "metrics-tool-permission",
+    "metrics-token-budget"
   ]
 }

--- a/docs/content/docs/(community)/metrics-token-budget.mdx
+++ b/docs/content/docs/(community)/metrics-token-budget.mdx
@@ -1,0 +1,198 @@
+---
+id: metrics-token-budget
+title: Token Budget
+sidebar_label: Token Budget
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} usesLLMs={false} agent={true} referenceless={true} />
+
+The Token Budget metric is a **fully deterministic** (no LLM required) agentic metric that gates an agent run against token and/or cost budgets. It walks the agent's full execution trace, sums token usage and cost across every LLM span, and checks the totals against the budgets you set — returning a score from **0.0** (far over budget) to **1.0** (within every budget).
+
+::::info
+Token Budget analyzes your **agent's full execution trace**, which requires [setting up tracing](/docs/evaluation-llm-tracing). Because it is fully deterministic, it runs in production without any API key or LLM call.
+::::
+
+## Required Arguments
+
+The `TokenBudgetMetric` is a **trace-only** metric. It reads token counts and per-token pricing from the LLM spans in the agent trace and does **not** require `tools_called` or `expected_tools`. It only requires the standard trace-based fields:
+
+- `input`
+- `actual_output`
+
+## Usage
+
+To begin, [set up tracing](/docs/evaluation-llm-tracing) and supply the `TokenBudgetMetric()` to your `evals_iterator`.
+
+```python
+from deepeval.tracing import observe, update_current_trace
+from deepeval.dataset import Golden, EvaluationDataset
+from deepeval.metrics.community import TokenBudgetMetric
+
+
+@observe()
+def my_agent(input: str) -> str:
+    # Your agent logic here (LLM calls recorded via @observe llm spans)
+    result = "..."
+    update_current_trace(input=input, output=result)
+    return result
+
+
+# Create dataset
+dataset = EvaluationDataset(goldens=[Golden(input="What is the weather in Paris?")])
+
+# Initialize metric — no model or API key needed. Fail runs that exceed
+# 10k total tokens OR $0.05 in cost.
+budget_metric = TokenBudgetMetric(max_total_tokens=10000, max_cost=0.05)
+
+# Evaluate
+for golden in dataset.evals_iterator(metrics=[budget_metric]):
+    my_agent(golden.input)
+```
+
+There are **EIGHT** optional parameters when creating a `TokenBudgetMetric` (at least one budget must be set):
+
+- [Optional] `max_total_tokens`: a float capping `input + output` tokens summed across all LLM spans. Defaulted to `None` (disabled).
+- [Optional] `max_input_tokens`: a float capping input (prompt) tokens only. Defaulted to `None` (disabled).
+- [Optional] `max_output_tokens`: a float capping output (completion) tokens only. Defaulted to `None` (disabled).
+- [Optional] `max_cost`: a float capping the total dollar cost across all LLM spans. Defaulted to `None` (disabled).
+- [Optional] `threshold`: a float representing the minimum passing score, defaulted to `1.0`.
+- [Optional] `include_reason`: a boolean which when `True` generates a human-readable reason for the score. Defaulted to `True`.
+- [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: 1 if every budget is respected, 0 if any is breached. It also overrides the current threshold and sets it to 1. Defaulted to `False`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console. Defaulted to `False`.
+
+::::caution
+`TokenBudgetMetric` raises a `ValueError` if you construct it without at least one of `max_total_tokens`, `max_input_tokens`, `max_output_tokens`, or `max_cost` — there is nothing to gate against otherwise.
+::::
+
+::::info
+The `TokenBudgetMetric` does **not** accept a `model` parameter. Every value it needs is read directly from the trace and summed — an LLM would add nothing. See [Why no `model` parameter?](#why-no-model-parameter) for the design rationale.
+::::
+
+To learn more about how the `evals_iterator` works, [click here.](/docs/evaluation-end-to-end-llm-evals#e2e-evals-for-tracing)
+
+### As a standalone
+
+You can also run `TokenBudgetMetric` on a single test case as a standalone, one-off execution:
+
+```python
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.community import TokenBudgetMetric
+
+# test_case._trace_dict must be populated from @observe tracing
+metric = TokenBudgetMetric(max_total_tokens=10000, max_cost=0.05)
+metric.measure(test_case)
+
+print(metric.score)         # e.g. 0.67
+print(metric.reason)        # e.g. "total tokens 15000 exceeded budget 10000 (1.50x budget)."
+print(metric.score_breakdown)
+```
+
+::::caution
+Running as a standalone is useful for debugging or building a custom pipeline, but you will **NOT** get the benefits of testing reports, Confident AI platform integration, or the optimizations (speed, caching, computation) that `evaluate()` or `deepeval test run` offer.
+::::
+
+## How Is It Calculated?
+
+The `TokenBudgetMetric` scores each enabled budget with a **graded ratio** and takes the **minimum** across them:
+
+<Equation formula="\text{Budget Score} = \min_{b \, \in \, \text{enabled}} \begin{cases} 1.0 & \text{if } \text{spent}_b \le \text{limit}_b \\ \dfrac{\text{limit}_b}{\text{spent}_b} & \text{if } \text{spent}_b > \text{limit}_b \end{cases}" />
+
+For each enabled budget, the metric computes `spent / limit`. A run under budget scores **1.0**; a run over budget degrades as `limit / spent`, so being twice over budget scores **0.5**, three times over scores **0.33**. The overall score is the **minimum** across all enabled budgets — a single breached budget fails the run, which is the correct behavior for a gate.
+
+| Budget | Enabled when | What it sums |
+|---|---|---|
+| Total tokens | `max_total_tokens` set | `input_token_count + output_token_count` across all LLM spans |
+| Input tokens | `max_input_tokens` set | `input_token_count` across all LLM spans |
+| Output tokens | `max_output_tokens` set | `output_token_count` across all LLM spans |
+| Cost | `max_cost` set | `Σ (input_token_count · cost_per_input_token + output_token_count · cost_per_output_token)` |
+
+### Cost accounting
+
+The trace dict exposes `cost_per_input_token` and `cost_per_output_token` as **per-token rates**, not totals. A span's cost is therefore:
+
+```
+input_token_count  * cost_per_input_token
++ output_token_count * cost_per_output_token
+```
+
+A span only contributes to the cost total when **both** the token count and its matching per-token rate are present. Spans that report token counts but no per-token rate are counted as **unpriced** and are surfaced in the reason so a cheap-looking run is never silently trusted.
+
+### Handling missing token data
+
+Token counts on a trace span are optional — a span from an integration that does not record usage will have no token fields at all. Such spans contribute **0** to the token sums but are counted as **untokened** and reported in the reason (e.g. `"2 of 5 LLM spans had no token data."`). The score is never silently computed on partial data without saying so.
+
+## Score Interpretation
+
+| Score range | Interpretation |
+|---|---|
+| `1.0` | Within every enabled budget |
+| `0.5–1.0` | Mildly over one or more budgets |
+| `0.0–0.5` | Substantially over budget (2x+) — investigate the run |
+
+**Example: within budget**
+```
+Token Budget
+Score:  1.0
+Reason: All token and cost budgets respected.
+```
+
+**Example: over budget**
+```
+Token Budget
+Score:  0.67
+Reason: total tokens 15000 exceeded budget 10000 (1.50x budget).
+        cost $0.075000 exceeded budget $0.050000 (1.50x budget).
+```
+
+## Score Breakdown
+
+The `score_breakdown` attribute exposes per-budget detail and diagnostics after evaluation:
+
+```python
+metric = TokenBudgetMetric(max_total_tokens=1000, max_cost=0.02)
+
+# After measure() runs:
+print(metric.score_breakdown)
+# {
+#     "total_tokens": {"spent": 1500, "limit": 1000, "ratio": 1.5, "sub_score": 0.667},
+#     "cost": {"spent": 0.025, "limit": 0.02, "ratio": 1.25, "sub_score": 0.8},
+#     "most_expensive_span": {"name": "gen", "cost": 0.025},
+#     "llm_span_count": 1,
+#     "untokened_spans": 0,
+#     "unpriced_spans": 0,
+# }
+```
+
+`most_expensive_span` flags the single priciest LLM span so you know where to look first. `untokened_spans` and `unpriced_spans` tell you how much of the run was measurable.
+
+## Limitations & Design Decisions
+
+### Why no `model` parameter?
+
+This metric is **fully deterministic by design**. Token counts and per-token rates are read straight from the trace and summed — there is nothing for an LLM to judge. This means:
+
+- **Zero cost** — runs in production without API keys or network calls.
+- **Deterministic** — identical traces always produce identical scores (critical for CI/CD gates).
+- **Zero latency** — no LLM round-trip; the metric completes in milliseconds.
+
+### No latency / duration budget
+
+This metric gates **tokens and cost only** — it cannot gate wall-clock latency. When the trace dict is built, `create_nested_spans_dict` strips `start_time` and `end_time` from every span (along with `uuid` and `status`), so span timing is simply not available to any trace-based metric. Token counts and per-token pricing **do** survive, which is what makes token and cost budgeting possible. This is an honest, hard constraint of the trace format — not an oversight.
+
+### Cost requires per-token rates
+
+The `max_cost` budget is only meaningful when your integration populates `cost_per_input_token` and `cost_per_output_token` on its LLM spans. An integration that records token counts but not pricing will produce accurate **token** budgets but a **cost** of `0` for those spans — which the metric reports as `unpriced_spans` rather than pretending the run was free. If you rely on `max_cost`, verify your integration sets per-token pricing.
+
+### Token counts are provider-reported
+
+The metric is only as accurate as the token counts recorded on the trace. It sums what the integration reported; it does not re-tokenize inputs or outputs.
+
+### Traces with no LLM spans
+
+If a trace contains no LLM spans at all (for example a tool-only agent turn), there is nothing to measure against the budget. The metric scores such a run `1.0` — an agent may legitimately make no LLM calls — but the reason explicitly states `"No LLM spans found in the trace; token/cost budgets could not be measured."` rather than falsely claiming the budget was respected. Check `score_breakdown["llm_span_count"]` if you need to distinguish "measured and passed" from "nothing to measure".
+
+---
+
+::::note Community Metric
+`TokenBudgetMetric` was contributed by [Jeel Thummar](https://github.com/Jeel3011). It complements DeepEval's cost-tracking work by turning per-run token and cost usage into a deterministic pass/fail gate you can enforce in CI or production.
+::::

--- a/tests/test_token_budget.py
+++ b/tests/test_token_budget.py
@@ -1,0 +1,383 @@
+"""Tests for TokenBudgetMetric.
+
+All tests are fully deterministic — no API key, no network, no LLM required.
+"""
+
+import pytest
+
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.token_budget import TokenBudgetMetric
+
+# ---------------------------------------------------------------------------
+# Trace / test-case builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_span(
+    name: str = "llm_call",
+    input_tokens=None,
+    output_tokens=None,
+    cost_per_input=None,
+    cost_per_output=None,
+    children=None,
+) -> dict:
+    """Build an LLM span dict matching DeepEval's _trace_dict format.
+
+    Token/cost fields are only included when non-None, mirroring
+    ``create_nested_spans_dict`` which drops all None-valued keys.
+    """
+    span = {
+        "type": "llm",
+        "name": name,
+        "input": "some prompt",
+        "output": "some completion",
+        "children": children or [],
+    }
+    if input_tokens is not None:
+        span["input_token_count"] = input_tokens
+    if output_tokens is not None:
+        span["output_token_count"] = output_tokens
+    if cost_per_input is not None:
+        span["cost_per_input_token"] = cost_per_input
+    if cost_per_output is not None:
+        span["cost_per_output_token"] = cost_per_output
+    return span
+
+
+def _make_tool_span(name: str, input_data: dict, children=None) -> dict:
+    return {
+        "type": "tool",
+        "name": name,
+        "input": input_data,
+        "output": f"result of {name}",
+        "children": children or [],
+    }
+
+
+def _make_agent_span(name: str, children: list) -> dict:
+    return {
+        "type": "agent",
+        "name": name,
+        "input": "user query",
+        "output": "agent answer",
+        "children": children,
+    }
+
+
+def _make_test_case(trace_dict: dict) -> LLMTestCase:
+    tc = LLMTestCase(input="test input", actual_output="test output")
+    tc._trace_dict = trace_dict
+    return tc
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Under budget → score 1.0
+# ---------------------------------------------------------------------------
+
+
+def test_under_budget_passes():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(input_tokens=100, output_tokens=50),
+            _make_llm_span(input_tokens=200, output_tokens=80),
+        ],
+    )
+    metric = TokenBudgetMetric(max_total_tokens=1000)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == 1.0
+    assert metric.success is True
+    assert metric.score_breakdown["total_tokens"]["spent"] == 430
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Over total-token budget → graded sub-score < 1.0
+# ---------------------------------------------------------------------------
+
+
+def test_over_total_token_budget_fails():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(input_tokens=600, output_tokens=600),
+        ],
+    )
+    # 1200 spent vs 600 budget → exactly 2x over → sub-score 0.5
+    metric = TokenBudgetMetric(max_total_tokens=600)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == pytest.approx(0.5)
+    assert metric.success is False
+    assert "total tokens" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Input-token budget only
+# ---------------------------------------------------------------------------
+
+
+def test_input_token_budget_only():
+    trace = _make_agent_span(
+        "agent",
+        [_make_llm_span(input_tokens=500, output_tokens=10000)],
+    )
+    # Only input tokens are gated; huge output must not affect the score.
+    metric = TokenBudgetMetric(max_input_tokens=1000)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == 1.0
+    assert "output_tokens" not in metric.score_breakdown
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Output-token budget only
+# ---------------------------------------------------------------------------
+
+
+def test_output_token_budget_only():
+    trace = _make_agent_span(
+        "agent",
+        [_make_llm_span(input_tokens=10000, output_tokens=2000)],
+    )
+    # 2000 output vs 1000 budget → 2x over → 0.5
+    metric = TokenBudgetMetric(max_output_tokens=1000)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == pytest.approx(0.5)
+    assert "input_tokens" not in metric.score_breakdown
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Cost budget with per-token rates
+# ---------------------------------------------------------------------------
+
+
+def test_cost_budget():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(
+                input_tokens=1000,
+                output_tokens=500,
+                cost_per_input=0.00001,
+                cost_per_output=0.00003,
+            ),
+        ],
+    )
+    # cost = 1000*1e-5 + 500*3e-5 = 0.01 + 0.015 = 0.025
+    metric = TokenBudgetMetric(max_cost=0.05)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == 1.0
+    assert metric.score_breakdown["cost"]["spent"] == pytest.approx(0.025)
+
+
+def test_cost_budget_exceeded():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(
+                input_tokens=1000,
+                output_tokens=1000,
+                cost_per_input=0.00002,
+                cost_per_output=0.00002,
+            ),
+        ],
+    )
+    # cost = 0.04; budget 0.02 → 2x over → 0.5
+    metric = TokenBudgetMetric(max_cost=0.02)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == pytest.approx(0.5)
+    assert metric.success is False
+    assert "cost" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Most-expensive-span flag
+# ---------------------------------------------------------------------------
+
+
+def test_most_expensive_span_flagged():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(
+                name="cheap",
+                input_tokens=10,
+                output_tokens=10,
+                cost_per_input=0.000001,
+                cost_per_output=0.000001,
+            ),
+            _make_llm_span(
+                name="expensive",
+                input_tokens=1000,
+                output_tokens=1000,
+                cost_per_input=0.00001,
+                cost_per_output=0.00001,
+            ),
+        ],
+    )
+    metric = TokenBudgetMetric(max_cost=1.0)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score_breakdown["most_expensive_span"]["name"] == "expensive"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Null token counts → counted, not crashed
+# ---------------------------------------------------------------------------
+
+
+def test_null_token_counts_reported():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(input_tokens=100, output_tokens=50),
+            _make_llm_span(),  # no token data at all
+        ],
+    )
+    metric = TokenBudgetMetric(max_total_tokens=1000)
+    metric._calculate_metric(_make_test_case(trace))
+
+    # Only the tokened span contributes; the null one is counted, not summed.
+    assert metric.score_breakdown["total_tokens"]["spent"] == 150
+    assert metric.score_breakdown["untokened_spans"] == 1
+    assert "no token data" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Tokens present but no pricing → unpriced, excluded from cost
+# ---------------------------------------------------------------------------
+
+
+def test_unpriced_spans_excluded_from_cost():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(input_tokens=1000, output_tokens=1000),  # no rates
+        ],
+    )
+    metric = TokenBudgetMetric(max_cost=0.05)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score_breakdown["cost"]["spent"] == 0.0
+    assert metric.score_breakdown["unpriced_spans"] == 1
+    assert "no per-token pricing" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 9: strict_mode → binary score
+# ---------------------------------------------------------------------------
+
+
+def test_strict_mode_binary():
+    trace = _make_agent_span(
+        "agent",
+        [_make_llm_span(input_tokens=600, output_tokens=200)],
+    )
+    # 800 spent vs 1000 budget → graded would be 1.0 anyway; make it breach:
+    metric = TokenBudgetMetric(max_total_tokens=500, strict_mode=True)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == 0.0
+    assert metric.threshold == 1.0
+
+    # And a passing run under strict_mode is exactly 1.0
+    metric_ok = TokenBudgetMetric(max_total_tokens=2000, strict_mode=True)
+    metric_ok._calculate_metric(_make_test_case(trace))
+    assert metric_ok.score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Minimum across multiple budgets is the gate
+# ---------------------------------------------------------------------------
+
+
+def test_min_across_budgets():
+    trace = _make_agent_span(
+        "agent",
+        [_make_llm_span(input_tokens=100, output_tokens=400)],
+    )
+    # total=500 (under 1000 → 1.0); output=400 vs 200 → 2x over → 0.5.
+    # score must be the min = 0.5.
+    metric = TokenBudgetMetric(max_total_tokens=1000, max_output_tokens=200)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == pytest.approx(0.5)
+    assert metric.score_breakdown["total_tokens"]["sub_score"] == 1.0
+    assert metric.score_breakdown["output_tokens"][
+        "sub_score"
+    ] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Test 11: All-None budgets → ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_no_budget_raises():
+    with pytest.raises(ValueError):
+        TokenBudgetMetric()
+
+
+# ---------------------------------------------------------------------------
+# Test 12: No trace data → score 0.0 with descriptive reason
+# ---------------------------------------------------------------------------
+
+
+def test_no_trace_returns_zero():
+    metric = TokenBudgetMetric(max_total_tokens=1000)
+    tc = LLMTestCase(input="x", actual_output="y")
+    tc._trace_dict = None
+    metric._calculate_metric(tc)
+
+    assert metric.score == 0.0
+    assert "No trace data" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 13: Nested spans are walked recursively
+# ---------------------------------------------------------------------------
+
+
+def test_nested_spans_walked():
+    deep_llm = _make_llm_span(input_tokens=300, output_tokens=100)
+    tool = _make_tool_span("search", {"q": "x"}, children=[deep_llm])
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_llm_span(input_tokens=100, output_tokens=50),
+            tool,  # LLM span buried under a tool span
+        ],
+    )
+    metric = TokenBudgetMetric(max_total_tokens=10000)
+    metric._calculate_metric(_make_test_case(trace))
+
+    # Both LLM spans counted: 150 + 400 = 550
+    assert metric.score_breakdown["total_tokens"]["spent"] == 550
+    assert metric.score_breakdown["llm_span_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 14: No LLM spans → 1.0 but reason must NOT claim the budget was respected
+# ---------------------------------------------------------------------------
+
+
+def test_no_llm_spans_reports_unmeasurable():
+    """A trace with tool/agent spans but zero LLM spans cannot have its token
+    budget measured. The score stays 1.0 (an agent may legitimately make no
+    LLM calls), but the reason must say the budget was unmeasurable rather
+    than falsely claiming it was respected."""
+    trace = _make_agent_span(
+        "agent",
+        [_make_tool_span("search", {"q": "x"})],  # no LLM span anywhere
+    )
+    metric = TokenBudgetMetric(max_total_tokens=1000, max_cost=0.05)
+    metric._calculate_metric(_make_test_case(trace))
+
+    assert metric.score == 1.0
+    assert metric.score_breakdown["llm_span_count"] == 0
+    assert "could not be measured" in metric.reason
+    assert "respected" not in metric.reason


### PR DESCRIPTION
## Summary

Adds `TokenBudgetMetric`, a **fully deterministic** (no LLM, no API key) community metric that gates an agent run against token and/or cost budgets. It walks the agent's execution trace, sums token usage and cost across every LLM span, and checks the totals against the budgets you set — returning a graded score from `0.0` (far over budget) to `1.0` (within every budget).

This complements the ongoing cost-tracking work (e.g. #2741) by turning per-run token and cost usage into a deterministic pass/fail gate you can enforce in CI or production. It follows the same deterministic-community-metric pattern as the recently merged `AgentLoopDetectionMetric` (#2645), `ToolPermissionMetric` (#2826), and `CitationFaithfulnessMetric` (#2811).

## Scoring

Each enabled budget gets a graded ratio; the overall score is the **minimum** across them (a single breached budget fails the run — the correct behavior for a gate):

| Budget | Enabled when | Sums |
|---|---|---|
| Total tokens | `max_total_tokens` set | `input + output` tokens across all LLM spans |
| Input tokens | `max_input_tokens` set | input tokens only |
| Output tokens | `max_output_tokens` set | output tokens only |
| Cost | `max_cost` set | `Σ (in_count·in_rate + out_count·out_rate)` |

- Under budget → sub-score `1.0`; over budget → `limit/spent` (2× over → `0.5`).
- `strict_mode` collapses to a binary `1.0` / `0.0`.

## Parameters

| Param | Default | Meaning |
|---|---|---|
| `max_total_tokens` | `None` | cap on input+output tokens (disabled when None) |
| `max_input_tokens` | `None` | cap on input tokens |
| `max_output_tokens` | `None` | cap on output tokens |
| `max_cost` | `None` | cap on total dollar cost |
| `threshold` | `1.0` | minimum passing score |
| `include_reason` | `True` | generate a human-readable reason |
| `strict_mode` | `False` | binary score; forces threshold to 1 |
| `verbose_mode` | `False` | print intermediate steps |

Constructing the metric with no budget set raises `ValueError` (nothing to gate).

## Design decisions

- **No `model` parameter** — every value is read straight from the trace and summed; an LLM would add nothing. Keeps the metric zero-cost, deterministic, and zero-latency.
- **Graded, not binary (by default)** — tells you *how far* over budget a run went, which is more actionable than a bare pass/fail. `strict_mode` is available for a binary gate.
- **Cost is per-token** — the trace exposes `cost_per_input_token` / `cost_per_output_token` as per-token *rates*, so a span's cost is `count · rate` and is only counted when both are present. Spans with tokens but no pricing are reported as `unpriced_spans`, not treated as free.
- **Missing data is reported, not guessed** — spans without token counts contribute `0` but are counted as `untokened_spans` and surfaced in the reason; a trace with no LLM spans is reported as *unmeasurable* rather than falsely "respected", so the score is never silently based on partial or absent data.

## Limitations (documented honestly in the .mdx)

- **No latency / duration budget.** `create_nested_spans_dict` strips `start_time` / `end_time` (and `uuid` / `status`) from every span, so span timing is unavailable to any trace-based metric. Token counts and per-token pricing survive, which is what makes token/cost budgeting possible — this metric gates tokens and cost only.
- **Cost requires per-token rates** — integrations that record counts but not pricing produce accurate token budgets but `0` cost for those spans (reported as `unpriced`).
- **Token counts are provider-reported** — the metric sums what the integration recorded; it does not re-tokenize.

## Test matrix (15 tests, fully deterministic, no API key)

under budget · over total-token budget · input-token-only budget · output-token-only budget · cost budget under/over · most-expensive-span flag · null token counts reported · unpriced spans excluded from cost · strict_mode binary (pass and fail) · min across multiple budgets · no-budget → `ValueError` · no-trace → `0.0` · nested spans walked recursively · no-LLM-spans → `1.0` but reason reports the budget was unmeasurable.

```
34 passed, 2 skipped   # 15 new + 19 existing metric tests; the 2 skips are OPENAI_API_KEY-gated and unrelated
```

The token/cost keys the metric reads were also confirmed against the **real** `create_nested_spans_dict` output (not only hand-built fixtures): a real `LlmSpan` emits `input_token_count` / `output_token_count` / `cost_per_input_token` / `cost_per_output_token` as top-level keys with `type == "llm"`, and a span with no usage data omits those keys entirely — exactly the null path the metric handles.

## Files

- `deepeval/metrics/token_budget/{__init__.py, token_budget.py}` — the metric
- `deepeval/metrics/__init__.py` — import + `__all__` (Agentic metrics group)
- `deepeval/metrics/community/__init__.py` — re-export so `from deepeval.metrics.community import TokenBudgetMetric` works
- `tests/test_token_budget.py` — 15 deterministic tests
- `docs/content/docs/(community)/metrics-token-budget.mdx` + `meta.json` page entry

All Python formatted with `black`.

---

Note: the `lint` CI check is currently red for a repo-wide reason unrelated to this PR — the `psf/black@stable` action pulls a newer black (26.5.1) than the codebase is formatted against and flags ~49 pre-existing files across the repo. None of them belong to this PR; every file added or modified here passes `black`.

