### PR TITLE
feat: add RedundantToolCallMetric — deterministic detection of wasted tool work in agent traces

### DIFF
--- a/deepeval/metrics/__init__.py
+++ b/deepeval/metrics/__init__.py
@@ -37,6 +37,7 @@ from .tool_use.tool_use import ToolUseMetric
 from .goal_accuracy.goal_accuracy import GoalAccuracyMetric
 from .argument_correctness.argument_correctness import ArgumentCorrectnessMetric
 from .agent_loop_detection.agent_loop_detection import AgentLoopDetectionMetric
+from .redundant_tool_call.redundant_tool_call import RedundantToolCallMetric
 from .mcp.mcp_task_completion import MCPTaskCompletionMetric
 from .mcp.multi_turn_mcp_use_metric import MultiTurnMCPUseMetric
 from .mcp_use_metric.mcp_use_metric import MCPUseMetric
@@ -120,6 +121,7 @@ __all__ = [
     "ToolUseMetric",
     "GoalAccuracyMetric",
     "AgentLoopDetectionMetric",
+    "RedundantToolCallMetric",
     # Conversational metrics
     "TurnRelevancyMetric",
     "ConversationCompletenessMetric",

--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,9 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from ..redundant_tool_call.redundant_tool_call import RedundantToolCallMetric
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "RedundantToolCallMetric",
 ]

--- a/deepeval/metrics/redundant_tool_call/__init__.py
+++ b/deepeval/metrics/redundant_tool_call/__init__.py
@@ -1,0 +1,3 @@
+from .redundant_tool_call import RedundantToolCallMetric
+
+__all__ = ["RedundantToolCallMetric"]

--- a/deepeval/metrics/redundant_tool_call/redundant_tool_call.py
+++ b/deepeval/metrics/redundant_tool_call/redundant_tool_call.py
@@ -1,0 +1,419 @@
+import json
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.metrics import BaseMetric
+from deepeval.metrics.utils import (
+    check_llm_test_case_params,
+    construct_verbose_logs,
+)
+from deepeval.metrics.indicator import metric_progress_indicator
+
+# A tool output shorter than this (after normalization) is not searched for in
+# LLM inputs -- a short string like "OK" or "42" would match incidentally and
+# report a wasteful call as consumed.
+_MIN_CONSUMPTION_MATCH_LENGTH = 12
+
+
+class RedundantToolCallMetric(BaseMetric):
+    """Detects *wasted* tool work in an agent trace.
+
+    Two independent, deterministic sub-signals are combined with ``min()``
+    so the metric behaves as a gate -- either form of waste fails it:
+
+    1. **Duplicate calls** -- the same ``(name, arguments)`` read-only tool
+       call made more than once. The second identical call to a cacheable
+       tool cannot return new information, so the work is wasted.
+
+    2. **Unconsumed output** -- a tool span whose output text never appears
+       in the input of any LLM span that is not one of its own ancestors.
+       The agent fetched data and then never fed it to a model.
+
+    Relationship to ``AgentLoopDetectionMetric``
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    The two metrics measure different failures and are complementary:
+
+    * ``AgentLoopDetectionMetric`` measures **volume** -- it asks "is this
+      agent stuck?" and only alarms once a call repeats
+      ``repetition_threshold`` times (3 by default). It is a loop alarm.
+    * This metric measures **waste** -- it alarms on the *first* redundant
+      pair (threshold 1), only for tools the caller declares read-only, and
+      additionally catches fetched-but-unused output. An agent that calls
+      ``search_kb`` twice and finishes is not looping (ALD scores it 1.0)
+      but it did burn a redundant call, which this metric reports.
+
+    Design decisions
+    ~~~~~~~~~~~~~~~~
+    * **Fully deterministic** -- no LLM and no API key, so it is free to run
+      as a CI gate.
+    * **Read-only scoping is opt-in per tool.** Re-calling a *write* tool is
+      usually intentional (sending two emails is not redundancy), so
+      duplicate detection is only meaningful for tools the caller marks as
+      cacheable via ``read_only_tools``. When ``read_only_tools`` is left as
+      ``None`` every tool is treated as cacheable; pass an explicit list for
+      any agent that performs writes.
+    * **Consumption is existence-based, not time-ordered.** The trace dict
+      produced by ``create_nested_spans_dict`` strips ``start_time`` and
+      ``end_time``, so spans cannot be ordered in time. Rather than invent an
+      ordering from traversal position (which is not chronological -- a tool
+      nested under an LLM span is visited *after* it), a tool output counts as
+      consumed if it appears in *any* non-ancestor LLM span's input. Ancestors
+      are excluded because an invoking span's input was already fixed before
+      its child tool ran, so it cannot have consumed the result.
+
+    Limitations
+    ~~~~~~~~~~~
+    * **Read-only classification is user-supplied.** Side effects cannot be
+      inferred from a trace, so a tool that is misdeclared as read-only will
+      have its intentional repeat calls reported as redundant.
+    * **Consumption uses normalized substring matching.** A tool output that
+      the agent summarized, reformatted, or quoted only in part before
+      passing it to the next LLM call will be reported as unconsumed even
+      though it was used. An LLM-as-judge check would handle paraphrase but
+      would sacrifice the deterministic, zero-cost properties.
+    * **No temporal ordering.** Because timing is stripped from the trace
+      dict, this metric cannot distinguish "consumed by a later call" from
+      "consumed by an unrelated branch of the trace".
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        read_only_tools: Optional[List[str]] = None,
+        check_duplicate_calls: bool = True,
+        check_unconsumed_output: bool = True,
+        threshold: float = 1.0,
+        include_reason: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+    ):
+        if not check_duplicate_calls and not check_unconsumed_output:
+            raise ValueError(
+                "RedundantToolCallMetric requires at least one of "
+                "`check_duplicate_calls` or `check_unconsumed_output` "
+                "to be enabled."
+            )
+        self.read_only_tools = (
+            set(read_only_tools) if read_only_tools is not None else None
+        )
+        self.check_duplicate_calls = check_duplicate_calls
+        self.check_unconsumed_output = check_unconsumed_output
+        self.threshold = 1.0 if strict_mode else threshold
+        self.include_reason = include_reason
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+        # Deterministic metric: no evaluation model is used.
+        self.model = None
+        self.using_native_model = False
+        self.evaluation_model = None
+        self.async_mode = False
+        self.requires_trace = True
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            test_case.multimodal,
+        )
+
+        self.evaluation_cost = 0
+
+        with metric_progress_indicator(
+            self,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        ):
+            self._calculate_metric(test_case)
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        # Deterministic metric -- no async work to do; reuse the sync path.
+        return self.measure(
+            test_case,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        )
+
+    def _calculate_metric(self, test_case: LLMTestCase):
+        if test_case._trace_dict is None:
+            self.score = 0.0
+            self.success = False
+            self.reason = (
+                "No trace data found. This metric requires trace "
+                "data from @observe."
+            )
+            self.verbose_logs = ""
+            return
+
+        all_spans = self._extract_all_spans(test_case._trace_dict)
+        tool_spans = [s for s in all_spans if s.get("type") == "tool"]
+
+        dup_score, dup_reason = 1.0, "Duplicate call check skipped."
+        duplicates: List[Tuple[str, int]] = []
+        if self.check_duplicate_calls:
+            dup_score, dup_reason, duplicates = self._score_duplicate_calls(
+                tool_spans
+            )
+
+        unc_score, unc_reason = 1.0, "Unconsumed output check skipped."
+        unconsumed: List[str] = []
+        if self.check_unconsumed_output:
+            unc_score, unc_reason, unconsumed = self._score_unconsumed_output(
+                test_case._trace_dict
+            )
+
+        self.score_breakdown = {
+            "duplicate_calls": dup_score,
+            "unconsumed_outputs": unc_score,
+            "redundant_calls": duplicates,
+            "unconsumed_tools": unconsumed,
+        }
+
+        enabled_scores = []
+        if self.check_duplicate_calls:
+            enabled_scores.append(dup_score)
+        if self.check_unconsumed_output:
+            enabled_scores.append(unc_score)
+        score = min(enabled_scores) if enabled_scores else 1.0
+
+        self.score = (
+            0.0 if self.strict_mode and score < self.threshold else score
+        )
+        self.success = self.score >= self.threshold
+
+        reasons = []
+        if self.check_duplicate_calls and dup_score < 1.0:
+            reasons.append(dup_reason)
+        if self.check_unconsumed_output and unc_score < 1.0:
+            reasons.append(unc_reason)
+
+        if not reasons:
+            self.reason = "No redundant tool usage detected."
+        else:
+            self.reason = " ".join(reasons)
+
+        self.verbose_logs = construct_verbose_logs(
+            self,
+            steps=[
+                f"Read-only tools: "
+                f"{sorted(self.read_only_tools) if self.read_only_tools is not None else 'ALL (default)'}",
+                f"Tool spans found: {[s.get('name') for s in tool_spans]}",
+                f"Duplicate Calls Score: {dup_score} ({dup_reason})",
+                f"Unconsumed Output Score: {unc_score} ({unc_reason})",
+                f"Score: {self.score}\nReason: {self.reason}",
+            ],
+        )
+
+    def _extract_all_spans(self, trace_dict: Optional[Dict]) -> List[Dict]:
+        if not trace_dict:
+            return []
+
+        spans = []
+
+        def traverse(span: Dict):
+            if span:
+                spans.append(span)
+                for child in span.get("children", []):
+                    traverse(child)
+
+        traverse(trace_dict)
+        return spans
+
+    def _is_read_only(self, tool_name: str) -> bool:
+        """A tool is cacheable when no allowlist was supplied (default: treat
+        every tool as read-only) or when it appears in the allowlist."""
+        if self.read_only_tools is None:
+            return True
+        return tool_name in self.read_only_tools
+
+    @staticmethod
+    def _args_signature(span: Dict) -> Tuple:
+        """Normalize a span's input into a hashable signature.
+
+        Mirrors ``AgentLoopDetectionMetric._score_tool_repetition`` so the two
+        metrics agree on what "the same call" means: JSON strings are parsed
+        when possible and dict keys are sorted so argument order never
+        affects identity.
+        """
+        input_val = span.get("input", {})
+        if isinstance(input_val, str):
+            try:
+                input_val = json.loads(input_val)
+            except Exception:
+                pass
+
+        if isinstance(input_val, dict):
+            return tuple(sorted((str(k), str(v)) for k, v in input_val.items()))
+        return (str(input_val),)
+
+    def _score_duplicate_calls(
+        self, tool_spans: List[Dict]
+    ) -> Tuple[float, str, List[Tuple[str, int]]]:
+        """Score the fraction of read-only tool calls that were not repeats.
+
+        A call is redundant when an identical ``(name, args)`` read-only call
+        already appeared in the trace. Unlike a loop alarm this fires on the
+        very first repeat -- two identical cacheable calls are already waste.
+        """
+        read_only_spans = [
+            s for s in tool_spans if self._is_read_only(s.get("name", ""))
+        ]
+        total = len(read_only_spans)
+        if total <= 1:
+            return 1.0, "Not enough read-only tool calls to be redundant.", []
+
+        counts: Dict[Tuple[str, Tuple], int] = {}
+        for span in read_only_spans:
+            key = (span.get("name", ""), self._args_signature(span))
+            counts[key] = counts.get(key, 0) + 1
+
+        redundant = [(k[0], c) for k, c in counts.items() if c > 1]
+        redundant_calls = sum(c - 1 for _, c in redundant)
+
+        if redundant_calls == 0:
+            return 1.0, "No redundant tool calls.", []
+
+        score = (total - redundant_calls) / total
+        offenders = ", ".join(
+            f"'{name}' called {count} times with identical arguments"
+            for name, count in sorted(redundant)
+        )
+        return (
+            score,
+            f"{redundant_calls} of {total} read-only tool call(s) were "
+            f"redundant re-fetches: {offenders}.",
+            sorted(redundant),
+        )
+
+    @staticmethod
+    def _flatten_to_text(value: Any) -> str:
+        """Flatten an arbitrary span input/output into searchable text.
+
+        ``BaseSpan.input``/``output`` are typed ``Optional[Any]``: an LLM span
+        input is typically a list of message dicts, a tool input a dict, and a
+        tool output often a plain string. Everything is reduced to one
+        lowercased, whitespace-collapsed string so the consumption check never
+        depends on a particular shape (and never raises on a non-string).
+
+        Structural JSON punctuation (braces, brackets, quotes, escapes) is
+        stripped so that the *content* is compared rather than its encoding.
+        Without this, a dict tool output serialized into an LLM message would
+        carry escaped quotes (``{\\"policy\\": ...}``) and would never match
+        the same payload serialized on its own -- reporting a genuinely
+        consumed output as unconsumed.
+        """
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            text = value
+        else:
+            try:
+                text = json.dumps(value, sort_keys=True, default=str)
+            except (TypeError, ValueError):
+                text = str(value)
+        text = text.lower()
+        for ch in ('\\"', "\\", '"', "'", "{", "}", "[", "]", ",", ":"):
+            text = text.replace(ch, " ")
+        return " ".join(text.split())
+
+    def _score_unconsumed_output(
+        self, trace_dict: Dict
+    ) -> Tuple[float, str, List[str]]:
+        """Score the fraction of tool outputs that reached an LLM.
+
+        A tool output is *consumed* when its normalized text appears in the
+        normalized input of some LLM span that is not one of its ancestors.
+        Ancestors are excluded because a parent span's input was fixed before
+        its child tool ever ran, so it cannot have consumed the output.
+        """
+        # Collect every tool span together with the identity of its ancestors,
+        # plus every LLM span's input text keyed by span identity.
+        tool_entries: List[Tuple[int, Dict, Set[int]]] = []
+        llm_inputs: List[Tuple[int, str]] = []
+
+        def traverse(span: Dict, ancestors: Tuple[int, ...]):
+            span_id = id(span)
+            span_type = span.get("type")
+            if span_type == "tool":
+                tool_entries.append((span_id, span, set(ancestors)))
+            elif span_type == "llm":
+                llm_inputs.append(
+                    (span_id, self._flatten_to_text(span.get("input")))
+                )
+            for child in span.get("children", []):
+                traverse(child, ancestors + (span_id,))
+
+        traverse(trace_dict, ())
+
+        if not tool_entries:
+            return 1.0, "No tool spans found.", []
+
+        considered = 0
+        unconsumed: List[str] = []
+        for tool_id, span, ancestor_ids in tool_entries:
+            needle = self._flatten_to_text(span.get("output"))
+            # Outputs too short to match distinctively are not judged -- a
+            # two-character output would collide with unrelated prose.
+            if len(needle) < _MIN_CONSUMPTION_MATCH_LENGTH:
+                continue
+
+            considered += 1
+            consumed = any(
+                llm_id not in ancestor_ids
+                and llm_id != tool_id
+                and needle in haystack
+                for llm_id, haystack in llm_inputs
+            )
+            if not consumed:
+                unconsumed.append(span.get("name", "unnamed"))
+
+        if considered == 0:
+            return (
+                1.0,
+                "No tool outputs long enough to check for consumption.",
+                [],
+            )
+
+        if not unconsumed:
+            return 1.0, "All tool outputs were consumed.", []
+
+        score = (considered - len(unconsumed)) / considered
+        names = ", ".join(f"'{n}'" for n in sorted(set(unconsumed)))
+        return (
+            score,
+            f"{len(unconsumed)} of {considered} tool output(s) were never "
+            f"passed to an LLM span: {names}.",
+            sorted(set(unconsumed)),
+        )
+
+    def is_successful(self) -> bool:
+        if self.error is not None:
+            self.success = False
+        else:
+            try:
+                self.success = self.score >= self.threshold
+            except TypeError:
+                self.success = False
+        return self.success
+
+    @property
+    def __name__(self):
+        return "Redundant Tool Call"

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -4,6 +4,7 @@
     "community-metrics-overview",
     "metrics-citation-faithfulness",
     "metrics-agent-loop-detection",
-    "metrics-tool-permission"
+    "metrics-tool-permission",
+    "metrics-redundant-tool-call"
   ]
 }

--- a/docs/content/docs/(community)/metrics-redundant-tool-call.mdx
+++ b/docs/content/docs/(community)/metrics-redundant-tool-call.mdx
@@ -1,0 +1,168 @@
+---
+id: metrics-redundant-tool-call
+title: Redundant Tool Call
+sidebar_label: Redundant Tool Call
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} agent={true} usesLLMs={false} referenceless={true} />
+
+The Redundant Tool Call metric is a **fully deterministic** (no LLM required) agentic metric that detects **wasted tool work** in an agent's execution trace. It combines two independent sub-signals and returns a score from **0.0** (all tool work wasted) to **1.0** (no waste detected).
+
+::::info
+Redundant Tool Call analyzes your **agent's full execution trace**, which requires [setting up tracing](/docs/evaluation-llm-tracing). Because it is fully deterministic, it runs in production without any API key or LLM call.
+::::
+
+## Required Arguments
+
+The `RedundantToolCallMetric` is a **trace-only** metric. It reads from the agent trace and does **not** require `tools_called` or `expected_tools`. It only requires the standard trace-based fields:
+
+- `input`
+- `actual_output`
+
+## Usage
+
+To begin, [set up tracing](/docs/evaluation-llm-tracing) and supply the `RedundantToolCallMetric()` to your `evals_iterator`.
+
+```python
+from deepeval.tracing import observe, update_current_trace
+from deepeval.dataset import Golden, EvaluationDataset
+from deepeval.metrics.community import RedundantToolCallMetric
+
+
+@observe()
+def search_kb(query: str) -> str:
+    # A read-only, cacheable tool
+    return f"Results for: {query}"
+
+
+@observe()
+def my_agent(input: str) -> str:
+    result = search_kb(input)
+    update_current_trace(input=input, output=result)
+    return result
+
+
+# Create dataset
+dataset = EvaluationDataset(goldens=[Golden(input="What is your refund policy?")])
+
+# Initialize metric — no model or API key needed
+redundancy_metric = RedundantToolCallMetric(
+    read_only_tools=["search_kb"],  # only these are treated as cacheable
+    threshold=1.0,
+    verbose_mode=True,
+)
+
+for golden in dataset.evals_iterator(metrics=[redundancy_metric]):
+    my_agent(golden.input)
+```
+
+There are **SIX** optional parameters when creating a `RedundantToolCallMetric`:
+
+- [Optional] `read_only_tools`: a list of tool names that are safe to cache (i.e. calling them twice with the same arguments cannot produce new information). Only these tools are considered for duplicate detection. Defaulted to `None`, which treats **every** tool as read-only.
+- [Optional] `check_duplicate_calls`: a boolean which enables the duplicate call sub-signal. Defaulted to `True`.
+- [Optional] `check_unconsumed_output`: a boolean which enables the unconsumed output sub-signal. Defaulted to `True`.
+- [Optional] `threshold`: a float representing the minimum passing threshold, defaulted to 1.0 (any redundancy fails).
+- [Optional] `include_reason`: a boolean which when set to `True`, includes a reason naming the redundant and unconsumed tools. Defaulted to `True`.
+- [Optional] `strict_mode`: a boolean which enforces a binary metric score, defaulted to `False`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate the metric to the console. Defaulted to `False`.
+
+At least one of `check_duplicate_calls` or `check_unconsumed_output` must be enabled.
+
+:::caution
+If your agent calls tools that have **side effects** (sending an email, issuing a refund, writing to a database), you should pass an explicit `read_only_tools` list. Calling a write tool twice is usually intentional, not redundant, and the default (`None`, meaning *all* tools are cacheable) would report it as waste.
+:::
+
+### As a Standalone
+
+You can also run the `RedundantToolCallMetric` on a single test case as a standalone, one-off execution.
+
+```python
+...
+
+metric.measure(test_case)
+print(metric.score, metric.reason)
+```
+
+## How Is It Calculated?
+
+The `RedundantToolCallMetric` score is the **minimum** of its two enabled sub-signals, so either form of waste is enough to fail the gate:
+
+<Equation formula="\text{Redundant Tool Call Score} = \min(\text{Duplicate Calls Score}, \text{Unconsumed Output Score})" />
+
+| Sub-signal            | Score                                                                   | What it catches                                                             |
+| --------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Duplicate Calls**   | `(read-only calls − redundant re-fetches) / read-only calls`             | The same `(name, arguments)` cacheable call made more than once.             |
+| **Unconsumed Output** | `(consumed tool outputs − unconsumed) / consumed tool outputs`           | A tool output that never reached any LLM span — data fetched and thrown away. |
+
+A call is a **redundant re-fetch** when an identical `(name, arguments)` read-only call already appeared in the trace. Arguments are normalized before comparison (JSON strings are parsed, dict key order is ignored), so `{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` are the same call.
+
+A tool output is **consumed** when its normalized text appears in the input of an LLM span that is not one of its own ancestors. Ancestor spans are excluded because a parent span's input was fixed *before* its child tool ran, so it cannot have consumed that tool's result. Outputs shorter than 12 characters are not judged, since a short string like `OK` would match unrelated text by coincidence.
+
+When no tools were called, the score is `1`. The metric is successful when the score is greater than or equal to the `threshold`.
+
+## Design Decisions
+
+- **Fully deterministic.** Every sub-signal is computed with plain string and dictionary operations, so the metric costs nothing and adds no latency. There is no `model` parameter, because accepting one would be misleading.
+- **Read-only scoping is opt-in per tool.** Side effects cannot be inferred from a trace. Rather than guess, the metric asks you to declare which tools are cacheable.
+- **Consumption is existence-based, not time-ordered.** See *Limitations* below.
+
+## Limitations
+
+- **Read-only classification is user-supplied.** The metric cannot tell a read from a write by looking at a trace. A tool misdeclared in `read_only_tools` will have its intentional repeat calls reported as redundant.
+- **Consumption uses substring matching.** A tool output that the agent summarized, reformatted, or quoted only in part before passing it to the next LLM call is reported as unconsumed even though it was genuinely used. An LLM-as-judge check would understand paraphrase, but would sacrifice the deterministic, zero-cost properties that make this metric usable as a CI gate.
+- **No temporal ordering.** The trace dictionary strips `start_time` and `end_time`, so spans cannot be ordered in time. The metric therefore cannot distinguish "consumed by a later call" from "consumed by an unrelated branch of the trace", and it cannot report *when* the waste occurred.
+- **Structural, not semantic.** Two calls with different arguments that return the same information (`search("refund")` and `search("refunds")`) are not detected as redundant.
+
+## FAQs
+
+<FAQs
+  qas={[
+    {
+      question: "How is this different from the Agent Loop Detection metric?",
+      answer: (
+        <>
+          They measure different failures.{" "}
+          <code>AgentLoopDetectionMetric</code> measures <em>volume</em>: it
+          asks whether the agent is <em>stuck</em>, and only alarms once a call
+          repeats <code>repetition_threshold</code> times (3 by default).{" "}
+          <code>RedundantToolCallMetric</code> measures <em>waste</em>: it
+          alarms on the <em>first</em> redundant pair, only for tools you
+          declare read-only, and additionally catches output that was fetched
+          but never used. An agent that calls <code>search_kb</code> twice and
+          then finishes is not looping — Agent Loop Detection scores it{" "}
+          <code>1.0</code> — but it did burn a redundant call, which this
+          metric reports as <code>0.5</code>. Use both: one catches runaway
+          agents, the other catches inefficient ones.
+        </>
+      ),
+    },
+    {
+      question: "Why does re-calling a write tool not count as redundant?",
+      answer: (
+        <>
+          Because it usually isn't. Sending two emails or issuing two refunds
+          are two distinct actions with two distinct effects, even if the
+          arguments match. Only a <em>cacheable</em> tool — one whose repeated
+          call cannot return new information — wastes work when repeated. Pass{" "}
+          <code>read_only_tools</code> to declare which of your tools those
+          are. Passing an empty list disables duplicate detection entirely.
+        </>
+      ),
+    },
+    {
+      question: "Why is my tool output reported as unconsumed?",
+      answer: (
+        <>
+          The check looks for the tool's output text inside a later LLM span's
+          input. If your agent summarizes or reformats a tool result before
+          passing it to the model, the original text will not appear verbatim
+          and the output is reported as unconsumed. This is a known
+          false-positive documented under <em>Limitations</em>. If it is noisy
+          for your agent, disable that sub-signal with{" "}
+          <code>check_unconsumed_output=False</code> and keep duplicate
+          detection.
+        </>
+      ),
+    },
+  ]}
+/>

--- a/tests/test_redundant_tool_call.py
+++ b/tests/test_redundant_tool_call.py
@@ -1,0 +1,403 @@
+"""Deterministic tests for RedundantToolCallMetric. No API key required."""
+
+import pytest
+
+from deepeval.metrics import RedundantToolCallMetric
+from deepeval.test_case import LLMTestCase
+
+
+def _tool(name, input=None, output=None, children=None):
+    span = {"name": name, "type": "tool", "children": children or []}
+    if input is not None:
+        span["input"] = input
+    if output is not None:
+        span["output"] = output
+    return span
+
+
+def _llm(name, input=None, output=None, children=None):
+    span = {
+        "name": name,
+        "type": "llm",
+        "model": "gpt-4o",
+        "children": children or [],
+    }
+    if input is not None:
+        span["input"] = input
+    if output is not None:
+        span["output"] = output
+    return span
+
+
+def _agent(name="agent", children=None):
+    return {"name": name, "type": "base", "children": children or []}
+
+
+def _test_case(trace_dict):
+    tc = LLMTestCase(input="q", actual_output="a")
+    tc._trace_dict = trace_dict
+    return tc
+
+
+LONG_A = "Refunds are allowed within thirty days of purchase."
+LONG_B = "The warranty covers manufacturing defects for two years."
+
+
+def test_no_trace_scores_zero():
+    metric = RedundantToolCallMetric()
+    tc = LLMTestCase(input="q", actual_output="a")
+    assert metric.measure(tc) == 0.0
+    assert metric.is_successful() is False
+    assert "No trace data found" in metric.reason
+
+
+def test_distinct_consumed_calls_score_one():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("lookup", input={"q": "warranty"}, output=LONG_B),
+            _llm("answer", input=f"{LONG_A} {LONG_B}", output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 1.0
+    assert metric.is_successful() is True
+    assert metric.reason == "No redundant tool usage detected."
+
+
+def test_duplicate_read_only_call_penalized():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    score = metric.measure(_test_case(trace))
+    # 2 read-only calls, 1 of them a redundant re-fetch -> 1/2
+    assert score == 0.5
+    assert metric.score_breakdown["duplicate_calls"] == 0.5
+    assert metric.is_successful() is False
+    assert "redundant re-fetches" in metric.reason
+
+
+def test_duplicate_write_tool_not_penalized():
+    """Re-calling a tool outside `read_only_tools` is intentional, not waste."""
+    trace = _agent(
+        children=[
+            _tool("send_email", input={"to": "a@b.c"}, output=LONG_A),
+            _tool("send_email", input={"to": "a@b.c"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric(read_only_tools=["search"])
+    assert metric.measure(_test_case(trace)) == 1.0
+    assert metric.score_breakdown["duplicate_calls"] == 1.0
+
+
+def test_empty_read_only_list_disables_duplicate_detection():
+    """An empty allowlist declares that no tool is cacheable, so no repeat
+    can be redundant. Distinct from `None`, which treats every tool as
+    read-only."""
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric(read_only_tools=[])
+    assert metric.measure(_test_case(trace)) == 1.0
+    assert metric.score_breakdown["duplicate_calls"] == 1.0
+
+
+def test_three_identical_calls_scale_with_waste():
+    """Redundancy is proportional: 2 of 3 calls wasted -> 1/3."""
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == pytest.approx(1 / 3)
+
+
+def test_duplicate_with_different_args_not_redundant():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "warranty"}, output=LONG_B),
+            _llm("answer", input=f"{LONG_A} {LONG_B}", output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 1.0
+
+
+def test_arg_order_does_not_affect_identity():
+    """Same args in a different key order is still the same call."""
+    trace = _agent(
+        children=[
+            _tool("search", input={"a": "1", "b": "2"}, output=LONG_A),
+            _tool("search", input={"b": "2", "a": "1"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 0.5
+
+
+def test_json_string_input_normalized_like_dict():
+    trace = _agent(
+        children=[
+            _tool("search", input='{"q": "refund"}', output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 0.5
+
+
+def test_unconsumed_output_penalized():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("lookup", input={"q": "warranty"}, output=LONG_B),
+            # Only LONG_A reaches the model; LONG_B was fetched and dropped.
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    score = metric.measure(_test_case(trace))
+    assert score == 0.5
+    assert metric.score_breakdown["unconsumed_outputs"] == 0.5
+    assert metric.score_breakdown["unconsumed_tools"] == ["lookup"]
+    assert "never passed to an LLM span" in metric.reason
+
+
+def test_output_consumed_by_llm_with_list_message_input():
+    """LLM span input is a list of message dicts in real traces."""
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm(
+                "answer",
+                input=[{"role": "user", "content": f"Context: {LONG_A}"}],
+                output="done",
+            ),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 1.0
+
+
+def test_ancestor_llm_input_does_not_count_as_consumption():
+    """A parent LLM's input was fixed before its child tool ran, so it cannot
+    have consumed that tool's output even though the text coincides."""
+    trace = _agent(
+        children=[
+            _llm(
+                "decide",
+                input=LONG_A,
+                output="call search",
+                children=[_tool("search", input={"q": "r"}, output=LONG_A)],
+            ),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    score = metric.measure(_test_case(trace))
+    assert score == 0.0
+    assert metric.score_breakdown["unconsumed_tools"] == ["search"]
+
+
+def test_short_output_skipped_from_consumption_check():
+    """Outputs too short to match distinctively are not judged."""
+    trace = _agent(
+        children=[
+            _tool("ping", input={}, output="OK"),
+            _llm("answer", input="unrelated prose", output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 1.0
+    assert metric.score_breakdown["unconsumed_tools"] == []
+
+
+def test_non_string_tool_output_is_flattened_not_crashed():
+    payload = {"policy": "Refunds are allowed within thirty days of purchase."}
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=payload),
+            _llm(
+                "answer",
+                input=[
+                    {
+                        "role": "user",
+                        "content": '{"policy": "Refunds are allowed within '
+                        'thirty days of purchase."}',
+                    }
+                ],
+                output="done",
+            ),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 1.0
+
+
+def test_missing_output_key_does_not_crash():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}),
+            _llm("answer", input="prose", output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 1.0
+
+
+def test_both_signals_firing_takes_minimum():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("lookup", input={"q": "warranty"}, output=LONG_B),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    score = metric.measure(_test_case(trace))
+    # duplicates: 1 redundant of 3 -> 2/3; unconsumed: LONG_B of 3 -> 2/3
+    assert metric.score_breakdown["duplicate_calls"] == pytest.approx(2 / 3)
+    assert metric.score_breakdown["unconsumed_outputs"] == pytest.approx(2 / 3)
+    assert score == pytest.approx(2 / 3)
+
+
+def test_disable_duplicate_check():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric(check_duplicate_calls=False)
+    assert metric.measure(_test_case(trace)) == 1.0
+
+
+def test_disable_unconsumed_check():
+    trace = _agent(
+        children=[
+            _tool("lookup", input={"q": "warranty"}, output=LONG_B),
+            _llm("answer", input="unrelated", output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric(check_unconsumed_output=False)
+    assert metric.measure(_test_case(trace)) == 1.0
+
+
+def test_disabling_both_checks_raises():
+    with pytest.raises(ValueError):
+        RedundantToolCallMetric(
+            check_duplicate_calls=False, check_unconsumed_output=False
+        )
+
+
+def test_strict_mode_is_binary():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric(strict_mode=True)
+    assert metric.measure(_test_case(trace)) == 0.0
+    assert metric.threshold == 1.0
+
+
+def test_no_tool_spans_scores_one():
+    trace = _agent(children=[_llm("answer", input="q", output="done")])
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 1.0
+
+
+def test_nested_spans_are_walked_recursively():
+    """Duplicates buried at different depths must still be found."""
+    trace = _agent(
+        children=[
+            _agent(
+                "sub",
+                children=[_tool("search", input={"q": "r"}, output=LONG_A)],
+            ),
+            _agent(
+                "sub2",
+                children=[
+                    _agent(
+                        "deep",
+                        children=[
+                            _tool("search", input={"q": "r"}, output=LONG_A)
+                        ],
+                    )
+                ],
+            ),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert metric.measure(_test_case(trace)) == 0.5
+
+
+def test_real_trace_dict_from_tracing_module():
+    """Guard the fakes above against drift in the real trace dict shape."""
+    import time
+
+    from deepeval.tracing.tracing import trace_manager
+    from deepeval.tracing.types import BaseSpan, LlmSpan, ToolSpan
+
+    def mk(cls, name, children=None, **kw):
+        return cls(
+            uuid=name,
+            trace_uuid="tr",
+            parent_uuid=None,
+            start_time=time.perf_counter(),
+            end_time=time.perf_counter(),
+            status="SUCCESS",
+            children=children or [],
+            name=name,
+            **kw,
+        )
+
+    tool_1 = mk(ToolSpan, "search", input={"q": "refund"}, output=LONG_A)
+    tool_2 = mk(ToolSpan, "search", input={"q": "refund"}, output=LONG_A)
+    llm = mk(
+        LlmSpan,
+        "answer",
+        model="gpt-4o",
+        input=[{"role": "user", "content": LONG_A}],
+        output="done",
+    )
+    root = mk(BaseSpan, "agent", children=[tool_1, tool_2, llm])
+    trace_dict = trace_manager.create_nested_spans_dict(root)
+
+    metric = RedundantToolCallMetric()
+    # Real trace: identical read-only re-fetch -> 1 of 2 calls redundant.
+    assert metric.measure(_test_case(trace_dict)) == 0.5
+
+
+@pytest.mark.asyncio
+async def test_a_measure_matches_measure():
+    trace = _agent(
+        children=[
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _tool("search", input={"q": "refund"}, output=LONG_A),
+            _llm("answer", input=LONG_A, output="done"),
+        ]
+    )
+    metric = RedundantToolCallMetric()
+    assert await metric.a_measure(_test_case(trace)) == 0.5


### PR DESCRIPTION
## Summary

Adds `RedundantToolCallMetric`, a **fully deterministic** (no LLM, no API key, zero cost) community metric that detects **wasted tool work** in an agent's execution trace. It's built as a CI gate: two independent sub-signals combined with `min()`, so either form of waste fails the run.

| Sub-signal | Score | What it catches |
| --- | --- | --- |
| **Duplicate calls** | `(read-only calls − redundant re-fetches) / read-only calls` | The same `(name, arguments)` cacheable call made more than once |
| **Unconsumed output** | `(judged outputs − unconsumed) / judged outputs` | A tool output that never reached any LLM span — data fetched and thrown away |

## How is this different from `AgentLoopDetectionMetric`?

That's the first question I'd ask, so here it is up front — the two measure different failures and are complementary:

- **`AgentLoopDetectionMetric` measures volume.** It asks "is the agent *stuck*?" and only alarms once a call repeats `repetition_threshold` times (3 by default). It's a loop alarm.
- **`RedundantToolCallMetric` measures waste.** It alarms on the *first* redundant pair (threshold 1), only for tools the caller declares read-only, and additionally catches fetched-but-unused output.

Concretely — an agent that calls `search_kb` twice with identical arguments and then finishes is not looping. Running both metrics on that exact trace:

```
AgentLoopDetectionMetric  -> 1.0   (correctly: not stuck)
RedundantToolCallMetric   -> 0.5   (correctly: 1 of 2 calls was wasted)
```

The **unconsumed-output** signal has no equivalent in the repo today.

## Parameters

All optional:

- `read_only_tools`: tool names safe to cache. Only these are considered for duplicate detection. Defaults to `None` = treat every tool as read-only. An empty list disables duplicate detection.
- `check_duplicate_calls` / `check_unconsumed_output`: enable each sub-signal (default `True`). Disabling both raises `ValueError`.
- `threshold` (default `1.0`), `include_reason`, `strict_mode`, `verbose_mode`.

Write tools are **not** penalized for repeating: sending two emails is two intentional actions, not redundancy. Side effects can't be inferred from a trace, so the metric asks rather than guesses.

## Design decisions

- **Consumption is existence-based, not time-ordered.** `create_nested_spans_dict` strips `start_time`/`end_time`, so spans can't be ordered in time. Traversal position isn't chronological either — a tool nested under an LLM span is visited *after* it, yet ran *during* it. Rather than invent an ordering the trace can't support, an output counts as consumed if it appears in *any* non-ancestor LLM span's input. Ancestors are excluded because a parent's input was fixed before its child tool ran.
- **Shape-agnostic text flattening.** `BaseSpan.input`/`output` are `Optional[Any]` — an LLM input is typically a list of message dicts, a tool input a dict, a tool output often a string. All are flattened to normalized text, with JSON punctuation stripped so a dict output still matches when embedded (escaped) inside an LLM message.
- **Argument normalization matches `AgentLoopDetectionMetric`** (JSON strings parsed, key order ignored) so the two metrics agree on what "the same call" means.
- **Min-length guard (12 chars)** on the consumption needle, so a short output like `OK` can't match unrelated prose by coincidence.

## Limitations (documented in the doc)

- Read-only classification is user-supplied; a misdeclared tool has intentional repeats reported as redundant.
- Consumption uses substring matching, so a summarized or reformatted tool result reads as unconsumed (false positive). An LLM judge would fix this but would sacrifice determinism.
- No temporal ordering — can't distinguish "consumed later" from "consumed by an unrelated branch", and can't report *when* the waste occurred.
- Structural, not semantic: `search("refund")` vs `search("refunds")` returning the same data isn't detected.

## Tests

24 deterministic tests, no API key required (`tests/test_redundant_tool_call.py`):

no-trace → 0.0 · distinct calls → 1.0 · duplicate read-only pair → 0.5 · empty read-only list disables detection · 3 identical calls → 1/3 · write tool repeat not penalized · different args not redundant · arg-order independence · JSON-string input normalization · unconsumed output penalized · list-of-messages LLM input · ancestor input ≠ consumption · short output skipped · non-string output flattened (no crash) · missing output key (no crash) · both signals → min · each sub-check disabled · disabling both raises · strict mode binary · no tool spans → 1.0 · nested spans walked recursively · **real trace dict built through `trace_manager.create_nested_spans_dict`** (guards the fixtures against drift) · async `a_measure` parity.

## Checks

- `black` clean.
- Full run: 43 passed — 24 new, plus existing `test_agent_loop_detection.py` and `test_tool_permission_metric.py` unchanged.
- Registered in `deepeval/metrics/__init__.py` (Agentic group) and re-exported from `deepeval/metrics/community/__init__.py`, so both import paths work.
- Docs: `metrics-redundant-tool-call.mdx` + added to `(community)/meta.json`.
