### PR TITLE
fix(prompt): read branch-pinned prompts from the branch cache section

### DIFF
--- a/deepeval/prompt/prompt.py
+++ b/deepeval/prompt/prompt.py
@@ -344,7 +344,7 @@ class Prompt:
                         )
                 elif branch:
                     if (
-                        HASH_CACHE_KEY in cache_data[alias]
+                        BRANCH_CACHE_KEY in cache_data[alias]
                         and branch in cache_data[alias][BRANCH_CACHE_KEY]
                     ):
                         return CachedPrompt(

--- a/tests/test_core/test_prompts/test_prompt.py
+++ b/tests/test_core/test_prompts/test_prompt.py
@@ -4,6 +4,7 @@ import pytest
 
 from tests.test_core.stubs import RecordingPortalockerLock
 import deepeval.prompt.prompt as prompt_mod
+from deepeval.prompt.api import PromptType, PromptInterpolationType
 from tests.test_core.helpers import _make_fake_portalocker
 
 
@@ -61,3 +62,42 @@ def test_write_to_cache_flushes_and_syncs(
         fsync_calls
     ), "Prompt._write_to_cache should call os.fsync(f.fileno())"
     assert fsync_calls[-1] == f.fileno()
+
+
+def test_read_from_cache_branch_round_trip(monkeypatch, tmp_path):
+    """A branch-pinned prompt written to the cache must be readable back.
+
+    _write_to_cache stores branch pulls under the "branch" section only, but
+    _read_from_cache gated the branch lookup on the presence of the unrelated
+    "hash" section, so a valid cached branch prompt was a silent cache miss
+    (and a spurious hard failure in the offline fallback path).
+    """
+    cache_path = tmp_path / "prompt_cache.json"
+    monkeypatch.setattr(
+        prompt_mod, "CACHE_FILE_NAME", str(cache_path), raising=False
+    )
+    monkeypatch.setattr(prompt_mod, "HIDDEN_DIR", str(tmp_path), raising=False)
+
+    dummy_self = types.SimpleNamespace(alias="my-alias")
+
+    # A branch pull writes a "branch" section and no "hash" section.
+    prompt_mod.Prompt._write_to_cache(
+        dummy_self,
+        cache_key=prompt_mod.BRANCH_CACHE_KEY,
+        hash="h1",
+        branch="main",
+        text_template="hello {name}",
+        prompt_id="p1",
+        type=PromptType.TEXT,
+        interpolation_type=PromptInterpolationType.FSTRING,
+    )
+
+    cached = prompt_mod.Prompt._read_from_cache(
+        dummy_self, alias="my-alias", branch="main"
+    )
+
+    assert (
+        cached is not None
+    ), "branch-pinned prompt in cache should be a hit, not a silent miss"
+    assert cached.template == "hello {name}"
+    assert cached.branch == "main"


### PR DESCRIPTION
## Summary

`Prompt._read_from_cache` looks up **branch**-pinned prompts using the wrong cache-key guard. In the `elif branch:` block it checks whether the unrelated `"hash"` section exists (`HASH_CACHE_KEY in cache_data[alias]`) while indexing the `"branch"` section:

```python
elif branch:
    if (
        HASH_CACHE_KEY in cache_data[alias]        # wrong key
        and branch in cache_data[alias][BRANCH_CACHE_KEY]
    ):
        return CachedPrompt(**cache_data[alias][BRANCH_CACHE_KEY][branch])
```

But `_write_to_cache` (and the poll path, which sets `CACHE_KEY = BRANCH_CACHE_KEY`) stores a branch pull under `cache_data[alias]["branch"][branch]` **only** — it never creates a `"hash"` section. So after a normal `pull(branch=...)`, `HASH_CACHE_KEY in cache_data[alias]` is `False` and the valid cached branch prompt is never returned. The `hash`/`version`/`label` branches already check their own keys; only the `branch` branch has the mismatch.

### Impact
- **Online:** the branch cache is silently ineffective → a needless refetch on every branch pull.
- **Offline / fetch-failure fallback:** `_load_from_cache_with_progress` raises `ValueError("Unable to fetch prompt and load from cache")` even though a valid cached copy exists, breaking offline use of branch-pinned prompts.

## Fix
One-line change: check `BRANCH_CACHE_KEY` (not `HASH_CACHE_KEY`) in the branch guard, matching the write path and the sibling branches.

## Test
Adds `test_read_from_cache_branch_round_trip`: writes a branch-pinned prompt via `_write_to_cache` (which produces a `"branch"` section and no `"hash"` section) and asserts reading it back by branch is a cache hit. It fails on `main` (silent miss → `None`) and passes with the fix. Full `tests/test_core/test_prompts/` suite passes (98 tests); `black` clean.

---
_Bug found and fix drafted with AI assistance (Claude Code); reviewed, reproduced, and tested locally by me before submitting._