### PR TITLE
fix: prevent trim_and_load_json from corrupting valid JSON strings

### DIFF
--- a/deepeval/models/llms/utils.py
+++ b/deepeval/models/llms/utils.py
@@ -17,12 +17,18 @@ def trim_and_load_json(
         input_string = input_string + "}"
         end = len(input_string)
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
-    jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
+
     try:
         return json.loads(jsonStr)
     except json.JSONDecodeError:
-        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
-        raise DeepEvalError(error_str)
+        # Some models emit a trailing comma before a closing ] or }. Strip it
+        # and retry, but only after a direct parse fails, so valid JSON string
+        # values containing ", ]" or ", }" are never corrupted.
+        try:
+            return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
+        except json.JSONDecodeError:
+            error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+            raise DeepEvalError(error_str)
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
 


### PR DESCRIPTION
## What was the bug

`trim_and_load_json` in `deepeval/models/llms/utils.py` corrupts valid JSON whose **string values** contain `, ]` or `, }`. It unconditionally ran `re.sub(r",\s*([\]}])", r"\1", jsonStr)` on the whole string *before* parsing, so it can't tell a structural trailing comma from a comma that legitimately appears inside a string value.

This copy of the helper is imported by every concrete model backend (`openai_model`, `anthropic_model`, `azure_model`, `amazon_bedrock_model`, `local_model`, `deepseek_model`, `litellm_model`, `grok_model`, `kimi_model`, `gateway_model`), so any metric whose JSON `reason`/`verdict` free-text contains `, }` or `, ]` gets silently corrupted.

## Root cause

This is the same bug PR #2701 (commit `2340aab`) fixed — but that fix only patched the other two copies of this helper (`deepeval/metrics/utils.py` and `deepeval/dataset/utils.py`). This third copy, `deepeval/models/llms/utils.py::trim_and_load_json`, was missed.

## What the fix does

Attempts `json.loads(jsonStr)` directly first. Only on `JSONDecodeError` does it fall back to the trailing-comma-stripping regex and retry — matching the pattern already used in the two sibling copies. Valid JSON with commas inside string values is never touched; malformed JSON with a genuine trailing comma is still recovered.

## How to reproduce / verify

```python
from deepeval.models.llms.utils import trim_and_load_json

# Before this fix: silently corrupted to {'reason': 'score is 1} good'}
# After this fix: passes unchanged
assert trim_and_load_json('{"reason": "score is 1,} good"}') == {"reason": "score is 1,} good"}

# Trailing-comma recovery still works as a fallback
assert trim_and_load_json('{"a": 1, "b": 2,}') == {"a": 1, "b": 2}
```

Both assertions pass against the patched function.

Closes #2770