### PR TITLE
fix: correctly accrue context-generation cost in Synthesizer.synthesis_cost

### DIFF
--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -486,7 +486,7 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
-                if self.synthesis_cost:
+                if self.synthesis_cost is not None:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
                     SynthesizerStatus.SUCCESS,
@@ -605,7 +605,7 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
-            if self.synthesis_cost:
+            if self.synthesis_cost is not None:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(
                 SynthesizerStatus.SUCCESS,
@@ -2119,7 +2119,7 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
-                if self.synthesis_cost:
+                if self.synthesis_cost is not None:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
                     SynthesizerStatus.SUCCESS,
@@ -2236,7 +2236,7 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
-            if self.synthesis_cost:
+            if self.synthesis_cost is not None:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(
                 SynthesizerStatus.SUCCESS,


### PR DESCRIPTION
## What was the bug

`Synthesizer.synthesis_cost` silently drops the first cost accrual from context generation when using a native model, because the truthiness check treats the initial `0` value as "no cost yet."

## Root cause

`deepeval/synthesizer/synthesizer.py` sets `self.synthesis_cost = 0 if self.using_native_model else None`. Four call sites (in `generate_goldens_from_docs`, `a_generate_goldens_from_docs`, `generate_conversational_goldens_from_docs`, and `a_generate_conversational_goldens_from_docs`) then guarded the accrual with:

```python
if self.synthesis_cost:
    self.synthesis_cost += context_generator.total_cost
```

`0` is falsy in Python, so this evaluates to `False` on the very first accrual, and `context_generator.total_cost` — the real per-chunk LLM cost from context quality scoring — is never added.

Four *other* cost-accrual sites in the same file already use the correct pattern: `if self.synthesis_cost is not None:`. This confirms the four broken sites are a copy/refactor slip, not an intentional design choice.

## What the fix does

Changes the four truthy checks to `is not None`, matching the pattern already used elsewhere in the file. `synthesis_cost` now correctly accumulates the context-generation cost on its first accrual for native models, instead of silently dropping it.

## How to reproduce / verify

```python
class FakeSynth:
    def __init__(self, using_native_model):
        self.using_native_model = using_native_model
        self.synthesis_cost = 0 if using_native_model else None
    def accrue(self, total_cost):
        if self.synthesis_cost is not None:   # was: `if self.synthesis_cost:`
            self.synthesis_cost += total_cost

s = FakeSynth(using_native_model=True)
s.accrue(0.0042)
assert s.synthesis_cost == 0.0042   # was 0 before the fix — cost silently dropped
```

Any call to `generate_goldens_from_docs` (or its async/conversational variants) with a native model now correctly includes the context-generation cost in `synthesis_cost`.

Closes #2881