### PR TITLE
fix: unwrap tuple returns from non-native models in Synthesizer

### DIFF
--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -844,11 +844,15 @@ class ContextGenerator:
                 res: ContextScore = self.model.generate(
                     prompt, schema=ContextScore
                 )
+                if isinstance(res, tuple):
+                    res = res[0]
                 return (
                     res.clarity + res.depth + res.structure + res.relevance
                 ) / 4
             except TypeError:
                 res = self.model.generate(prompt)
+                if isinstance(res, tuple):
+                    res = res[0]
                 data = trimAndLoadJson(res, self)
                 score = (
                     data["clarity"]
@@ -870,11 +874,15 @@ class ContextGenerator:
                 res: ContextScore = await self.model.a_generate(
                     prompt, schema=ContextScore
                 )
+                if isinstance(res, tuple):
+                    res = res[0]
                 return (
                     res.clarity + res.depth + res.structure + res.relevance
                 ) / 4
             except TypeError:
                 res: ContextScore = await self.model.a_generate(prompt)
+                if isinstance(res, tuple):
+                    res = res[0]
                 data = trimAndLoadJson(res, self)
                 score = (
                     data["clarity"]

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -1692,9 +1692,13 @@ class Synthesizer:
         else:
             try:
                 res = model.generate(prompt, schema=schema)
+                if isinstance(res, tuple):
+                    res = res[0]
                 return res
             except TypeError:
                 res = model.generate(prompt)
+                if isinstance(res, tuple):
+                    res = res[0]
                 data = trimAndLoadJson(res, self)
                 # `SyntheticDataList` is nested, so must be manually processed
                 # if custom model doesn't support schema
@@ -1718,9 +1722,13 @@ class Synthesizer:
         else:
             try:
                 res = await model.a_generate(prompt, schema=schema)
+                if isinstance(res, tuple):
+                    res = res[0]
                 return res
             except TypeError:
                 res = await model.a_generate(prompt)
+                if isinstance(res, tuple):
+                    res = res[0]
                 data = trimAndLoadJson(res, self)
                 # `SyntheticDataList` is nested, so must be manually processed
                 # if custom model doesn't support schema
@@ -1739,9 +1747,13 @@ class Synthesizer:
         else:
             try:
                 res: Response = self.model.generate(prompt, schema=Response)
+                if isinstance(res, tuple):
+                    res = res[0]
                 return res.response
             except TypeError:
                 res = self.model.generate(prompt)
+                if isinstance(res, tuple):
+                    res = res[0]
                 return res
 
     async def _a_generate(self, prompt: str) -> str:
@@ -1755,9 +1767,13 @@ class Synthesizer:
                 res: Response = await self.model.a_generate(
                     prompt, schema=Response
                 )
+                if isinstance(res, tuple):
+                    res = res[0]
                 return res.response
             except TypeError:
                 res = await self.model.a_generate(prompt)
+                if isinstance(res, tuple):
+                    res = res[0]
                 return res
 
     #############################################################


### PR DESCRIPTION
## What was the bug

Custom `DeepEvalBaseLLM` subclasses used as `critic_model` in `ContextConstructionConfig` (or as the main `model`) can cause `Synthesizer.generate_goldens_from_docs()` to silently return 0 goldens, with no error surfaced. Native models (e.g. `DeepSeekModel`, `OpenAIModel`) work fine.

## Root cause

The abstract `DeepEvalBaseLLM.generate()` / `a_generate()` signatures are typed to return `str`, but every native model implementation actually returns `Tuple[Union[str, BaseModel], float]` (value, cost) — an undocumented but universal runtime convention every built-in model follows.

Custom subclasses that follow this same tuple convention aren't recognized as "native" by `is_native_model()` (only specific built-in classes are), so they fall into non-native code paths that assume a plain (non-tuple) return value and immediately do attribute access on it:

- `Synthesizer._generate_schema()` — `res = model.generate(prompt, schema=schema)` → `return res` (used downstream as `res.input`, etc.)
- `Synthesizer._generate()` — `res: Response = self.model.generate(prompt, schema=Response)` → `res.response`
- `ContextGenerator.evaluate_chunk()` — `res: ContextScore = self.model.generate(prompt, schema=ContextScore)` → `res.clarity`

Since `res` is actually a tuple in this scenario, these attribute accesses raise `AttributeError`, which is caught by a broad `except Exception` further up the call chain (e.g. in `generate_contexts()`) and surfaces only as "0 goldens generated," with no visible error to the user.

## What the fix does

Adds `if isinstance(res, tuple): res = res[0]` immediately after each non-native `model.generate(...)` / `model.a_generate(...)` call, before the result is used, across all 6 affected code paths:

- `Synthesizer._generate_schema` / `_a_generate_schema`
- `Synthesizer._generate` / `_a_generate`
- `ContextGenerator.evaluate_chunk` / `a_evaluate_chunk`

Well-behaved custom models that already return a plain value are unaffected (the `isinstance` check is a no-op for them); custom models that follow the tuple convention are now unwrapped correctly instead of crashing on attribute access.

## How to reproduce / verify

```python
class Response:
    def __init__(self, response): self.response = response

class FakeCustomModel:
    def generate(self, prompt, schema=None):
        if schema is Response:
            return Response("hello world"), 0.0  # tuple convention, like every native model
        raise TypeError("no schema support")

def _generate(model, prompt):
    try:
        res = model.generate(prompt, schema=Response)
        if isinstance(res, tuple):
            res = res[0]
        return res.response
    except TypeError:
        res = model.generate(prompt)
        if isinstance(res, tuple):
            res = res[0]
        return res

assert _generate(FakeCustomModel(), "hi") == "hello world"
# Before this fix: AttributeError: 'tuple' object has no attribute 'response'
```

Closes #2885