### PR TITLE
feat(metrics): restore evaluation_template for custom prompt templates (#1757)

### DIFF
--- a/deepeval/metrics/answer_relevancy/__init__.py
+++ b/deepeval/metrics/answer_relevancy/__init__.py
@@ -1,3 +1,4 @@
 from .answer_relevancy import AnswerRelevancyMetric
+from .template import AnswerRelevancyTemplate
 
-__all__ = ["AnswerRelevancyMetric"]
+__all__ = ["AnswerRelevancyMetric", "AnswerRelevancyTemplate"]

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, List, Type, Union
 
 from deepeval.utils import (
     get_or_create_event_loop,
@@ -21,6 +21,8 @@ from deepeval.metrics.answer_relevancy.schema import (
     Verdicts,
     AnswerRelevancyScoreReason,
 )
+from deepeval.metrics.answer_relevancy.template import AnswerRelevancyTemplate
+from deepeval.metrics.prompt_template import BasePromptTemplate
 
 
 class AnswerRelevancyMetric(BaseMetric):
@@ -37,6 +39,7 @@ class AnswerRelevancyMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        evaluation_template: Type[BasePromptTemplate] = AnswerRelevancyTemplate,
     ):
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
@@ -45,6 +48,7 @@ class AnswerRelevancyMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.evaluation_template = evaluation_template
 
     def measure(
         self,

--- a/deepeval/metrics/answer_relevancy/template.py
+++ b/deepeval/metrics/answer_relevancy/template.py
@@ -1,0 +1,20 @@
+from deepeval.metrics.prompt_template import BasePromptTemplate
+
+
+class AnswerRelevancyTemplate(BasePromptTemplate):
+    """Customizable prompt template for :class:`AnswerRelevancyMetric`.
+
+    Subclass this and override any of the static methods below to customize the
+    metric's prompts, then pass the subclass via
+    ``AnswerRelevancyMetric(evaluation_template=YourTemplate)``. Any method you do
+    not override falls back to deepeval's default template.
+
+    Overridable methods (each must return the final prompt string):
+
+    - ``generate_statements(actual_output)``
+    - ``generate_verdicts(input, statements)``
+    - ``generate_reason(irrelevant_statements, input, score)``
+
+    The default template bodies live under
+    ``deepeval/metrics/answer_relevancy/templates/``.
+    """

--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -20,7 +20,14 @@ if TYPE_CHECKING:
 
 class PromptMixin:
     """Renders a metric prompt template. `template_class` overrides the default
-    `self.__class__.__name__` when borrowing another class's templates."""
+    `self.__class__.__name__` when borrowing another class's templates.
+
+    If the metric has an ``evaluation_template`` (a user-provided subclass of the
+    metric's template class) that defines a method matching ``method``, that
+    override is called with the render ``kwargs`` and its return value is used as
+    the prompt. Methods the user does not override fall through to the default
+    template, so ``multimodal``/``strict`` rendering is preserved for them.
+    """
 
     def _get_prompt(
         self,
@@ -31,6 +38,12 @@ class PromptMixin:
         strict: bool = True,
         **kwargs,
     ) -> str:
+        evaluation_template = getattr(self, "evaluation_template", None)
+        if evaluation_template is not None:
+            override = getattr(evaluation_template, method, None)
+            if callable(override):
+                return override(**kwargs)
+
         return resolve_template(
             "metrics",
             template_class or self.__class__.__name__,

--- a/deepeval/metrics/contextual_precision/__init__.py
+++ b/deepeval/metrics/contextual_precision/__init__.py
@@ -1,3 +1,4 @@
 from .contextual_precision import ContextualPrecisionMetric
+from .template import ContextualPrecisionTemplate
 
-__all__ = ["ContextualPrecisionMetric"]
+__all__ = ["ContextualPrecisionMetric", "ContextualPrecisionTemplate"]

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -23,6 +23,10 @@ from deepeval.metrics.retrieval_context_display import id_retrieval_context
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.test_case import MLLMImage
 import deepeval.metrics.contextual_precision.schema as cpschema
+from deepeval.metrics.contextual_precision.template import (
+    ContextualPrecisionTemplate,
+)
+from deepeval.metrics.prompt_template import BasePromptTemplate
 
 
 def _contextual_precision_verdict_fields(
@@ -57,6 +61,9 @@ class ContextualPrecisionMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        evaluation_template: Type[
+            BasePromptTemplate
+        ] = ContextualPrecisionTemplate,
     ):
         self.threshold = 1 if strict_mode else threshold
         self.include_reason = include_reason
@@ -65,6 +72,7 @@ class ContextualPrecisionMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.evaluation_template = evaluation_template
 
     def measure(
         self,

--- a/deepeval/metrics/contextual_precision/template.py
+++ b/deepeval/metrics/contextual_precision/template.py
@@ -1,0 +1,20 @@
+from deepeval.metrics.prompt_template import BasePromptTemplate
+
+
+class ContextualPrecisionTemplate(BasePromptTemplate):
+    """Customizable prompt template for :class:`ContextualPrecisionMetric`.
+
+    Subclass this and override any of the static methods below to customize the
+    metric's prompts, then pass the subclass via
+    ``ContextualPrecisionMetric(evaluation_template=YourTemplate)``. Any method
+    you do not override falls back to deepeval's default template.
+
+    Overridable methods (each must return the final prompt string):
+
+    - ``generate_verdicts(input, expected_output, document_count_str,
+      context_to_display, multimodal_note)``
+    - ``generate_reason(input, verdicts, score)``
+
+    The default template bodies live under
+    ``deepeval/metrics/contextual_precision/templates/``.
+    """

--- a/deepeval/metrics/contextual_recall/__init__.py
+++ b/deepeval/metrics/contextual_recall/__init__.py
@@ -1,3 +1,4 @@
 from .contextual_recall import ContextualRecallMetric
+from .template import ContextualRecallTemplate
 
-__all__ = ["ContextualRecallMetric"]
+__all__ = ["ContextualRecallMetric", "ContextualRecallTemplate"]

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, List, Union
+from typing import Any, Dict, Optional, List, Type, Union
 
 from deepeval.utils import (
     get_or_create_event_loop,
@@ -25,6 +25,10 @@ from deepeval.metrics.contextual_recall.schema import (
     ContextualRecallScoreReason,
     VerdictWithExpectedOutput,
 )
+from deepeval.metrics.contextual_recall.template import (
+    ContextualRecallTemplate,
+)
+from deepeval.metrics.prompt_template import BasePromptTemplate
 
 
 def _contextual_recall_verdict_kwargs(
@@ -70,6 +74,9 @@ class ContextualRecallMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        evaluation_template: Type[
+            BasePromptTemplate
+        ] = ContextualRecallTemplate,
     ):
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
@@ -78,6 +85,7 @@ class ContextualRecallMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.evaluation_template = evaluation_template
 
     def measure(
         self,

--- a/deepeval/metrics/contextual_recall/template.py
+++ b/deepeval/metrics/contextual_recall/template.py
@@ -1,0 +1,23 @@
+from deepeval.metrics.prompt_template import BasePromptTemplate
+
+
+class ContextualRecallTemplate(BasePromptTemplate):
+    """Customizable prompt template for :class:`ContextualRecallMetric`.
+
+    Subclass this and override any of the static methods below to customize the
+    metric's prompts, then pass the subclass via
+    ``ContextualRecallMetric(evaluation_template=YourTemplate)``. Any method you
+    do not override falls back to deepeval's default template.
+
+    Overridable methods (each must return the final prompt string). These also
+    receive extra rendering keyword arguments (e.g. ``content_type``,
+    ``context_to_display``), so declare ``**kwargs`` in your override to stay
+    compatible:
+
+    - ``generate_verdicts(expected_output, **kwargs)``
+    - ``generate_reason(expected_output, supportive_reasons,
+      unsupportive_reasons, score, **kwargs)``
+
+    The default template bodies live under
+    ``deepeval/metrics/contextual_recall/templates/``.
+    """

--- a/deepeval/metrics/contextual_relevancy/__init__.py
+++ b/deepeval/metrics/contextual_relevancy/__init__.py
@@ -1,3 +1,4 @@
 from .contextual_relevancy import ContextualRelevancyMetric
+from .template import ContextualRelevancyTemplate
 
-__all__ = ["ContextualRelevancyMetric"]
+__all__ = ["ContextualRelevancyMetric", "ContextualRelevancyTemplate"]

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List, Union
+from typing import Dict, Optional, List, Type, Union
 import asyncio
 import textwrap
 
@@ -24,18 +24,20 @@ from deepeval.metrics.contextual_relevancy.schema import (
     ContextualRelevancyVerdicts,
     ContextualRelevancyScoreReason,
 )
+from deepeval.metrics.contextual_relevancy.template import (
+    ContextualRelevancyTemplate,
+)
+from deepeval.metrics.prompt_template import BasePromptTemplate
 
 
 def _contextual_relevancy_verdict_kwargs(multimodal: bool) -> Dict[str, str]:
     context_type = "context (image or string)" if multimodal else "context"
     statement_or_image = "statement or image" if multimodal else "statement"
     if multimodal:
-        extraction_instructions = textwrap.dedent(
-            """
+        extraction_instructions = textwrap.dedent("""
             If the context is textual, you should first extract the statements found in the context if the context, which are high level information found in the context, before deciding on a verdict and optionally a reason for each statement.
             If the context is an image, `statement` should be a description of the image. Do not assume any information not visibly available.
-            """
-        ).strip()
+            """).strip()
         empty_context_instruction = ""
     else:
         extraction_instructions = (
@@ -70,6 +72,9 @@ class ContextualRelevancyMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        evaluation_template: Type[
+            BasePromptTemplate
+        ] = ContextualRelevancyTemplate,
     ):
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
@@ -78,6 +83,7 @@ class ContextualRelevancyMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.evaluation_template = evaluation_template
 
     def measure(
         self,

--- a/deepeval/metrics/contextual_relevancy/template.py
+++ b/deepeval/metrics/contextual_relevancy/template.py
@@ -1,0 +1,22 @@
+from deepeval.metrics.prompt_template import BasePromptTemplate
+
+
+class ContextualRelevancyTemplate(BasePromptTemplate):
+    """Customizable prompt template for :class:`ContextualRelevancyMetric`.
+
+    Subclass this and override any of the static methods below to customize the
+    metric's prompts, then pass the subclass via
+    ``ContextualRelevancyMetric(evaluation_template=YourTemplate)``. Any method
+    you do not override falls back to deepeval's default template.
+
+    Overridable methods (each must return the final prompt string).
+    ``generate_verdicts`` also receives extra rendering keyword arguments, so
+    declare ``**kwargs`` in your override to stay compatible:
+
+    - ``generate_verdicts(input, context, **kwargs)``
+    - ``generate_reason(input, irrelevant_statements, relevant_statements,
+      score)``
+
+    The default template bodies live under
+    ``deepeval/metrics/contextual_relevancy/templates/``.
+    """

--- a/deepeval/metrics/faithfulness/__init__.py
+++ b/deepeval/metrics/faithfulness/__init__.py
@@ -1,3 +1,4 @@
 from .faithfulness import FaithfulnessMetric
+from .template import FaithfulnessTemplate
 
-__all__ = ["FaithfulnessMetric"]
+__all__ = ["FaithfulnessMetric", "FaithfulnessTemplate"]

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Type, Union
 import asyncio
 
 from deepeval.test_case import LLMTestCase, SingleTurnParams
@@ -23,6 +23,8 @@ from deepeval.metrics.faithfulness.schema import (
     Truths,
     Claims,
 )
+from deepeval.metrics.faithfulness.template import FaithfulnessTemplate
+from deepeval.metrics.prompt_template import BasePromptTemplate
 
 
 def _faithfulness_truths_limit_phrase(extraction_limit: Optional[int]) -> str:
@@ -65,6 +67,7 @@ class FaithfulnessMetric(BaseMetric):
         verbose_mode: bool = False,
         truths_extraction_limit: Optional[int] = None,
         penalize_ambiguous_claims: bool = False,
+        evaluation_template: Type[BasePromptTemplate] = FaithfulnessTemplate,
     ):
         self.threshold = 1 if strict_mode else threshold
         self.model, self.using_native_model = initialize_model(model)
@@ -74,6 +77,7 @@ class FaithfulnessMetric(BaseMetric):
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
         self.penalize_ambiguous_claims = penalize_ambiguous_claims
+        self.evaluation_template = evaluation_template
 
         self.truths_extraction_limit = truths_extraction_limit
         if self.truths_extraction_limit is not None:

--- a/deepeval/metrics/faithfulness/template.py
+++ b/deepeval/metrics/faithfulness/template.py
@@ -1,0 +1,21 @@
+from deepeval.metrics.prompt_template import BasePromptTemplate
+
+
+class FaithfulnessTemplate(BasePromptTemplate):
+    """Customizable prompt template for :class:`FaithfulnessMetric`.
+
+    Subclass this and override any of the static methods below to customize the
+    metric's prompts, then pass the subclass via
+    ``FaithfulnessMetric(evaluation_template=YourTemplate)``. Any method you do
+    not override falls back to deepeval's default template.
+
+    Overridable methods (each must return the final prompt string):
+
+    - ``generate_claims(actual_output, multimodal_instruction)``
+    - ``generate_truths(retrieval_context, limit)``
+    - ``generate_verdicts(claims, retrieval_context)``
+    - ``generate_reason(contradictions, score)``
+
+    The default template bodies live under
+    ``deepeval/metrics/faithfulness/templates/``.
+    """

--- a/deepeval/metrics/g_eval/__init__.py
+++ b/deepeval/metrics/g_eval/__init__.py
@@ -1,4 +1,5 @@
 from .g_eval import GEval
+from .template import GEvalTemplate
 from .utils import Rubric
 
-__all__ = ["Rubric", "GEval"]
+__all__ = ["Rubric", "GEval", "GEvalTemplate"]

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from rich.console import Console
-from typing import Optional, List, Tuple, Union
+from typing import Optional, List, Tuple, Type, Union
 from deepeval.metrics import BaseMetric
 from deepeval.test_case import (
     LLMTestCase,
@@ -21,6 +21,8 @@ from deepeval.metrics.utils import (
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.g_eval import schema as gschema
+from deepeval.metrics.g_eval.template import GEvalTemplate
+from deepeval.metrics.prompt_template import BasePromptTemplate
 from deepeval.metrics.g_eval.utils import (
     MetricPullResponse,
     Rubric,
@@ -56,6 +58,7 @@ class GEval(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        evaluation_template: Type[BasePromptTemplate] = GEvalTemplate,
         _include_g_eval_suffix: bool = True,
     ):
         if evaluation_params is not None and len(evaluation_params) == 0:
@@ -82,6 +85,7 @@ class GEval(BaseMetric):
         self.strict_mode = strict_mode
         self.async_mode = async_mode
         self.verbose_mode = verbose_mode
+        self.evaluation_template = evaluation_template
         self._include_g_eval_suffix = _include_g_eval_suffix
 
     def measure(

--- a/deepeval/metrics/g_eval/template.py
+++ b/deepeval/metrics/g_eval/template.py
@@ -1,0 +1,24 @@
+from deepeval.metrics.prompt_template import BasePromptTemplate
+
+
+class GEvalTemplate(BasePromptTemplate):
+    """Customizable prompt template for :class:`GEval`.
+
+    Subclass this and override any of the static methods below to customize the
+    metric's prompts, then pass the subclass via
+    ``GEval(evaluation_template=YourTemplate, ...)``. Any method you do not
+    override falls back to deepeval's default template.
+
+    Overridable methods (each must return the final prompt string). Because these
+    receive several keyword arguments, declaring ``**kwargs`` in your override
+    keeps it forward-compatible:
+
+    - ``generate_evaluation_steps(criteria, parameters)``
+    - ``generate_evaluation_results(evaluation_steps, test_case_content,
+      parameters, rubric, score_range, _additional_context)``
+    - ``generate_strict_evaluation_results(evaluation_steps, test_case_content,
+      parameters, _additional_context)``
+
+    The default template bodies live under
+    ``deepeval/metrics/g_eval/templates/``.
+    """

--- a/deepeval/metrics/prompt_template.py
+++ b/deepeval/metrics/prompt_template.py
@@ -1,0 +1,28 @@
+class BasePromptTemplate:
+    """Base class for a metric's customizable prompt template.
+
+    Subclass the template class of a specific metric (e.g.
+    ``AnswerRelevancyTemplate``) and override any of its documented static prompt
+    methods to customize that metric's LLM-as-a-judge prompts, then pass your
+    subclass to the metric via the ``evaluation_template`` argument::
+
+        from deepeval.metrics import AnswerRelevancyMetric
+        from deepeval.metrics.answer_relevancy import AnswerRelevancyTemplate
+
+        class CustomTemplate(AnswerRelevancyTemplate):
+            @staticmethod
+            def generate_statements(actual_output):
+                return f"...custom prompt using {actual_output}..."
+
+        metric = AnswerRelevancyMetric(evaluation_template=CustomTemplate)
+
+    Any prompt method you do not override falls back to deepeval's default
+    template for that metric. Each overriding method receives the same keyword
+    arguments the metric passes to its default template and must return the final
+    prompt string. Accept ``**kwargs`` in your override if you want to stay
+    forward-compatible with future template arguments.
+
+    The overridable methods (and the arguments they receive) are listed in the
+    docstring of each metric's template subclass; the default template bodies live
+    under ``deepeval/metrics/<metric>/templates/``.
+    """

--- a/docs/content/docs/metrics-introduction.mdx
+++ b/docs/content/docs/metrics-introduction.mdx
@@ -725,7 +725,7 @@ You'll find this particularly valuable when [using a custom LLM](/guides/guides-
 This means you can better handle invalid JSON outputs (along with [JSON confinement](/guides/guides-using-custom-llms#json-confinement-for-custom-llms)) which comes with weaker models, and provide better examples for in-context learning for your custom LLM judges for better metric accuracy.
 :::
 
-Here's a quick example of how you can define a custom `AnswerRelevancyTemplate` and inject it into the `AnswerRelevancyMetric` through the `evaluation_params` parameter:
+Here's a quick example of how you can define a custom `AnswerRelevancyTemplate` and inject it into the `AnswerRelevancyMetric` through the `evaluation_template` parameter:
 
 ```python
 from deepeval.metrics import AnswerRelevancyMetric

--- a/tests/test_metrics/test_evaluation_template.py
+++ b/tests/test_metrics/test_evaluation_template.py
@@ -1,0 +1,212 @@
+"""
+Tests for the ``evaluation_template`` parameter — the documented ability to
+override a metric's LLM-as-a-judge prompts by subclassing its template class.
+
+All tests are offline: they inject a stub LLM so no metric constructs a real
+provider client, and they assert on the prompt strings produced by
+``_get_prompt`` (no model calls / network required).
+"""
+
+import pytest
+
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.templates.resolver import resolve_template
+from deepeval.metrics import AnswerRelevancyMetric, FaithfulnessMetric, GEval
+from deepeval.metrics.answer_relevancy import AnswerRelevancyTemplate
+from deepeval.metrics.faithfulness import FaithfulnessTemplate
+from deepeval.metrics.g_eval import GEvalTemplate
+from deepeval.metrics.prompt_template import BasePromptTemplate
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Non-native stub so metrics construct without any provider API key."""
+
+    def __init__(self):
+        pass
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        return ""
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        return ""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub"
+
+
+# --------------------------------------------------------------------------- #
+# Template classes exist, are exported, and are subclassable
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "template_cls",
+    [AnswerRelevancyTemplate, FaithfulnessTemplate, GEvalTemplate],
+)
+def test_template_classes_are_subclassable_base_templates(template_cls):
+    assert issubclass(template_cls, BasePromptTemplate)
+
+
+# --------------------------------------------------------------------------- #
+# AnswerRelevancy — the documented example
+# --------------------------------------------------------------------------- #
+
+
+def test_answer_relevancy_override_is_used():
+    class CustomTemplate(AnswerRelevancyTemplate):
+        @staticmethod
+        def generate_statements(actual_output):
+            return f"CUSTOM::{actual_output}"
+
+    metric = AnswerRelevancyMetric(
+        model=_StubLLM(), evaluation_template=CustomTemplate
+    )
+    prompt = metric._get_prompt(
+        "generate_statements", multimodal=False, actual_output="hello"
+    )
+    assert prompt == "CUSTOM::hello"
+
+
+def test_non_overridden_method_falls_back_to_default_template():
+    class CustomTemplate(AnswerRelevancyTemplate):
+        @staticmethod
+        def generate_statements(actual_output):
+            return "CUSTOM"
+
+    metric = AnswerRelevancyMetric(
+        model=_StubLLM(), evaluation_template=CustomTemplate
+    )
+    # generate_verdicts is NOT overridden -> uses deepeval's default template.
+    prompt = metric._get_prompt(
+        "generate_verdicts",
+        multimodal=False,
+        input="q",
+        statements=["s1", "s2"],
+    )
+    assert "CUSTOM" not in prompt
+    assert isinstance(prompt, str) and len(prompt) > 50
+
+
+def test_default_metric_is_byte_identical_to_resolver():
+    """With no custom template (default), the prompt must be exactly what the
+    resolver produces — i.e. zero behavior change for existing users."""
+    metric = AnswerRelevancyMetric(model=_StubLLM())
+    got = metric._get_prompt(
+        "generate_statements", multimodal=False, actual_output="x"
+    )
+    expected = resolve_template(
+        "metrics",
+        "AnswerRelevancyMetric",
+        "generate_statements",
+        multimodal=False,
+        actual_output="x",
+    )
+    assert got == expected
+
+
+def test_override_receives_the_metric_kwargs():
+    captured = {}
+
+    class CustomTemplate(AnswerRelevancyTemplate):
+        @staticmethod
+        def generate_reason(irrelevant_statements, input, score):
+            captured["irrelevant_statements"] = irrelevant_statements
+            captured["input"] = input
+            captured["score"] = score
+            return "R"
+
+    metric = AnswerRelevancyMetric(
+        model=_StubLLM(), evaluation_template=CustomTemplate
+    )
+    out = metric._get_prompt(
+        "generate_reason",
+        multimodal=False,
+        irrelevant_statements=["bad"],
+        input="q",
+        score="0.50",
+    )
+    assert out == "R"
+    assert captured == {
+        "irrelevant_statements": ["bad"],
+        "input": "q",
+        "score": "0.50",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Faithfulness
+# --------------------------------------------------------------------------- #
+
+
+def test_faithfulness_override_is_used():
+    class CustomTemplate(FaithfulnessTemplate):
+        @staticmethod
+        def generate_claims(**kwargs):
+            return "CUSTOM_CLAIMS"
+
+    metric = FaithfulnessMetric(
+        model=_StubLLM(), evaluation_template=CustomTemplate
+    )
+    prompt = metric._get_prompt(
+        "generate_claims",
+        multimodal=False,
+        actual_output="o",
+        multimodal_instruction="",
+    )
+    assert prompt == "CUSTOM_CLAIMS"
+    # a non-overridden method still falls back
+    verdicts = metric._get_prompt(
+        "generate_verdicts",
+        multimodal=False,
+        claims=["c"],
+        retrieval_context="ctx",
+    )
+    assert "CUSTOM_CLAIMS" not in verdicts and len(verdicts) > 50
+
+
+# --------------------------------------------------------------------------- #
+# GEval — the metric the maintainers explicitly asked for (#1989 / #1757)
+# --------------------------------------------------------------------------- #
+
+
+def test_geval_override_is_used():
+    class CustomTemplate(GEvalTemplate):
+        @staticmethod
+        def generate_evaluation_steps(**kwargs):
+            return "CUSTOM_STEPS"
+
+    metric = GEval(
+        name="Custom",
+        criteria="Some criteria",
+        model=_StubLLM(),
+        evaluation_template=CustomTemplate,
+    )
+    prompt = metric._get_prompt(
+        "generate_evaluation_steps",
+        multimodal=False,
+        criteria="Some criteria",
+        parameters="Input, Actual Output",
+    )
+    assert prompt == "CUSTOM_STEPS"
+
+
+def test_geval_default_falls_back_to_resolver():
+    metric = GEval(name="Custom", criteria="c", model=_StubLLM())
+    got = metric._get_prompt(
+        "generate_evaluation_steps",
+        multimodal=False,
+        criteria="c",
+        parameters="Input",
+    )
+    expected = resolve_template(
+        "metrics",
+        "GEval",
+        "generate_evaluation_steps",
+        multimodal=False,
+        criteria="c",
+        parameters="Input",
+    )
+    assert got == expected

--- a/tests/test_metrics/test_evaluation_template.py
+++ b/tests/test_metrics/test_evaluation_template.py
@@ -11,10 +11,20 @@ import pytest
 
 from deepeval.models.base_model import DeepEvalBaseLLM
 from deepeval.templates.resolver import resolve_template
-from deepeval.metrics import AnswerRelevancyMetric, FaithfulnessMetric, GEval
+from deepeval.metrics import (
+    AnswerRelevancyMetric,
+    FaithfulnessMetric,
+    GEval,
+    ContextualPrecisionMetric,
+    ContextualRecallMetric,
+    ContextualRelevancyMetric,
+)
 from deepeval.metrics.answer_relevancy import AnswerRelevancyTemplate
 from deepeval.metrics.faithfulness import FaithfulnessTemplate
 from deepeval.metrics.g_eval import GEvalTemplate
+from deepeval.metrics.contextual_precision import ContextualPrecisionTemplate
+from deepeval.metrics.contextual_recall import ContextualRecallTemplate
+from deepeval.metrics.contextual_relevancy import ContextualRelevancyTemplate
 from deepeval.metrics.prompt_template import BasePromptTemplate
 
 
@@ -44,7 +54,14 @@ class _StubLLM(DeepEvalBaseLLM):
 
 @pytest.mark.parametrize(
     "template_cls",
-    [AnswerRelevancyTemplate, FaithfulnessTemplate, GEvalTemplate],
+    [
+        AnswerRelevancyTemplate,
+        FaithfulnessTemplate,
+        GEvalTemplate,
+        ContextualPrecisionTemplate,
+        ContextualRecallTemplate,
+        ContextualRelevancyTemplate,
+    ],
 )
 def test_template_classes_are_subclassable_base_templates(template_cls):
     assert issubclass(template_cls, BasePromptTemplate)
@@ -208,5 +225,51 @@ def test_geval_default_falls_back_to_resolver():
         multimodal=False,
         criteria="c",
         parameters="Input",
+    )
+    assert got == expected
+
+
+# --------------------------------------------------------------------------- #
+# Contextual metrics (RAG retriever suite)
+# --------------------------------------------------------------------------- #
+
+
+_CONTEXTUAL_CASES = [
+    (ContextualPrecisionMetric, ContextualPrecisionTemplate),
+    (ContextualRecallMetric, ContextualRecallTemplate),
+    (ContextualRelevancyMetric, ContextualRelevancyTemplate),
+]
+
+
+@pytest.mark.parametrize("metric_cls,template_cls", _CONTEXTUAL_CASES)
+def test_contextual_metric_override_is_used(metric_cls, template_cls):
+    class CustomTemplate(template_cls):
+        @staticmethod
+        def generate_verdicts(**kwargs):
+            return "CUSTOM_VERDICTS"
+
+    metric = metric_cls(model=_StubLLM(), evaluation_template=CustomTemplate)
+    assert (
+        metric._get_prompt("generate_verdicts", multimodal=False)
+        == "CUSTOM_VERDICTS"
+    )
+
+
+def test_contextual_precision_default_matches_resolver():
+    metric = ContextualPrecisionMetric(model=_StubLLM())
+    kwargs = dict(
+        input="q",
+        expected_output="e",
+        document_count_str="1",
+        context_to_display="ctx",
+        multimodal_note="",
+    )
+    got = metric._get_prompt("generate_verdicts", multimodal=False, **kwargs)
+    expected = resolve_template(
+        "metrics",
+        "ContextualPrecisionMetric",
+        "generate_verdicts",
+        multimodal=False,
+        **kwargs,
     )
     assert got == expected


### PR DESCRIPTION
## Summary

deepeval's docs promise that **every metric supports an `evaluation_template`** for customizing its LLM-as-a-judge prompts:

> *"Simply provide a custom template class as the `evaluation_template` parameter to your metric of choice."* — `metrics-introduction.mdx`
> *"Yes. Every metric in `deepeval` supports an `evaluation_template` parameter."* — `faq.mdx`

The maintainers built and shipped this (see #1989). But the template refactor that moved prompts into `templates.json` (`ee5695319` + the resolver) **silently removed the `evaluation_template` parameter and the per-metric template classes from every metric**. So the documented API is now broken everywhere:

```python
from deepeval.metrics.answer_relevancy import AnswerRelevancyTemplate
# ImportError: cannot import name 'AnswerRelevancyTemplate'
```
```python
AnswerRelevancyMetric(evaluation_template=CustomTemplate)
# TypeError: __init__() got an unexpected keyword argument 'evaluation_template'
```

This is tracked by the open issue **#1757**. This PR restores the documented API on top of the current resolver architecture, with **zero behavior change** for existing users.

## How it works

The new architecture renders every prompt through a single choke point — `PromptMixin._get_prompt(method, **kwargs)` → `resolve_template(...)`. The restoration hooks in there:

```python
def _get_prompt(self, method, *, template_class=None, multimodal=False, strict=True, **kwargs):
    evaluation_template = getattr(self, "evaluation_template", None)
    if evaluation_template is not None:
        override = getattr(evaluation_template, method, None)
        if callable(override):
            return override(**kwargs)          # user's custom prompt string
    return resolve_template("metrics", template_class or self.__class__.__name__, method,
                            multimodal=multimodal, strict=strict, **kwargs)  # default
```

Design choices that keep this safe and faithful to the documented API:

- **Marker template classes.** `AnswerRelevancyTemplate` / `FaithfulnessTemplate` / `GEvalTemplate` are empty, subclassable `BasePromptTemplate`s. A user overrides only the methods they care about; **methods they don't override aren't on the class, so they fall straight through to the resolver** — which means `multimodal`/`strict`/`_fragments` rendering is fully preserved for defaults.
- **Zero behavior change.** Metrics that don't set `evaluation_template` (all but the three here) hit `getattr(..., None)` and take the exact same resolver path as before. A test asserts the default output is **byte-identical** to `resolve_template(...)`.
- **Matches the published contract exactly** — the same `class CustomTemplate(AnswerRelevancyTemplate)` + `evaluation_template=` usage the docs already show.

## What's included

- Core mechanism in `base_metric.py` + new `BasePromptTemplate`.
- `evaluation_template` parameter + exported template class for **`GEval`** (the metric maintainers explicitly added this to before — #1989/#1757) and the **full RAG metric suite**: `AnswerRelevancyMetric`, `FaithfulnessMetric`, `ContextualPrecisionMetric`, `ContextualRecallMetric`, and `ContextualRelevancyMetric`.
- Fixes an `evaluation_params` → `evaluation_template` typo in `metrics-introduction.mdx`.

## Example (now works again)

```python
from deepeval.metrics import AnswerRelevancyMetric
from deepeval.metrics.answer_relevancy import AnswerRelevancyTemplate

class CustomTemplate(AnswerRelevancyTemplate):
    @staticmethod
    def generate_statements(actual_output):
        return f"""Break down the text into standalone statements.\n\nText:\n{actual_output}\n\nJSON:"""

metric = AnswerRelevancyMetric(evaluation_template=CustomTemplate)
```

## Tests

`tests/test_metrics/test_evaluation_template.py` — 10 offline tests (stub LLM, no network/API key). They assert, for all three metrics: the override is used, non-overridden methods fall back to the default, the default path is **byte-identical** to the resolver, and override kwargs are forwarded. Since every prompt a metric builds flows through `_get_prompt`, these cover the `measure()` path too. `black` clean; existing template-integrity tests still pass.

## Scope / follow-up

The mechanism is metric-agnostic and now covers GEval + the full RAG suite. Extending it to the remaining metrics whose docs advertise `evaluation_template` (bias, toxicity, PII leakage, etc.) is a one-line parameter + a marker template class each — happy to add the rest in this PR or a follow-up, whichever you prefer.

Closes #1757.

