### PR TITLE
fix: RoleViolationMetric strict_mode always succeeded (threshold=0)

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/dataset/golden.py
+++ b/deepeval/dataset/golden.py
@@ -202,9 +202,7 @@ class Golden(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     source_file: Optional[str] = Field(
         default=None, serialization_alias="sourceFile"

--- a/deepeval/metrics/role_violation/role_violation.py
+++ b/deepeval/metrics/role_violation/role_violation.py
@@ -44,7 +44,7 @@ class RoleViolationMetric(BaseMetric):
                 "Role parameter is required. Please specify the expected role (e.g., 'helpful assistant', 'customer service agent', etc.)"
             )
 
-        self.threshold = 0 if strict_mode else threshold
+        self.threshold = 1 if strict_mode else threshold
         self.role = role
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()

--- a/deepeval/metrics/role_violation/role_violation.py
+++ b/deepeval/metrics/role_violation/role_violation.py
@@ -52,7 +52,7 @@ class RoleViolationMetric(BaseMetric):
                 "Role parameter is required. Please specify the expected role (e.g., 'helpful assistant', 'customer service agent', etc.)"
             )
 
-        self.threshold = 0 if strict_mode else threshold
+        self.threshold = 1 if strict_mode else threshold
         self.role = role
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -402,9 +402,7 @@ class LLMTestCase(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     completion_time: Optional[float] = Field(
         default=None,

--- a/tests/test_metrics/test_role_violation_metric_strict_mode.py
+++ b/tests/test_metrics/test_role_violation_metric_strict_mode.py
@@ -1,0 +1,48 @@
+"""Regression tests for #2901: RoleViolationMetric's strict_mode always
+succeeded because the threshold was initialized to 0 instead of 1.
+
+RoleViolationMetric's score is binary (0.0 = violation detected, 1.0 = no
+violation). With `self.threshold = 0 if strict_mode else threshold`, a
+detected violation (score=0.0) satisfied `0.0 >= 0`, so strict_mode had no
+effect. These tests use DummyModel and do not require OPENAI_API_KEY.
+"""
+
+from unittest.mock import patch
+
+from deepeval.metrics import RoleViolationMetric
+from tests.test_core.stubs import DummyModel
+
+
+def make_metric(*, strict_mode: bool, threshold: float = 0.5):
+    """Create RoleViolationMetric with DummyModel so no LLM calls are made."""
+    with patch(
+        "deepeval.metrics.role_violation.role_violation.initialize_model"
+    ) as mock_init:
+        mock_init.return_value = (DummyModel(), True)
+        return RoleViolationMetric(
+            role="helpful assistant",
+            threshold=threshold,
+            strict_mode=strict_mode,
+        )
+
+
+def test_strict_mode_threshold_is_one():
+    metric = make_metric(strict_mode=True)
+    assert metric.threshold == 1
+
+
+def test_non_strict_mode_keeps_configured_threshold():
+    metric = make_metric(strict_mode=False, threshold=0.5)
+    assert metric.threshold == 0.5
+
+
+def test_strict_mode_fails_on_role_violation():
+    metric = make_metric(strict_mode=True)
+    metric.score = 0.0  # a detected role violation always scores 0.0
+    assert metric.is_successful() is False
+
+
+def test_strict_mode_passes_on_no_violation():
+    metric = make_metric(strict_mode=True)
+    metric.score = 1.0  # no role violation detected
+    assert metric.is_successful() is True


### PR DESCRIPTION
## Summary

`RoleViolationMetric.__init__` initializes the threshold as:

```python
self.threshold = 0 if strict_mode else threshold
```

`RoleViolationMetric`'s score is binary — `_calculate_score()` returns `0.0` when a role violation is detected, `1.0` otherwise. With `strict_mode=True`, the threshold becomes `0`, so a detected violation still satisfies `self.success = self.score >= self.threshold` (`0.0 >= 0` is `True`). Strict mode therefore never fails, even when a clear role violation is found.

Every other binary metric in the codebase (e.g. `g_eval`, `answer_relevancy`, `contextual_recall`, `summarization`) uses `1` as the strict-mode threshold; `role_violation` was the sole outlier.

## Fix

```python
self.threshold = 1 if strict_mode else threshold
```

## Testing

Added `tests/test_metrics/test_role_violation_metric_strict_mode.py` — uses `DummyModel` (no `OPENAI_API_KEY` needed, following the pattern in `test_answer_relevancy_metric_empty_output.py`) to test the threshold/success logic directly:
- `strict_mode=True` → `threshold == 1`
- `strict_mode=False` → threshold stays as configured
- a detected violation (`score=0.0`) under `strict_mode=True` → `is_successful() is False`
- no violation (`score=1.0`) under `strict_mode=True` → `is_successful() is True`

Verified these tests actually catch the bug: reverted the fix locally, confirmed 2 of the 4 new tests fail as expected, then restored the fix — all 4 pass. Also ran the full non-API-key-dependent metrics suite (103 tests) to check for regressions — all pass. `black`/`ruff` clean.

Fixes #2901