### PR TITLE
fix(anthropic): extract output and tools by block type, not content[0]

### DIFF
--- a/deepeval/anthropic/extractors.py
+++ b/deepeval/anthropic/extractors.py
@@ -65,6 +65,9 @@ def extract_messages_api_output_parameters(
     message_response: Message,
     input_parameters: InputParameters,
 ) -> OutputParameters:
+    # Anthropic responses may lead with a non-text block (a tool_use or
+    # thinking block), so read text from the first TextBlock rather than
+    # assuming content[0] holds it.
     text_blocks = [
         block
         for block in message_response.content
@@ -92,6 +95,8 @@ def extract_messages_api_output_parameters(
                 )
             )
 
+    # A tool-only turn has no TextBlock, so preserve the tool calls as the
+    # structured output instead of returning an empty string.
     if not output and tools_called:
         tool_calls = []
         for tool_call in tools_called:

--- a/deepeval/anthropic/extractors.py
+++ b/deepeval/anthropic/extractors.py
@@ -1,5 +1,5 @@
 from anthropic.types.message import Message
-from anthropic.types import ToolUseBlock
+from anthropic.types import TextBlock, ToolUseBlock
 from typing import Any, Dict
 
 from deepeval.anthropic.utils import (
@@ -65,7 +65,12 @@ def extract_messages_api_output_parameters(
     message_response: Message,
     input_parameters: InputParameters,
 ) -> OutputParameters:
-    output = str(message_response.content[0].text)
+    text_blocks = [
+        block
+        for block in message_response.content
+        if isinstance(block, TextBlock)
+    ]
+    output = str(text_blocks[0].text) if text_blocks else ""
     prompt_tokens = message_response.usage.input_tokens
     completion_tokens = message_response.usage.output_tokens
 
@@ -86,6 +91,13 @@ def extract_messages_api_output_parameters(
                     description=tool_descriptions.get(tool_call.name),
                 )
             )
+
+    if not output and tools_called:
+        tool_calls = []
+        for tool_call in tools_called:
+            tool_calls.append(tool_call)
+        output = tool_calls
+
     return OutputParameters(
         output=output,
         prompt_tokens=prompt_tokens,

--- a/tests/test_core/test_models/test_anthropic_extractors.py
+++ b/tests/test_core/test_models/test_anthropic_extractors.py
@@ -1,0 +1,142 @@
+from anthropic.types.message import Message
+
+from deepeval.anthropic.extractors import (
+    extract_messages_api_output_parameters,
+    safe_extract_output_parameters,
+)
+from deepeval.model_integrations.types import InputParameters
+from deepeval.test_case.llm_test_case import ToolCall
+
+
+def _message(content, input_tokens=1234, output_tokens=56):
+    # Parse through the real Anthropic SDK so the content items are the
+    # concrete block types (TextBlock / ToolUseBlock / ThinkingBlock) the
+    # extractor branches on, exactly as they arrive from messages.create(...).
+    return Message.model_validate(
+        {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "stop_reason": "tool_use",
+            "stop_sequence": None,
+            "content": content,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+        }
+    )
+
+
+_INPUT = InputParameters(
+    model="claude-sonnet-4-5",
+    tool_descriptions={"get_weather": "Get the weather for a city"},
+)
+
+
+def test_tool_use_first_response_preserves_tokens_and_tools_called():
+    # A forced single tool call (tool_choice) returns content == [ToolUseBlock],
+    # so content[0] has no `.text`. Token counts and the tool call must survive,
+    # and output falls back to the tool calls (mirrors the OpenAI extractor).
+    message = _message(
+        [
+            {
+                "type": "tool_use",
+                "id": "tu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+            }
+        ]
+    )
+
+    params = extract_messages_api_output_parameters(message, _INPUT)
+
+    assert params.prompt_tokens == 1234
+    assert params.completion_tokens == 56
+    assert params.tools_called is not None
+    assert len(params.tools_called) == 1
+    assert params.tools_called[0].name == "get_weather"
+    assert params.tools_called[0].input_parameters == {"city": "Paris"}
+    assert isinstance(params.output, list)
+    assert params.output[0].name == "get_weather"
+
+
+def test_tool_use_first_response_is_not_swallowed_by_safe_wrapper():
+    # Regression: previously content[0].text raised AttributeError, which the
+    # bare `except` in safe_extract_output_parameters swallowed, returning an
+    # empty OutputParameters (span recorded output='NA', no tokens, no tools).
+    message = _message(
+        [
+            {
+                "type": "tool_use",
+                "id": "tu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+            }
+        ]
+    )
+
+    params = safe_extract_output_parameters(message, _INPUT)
+
+    assert params.prompt_tokens == 1234
+    assert params.completion_tokens == 56
+    assert isinstance(params.tools_called, list) and params.tools_called
+    assert params.output  # not None/empty -> not recorded as 'NA'
+
+
+def test_thinking_first_response_extracts_text_and_preserves_tokens():
+    # Extended thinking puts a ThinkingBlock before the answer's TextBlock.
+    message = _message(
+        [
+            {
+                "type": "thinking",
+                "thinking": "reasoning...",
+                "signature": "sig",
+            },
+            {"type": "text", "text": "The answer is 42."},
+        ]
+    )
+
+    params = extract_messages_api_output_parameters(message, _INPUT)
+
+    assert params.output == "The answer is 42."
+    assert params.prompt_tokens == 1234
+    assert params.completion_tokens == 56
+    assert params.tools_called is None
+
+
+def test_text_first_response_unchanged():
+    # Control: a plain text answer is unaffected by the fix.
+    message = _message([{"type": "text", "text": "Hello!"}])
+
+    params = extract_messages_api_output_parameters(message, _INPUT)
+
+    assert params.output == "Hello!"
+    assert params.prompt_tokens == 1234
+    assert params.completion_tokens == 56
+    assert params.tools_called is None
+
+
+def test_text_and_tool_use_response_keeps_text_output_and_tools():
+    # When both are present, the text stays the output and the tool is captured.
+    message = _message(
+        [
+            {"type": "text", "text": "Let me check the weather."},
+            {
+                "type": "tool_use",
+                "id": "tu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+            },
+        ]
+    )
+
+    params = extract_messages_api_output_parameters(message, _INPUT)
+
+    assert params.output == "Let me check the weather."
+    assert params.tools_called is not None
+    assert params.tools_called[0].name == "get_weather"
+    assert isinstance(
+        params.tools_called[0], ToolCall
+    )  # ToolCall imported for type assertion


### PR DESCRIPTION
Fixes #2913

### Root cause

`extract_messages_api_output_parameters` reads the output as `str(message_response.content[0].text)`. Anthropic returns a list of content *blocks*, and the first one is not always a `TextBlock`:

- a forced tool call (`tool_choice={"type": "tool", ...}` / `disable_parallel_tool_use=True`) returns `content == [ToolUseBlock]`;
- extended thinking returns a `ThinkingBlock` first.

`ToolUseBlock`/`ThinkingBlock` have no `.text`, so the line raises `AttributeError`. `safe_extract_output_parameters` catches it with a bare `except` and returns an empty `OutputParameters()`, so the span records `output='NA'`, no token counts, and `tools_called=None`, and `create_child_tool_spans` is skipped. On the documented tool-use path this is a silently wrong eval number, not an error: a metric scores the string `'NA'`, and the `ToolUseBlock` handling already in this function is unreachable because the `content[0].text` line above it raises first.

An earlier revision of this integration guarded `content[0]` by type; the guard was collapsed to the unconditional `.text` access in a later schema-alignment commit (`c088f1c0d`), which is what makes the tool-use branch unreachable.

### Invariant

Every `messages.create(...)` span captures the output, token counts, and `tools_called` regardless of content-block ordering, as `docs/.../anthropic.mdx` describes and as the OpenAI extractor already does.

### Fix

Select the first `TextBlock` by type (empty string when there is none) instead of indexing `content[0]`, and fall back to the tool calls as the output when there is no text. This mirrors `extract_output_parameters_from_completion` in `deepeval/openai/extractors.py` (`choices[0].message.content or ""` plus the tool-call fallback). Token counts and `tools_called` now survive regardless of ordering.

### Verification

Reproduced and fixed in a clean Docker container (`python:3.11-slim`, `--network=none`), keyless, against `main` (58c9ef78). The installed `deepeval/anthropic/extractors.py` was sha256-identical to the reviewed source. Responses were built by parsing real Anthropic SDK objects (`Message.model_validate`), so the content items are the concrete block types the extractor branches on.

New tests in `tests/test_core/test_models/test_anthropic_extractors.py`:

- `tool_use`-first: on `main` `extract_messages_api_output_parameters` raises `AttributeError` and `safe_extract_output_parameters` returns empty (token counts and the tool lost); on this branch tokens and `tools_called` are preserved and `output` falls back to the tool calls.
- `thinking`-first (extended thinking): same total loss on `main`; text and tokens preserved here.
- text-first and text+tool: unchanged (controls, pass on both).

The three fault-exercising tests fail on `main` and pass here; the two controls pass on both. `tests/test_core/test_models/test_models_utils.py` and `test_openai_extractors.py` still pass (16). `black --check` (line-length 80) is clean on both changed files.

Scope: I verified the extractor return values directly. The `'NA'` output and skipped tool spans downstream follow from `model_integrations/utils.py` reading `output_parameters.output or "NA"` and gating `create_child_tool_spans` on `tools_called`; I read that path but did not exercise the full trace end to end. I did not make live API calls.
