### PR TITLE
fix(metrics): compare ragas version semantically, not lexicographically

### DIFF
--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -565,12 +565,19 @@ class RagasMetric(BaseMetric):
 
 def import_ragas():
     import ragas
+    from packaging.version import InvalidVersion, Version
 
     required_version = "0.2.1"
     if not hasattr(ragas, "__version__"):
         raise ImportError("Version information is not available for ragas.")
     installed_version = ragas.__version__
-    if installed_version < required_version:
+    try:
+        outdated = Version(installed_version) < Version(required_version)
+    except InvalidVersion:
+        # Unparseable version string: fall back to the original lexicographic
+        # comparison rather than raising on the version check itself.
+        outdated = installed_version < required_version
+    if outdated:
         raise ImportError(
             f"ragas version {required_version} or higher is required, but {installed_version} is installed."
         )

--- a/tests/test_metrics/test_ragas_version_check.py
+++ b/tests/test_metrics/test_ragas_version_check.py
@@ -1,0 +1,37 @@
+import sys
+import types
+
+import pytest
+
+from deepeval.metrics.ragas import import_ragas
+
+
+def _install_fake_ragas(monkeypatch, version):
+    module = types.ModuleType("ragas")
+    if version is not None:
+        module.__version__ = version
+    monkeypatch.setitem(sys.modules, "ragas", module)
+    return module
+
+
+@pytest.mark.parametrize("version", ["0.2.1", "0.3.0", "0.10.0", "1.0.0"])
+def test_import_ragas_accepts_supported_versions(monkeypatch, version):
+    # 0.10.0 is the regression from #2905: a lexicographic compare made
+    # "0.10.0" < "0.2.1" true, falsely rejecting it.
+    _install_fake_ragas(monkeypatch, version)
+    import_ragas()
+
+
+@pytest.mark.parametrize("version", ["0.0.1", "0.2.0", "0.1.9"])
+def test_import_ragas_rejects_old_versions(monkeypatch, version):
+    _install_fake_ragas(monkeypatch, version)
+    with pytest.raises(ImportError, match="0.2.1 or higher is required"):
+        import_ragas()
+
+
+def test_import_ragas_requires_version_attribute(monkeypatch):
+    _install_fake_ragas(monkeypatch, None)
+    with pytest.raises(
+        ImportError, match="Version information is not available"
+    ):
+        import_ragas()


### PR DESCRIPTION
## Root cause

`import_ragas()` (`deepeval/metrics/ragas.py`) gates on a string comparison:

```python
required_version = "0.2.1"
installed_version = ragas.__version__
if installed_version < required_version:
    raise ImportError(...)
```

`str.__lt__` compares lexicographically, character by character, so `"0.10.0" < "0.2.1"` is `True` (`'1' < '2'` at the third character). Every ragas release whose minor component reached two digits, i.e. 0.10.x and up, is therefore rejected with `ragas version 0.2.1 or higher is required, but 0.10.0 is installed`, even though it satisfies the requirement. This is #2905.

## Fix

Parse both operands with `packaging.version.Version` so the comparison follows release ordering. An unparseable installed version falls back to the previous lexicographic behaviour rather than raising from the check itself.

`packaging` is already present transitively (it is a dependency of `pytest`, a core dependency here), so this adds no new distribution requirement.

## Verification

Reproduced on HEAD `58c9ef78` in a clean `python:3.12-slim` container with an editable install (`print(module.__file__)` confirmed the running module is the repo copy, not a site-packages shadow). A regression test injects a fake `ragas` module via `monkeypatch.setitem(sys.modules, ...)` and exercises the boundary in both directions:

- accepts `0.2.1`, `0.3.0`, `0.10.0`, `1.0.0`
- rejects `0.0.1`, `0.2.0`, `0.1.9`
- still raises when `__version__` is absent

The `0.10.0` case fails on `main` with the exact ImportError above and passes on this branch; the other cases pass on both. `black --check` is clean on the changed files.

Not verified: this does not run ragas itself (the metric code is unchanged); it verifies only the version-gate behaviour.

Fixes #2905
