### PR TITLE
fix(benchmarks): correct silent answer mis-scoring in MathQA, DROP, and BigBenchHard

### DIFF
--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -246,7 +246,8 @@ class BigBenchHard(DeepEvalBaseBenchmark):
             responses: List = model.batch_generate(
                 prompts=prompts, schemas=[pydantic_model for i in prompts]
             )
-            predictions = [res.answer for res in responses]
+            predictions = [str(res.answer) for res in responses]
+            used_schema = True
         except TypeError:
             prompts = [
                 prompt + "Make sure to output only the numerical answer."
@@ -254,6 +255,7 @@ class BigBenchHard(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
             predictions = [str(pred) for pred in predictions]
+            used_schema = False
 
         if len(predictions) is not len(goldens):
             raise ValueError(
@@ -263,8 +265,14 @@ class BigBenchHard(DeepEvalBaseBenchmark):
         res = []
         for i in range(len(predictions)):
             prediction = predictions[i]
-            prediction = prediction.split()[-1]
-            prediction = prediction[:-1] if self.enable_cot else prediction
+            # Schema-constrained answers are already the final answer (e.g.
+            # "(A)"); only free-text generations need last-token extraction and
+            # trailing-punctuation trimming. Applying these to a schema answer
+            # would turn "(A)" into "(A" and silently score it 0 — and diverged
+            # from the non-batch `predict`, which never post-processes.
+            if not used_schema:
+                prediction = prediction.split()[-1]
+                prediction = prediction[:-1] if self.enable_cot else prediction
             golden = goldens[i]
 
             # Define Metric

--- a/deepeval/benchmarks/drop/drop.py
+++ b/deepeval/benchmarks/drop/drop.py
@@ -22,7 +22,12 @@ from deepeval.benchmarks.schema import (
 from deepeval.telemetry import capture_benchmark_run
 
 logger = logging.getLogger(__name__)
-DELIMITER = ","
+# Internal separator used only to pack/unpack a golden's list of answer spans
+# into its `expected_output` string. It must NOT be a character that can occur
+# inside a DROP answer span — a "," (the previous value) shattered legitimate
+# answers such as "1,000" into ["1", "000"], so the correct prediction could
+# never match. The unit-separator control char cannot appear in DROP answers.
+DELIMITER = "\x1f"
 
 
 class DROP(DeepEvalBaseBenchmark):

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -41,7 +41,7 @@ class MathQA(DeepEvalBaseBenchmark):
         self.verbose_mode = verbose_mode
         if not confinement_instructions:
             self.confinement_instructions = (
-                "Output 'a', 'b', 'c', or 'd'. Full answer not needed."
+                "Output 'a', 'b', 'c', 'd', or 'e'. Full answer not needed."
             )
         else:
             self.confinement_instructions = confinement_instructions
@@ -215,7 +215,7 @@ class MathQA(DeepEvalBaseBenchmark):
         except TypeError:
             prompts = [
                 prompt
-                + "\n\nOutput 'a', 'b', 'c', or 'd'. Full answer not needed."
+                + "\n\nOutput 'a', 'b', 'c', 'd', or 'e'. Full answer not needed."
                 for prompt in prompts
             ]
             predictions = model.batch_generate(prompts)

--- a/deepeval/benchmarks/schema.py
+++ b/deepeval/benchmarks/schema.py
@@ -40,7 +40,11 @@ class TrinaryChoiceSchema(BaseModel):
 
 
 class MultipleChoiceSchemaLower(BaseModel):
-    answer: Literal["a", "b", "c", "d"]
+    # MathQA (AQuA-RAT) questions always have five options, a-e (option "e" is
+    # frequently "none of these"). Omitting "e" made every question whose answer
+    # is "e" unrepresentable, so schema-constrained models could never emit it
+    # and those items were always scored 0.
+    answer: Literal["a", "b", "c", "d", "e"]
 
 
 # DROP Models #############################

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -1,0 +1,103 @@
+"""
+Regression tests for silent answer-scoring bugs in the benchmarks.
+
+Each test targets a case where a *correct* prediction was previously scored 0
+without any error being raised. They are offline: no model, network, dataset
+download, or API key required.
+"""
+
+import pytest
+
+from deepeval.scorer.scorer import Scorer
+from deepeval.benchmarks.schema import MultipleChoiceSchemaLower
+from deepeval.benchmarks.drop.template import DROPTemplate
+from deepeval.benchmarks.drop.drop import DELIMITER
+from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
+from deepeval.benchmarks.tasks import BigBenchHardTask
+from deepeval.dataset import Golden
+
+# --------------------------------------------------------------------------- #
+# MathQA: the answer schema must be able to represent option "e"
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("option", ["a", "b", "c", "d", "e"])
+def test_mathqa_schema_accepts_all_five_options(option):
+    # MathQA (AQuA-RAT) questions always have options a-e. Previously the schema
+    # was Literal["a","b","c","d"], so a schema-constrained model could never
+    # emit "e" and every "e"-answer item was scored 0.
+    assert MultipleChoiceSchemaLower(answer=option).answer == option
+
+
+# --------------------------------------------------------------------------- #
+# DROP: packing/unpacking answer spans must not corrupt answers with commas
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "span",
+    ["1,000", "25,000", "1,234,567", "New York, New York"],
+)
+def test_drop_single_span_with_comma_survives_round_trip(span):
+    packed = DROPTemplate.parse_list_to_str([span], DELIMITER)
+    unpacked = DROPTemplate.parse_str_to_list(packed, DELIMITER)
+    assert unpacked == [span]
+    # a perfect prediction of the gold span must score 1
+    assert Scorer.quasi_contains_score(unpacked, span) == 1
+
+
+def test_drop_multi_span_still_splits():
+    spans = ["Paris", "London"]
+    packed = DROPTemplate.parse_list_to_str(spans, DELIMITER)
+    unpacked = DROPTemplate.parse_str_to_list(packed, DELIMITER)
+    assert unpacked == spans
+    assert Scorer.quasi_contains_score(unpacked, "London") == 1
+
+
+def test_drop_delimiter_is_not_a_character_that_occurs_in_answers():
+    # The separator must not be something that can appear inside a DROP answer.
+    assert DELIMITER not in "0123456789,.- abcdefghijklmnopqrstuvwxyz"
+
+
+# --------------------------------------------------------------------------- #
+# BigBenchHard: the batch path must not corrupt schema-constrained answers
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSchemaBatchModel:
+    """A native/schema model: batch_generate(schemas=...) returns schema
+    instances. Simulates a perfect model that always selects "(A)"."""
+
+    def get_model_name(self):
+        return "fake"
+
+    def batch_generate(self, prompts, schemas=None):
+        if schemas is None:
+            # signal "no schema support" so callers fall back to free text
+            raise TypeError("schema-less generation not supported")
+        return [schema(answer="(A)") for schema in schemas]
+
+
+def _bbh(enable_cot: bool) -> BigBenchHard:
+    # Bypass __init__ (which imports the optional HF `datasets` package); the
+    # batch path only needs these three attributes.
+    bench = BigBenchHard.__new__(BigBenchHard)
+    bench.n_shots = 0
+    bench.enable_cot = enable_cot
+    bench.scorer = Scorer()
+    return bench
+
+
+@pytest.mark.parametrize("enable_cot", [True, False])
+def test_bbh_batch_predict_scores_schema_answer_correctly(enable_cot):
+    bench = _bbh(enable_cot=enable_cot)
+    goldens = [Golden(input="pick the right sentence", expected_output="(A)")]
+
+    result = bench.batch_predict(
+        _FakeSchemaBatchModel(), BigBenchHardTask.HYPERBATON, goldens
+    )
+
+    # Previously, with enable_cot=True the batch path ran prediction[:-1] on the
+    # schema answer, turning "(A)" into "(A)" -> "(A" and scoring it 0.
+    assert result[0]["prediction"] == "(A)"
+    assert result[0]["score"] == 1


### PR DESCRIPTION
Closes #2917.

## Summary

While auditing the benchmark answer-scoring paths, I found **three silent bugs** — cases where a **correct** prediction is scored `0` with no error raised, systematically deflating reported benchmark accuracy. Each is reproduced below and covered by an offline regression test that fails on the current code.

`normalize_text` (the SQuAD-style normalizer behind exact-match) was checked against the official SQuAD `normalize_answer` and matches it exactly, so it is *not* changed here.

---

### 1. MathQA — the answer schema can't represent option `(e)`  *(severe)*

MathQA (AQuA-RAT) questions **always have five options `a`–`e`** (option `e` is frequently *"none of these"*), but the schema used to constrain/extract the answer only allowed four:

```python
# deepeval/benchmarks/schema.py
class MultipleChoiceSchemaLower(BaseModel):
    answer: Literal["a", "b", "c", "d"]   # <- no "e"
```

```python
>>> from deepeval.benchmarks.schema import MultipleChoiceSchemaLower
>>> MultipleChoiceSchemaLower(answer="e")
pydantic_core._pydantic_core.ValidationError: 1 validation error for MultipleChoiceSchemaLower
answer: Input should be 'a', 'b', 'c' or 'd'
```

A schema-constrained (native) model can therefore **never emit `e`**, and the confinement instruction for non-native models also said *"Output 'a', 'b', 'c', or 'd'."* So **every MathQA item whose gold answer is `e` (~1/5 of the dataset) is scored 0**, even for a perfect model.

**Fix:** add `"e"` to `MultipleChoiceSchemaLower` and to both confinement strings. (`MultipleChoiceSchemaLower` is used only by MathQA.)

### 2. DROP — comma-delimited span packing corrupts answers containing commas  *(severe)*

Each golden's answer spans are packed into `expected_output` with a delimiter and split back apart at scoring time. The delimiter was `","`:

```python
# deepeval/benchmarks/drop/drop.py
DELIMITER = ","
```

So a single-span answer that itself contains a comma is shattered:

```python
>>> from deepeval.benchmarks.drop.template import DROPTemplate
>>> from deepeval.scorer.scorer import Scorer
>>> packed = DROPTemplate.parse_list_to_str(["1,000"], ",")     # dataset build
>>> DROPTemplate.parse_str_to_list(packed, ",")                  # scoring time
['1', '000']
>>> Scorer.quasi_contains_score(['1', '000'], "1,000")          # perfect prediction
0     # expected 1
```

Any DROP answer with a comma — every number ≥ 1,000 written with a thousands separator, spans like `"New York, New York"` — can **never be matched**.

**Fix:** use the unit-separator control char (`\x1f`) as the internal delimiter; it cannot occur inside a DROP answer. Multi-span behavior is unchanged.

### 3. BigBenchHard — the batch path corrupts schema-constrained answers (inconsistent with the non-batch path)  *(moderate)*

`batch_predict` applies free-text extraction to **every** prediction, including clean schema outputs:

```python
# deepeval/benchmarks/big_bench_hard/big_bench_hard.py (batch_predict)
prediction = prediction.split()[-1]
prediction = prediction[:-1] if self.enable_cot else prediction
```

With `enable_cot=True` (the default), a schema answer `"(A)"` becomes `"(A"` → scored 0. The non-batch `predict` doesn't do this — it uses `str(res.answer)` directly — so the two paths **disagree** on the same input:

```python
# schema (native) model, enable_cot=True, gold "(A)", model correctly returns "(A)"
predict(...)        -> prediction "(A)",  score 1
batch_predict(...)  -> prediction "(A",   score 0     # silently wrong
```

**Fix:** apply the last-token / trailing-punctuation trimming only to free-text generations, matching the non-batch path (this also fixes a latent crash where numeric schema answers, an `int`, hit `.split()`).

---

## Tests

New offline regression tests under `tests/test_benchmarks/` (no model, network, dataset download, or API key). They fail on the current code and pass with this change:
- MathQA schema accepts all of `a`–`e`.
- DROP single-span answers with commas survive the round-trip and score 1; multi-span still splits.
- BBH `batch_predict` scores a schema answer correctly with and without CoT.

`black` clean. Happy to split into per-benchmark PRs if you'd prefer.

