### PR TITLE
fix: resolve Windows-specific test failures (UTF-8 encoding and expanduser path)

### DIFF
--- a/tests/test_core/test_config/test_settings.py
+++ b/tests/test_core/test_config/test_settings.py
@@ -201,7 +201,10 @@ def test_secret_not_persisted_to_json(monkeypatch):
 
 
 def test_env_dir_path_expanduser(monkeypatch, tmp_path: Path):
+    # Mock both HOME (POSIX) and USERPROFILE (Windows) so expanduser("~")
+    # resolves to tmp_path on every platform.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("ENV_DIR_PATH", "~/envdir")
     s = get_settings()
     assert s.ENV_DIR_PATH == tmp_path / "envdir"

--- a/tests/test_core/test_evaluation/test_console_report.py
+++ b/tests/test_core/test_evaluation/test_console_report.py
@@ -38,7 +38,7 @@ def test_evaluation_console_report_exports(tmp_path: Path):
     )
     html_files = list(tmp_path.glob("test_eval_*.html"))
     assert len(html_files) == 1
-    html_content = html_files[0].read_text()
+    html_content = html_files[0].read_text(encoding="utf-8")
     assert "DeepEval Evaluation Results" in html_content
     assert "demo" in html_content
     assert "Answer Relevancy" in html_content
@@ -50,7 +50,7 @@ def test_evaluation_console_report_exports(tmp_path: Path):
     )
     md_files = list(tmp_path.glob("test_eval_*.md"))
     assert len(md_files) == 1
-    md_content = md_files[0].read_text()
+    md_content = md_files[0].read_text(encoding="utf-8")
     assert "DeepEval Evaluation Results" in md_content
     assert "demo" in md_content
     assert "Answer Relevancy" in md_content


### PR DESCRIPTION
Fixes #2906

Two tests fail on Windows (Python 3.12) due to platform assumptions:

1. **Encoding** — `tests/test_core/test_evaluation/test_console_report.py::test_evaluation_console_report_exports` reads the exported HTML/Markdown with `Path.read_text()` and no `encoding`. On Windows the default is cp1252, so the UTF-8 box-drawing/emoji characters in the report raise `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90`. Fixed by passing `encoding="utf-8"` to both reads.
2. **Path expansion** — `tests/test_core/test_config/test_settings.py::test_env_dir_path_expanduser` mocks only `HOME`, but `os.path.expanduser("~")` uses `USERPROFILE` on Windows, so `~/envdir` expanded to the real profile and the assertion failed. Fixed by also mocking `USERPROFILE`, making the test correct on both POSIX and Windows.

Changes are confined to the two test files (5 lines). Verified locally on Windows 11 / Python 3.12: both target tests failed before and all 60 tests in the two files pass after. `black` reports no formatting changes.

_AI-assistance disclosure: this fix was drafted with AI assistance and verified locally on Windows 11 (Python 3.12) — I reproduced both failures on `main` and confirmed all affected tests pass after the change._
