### PR TITLE
docs: tag llms.txt Confident AI links with UTMs

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,6 +1,6 @@
 # DeepEval
 
-> DeepEval is an open-source LLM evaluation framework designed to unit-test LLM powered applications such as agents, chatbots, and RAG. DeepEval incorporates the latest research to evaluate LLM outputs based on metrics such as G-Eval, hallucination, answer relevancy, fluency, etc., which uses LLMs and various other NLP models that runs locally on your machine for evaluation. DeepEval integrates natively with [Confident AI](https://www.confident-ai.com), a separate AI quality platform with observability, evals, and monitoring that adds team-wide collaboration on top of DeepEval evals.
+> DeepEval is an open-source LLM evaluation framework designed to unit-test LLM powered applications such as agents, chatbots, and RAG. DeepEval incorporates the latest research to evaluate LLM outputs based on metrics such as G-Eval, hallucination, answer relevancy, fluency, etc., which uses LLMs and various other NLP models that runs locally on your machine for evaluation. DeepEval integrates natively with [Confident AI](https://www.confident-ai.com?utm_source=deepeval&utm_medium=llms_txt&utm_content=intro_mention), a separate AI quality platform with observability, evals, and monitoring that adds team-wide collaboration on top of DeepEval evals.
 
 - [DeepEval LLM Evaluation](https://deepeval.com/): Open-source framework for evaluating large language models effectively.
 - [DeepEval Framework Quickstart](https://deepeval.com/docs/getting-started): DeepEval is an open-source framework for evaluating LLM applications.
@@ -61,7 +61,7 @@
 - [Generate Synthetic Goldens](https://deepeval.com/docs/synthesizer-generate-from-goldens): Generate synthetic Goldens from existing Goldens easily.
 - [Improving QA Agent](https://deepeval.com/tutorials/qa-agent-improving-hyperparameters): Learn to enhance QA agent performance through hyperparameter tuning.
 - [Red Teaming Bias](https://www.trydeepteam.com/docs/red-teaming-vulnerabilities-bias): Test LLMs for bias in responses across various categories.
-- [Confident AI Documentation](https://www.confident-ai.com/docs/): AI quality platform with observability, evals, and monitoring — DeepEval integrates with it natively.
+- [Confident AI Documentation](https://www.confident-ai.com/docs/?utm_source=deepeval&utm_medium=llms_txt&utm_content=resources_docs_link): AI quality platform with observability, evals, and monitoring — DeepEval integrates with it natively.
 - [BIG-Bench Hard Evaluation](https://deepeval.com/docs/benchmarks-big-bench-hard): Evaluate language models with challenging BIG-Bench Hard tasks.
 - [LLM Tracing Guide](https://deepeval.com/docs/evaluation-llm-tracing): Learn to evaluate LLM interactions with tracing metrics.
 - [Document Summarization Datasets](https://deepeval.com/tutorials/doc-summarization-annotating-datasets): Learn to create and maintain datasets for document summarization.


### PR DESCRIPTION
llms.txt was the one outbound surface without attribution: the README links carry the full UTM triplet, the docs site stamps every anchor at click time, and the CLI has with_utm — but the two Confident AI links in llms.txt carried nothing.

Both now carry utm_source=deepeval&utm_medium=llms_txt with a per-link utm_content. llms.txt is read by AI assistants, so arrivals from links they quote become measurable as their own channel in GA4 — worth having as ChatGPT/Perplexity referrals grow.

No content changes, parameters only. utm_medium=llms_txt is a new medium value used only in this static file; the runtime UtmMedium type in docs/src/utils/utm.ts is untouched since no runtime callsite uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)