### PR TITLE
style: apply black 26.5.1 formatting (fixes red lint on main)

### DIFF
--- a/deepeval/cli/inspect.py
+++ b/deepeval/cli/inspect.py
@@ -14,7 +14,6 @@ from typing import Optional
 import typer
 from rich import print
 
-
 _INSTALL_HINT = (
     "[bold red]deepeval inspect[/bold red] requires extras that are not "
     "installed.\n"

--- a/deepeval/inspect/widgets/_styling.py
+++ b/deepeval/inspect/widgets/_styling.py
@@ -12,7 +12,6 @@ from rich.text import Text
 
 from deepeval.inspect.types import Trace, TraceOrSpan
 
-
 # `(glyph, tag, rich style)` per span type. Tags are full words rather
 # than abbreviations because the tree pane is wide enough to spell them
 # out, and "RETRIEVER" reads instantly while "RET" trips users into

--- a/deepeval/inspect/widgets/details.py
+++ b/deepeval/inspect/widgets/details.py
@@ -30,7 +30,6 @@ from deepeval.inspect.widgets._styling import (
     type_prefix,
 )
 
-
 # Matches the TRACE tag so the eye learns "cyan = structure markers".
 _HEADER_ACCENT = "#8be9fd"
 _CTA_ACCENT = "#bd93f9"

--- a/deepeval/inspect/widgets/help_modal.py
+++ b/deepeval/inspect/widgets/help_modal.py
@@ -9,7 +9,6 @@ from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
-
 _HELP_ROWS = [
     ("↑ ↓ / k j", "move selection in the tree"),
     ("h / l", "go to parent / select child in the tree"),

--- a/deepeval/inspect/widgets/span_tree.py
+++ b/deepeval/inspect/widgets/span_tree.py
@@ -25,7 +25,6 @@ from deepeval.inspect.widgets._styling import (
     type_prefix,
 )
 
-
 # Minimum gap (in cells) between the left content (name + metric badge +
 # optional ERRORED pill) and the right-aligned duration. Below this the
 # right column gives up trying to right-align and just leaves the

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -30,12 +30,10 @@ def _contextual_relevancy_verdict_kwargs(multimodal: bool) -> Dict[str, str]:
     context_type = "context (image or string)" if multimodal else "context"
     statement_or_image = "statement or image" if multimodal else "statement"
     if multimodal:
-        extraction_instructions = textwrap.dedent(
-            """
+        extraction_instructions = textwrap.dedent("""
             If the context is textual, you should first extract the statements found in the context if the context, which are high level information found in the context, before deciding on a verdict and optionally a reason for each statement.
             If the context is an image, `statement` should be a description of the image. Do not assume any information not visibly available.
-            """
-        ).strip()
+            """).strip()
         empty_context_instruction = ""
     else:
         extraction_instructions = (

--- a/deepeval/metrics/dag/serialization/registry.py
+++ b/deepeval/metrics/dag/serialization/registry.py
@@ -15,7 +15,6 @@ from deepeval.metrics.conversational_dag.nodes import (
 
 from .types import NodeType
 
-
 NODE_CLASSES: Dict[bool, Dict[NodeType, Type]] = {
     False: {
         NodeType.TASK: TaskNode,

--- a/deepeval/metrics/dag/serialization/serialization.py
+++ b/deepeval/metrics/dag/serialization/serialization.py
@@ -61,7 +61,6 @@ from deepeval.test_case import SingleTurnParams, MultiTurnParams
 from .registry import CLASS_TO_NODE_TYPE, NODE_CLASSES
 from .types import ChildType, NodeType
 
-
 # ----------------------------------------------------------------------------
 # Public API
 # ----------------------------------------------------------------------------

--- a/deepeval/metrics/multimodal_metrics/image_editing/image_editing.py
+++ b/deepeval/metrics/multimodal_metrics/image_editing/image_editing.py
@@ -287,15 +287,13 @@ class ImageEditingMetric(BaseMetric):
     def _generate_reason(
         self,
     ) -> str:
-        return textwrap.dedent(
-            f"""
+        return textwrap.dedent(f"""
             The overall score is {self.score:.2f} because the lowest score from semantic consistency was {min(self.SC_scores)} 
             and the lowest score from perceptual quality was {min(self.PQ_scores)}. These scores were combined to reflect the 
             overall effectiveness and quality of the AI-generated image(s).
             Reason for Semantic Consistency score: {self.SC_reasoning}
             Reason for Perceptual Quality score: {self.PQ_reasoning}
-        """
-        )
+        """)
 
     @property
     def __name__(self):

--- a/deepeval/metrics/multimodal_metrics/text_to_image/text_to_image.py
+++ b/deepeval/metrics/multimodal_metrics/text_to_image/text_to_image.py
@@ -289,15 +289,13 @@ class TextToImageMetric(BaseMetric):
         return self.success
 
     def _generate_reason(self) -> str:
-        return textwrap.dedent(
-            f"""
+        return textwrap.dedent(f"""
             The overall score is {self.score:.2f} because the lowest score from semantic consistency was {min(self.SC_scores)} 
             and the lowest score from perceptual quality was {min(self.PQ_scores)}. These scores were combined to reflect the 
             overall effectiveness and quality of the AI-generated image(s).
             Reason for Semantic Consistency score: {self.SC_reasoning}
             Reason for Perceptual Quality score: {self.PQ_reasoning}
-        """
-        )
+        """)
 
     @property
     def __name__(self):

--- a/deepeval/metrics/turn_contextual_relevancy/turn_contextual_relevancy.py
+++ b/deepeval/metrics/turn_contextual_relevancy/turn_contextual_relevancy.py
@@ -31,12 +31,10 @@ def _contextual_relevancy_verdict_kwargs(multimodal: bool) -> Dict[str, str]:
     context_type = "context (image or string)" if multimodal else "context"
     statement_or_image = "statement or image" if multimodal else "statement"
     if multimodal:
-        extraction_instructions = textwrap.dedent(
-            """
+        extraction_instructions = textwrap.dedent("""
             If the context is textual, you should first extract the statements found in the context if the context, which are high level information found in the context, before deciding on a verdict and optionally a reason for each statement.
             If the context is an image, `statement` should be a description of the image. Do not assume any information not visibly available.
-            """
-        ).strip()
+            """).strip()
         empty_context_instruction = ""
     else:
         extraction_instructions = (

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -444,8 +444,7 @@ class Scorer:
         evaluation_model: DeepEvalBaseLLM,
         using_native_evaluation_model: bool,
     ):
-        prompt = textwrap.dedent(
-            f"""
+        prompt = textwrap.dedent(f"""
             Given the question and context, evaluate if the prediction is correct based on the expected output.
             Ensure to account for cases where the prediction and expected output might differ in form, such as '2' versus 'two'.
 
@@ -459,8 +458,7 @@ class Scorer:
             {{
                 "answer": <number>
             }}
-        """
-        )
+        """)
 
         # Generate the score using the model
         if using_native_evaluation_model:

--- a/deepeval/simulator/controller/template.py
+++ b/deepeval/simulator/controller/template.py
@@ -6,8 +6,7 @@ class SimulatorControllerTemplate:
     def check_expected_outcome(
         previous_conversation: str, expected_outcome: str
     ) -> str:
-        prompt = textwrap.dedent(
-            f"""You are a Conversation Completion Checker.
+        prompt = textwrap.dedent(f"""You are a Conversation Completion Checker.
             Your task is to determine whether the conversation has achieved the expected outcome and should be terminated.
 
             Guidelines:
@@ -34,6 +33,5 @@ class SimulatorControllerTemplate:
             Conversation History:
             {previous_conversation}
             JSON Output:
-            """
-        )
+            """)
         return prompt

--- a/deepeval/simulator/template.py
+++ b/deepeval/simulator/template.py
@@ -59,8 +59,7 @@ class SimulationTemplate:
         previous_conversation = serialize_to_json(
             turns, indent=4, ensure_ascii=False
         )
-        prompt = textwrap.dedent(
-            f"""
+        prompt = textwrap.dedent(f"""
             Pretend you are a user of an LLM app. Your task is to generate the next user input in {language} 
             based on the provided scenario, user profile, and the previous conversation.
 
@@ -95,6 +94,5 @@ class SimulationTemplate:
             {previous_conversation}
 
             JSON Output:
-        """
-        )
+        """)
         return prompt

--- a/deepeval/synthesizer/templates/template.py
+++ b/deepeval/synthesizer/templates/template.py
@@ -721,9 +721,7 @@ class EvolutionTemplate:
 
     @staticmethod
     def multi_context_evolution(input, context):
-        return (
-            EvolutionTemplate.base_instruction
-            + f"""
+        return EvolutionTemplate.base_instruction + f"""
             1. `Input` should be rewritten to require readers to use information from all elements of `Context`. 
             2. `Rewritten Input` must be fully answerable from information in `Context`. 
             3. `Rewritten Input` should be concise and understandable by humans.
@@ -765,13 +763,10 @@ class EvolutionTemplate:
             {input}
             Rewritten Input:            
             """
-        )
 
     @staticmethod
     def reasoning_evolution(input, context):
-        return (
-            EvolutionTemplate.base_instruction
-            + f"""
+        return EvolutionTemplate.base_instruction + f"""
             1. If `Input` can be solved with just a few simple thinking processes, you can rewrite it to explicitly request multiple-step reasoning.
             2. `Rewritten Input` should require readers to make multiple logical connections or inferences.
             3. `Rewritten Input` should be concise and understandable by humans.
@@ -814,13 +809,10 @@ class EvolutionTemplate:
             {input}
             Rewritten Input:            
             """
-        )
 
     @staticmethod
     def concretizing_evolution(input, context):
-        return (
-            EvolutionTemplate.base_instruction
-            + f"""
+        return EvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` by replacing general concepts/inquiries with more specific ones.
             2. `Rewritten Input` should be concise and understandable by humans.
             3. `Rewritten Input` should not contain phrases like  'based on the provided context' or 'according to the context'.
@@ -864,13 +856,10 @@ class EvolutionTemplate:
             {context}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def constrained_evolution(input, context):
-        return (
-            EvolutionTemplate.base_instruction
-            + f"""
+        return EvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` by adding at least one more constraints/requirements.
             2. `Rewritten Input` must be fully answerable from information in `Context`. 
             5. `Rewritten Input` should not contain more than 15 words. Use abbreviation wherever possible.
@@ -912,13 +901,10 @@ class EvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def comparative_question_evolution(input, context):
-        return (
-            EvolutionTemplate.base_instruction
-            + f"""
+        return EvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` to focus on comparing two or more entities, concepts, or processes.
             2. `Rewritten Input` should encourage a detailed comparison that highlights similarities and differences.
             3. `Rewritten Input` must be fully answerable from information in `Context`. 
@@ -961,13 +947,10 @@ class EvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def hypothetical_scenario_evolution(input, context):
-        return (
-            EvolutionTemplate.base_instruction
-            + f"""
+        return EvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` to include a hypothetical or speculative scenario that is relevant to the `Context`.
             2. `Rewritten Input` should encourage the reader to apply knowledge from the `Context` to imagine or deduce outcomes.
             3. `Rewritten Input` should be concise, clear, and understandable by humans.
@@ -1010,13 +993,10 @@ class EvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def in_breadth_evolution(input, context):
-        return (
-            EvolutionTemplate.base_instruction
-            + f"""
+        return EvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` to create a brand new prompt.
             2. `Rewritten Input` should belong to the same domain as the `input` but be even more rare.
             3. `Rewritten Input` should be concise, clear, and understandable by humans.
@@ -1058,7 +1038,6 @@ class EvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
 
 class ConversationalEvolutionTemplate:
@@ -1069,9 +1048,7 @@ class ConversationalEvolutionTemplate:
 
     @staticmethod
     def multi_context_evolution(scenario, context):
-        return (
-            ConversationalEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalEvolutionTemplate.base_instruction + f"""
             1. `Scenario` must be rewritten so participants must naturally rely on **all elements of `Context`** during the conversation.
             2. `Rewritten Scenario` MUST remain a realistic multi-turn conversation setup.
             3. Keep the rewritten scenario under **60 words**.
@@ -1108,13 +1085,10 @@ class ConversationalEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def reasoning_evolution(scenario, context):
-        return (
-            ConversationalEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` so the resulting conversation requires multi-step reasoning between participants.
             2. Add layered inferential or analytical demands grounded in `Context`.
             3. Keep the rewritten scenario under **60 words**.
@@ -1148,13 +1122,10 @@ class ConversationalEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def concretizing_evolution(scenario, context):
-        return (
-            ConversationalEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` by replacing general conversational settings with **highly specific**, concrete circumstances tied to `Context`.
             2. Add situational cues, named events, or explicit constraints.
             3. Keep the rewritten scenario under **60 words**.
@@ -1187,13 +1158,10 @@ class ConversationalEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def constrained_evolution(scenario, context):
-        return (
-            ConversationalEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` by adding at least **one new constraint** that shapes how the conversation unfolds.
             2. The constraint must logically follow from `Context`.
             3. Keep the rewritten scenario under **60 words**.
@@ -1226,13 +1194,10 @@ class ConversationalEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def comparative_question_evolution(scenario, context):
-        return (
-            ConversationalEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` so the conversation naturally compares two or more concepts, tools, or approaches.
             2. The comparison must be central to the multi-turn dialogue.
             3. Keep the rewritten scenario under **60 words**.
@@ -1264,13 +1229,10 @@ class ConversationalEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def hypothetical_scenario_evolution(scenario, context):
-        return (
-            ConversationalEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` by adding a hypothetical twist grounded in `Context`.
             2. The speculative change MUST drive the conversation.
             3. Must remain realistic and multi-turn.
@@ -1303,13 +1265,10 @@ class ConversationalEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def in_breadth_evolution(scenario, context):
-        return (
-            ConversationalEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` into a brand-new conversational setup.
             2. It must remain in the **same domain** but shift toward a **rarer or niche** topic.
             3. Must remain a realistic multi-turn dialogue setup.
@@ -1342,4 +1301,3 @@ class ConversationalEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )

--- a/deepeval/synthesizer/templates/template_prompt.py
+++ b/deepeval/synthesizer/templates/template_prompt.py
@@ -116,9 +116,7 @@ class PromptEvolutionTemplate:
 
     @staticmethod
     def reasoning_evolution(input):
-        return (
-            PromptEvolutionTemplate.base_instruction
-            + f"""
+        return PromptEvolutionTemplate.base_instruction + f"""
             1. If `Input` can be solved with just a few simple thinking processes, you can rewrite it to explicitly request multiple-step reasoning.
             2. `Rewritten Input` should require readers to make multiple logical connections or inferences.
             3. `Rewritten Input` should be concise and understandable by humans.
@@ -151,13 +149,10 @@ class PromptEvolutionTemplate:
             {input}
             Rewritten Input:            
             """
-        )
 
     @staticmethod
     def concretizing_evolution(input):
-        return (
-            PromptEvolutionTemplate.base_instruction
-            + f"""
+        return PromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` by replacing general concepts/inquiries with more specific ones.
             2. `Rewritten Input` should be concise and understandable by humans.
             3. `Rewritten Input` should not contain more than 15 words. Use abbreviation wherever possible.
@@ -189,13 +184,10 @@ class PromptEvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def constrained_evolution(input):
-        return (
-            PromptEvolutionTemplate.base_instruction
-            + f"""
+        return PromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` by adding at least one more constraints/requirements.
             2. `Rewritten Input` should not contain more than 15 words. Use abbreviation wherever possible.
 
@@ -226,13 +218,10 @@ class PromptEvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def comparative_question_evolution(input):
-        return (
-            PromptEvolutionTemplate.base_instruction
-            + f"""
+        return PromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` to focus on comparing two or more entities, concepts, or processes.
             2. `Rewritten Input` should encourage a detailed comparison that highlights similarities and differences.
             3. `Rewritten Input` should be concise and understandable by humans.
@@ -266,13 +255,10 @@ class PromptEvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def hypothetical_scenario_evolution(input):
-        return (
-            PromptEvolutionTemplate.base_instruction
-            + f"""
+        return PromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` to include a hypothetical or speculative scenario.
             2. `Rewritten Input` should encourage the reader to apply knowledge to imagine or deduce outcomes.
             3. `Rewritten Input` should be concise, clear, and understandable by humans.
@@ -305,13 +291,10 @@ class PromptEvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
     @staticmethod
     def in_breadth_evolution(input):
-        return (
-            PromptEvolutionTemplate.base_instruction
-            + f"""
+        return PromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Input` to create a create a brand new prompt.
             2. `Rewritten Input` should belong to the same domain as the `input` but be even more rare.
             3. `Rewritten Input` should be concise, clear, and understandable by humans.
@@ -344,7 +327,6 @@ class PromptEvolutionTemplate:
             {input}
             Rewritten Input:
             """
-        )
 
 
 class ConversationalPromptEvolutionTemplate:
@@ -354,9 +336,7 @@ class ConversationalPromptEvolutionTemplate:
 
     @staticmethod
     def reasoning_evolution(scenario):
-        return (
-            ConversationalPromptEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalPromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` to force participants into multi-step conversational reasoning.
             2. Add layered inferences or analytical leaps required in dialogue.
             3. `Rewritten Scenario` must stay concise, human-readable, and remain a conversation setup.
@@ -383,13 +363,10 @@ class ConversationalPromptEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def concretizing_evolution(scenario):
-        return (
-            ConversationalPromptEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalPromptEvolutionTemplate.base_instruction + f"""
             1. Replace broad conversation setup with a **more specific, concrete** conversational scene.
             2. Add real-world detail (location, constraint, specific topic).
             3. Keep under **15 words**, concise, and still a dialogue setup.
@@ -415,13 +392,10 @@ class ConversationalPromptEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def constrained_evolution(scenario):
-        return (
-            ConversationalPromptEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalPromptEvolutionTemplate.base_instruction + f"""
             1. Add at least one new constraint shaping the conversation.
             2. Constraint must significantly affect the dialogue.
             3. Keep under **15 words**, concise, conversational.
@@ -447,13 +421,10 @@ class ConversationalPromptEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def comparative_question_evolution(scenario):
-        return (
-            ConversationalPromptEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalPromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` so the conversation centers on comparing two+ items.
             2. Must highlight similarities/differences through dialogue.
             3. Keep under **15 words**, concise, conversational.
@@ -479,13 +450,10 @@ class ConversationalPromptEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def hypothetical_scenario_evolution(scenario):
-        return (
-            ConversationalPromptEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalPromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` to introduce a hypothetical twist derived from the setup.
             2. The hypothetical MUST drive the conversation.
             3. Keep under **15 words**, concise, conversational.
@@ -511,13 +479,10 @@ class ConversationalPromptEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )
 
     @staticmethod
     def in_breadth_evolution(scenario):
-        return (
-            ConversationalPromptEvolutionTemplate.base_instruction
-            + f"""
+        return ConversationalPromptEvolutionTemplate.base_instruction + f"""
             1. Rewrite `Scenario` into a new conversation within the same domain.
             2. The new conversation must explore a rarer, niche angle.
             3. Keep under **15 words**, concise, conversational.
@@ -543,4 +508,3 @@ class ConversationalPromptEvolutionTemplate:
             {scenario}
             Rewritten Scenario:
             """
-        )

--- a/examples/community/chatbot_evaluation/evaluate.py
+++ b/examples/community/chatbot_evaluation/evaluate.py
@@ -8,7 +8,6 @@ import os
 from deepeval.test_case import LLMTestCase
 from deepeval.metrics import AnswerRelevancyMetric
 
-
 BASE_DIR = os.path.dirname(__file__)
 DATA_PATH = os.path.join(BASE_DIR, "outputs.json")
 

--- a/manual_after_evals_iterator.py
+++ b/manual_after_evals_iterator.py
@@ -19,7 +19,6 @@ from deepeval.tracing import (
 )
 from deepeval.tracing.context import next_agent_span
 
-
 RUN_ID = f"{Path(__file__).stem}-{uuid.uuid4().hex[:8]}"
 
 

--- a/scripts/check_openai_model_capabilities.py
+++ b/scripts/check_openai_model_capabilities.py
@@ -19,7 +19,6 @@ from typing import Any, Callable
 
 from deepeval.models.llms.constants import OPENAI_MODELS_DATA
 
-
 DEFAULT_MODELS = ("gpt-5.4", "gpt-5.5")
 
 

--- a/skills/deepeval/templates/metrics.py
+++ b/skills/deepeval/templates/metrics.py
@@ -5,7 +5,6 @@ from deepeval.metrics import (
     TaskCompletionMetric,
 )
 
-
 # Keep metrics in one module so eval files stay focused on app execution.
 # Reuse existing project metrics and thresholds before adding new ones.
 SINGLE_TURN_TRACE_METRICS = [

--- a/skills/deepeval/templates/test_single_turn_no_tracing.py
+++ b/skills/deepeval/templates/test_single_turn_no_tracing.py
@@ -8,7 +8,6 @@ from deepeval.test_case import LLMTestCase
 
 from metrics import SINGLE_TURN_NO_TRACING_METRICS
 
-
 ai_app = import_module("ai_app")
 
 

--- a/skills/deepeval/templates/test_single_turn_tracing.py
+++ b/skills/deepeval/templates/test_single_turn_tracing.py
@@ -7,7 +7,6 @@ from deepeval.dataset import EvaluationDataset, Golden
 
 from metrics import SINGLE_TURN_TRACE_METRICS
 
-
 ai_app = import_module("ai_app")
 
 

--- a/test_agentcore_agent.py
+++ b/test_agentcore_agent.py
@@ -34,7 +34,6 @@ from deepeval.integrations.agentcore import instrument_agentcore
 from deepeval.metrics import AnswerRelevancyMetric
 from deepeval.tracing.context import next_agent_span
 
-
 RUN_ID = f"{Path(__file__).stem}-{uuid.uuid4().hex[:8]}"
 
 

--- a/test_pydantic_agent.py
+++ b/test_pydantic_agent.py
@@ -29,7 +29,6 @@ from deepeval.integrations.pydantic_ai import DeepEvalInstrumentationSettings
 from deepeval.metrics import AnswerRelevancyMetric
 from deepeval.tracing.context import next_agent_span
 
-
 RUN_ID = f"{Path(__file__).stem}-{uuid.uuid4().hex[:8]}"
 
 

--- a/tests/test_agent_loop_detection.py
+++ b/tests/test_agent_loop_detection.py
@@ -8,7 +8,6 @@ import pytest
 from deepeval.test_case import LLMTestCase
 from deepeval.metrics.agent_loop_detection import AgentLoopDetectionMetric
 
-
 # ---------------------------------------------------------------------------
 # Trace / test-case builder helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_evaluation/test_local_store.py
+++ b/tests/test_core/test_evaluation/test_local_store.py
@@ -19,7 +19,6 @@ from deepeval.test_run.test_run import (
     TestRunManager as _TestRunManager,
 )
 
-
 FILENAME_RE = re.compile(r"^test_run_\d{8}_\d{6}(?:_(\d+))?\.json$")
 
 

--- a/tests/test_core/test_simulator/test_conversation_simulator_decision_graph.py
+++ b/tests/test_core/test_simulator/test_conversation_simulator_decision_graph.py
@@ -15,7 +15,6 @@ from tests.test_core.test_simulator.helpers import (
     static_callback,
 )
 
-
 # ---------------------------------------------------------------------------
 # Builder / validation tests
 # ---------------------------------------------------------------------------

--- a/tests/test_integrations/test_agentcore/test_evaluate_agent.py
+++ b/tests/test_integrations/test_agentcore/test_evaluate_agent.py
@@ -35,7 +35,6 @@ from tests.test_integrations.test_agentcore.apps.agentcore_eval_app import (
     init_evals_agentcore,
 )
 
-
 pytestmark = pytest.mark.skipif(
     not os.getenv("AWS_ACCESS_KEY_ID") or not os.getenv("OPENAI_API_KEY"),
     reason=(

--- a/tests/test_integrations/test_agentcore/test_span_interceptor.py
+++ b/tests/test_integrations/test_agentcore/test_span_interceptor.py
@@ -48,7 +48,6 @@ from deepeval.tracing.context import (
 )
 from deepeval.tracing.trace_context import trace
 
-
 _span_id_counter = count(start=1)
 _trace_id_counter = count(start=1)
 

--- a/tests/test_integrations/test_googleadk/apps/googleadk_eval_app.py
+++ b/tests/test_integrations/test_googleadk/apps/googleadk_eval_app.py
@@ -27,7 +27,6 @@ from google.genai import types
 from deepeval.integrations.google_adk import instrument_google_adk
 from deepeval.tracing import update_current_span
 
-
 _APP_NAME = "deepeval-googleadk-evals"
 
 

--- a/tests/test_integrations/test_googleadk/apps/googleadk_multiple_tools_app.py
+++ b/tests/test_integrations/test_googleadk/apps/googleadk_multiple_tools_app.py
@@ -16,7 +16,6 @@ from google.genai import types
 
 from deepeval.integrations.google_adk import instrument_google_adk
 
-
 _APP_NAME = "deepeval-googleadk-multiple-tools"
 
 

--- a/tests/test_integrations/test_googleadk/apps/googleadk_simple_app.py
+++ b/tests/test_integrations/test_googleadk/apps/googleadk_simple_app.py
@@ -15,7 +15,6 @@ from google.genai import types
 
 from deepeval.integrations.google_adk import instrument_google_adk
 
-
 _APP_NAME = "deepeval-googleadk-simple"
 
 

--- a/tests/test_integrations/test_googleadk/apps/googleadk_tool_app.py
+++ b/tests/test_integrations/test_googleadk/apps/googleadk_tool_app.py
@@ -15,7 +15,6 @@ from google.genai import types
 
 from deepeval.integrations.google_adk import instrument_google_adk
 
-
 _APP_NAME = "deepeval-googleadk-tool"
 
 

--- a/tests/test_integrations/test_googleadk/conftest.py
+++ b/tests/test_integrations/test_googleadk/conftest.py
@@ -29,7 +29,6 @@ from tests.test_integrations.utils import (
     is_generate_mode,
 )
 
-
 _current_dir = os.path.dirname(os.path.abspath(__file__))
 _schemas_dir = os.path.join(_current_dir, "schemas")
 

--- a/tests/test_integrations/test_googleadk/test_async.py
+++ b/tests/test_integrations/test_googleadk/test_async.py
@@ -37,7 +37,6 @@ from tests.test_integrations.test_googleadk.apps.googleadk_eval_app import (
 )
 from tests.test_integrations.test_googleadk.conftest import trace_test
 
-
 pytestmark = pytest.mark.skipif(
     not os.getenv("GOOGLE_API_KEY"),
     reason="GOOGLE_API_KEY is required to run Google ADK tests against Gemini.",

--- a/tests/test_integrations/test_googleadk/test_evaluate_agent.py
+++ b/tests/test_integrations/test_googleadk/test_evaluate_agent.py
@@ -35,7 +35,6 @@ from tests.test_integrations.test_googleadk.apps.googleadk_eval_app import (
     init_evals_googleadk,
 )
 
-
 pytestmark = pytest.mark.skipif(
     not os.getenv("GOOGLE_API_KEY") or not os.getenv("OPENAI_API_KEY"),
     reason=(

--- a/tests/test_integrations/test_googleadk/test_span_interceptor.py
+++ b/tests/test_integrations/test_googleadk/test_span_interceptor.py
@@ -66,7 +66,6 @@ from deepeval.tracing.context import (
 )
 from deepeval.tracing.trace_context import trace
 
-
 _span_id_counter = count(start=1)
 _trace_id_counter = count(start=1)
 

--- a/tests/test_integrations/test_googleadk/test_sync.py
+++ b/tests/test_integrations/test_googleadk/test_sync.py
@@ -40,7 +40,6 @@ from tests.test_integrations.test_googleadk.apps.googleadk_eval_app import (
 )
 from tests.test_integrations.test_googleadk.conftest import trace_test
 
-
 pytestmark = pytest.mark.skipif(
     not os.getenv("GOOGLE_API_KEY"),
     reason="GOOGLE_API_KEY is required to run Google ADK tests against Gemini.",

--- a/tests/test_integrations/test_langchain/test_next_span.py
+++ b/tests/test_integrations/test_langchain/test_next_span.py
@@ -41,7 +41,6 @@ from deepeval.tracing import (
 )
 from deepeval.tracing.types import LlmSpan, RetrieverSpan, ToolSpan
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_integrations/test_langgraph/test_next_span.py
+++ b/tests/test_integrations/test_langgraph/test_next_span.py
@@ -30,7 +30,6 @@ from deepeval.tracing import (
 )
 from deepeval.tracing.types import LlmSpan, ToolSpan
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_integrations/test_pydanticai/apps/pydanticai_isolation_app.py
+++ b/tests/test_integrations/test_pydanticai/apps/pydanticai_isolation_app.py
@@ -32,7 +32,6 @@ from pydantic_ai import Agent
 from deepeval.integrations.pydantic_ai import DeepEvalInstrumentationSettings
 from deepeval.tracing import update_current_span, update_current_trace
 
-
 # Per-request ContextVar carrying request data the tool body reads back.
 # In each task / worker thread we ``set`` this BEFORE calling agent.run;
 # inside the tool we ``get`` it. The whole point is to confirm the value

--- a/tests/test_integrations/test_pydanticai/test_span_interceptor.py
+++ b/tests/test_integrations/test_pydanticai/test_span_interceptor.py
@@ -44,7 +44,6 @@ from deepeval.tracing.otel.context_aware_processor import (
 )
 from deepeval.tracing.trace_context import trace
 
-
 _span_id_counter = count(start=1)
 _trace_id_counter = count(start=1)
 

--- a/tests/test_integrations/test_strands/apps/strands_eval_app.py
+++ b/tests/test_integrations/test_strands/apps/strands_eval_app.py
@@ -24,7 +24,6 @@ from strands.models.openai import OpenAIModel
 from deepeval.integrations.strands import instrument_strands
 from deepeval.tracing import update_current_span
 
-
 _DEFAULT_MODEL_ID = os.environ.get("STRANDS_TEST_MODEL", "gpt-4o-mini")
 
 

--- a/tests/test_integrations/test_strands/apps/strands_multiple_tools_app.py
+++ b/tests/test_integrations/test_strands/apps/strands_multiple_tools_app.py
@@ -5,7 +5,6 @@ from strands.models.openai import OpenAIModel
 
 from deepeval.integrations.strands import instrument_strands
 
-
 _DEFAULT_MODEL_ID = os.environ.get("STRANDS_TEST_MODEL", "gpt-4o-mini")
 
 

--- a/tests/test_integrations/test_strands/apps/strands_simple_app.py
+++ b/tests/test_integrations/test_strands/apps/strands_simple_app.py
@@ -5,7 +5,6 @@ from strands.models.openai import OpenAIModel
 
 from deepeval.integrations.strands import instrument_strands
 
-
 _DEFAULT_MODEL_ID = os.environ.get("STRANDS_TEST_MODEL", "gpt-4o-mini")
 
 

--- a/tests/test_integrations/test_strands/apps/strands_tool_app.py
+++ b/tests/test_integrations/test_strands/apps/strands_tool_app.py
@@ -5,7 +5,6 @@ from strands.models.openai import OpenAIModel
 
 from deepeval.integrations.strands import instrument_strands
 
-
 _DEFAULT_MODEL_ID = os.environ.get("STRANDS_TEST_MODEL", "gpt-4o-mini")
 
 

--- a/tests/test_integrations/test_strands/test_evaluate_agent.py
+++ b/tests/test_integrations/test_strands/test_evaluate_agent.py
@@ -35,7 +35,6 @@ from tests.test_integrations.test_strands.apps.strands_eval_app import (
     init_evals_strands,
 )
 
-
 pytestmark = pytest.mark.skipif(
     not os.getenv("OPENAI_API_KEY"),
     reason=(

--- a/tests/test_integrations/test_strands/test_span_interceptor.py
+++ b/tests/test_integrations/test_strands/test_span_interceptor.py
@@ -48,7 +48,6 @@ from deepeval.tracing.context import (
 )
 from deepeval.tracing.trace_context import trace
 
-
 _span_id_counter = count(start=1)
 _trace_id_counter = count(start=1)
 

--- a/tests/test_metrics/test_dag_serialization.py
+++ b/tests/test_metrics/test_dag_serialization.py
@@ -27,7 +27,6 @@ from deepeval.metrics.conversational_dag import (
 from deepeval.metrics.dag.utils import is_valid_dag_from_roots
 from deepeval.test_case import SingleTurnParams, MultiTurnParams
 
-
 # ----------------------------------------------------------------------------
 # Single-turn structural round-trips (no LLM dependency)
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
The lint job (psf/black@stable, resolving to 26.5.1) currently fails on main itself: 49 files drifted from the formatter's output, so every PR shows a red lint check regardless of content — including trivial ones like #2920.

This is a purely mechanical `black .` run using the repo's own pyproject configuration (line length 80). No manual edits. Verify by re-running `black --check .` — it passes after this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)