### PR TITLE
fix(synthesizer): prevent silent empty goldens when model cost is unknown (#2884)

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -1269,7 +1269,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            mode="json",
+                                            by_alias=True,
+                                            exclude_none=True,
                                         )
                                     )
                                 elif hasattr(t, "dict"):
@@ -1395,7 +1397,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            mode="json",
+                                            by_alias=True,
+                                            exclude_none=True,
                                         )
                                     )
                                 elif hasattr(t, "dict"):
@@ -1476,7 +1480,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            mode="json",
+                                            by_alias=True,
+                                            exclude_none=True,
                                         )
                                     )
                                 elif hasattr(t, "dict"):

--- a/deepeval/dataset/utils.py
+++ b/deepeval/dataset/utils.py
@@ -187,7 +187,11 @@ def format_turns(turns: List[Turn]) -> str:
             for m in models:
                 if hasattr(m, "model_dump"):
                     dumped.append(
-                        m.model_dump(by_alias=True, exclude_none=True)
+                        m.model_dump(
+                            mode="json",
+                            by_alias=True,
+                            exclude_none=True,
+                        )
                     )
                 elif hasattr(m, "dict"):
                     dumped.append(m.dict(exclude_none=True))

--- a/deepeval/models/llms/constants.py
+++ b/deepeval/models/llms/constants.py
@@ -1100,6 +1100,22 @@ DEEPSEEK_MODELS_DATA = ModelDataRegistry(
             input_price=1.00 / 1e6,
             output_price=2.00 / 1e6,
         ),
+        "deepseek-v4-flash": make_model_data(
+            supports_log_probs=False,
+            supports_multimodal=False,
+            supports_structured_outputs=True,
+            supports_json=True,
+            input_price=0.14 / 1e6,
+            output_price=0.28 / 1e6,
+        ),
+        "deepseek-v4-pro": make_model_data(
+            supports_log_probs=False,
+            supports_multimodal=False,
+            supports_structured_outputs=True,
+            supports_json=True,
+            input_price=0.435 / 1e6,
+            output_price=0.87 / 1e6,
+        ),
     }
 )
 

--- a/deepeval/synthesizer/chunking/context_generator.py
+++ b/deepeval/synthesizer/chunking/context_generator.py
@@ -27,6 +27,7 @@ from deepeval.models.base_model import (
     DeepEvalBaseEmbeddingModel,
     DeepEvalBaseLLM,
 )
+from deepeval.errors import DeepEvalError
 from deepeval.utils import update_pbar, add_pbar, remove_pbars
 from deepeval.config.settings import get_settings
 
@@ -209,6 +210,7 @@ class ContextGenerator:
             update_pbar(progress, pbar_id, remove=False)
 
             # process each doc end-to-end (sync), with per-doc error logging
+            docs_with_errors: List[str] = []
             for path, chunker in source_file_to_chunker_map.items():
                 collection = None
                 try:
@@ -267,6 +269,7 @@ class ContextGenerator:
                     source_files.extend([path] * len(ctxs_for_doc))
 
                 except Exception as exc:
+                    docs_with_errors.append(path)
                     # record and continue with other docs
                     show_trace = bool(get_settings().DEEPEVAL_LOG_STACK_TRACES)
                     exc_info = (
@@ -304,6 +307,12 @@ class ContextGenerator:
                     SynthesizerStatus.WARNING,
                     "Filtering not applied",
                     "Not enough chunks in smallest document",
+                )
+
+            if docs_with_errors and not contexts:
+                raise DeepEvalError(
+                    f"Context generation failed for all {len(docs_with_errors)} "
+                    f"document(s). Check the logs above for per-document errors."
                 )
 
             return contexts, source_files, scores
@@ -432,8 +441,10 @@ class ContextGenerator:
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
             # Collect results, surface any errors after cleanup
+            docs_with_errors: List[str] = []
             for path, res in zip(paths, results):
                 if isinstance(res, Exception):
+                    docs_with_errors.append(path)
                     logger.error(
                         "Document pipeline failed for %s",
                         path,
@@ -461,6 +472,12 @@ class ContextGenerator:
                     SynthesizerStatus.WARNING,
                     "Filtering not applied",
                     "Not enough chunks in smallest document",
+                )
+
+            if docs_with_errors and not contexts:
+                raise DeepEvalError(
+                    f"Context generation failed for all {len(docs_with_errors)} "
+                    f"document(s). Check the logs above for per-document errors."
                 )
 
             return contexts, source_files, scores
@@ -837,7 +854,8 @@ class ContextGenerator:
         prompt = FilterTemplate.evaluate_context(chunk)
         if self.using_native_model:
             res, cost = self.model.generate(prompt, schema=ContextScore)
-            self.total_cost += cost
+            if cost is not None:
+                self.total_cost += cost
             return (res.clarity + res.depth + res.structure + res.relevance) / 4
         else:
             try:
@@ -862,7 +880,8 @@ class ContextGenerator:
         prompt = FilterTemplate.evaluate_context(chunk)
         if self.using_native_model:
             res, cost = await self.model.a_generate(prompt, schema=ContextScore)
-            self.total_cost += cost
+            if cost is not None:
+                self.total_cost += cost
             return (res.clarity + res.depth + res.structure + res.relevance) / 4
         else:
 

--- a/deepeval/synthesizer/synthesizer.py
+++ b/deepeval/synthesizer/synthesizer.py
@@ -15,6 +15,7 @@ import csv
 import os
 from contextlib import nullcontext
 
+from deepeval.errors import DeepEvalError
 from deepeval.utils import get_or_create_event_loop
 from deepeval.synthesizer.chunking.context_generator import ContextGenerator
 from deepeval.metrics.utils import (
@@ -486,6 +487,11 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
+                if not contexts:
+                    raise DeepEvalError(
+                        "No contexts were generated from the provided documents. "
+                        "This may be caused by an incompatible model or invalid document format."
+                    )
                 if self.synthesis_cost:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
@@ -605,6 +611,11 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
+            if not contexts:
+                raise DeepEvalError(
+                    "No contexts were generated from the provided documents. "
+                    "This may be caused by an incompatible model or invalid document format."
+                )
             if self.synthesis_cost:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(
@@ -1686,7 +1697,7 @@ class Synthesizer:
     ) -> BaseModel:
         if is_native_model(model):
             res, cost = model.generate(prompt, schema)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -1712,7 +1723,7 @@ class Synthesizer:
     ) -> BaseModel:
         if is_native_model(model):
             res, cost = await model.a_generate(prompt, schema)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -1733,7 +1744,7 @@ class Synthesizer:
     def _generate(self, prompt: str) -> str:
         if self.using_native_model:
             res, cost = self.model.generate(prompt)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -1747,7 +1758,7 @@ class Synthesizer:
     async def _a_generate(self, prompt: str) -> str:
         if self.using_native_model:
             res, cost = await self.model.a_generate(prompt)
-            if self.synthesis_cost is not None:
+            if cost is not None and self.synthesis_cost is not None:
                 self.synthesis_cost += cost
             return res
         else:
@@ -2119,6 +2130,11 @@ class Synthesizer:
                         pbar_id=pbar_id,
                     )
                 )
+                if not contexts:
+                    raise DeepEvalError(
+                        "No contexts were generated from the provided documents. "
+                        "This may be caused by an incompatible model or invalid document format."
+                    )
                 if self.synthesis_cost:
                     self.synthesis_cost += context_generator.total_cost
                 print_synthesizer_status(
@@ -2236,6 +2252,11 @@ class Synthesizer:
                     pbar_id=pbar_id,
                 )
             )
+            if not contexts:
+                raise DeepEvalError(
+                    "No contexts were generated from the provided documents. "
+                    "This may be caused by an incompatible model or invalid document format."
+                )
             if self.synthesis_cost:
                 self.synthesis_cost += context_generator.total_cost
             print_synthesizer_status(

--- a/tests/test_core/test_synthesizer/test_synthesizer_none_cost.py
+++ b/tests/test_core/test_synthesizer/test_synthesizer_none_cost.py
@@ -1,0 +1,280 @@
+"""Regression tests for #2884: Synthesizer silent empty goldens when cost is None."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.errors import DeepEvalError
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.models.llms.constants import DEEPSEEK_MODELS_DATA
+from deepeval.synthesizer.chunking.context_generator import (
+    ContextGenerator,
+    ContextScore,
+)
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        return ""
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        return ""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+class _NativeModelWithUnknownCost:
+    def generate(self, prompt, schema=None):
+        return (
+            ContextScore(
+                clarity=1.0,
+                depth=1.0,
+                structure=1.0,
+                relevance=1.0,
+            ),
+            None,
+        )
+
+    async def a_generate(self, prompt, schema=None):
+        return self.generate(prompt, schema)
+
+
+def _patch_langchain(monkeypatch):
+    class _FakeTextLoader:
+        def __init__(self, path, encoding=None, autodetect_encoding=True):
+            self._path = path
+
+        def load(self):
+            class _Doc:
+                page_content = "chunk one\nchunk two\nchunk three"
+
+            return [_Doc()]
+
+        async def aload(self):
+            return self.load()
+
+    class _FakeSplitter:
+        def __init__(self, chunk_size, chunk_overlap):
+            pass
+
+        def split_documents(self, docs):
+            class _Doc:
+                def __init__(self, txt):
+                    self.page_content = txt
+
+            return [_Doc(f"c{j}") for j in range(5)]
+
+    monkeypatch.setattr(
+        "deepeval.synthesizer.chunking.doc_chunker._langchain_ns",
+        SimpleNamespace(
+            LCDocument=object,
+            TokenTextSplitter=_FakeSplitter,
+            TextSplitter=_FakeSplitter,
+            PyPDFLoader=_FakeTextLoader,
+            TextLoader=_FakeTextLoader,
+            Docx2txtLoader=_FakeTextLoader,
+            BaseLoader=_FakeTextLoader,
+        ),
+        raising=True,
+    )
+
+
+class _StubEmbedder:
+    def embed_texts(self, xs):
+        return [[0.0, 0.0] for _ in xs]
+
+    async def a_embed_texts(self, xs):
+        return [[0.0, 0.0] for _ in xs]
+
+    def embed_text(self, x):
+        return [0.0, 0.0]
+
+    async def a_embed_text(self, x):
+        return [0.0, 0.0]
+
+
+class _CapturingCollection:
+    def __init__(self, name, count_value=5):
+        self.name = name
+        self._count_value = count_value
+
+    def count(self):
+        return self._count_value
+
+    def get(self, ids):
+        return {"documents": [f"D{i}" for i in ids]}
+
+    def query(self, _embedding, n_results):
+        docs = [["q"] + [f"n{j}" for j in range(n_results - 1)]]
+        dists = [[0.0] + [0.1] * (n_results - 1)]
+        return {"documents": docs, "distances": dists}
+
+
+class _CapturingClient:
+    def __init__(self, count_value=5):
+        self.collections = {}
+        self._count_value = count_value
+
+    def get_collection(self, name):
+        return self.collections[name]
+
+    def create_collection(self, name):
+        collection = _CapturingCollection(name, self._count_value)
+        self.collections[name] = collection
+        return collection
+
+    def delete_collection(self, name):
+        self.collections.pop(name, None)
+
+
+class _CapturingChromaMod:
+    def __init__(self, client=None):
+        self.client = client or _CapturingClient()
+
+    def PersistentClient(self, path, **kwargs):
+        return self.client
+
+
+class TestDeepSeekV4ModelRegistration:
+    def test_v4_models_have_cache_miss_pricing(self):
+        flash = DEEPSEEK_MODELS_DATA["deepseek-v4-flash"]
+        pro = DEEPSEEK_MODELS_DATA["deepseek-v4-pro"]
+
+        assert flash.input_price == pytest.approx(0.14 / 1e6)
+        assert flash.output_price == pytest.approx(0.28 / 1e6)
+        assert pro.input_price == pytest.approx(0.435 / 1e6)
+        assert pro.output_price == pytest.approx(0.87 / 1e6)
+
+
+class TestEvaluateChunkNoneCost:
+    def test_sync_evaluate_chunk_skips_none_cost(self):
+        generator = ContextGenerator(
+            document_paths=["dummy.txt"],
+            embedder=_StubEmbedder(),
+            model=_StubLLM(),
+        )
+        generator.using_native_model = True
+        generator.model = _NativeModelWithUnknownCost()
+
+        score = generator.evaluate_chunk("sample chunk")
+
+        assert score == 1.0
+        assert generator.total_cost == 0.0
+
+    @pytest.mark.asyncio
+    async def test_async_evaluate_chunk_skips_none_cost(self):
+        generator = ContextGenerator(
+            document_paths=["dummy.txt"],
+            embedder=_StubEmbedder(),
+            model=_StubLLM(),
+        )
+        generator.using_native_model = True
+        generator.model = _NativeModelWithUnknownCost()
+
+        score = await generator.a_evaluate_chunk("sample chunk")
+
+        assert score == 1.0
+        assert generator.total_cost == 0.0
+
+
+class TestContextGenerationErrors:
+    def test_all_document_failures_raise_deep_eval_error(
+        self, monkeypatch, tmp_path
+    ):
+        import sys
+
+        _patch_langchain(monkeypatch)
+
+        doc_path = tmp_path / "doc.md"
+        doc_path.write_text("hello", encoding="utf-8")
+
+        cap_chroma = _CapturingChromaMod()
+        monkeypatch.setattr(
+            "deepeval.synthesizer.chunking.doc_chunker._chroma_mod",
+            cap_chroma,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            "deepeval.synthesizer.chunking.context_generator.get_chromadb",
+            lambda: cap_chroma,
+            raising=True,
+        )
+        sys.modules["chromadb.config"] = SimpleNamespace(
+            Settings=lambda **kwargs: SimpleNamespace(**kwargs)
+        )
+
+        generator = ContextGenerator(
+            document_paths=[str(doc_path)],
+            embedder=_StubEmbedder(),
+            model=_StubLLM(),
+            chunk_size=50,
+            chunk_overlap=0,
+            max_retries=1,
+            filter_threshold=0.0,
+            similarity_threshold=0.0,
+        )
+        generator.using_native_model = True
+        generator.model = _NativeModelWithUnknownCost()
+
+        def _boom(_chunk):
+            raise TypeError("unsupported operand type(s) for +=: 'float' and 'NoneType'")
+
+        monkeypatch.setattr(generator, "evaluate_chunk", _boom)
+
+        with pytest.raises(DeepEvalError, match="Context generation failed for all"):
+            generator.generate_contexts(
+                max_contexts_per_source_file=1,
+                min_contexts_per_source_file=1,
+            )
+
+
+class TestSynthesizerEmptyContexts:
+    def test_generate_goldens_from_docs_raises_on_empty_contexts(self):
+        from deepeval.synthesizer.synthesizer import Synthesizer
+
+        fake_model = MagicMock()
+        fake_model.get_model_name.return_value = "fake-model"
+
+        with patch(
+            "deepeval.synthesizer.synthesizer.initialize_model",
+            return_value=(fake_model, True),
+        ), patch(
+            "deepeval.synthesizer.config.initialize_model",
+            return_value=(fake_model, True),
+        ), patch(
+            "deepeval.synthesizer.config.initialize_embedding_model",
+            side_effect=lambda embedder: embedder,
+        ), patch(
+            "deepeval.synthesizer.synthesizer.ContextGenerator"
+        ) as mock_context_generator_cls, patch(
+            "deepeval.synthesizer.synthesizer.synthesizer_progress_context"
+        ) as mock_progress:
+            mock_progress.return_value.__enter__ = MagicMock(
+                return_value=(MagicMock(), 0)
+            )
+            mock_progress.return_value.__exit__ = MagicMock(return_value=False)
+
+            mock_context_generator = MagicMock()
+            mock_context_generator.generate_contexts.return_value = ([], [], [])
+            mock_context_generator.total_chunks = 0
+            mock_context_generator_cls.return_value = mock_context_generator
+
+            synth = Synthesizer(model=fake_model, async_mode=False)
+            embedder = MagicMock()
+            embedder.get_model_name.return_value = "stub-embedder"
+
+            from deepeval.synthesizer.config import ContextConstructionConfig
+
+            with pytest.raises(DeepEvalError, match="No contexts were generated"):
+                synth.generate_goldens_from_docs(
+                    document_paths=["doc.txt"],
+                    context_construction_config=ContextConstructionConfig(
+                        embedder=embedder,
+                        critic_model=fake_model,
+                    ),
+                )

--- a/tests/test_core/test_synthesizer/test_synthesizer_none_cost.py
+++ b/tests/test_core/test_synthesizer/test_synthesizer_none_cost.py
@@ -222,11 +222,15 @@ class TestContextGenerationErrors:
         generator.model = _NativeModelWithUnknownCost()
 
         def _boom(_chunk):
-            raise TypeError("unsupported operand type(s) for +=: 'float' and 'NoneType'")
+            raise TypeError(
+                "unsupported operand type(s) for +=: 'float' and 'NoneType'"
+            )
 
         monkeypatch.setattr(generator, "evaluate_chunk", _boom)
 
-        with pytest.raises(DeepEvalError, match="Context generation failed for all"):
+        with pytest.raises(
+            DeepEvalError, match="Context generation failed for all"
+        ):
             generator.generate_contexts(
                 max_contexts_per_source_file=1,
                 min_contexts_per_source_file=1,
@@ -270,7 +274,9 @@ class TestSynthesizerEmptyContexts:
 
             from deepeval.synthesizer.config import ContextConstructionConfig
 
-            with pytest.raises(DeepEvalError, match="No contexts were generated"):
+            with pytest.raises(
+                DeepEvalError, match="No contexts were generated"
+            ):
                 synth.generate_goldens_from_docs(
                     document_paths=["doc.txt"],
                     context_construction_config=ContextConstructionConfig(


### PR DESCRIPTION
## Summary
- Guard `None` cost at `evaluate_chunk` / `a_evaluate_chunk` boundaries so unknown pricing no longer crashes context generation
- Register `deepseek-v4-flash` and `deepseek-v4-pro` with official cache-miss pricing
- Raise `DeepEvalError` when all document pipelines fail or when synthesizer receives zero contexts, instead of silently returning empty goldens

Fixes #2884

## Root cause
When `calculate_cost()` returned `None` for models with unknown pricing, `ContextGenerator.evaluate_chunk` executed `self.total_cost += None`, raising a `TypeError` that was swallowed by a broad `except`. Users saw `Utilizing 0 out of N chunks` and empty goldens with no error.

## Test plan
- [x] `pytest tests/test_core/test_synthesizer/test_synthesizer_none_cost.py` (5 tests, offline)
- [x] Verified v4 model pricing registration
- [x] Verified `None` cost no longer raises in sync/async chunk evaluation
- [x] Verified `DeepEvalError` on all-document failure and empty contexts