### PR TITLE
fix(dataset): preserve name/comments/source_file in save_as('jsonl') for single-turn goldens

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -1491,6 +1491,9 @@ class EvaluationDataset:
                             "expected_output": golden.expected_output,
                             "retrieval_context": retrieval_context,
                             "context": context,
+                            "name": golden.name,
+                            "comments": golden.comments,
+                            "source_file": golden.source_file,
                             "tools_called": _dump_tools(golden.tools_called),
                             "expected_tools": _dump_tools(
                                 golden.expected_tools

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -240,6 +240,40 @@ class TestSaveAndLoad:
                     custom_obj = json.loads(vals[custom_idx])
                     assert custom_obj["col"] == "val"
 
+    def test_save_as_jsonl_round_trips_single_turn_metadata_fields(self):
+        """save_as('jsonl') must write name, comments and source_file for
+        single-turn goldens, so a save -> add_goldens_from_jsonl_file cycle
+        preserves them. The JSON path already writes all three and the jsonl
+        loader already reads them; only the jsonl record dict omitted them."""
+        golden = Golden(
+            input="q",
+            expected_output="a",
+            name="case-1",
+            comments="a note",
+            source_file="/data/src.csv",
+        )
+        dataset = EvaluationDataset([golden])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = dataset.save_as(
+                "jsonl", directory=tmpdir, file_name="single_jsonl_meta"
+            )
+
+            # The written record carries the three fields.
+            with open(jsonl_path, "r", encoding="utf-8") as f:
+                row = json.loads(f.readline())
+            assert row["name"] == "case-1"
+            assert row["comments"] == "a note"
+            assert row["source_file"] == "/data/src.csv"
+
+            # They also survive a reload (final state, not just at save time).
+            reloaded = EvaluationDataset()
+            reloaded.add_goldens_from_jsonl_file(jsonl_path)
+            loaded = reloaded.goldens[0]
+            assert loaded.name == "case-1"
+            assert loaded.comments == "a note"
+            assert loaded.source_file == "/data/src.csv"
+
     def test_save_as_round_trips_retrieval_context_data(self):
         """save_as serializes a RetrievedContextData (a type-allowed member of
         Golden.retrieval_context that used to crash the save) as a namespaced,


### PR DESCRIPTION
### Summary

For single-turn goldens, `EvaluationDataset.save_as("jsonl")` omits `name`, `comments` and `source_file` from the written record, so a `save_as("jsonl")` then `add_goldens_from_jsonl_file` round trip silently drops all three.

### Root cause

The single-turn JSONL record dict in `save_as` (`deepeval/dataset/dataset.py`) writes `input`, `actual_output`, `expected_output`, `retrieval_context`, `context`, `tools_called`, `expected_tools`, `additional_metadata` and `custom_column_key_values`, but not `name`, `comments` or `source_file`. Every other path already handles them:

- the single-turn JSON path writes all three,
- the multi-turn JSONL record writes `name` and `comments`,
- `add_goldens_from_jsonl_file` already reads `name`, `comments` and `source_file` and passes them to `Golden(...)`.

So the loader looks for keys the single-turn JSONL writer never emits. Commit 90dfe82 ("include missing fields into save_as method") added these fields to the JSON and multi-turn JSONL paths but not to the single-turn JSONL record.

### Fix

Add `name`, `comments` and `source_file` to the single-turn JSONL record, in the same position as the JSON path. Three lines, with no change to any other format or to the loader.

### Verification

Ran in a clean `python:3.12-slim` container, module provenance confirmed via `__file__`:

- Before: a single-turn golden with `name`/`comments`/`source_file` set, saved to JSONL and reloaded, comes back with all three `None`.
- After: the round trip preserves all three.

Added `test_save_as_jsonl_round_trips_single_turn_metadata_fields`, which asserts the written record carries the three keys and that they survive a reload. It fails on `main` (`KeyError: 'name'`) and passes on this branch. Running `pytest tests/test_core/test_datasets/test_dataset.py` shows the new test passing; the four pre-existing failures in that file (a `deepeval/dataset/utils.py` `ValueError` unrelated to this change) are present on `main` as well.

Not verified: the Confident AI `push`/pull paths, which are separate from local file save and load.

### Note

Open PR #2543 (add `tags` field) also edits this record. The two changes are independent (different keys) and should rebase cleanly whichever lands first.
