### PR TITLE
fix(dataset): serialize tool call enums in JSON mode

### DIFF
--- a/deepeval/dataset/utils.py
+++ b/deepeval/dataset/utils.py
@@ -187,7 +187,9 @@ def format_turns(turns: List[Turn]) -> str:
             for m in models:
                 if hasattr(m, "model_dump"):
                     dumped.append(
-                        m.model_dump(by_alias=True, exclude_none=True)
+                        m.model_dump(
+                            mode="json", by_alias=True, exclude_none=True
+                        )
                     )
                 elif hasattr(m, "dict"):
                     dumped.append(m.dict(exclude_none=True))

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -351,6 +351,7 @@ class TestSaveAndLoad:
                 turns = data["turns"]
                 assert isinstance(turns, list) and turns[0]["user_id"] == "u1"
                 assert isinstance(turns[0]["tools_called"], list)
+                assert turns[0]["tools_called"][0]["type"] == "FUNCTION"
                 assert data["additional_metadata"]["gk"] == "gv"
                 assert data["custom_column_key_values"]["col"] == "val"
 
@@ -362,6 +363,7 @@ class TestSaveAndLoad:
                 turns = rec["turns"]
                 assert isinstance(turns, list) and turns[0]["user_id"] == "u1"
                 assert isinstance(turns[0]["tools_called"], list)
+                assert turns[0]["tools_called"][0]["type"] == "FUNCTION"
 
     def test_add_goldens_from_jsonl_file_loads_single_turn_goldens(self):
         """Load single-turn goldens from JSONL and preserve extra fields."""


### PR DESCRIPTION
## What Problem This Solves

Dataset saves fail when a `ToolCall` contains its default `ToolCallType` enum because Python-mode Pydantic dumps leave the enum object for `json.dumps()`.

## Why This Change Was Made

Serialize nested tool models with Pydantic's JSON mode in conversational and single-turn JSON, JSONL, and CSV paths. This preserves aliases while converting enum values to JSON-safe strings. The regression assertions verify that `ToolCallType.FUNCTION` is emitted as `"FUNCTION"`.

## User Impact

Users can save datasets containing tool calls without `Object of type ToolCallType is not JSON serializable` errors.

## Evidence

- `pytest -q tests/test_core/test_datasets/test_dataset.py` — 18 passed
- `black --check deepeval/dataset/utils.py deepeval/dataset/dataset.py tests/test_core/test_datasets/test_dataset.py` — passed
- `ruff check --ignore F401 deepeval/dataset/utils.py deepeval/dataset/dataset.py tests/test_core/test_datasets/test_dataset.py` — passed (`dataset.py` has unrelated pre-existing F401 findings)

Fixes confident-ai/deepeval#2902
