### PR TITLE
fix(dataset): serialize ToolCall enums safely in save_as

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -1269,7 +1269,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            by_alias=True,
+                                            exclude_none=True,
+                                            mode="json",
                                         )
                                     )
                                 elif hasattr(t, "dict"):
@@ -1395,7 +1397,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            by_alias=True,
+                                            exclude_none=True,
+                                            mode="json",
                                         )
                                     )
                                 elif hasattr(t, "dict"):
@@ -1476,7 +1480,9 @@ class EvaluationDataset:
                                 if hasattr(t, "model_dump"):
                                     dumped.append(
                                         t.model_dump(
-                                            by_alias=True, exclude_none=True
+                                            by_alias=True,
+                                            exclude_none=True,
+                                            mode="json",
                                         )
                                     )
                                 elif hasattr(t, "dict"):


### PR DESCRIPTION
## Summary
`EvaluationDataset.save_as()` crashed with:

```
TypeError: Object of type ToolCallType is not JSON serializable
```

when a `Golden` contained `ToolCall` objects, because `ToolCall.type` is a `ToolCallType` enum and `model_dump()` (default mode) keeps enums as enum instances.

## Change
Use `model_dump(..., mode="json")` in all three `save_as` tool-dump helpers (JSON / CSV / JSONL) so enums become plain strings.

## Test plan
- [ ] `tests/test_core/test_datasets/test_dataset.py::TestSaveAndLoad::test_save_as_includes_extra_single_turn_fields`
- Manual: `save_as("json")` with `tools_called=[ToolCall(name="x")]` succeeds

Fixes #2922.
