### PR TITLE
feat(anthropic): capture prompt-caching token counts in LLM span metadata

### DIFF
--- a/deepeval/anthropic/extractors.py
+++ b/deepeval/anthropic/extractors.py
@@ -68,6 +68,12 @@ def extract_messages_api_output_parameters(
     output = str(message_response.content[0].text)
     prompt_tokens = message_response.usage.input_tokens
     completion_tokens = message_response.usage.output_tokens
+    cache_creation_input_tokens = getattr(
+        message_response.usage, "cache_creation_input_tokens", None
+    )
+    cache_read_input_tokens = getattr(
+        message_response.usage, "cache_read_input_tokens", None
+    )
 
     tools_called = None
     anthropic_tool_calls = [
@@ -91,4 +97,6 @@ def extract_messages_api_output_parameters(
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
         tools_called=tools_called,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
     )

--- a/deepeval/model_integrations/types.py
+++ b/deepeval/model_integrations/types.py
@@ -18,3 +18,5 @@ class OutputParameters(BaseModel):
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
     tools_called: Optional[List[ToolCall]] = None
+    cache_creation_input_tokens: Optional[int] = None
+    cache_read_input_tokens: Optional[int] = None

--- a/deepeval/model_integrations/utils.py
+++ b/deepeval/model_integrations/utils.py
@@ -46,6 +46,20 @@ def _update_all_attributes(
     if current_span:
         current_span.integration = Integration.ANTHROPIC.value
         current_span.provider = Provider.ANTHROPIC.value
+        cache_meta = {}
+        if output_parameters.cache_creation_input_tokens is not None:
+            cache_meta["cache_creation_input_tokens"] = (
+                output_parameters.cache_creation_input_tokens
+            )
+        if output_parameters.cache_read_input_tokens is not None:
+            cache_meta["cache_read_input_tokens"] = (
+                output_parameters.cache_read_input_tokens
+            )
+        if cache_meta:
+            current_span.metadata = {
+                **(current_span.metadata or {}),
+                **cache_meta,
+            }
 
     if output_parameters.tools_called:
         create_child_tool_spans(output_parameters)

--- a/tests/test_core/test_models/test_anthropic_cache_tokens.py
+++ b/tests/test_core/test_models/test_anthropic_cache_tokens.py
@@ -1,0 +1,112 @@
+"""Tests for Anthropic prompt-caching token extraction in the output extractor."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from deepeval.anthropic.extractors import (
+    extract_messages_api_output_parameters,
+    safe_extract_output_parameters,
+)
+from deepeval.model_integrations.types import InputParameters
+
+
+def _make_usage(
+    input_tokens=100,
+    output_tokens=50,
+    cache_creation_input_tokens=None,
+    cache_read_input_tokens=None,
+):
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    usage.cache_creation_input_tokens = cache_creation_input_tokens
+    usage.cache_read_input_tokens = cache_read_input_tokens
+    return usage
+
+
+def _make_message(usage, content_text="Hello"):
+    content_block = MagicMock()
+    content_block.text = content_text
+    message = MagicMock()
+    message.content = [content_block]
+    message.usage = usage
+    return message
+
+
+_input_params = InputParameters(model="claude-sonnet-4-5")
+
+
+class TestCacheCreationTokens:
+    def test_cache_creation_tokens_extracted_when_present(self):
+        usage = _make_usage(cache_creation_input_tokens=200)
+        message = _make_message(usage)
+
+        params = extract_messages_api_output_parameters(message, _input_params)
+
+        assert params.cache_creation_input_tokens == 200
+        assert params.cache_read_input_tokens is None
+
+    def test_cache_read_tokens_extracted_when_present(self):
+        usage = _make_usage(cache_read_input_tokens=150)
+        message = _make_message(usage)
+
+        params = extract_messages_api_output_parameters(message, _input_params)
+
+        assert params.cache_creation_input_tokens is None
+        assert params.cache_read_input_tokens == 150
+
+    def test_both_cache_token_fields_extracted_together(self):
+        usage = _make_usage(
+            cache_creation_input_tokens=300, cache_read_input_tokens=75
+        )
+        message = _make_message(usage)
+
+        params = extract_messages_api_output_parameters(message, _input_params)
+
+        assert params.cache_creation_input_tokens == 300
+        assert params.cache_read_input_tokens == 75
+
+    def test_no_cache_tokens_when_not_set(self):
+        usage = _make_usage()
+        message = _make_message(usage)
+
+        params = extract_messages_api_output_parameters(message, _input_params)
+
+        assert params.cache_creation_input_tokens is None
+        assert params.cache_read_input_tokens is None
+
+    def test_regular_token_counts_unaffected(self):
+        usage = _make_usage(
+            input_tokens=123,
+            output_tokens=45,
+            cache_creation_input_tokens=60,
+        )
+        message = _make_message(usage)
+
+        params = extract_messages_api_output_parameters(message, _input_params)
+
+        assert params.prompt_tokens == 123
+        assert params.completion_tokens == 45
+
+    def test_safe_extract_returns_cache_tokens_when_present(self):
+        usage = _make_usage(
+            cache_creation_input_tokens=100, cache_read_input_tokens=50
+        )
+        message = _make_message(usage)
+
+        params = safe_extract_output_parameters(message, _input_params)
+
+        assert params.cache_creation_input_tokens == 100
+        assert params.cache_read_input_tokens == 50
+
+    def test_getattr_guard_when_usage_lacks_cache_fields(self):
+        """Usage objects from older SDK versions may not have cache fields at all."""
+        usage = MagicMock(spec=["input_tokens", "output_tokens"])
+        usage.input_tokens = 10
+        usage.output_tokens = 5
+        message = _make_message(usage)
+
+        params = extract_messages_api_output_parameters(message, _input_params)
+
+        assert params.cache_creation_input_tokens is None
+        assert params.cache_read_input_tokens is None


### PR DESCRIPTION
## Summary

Anthropic's prompt-caching API returns `cache_creation_input_tokens` and `cache_read_input_tokens` alongside the regular `input_tokens` / `output_tokens` in every response's `usage` object. The `extract_messages_api_output_parameters` extractor ignored both fields, so when users run evaluations with prompt caching enabled — for long system prompts, few-shot examples, or tool lists — the LLM span records no caching activity: the span metadata contains no cache token counts and cost tracking is silently incomplete.

Fixes #2741

## Root Cause / Motivation

`extract_messages_api_output_parameters` reads only `usage.input_tokens` and `usage.output_tokens`. `OutputParameters` had no fields for cache token counts, so they were never carried through `_update_all_attributes` to the span.

The demand signal: issue #2741 explicitly requests this. The openai_agents extractor already surfaces `cached_input_tokens` in `span.metadata` — the Anthropic extractor should be consistent.

## Design Decisions

- **`getattr` extraction** — `cache_creation_input_tokens` and `cache_read_input_tokens` were added to the Anthropic SDK's `Usage` type after the initial release. Using `getattr(..., None)` means the extractor works without change against any SDK version that predates prompt caching, and automatically captures the values when they are present.
- **Fields on `OutputParameters`, not passed separately** — keeps the data flowing through the existing `_update_all_attributes` single-entry-point, avoiding a new code path or a separate parameter.
- **`span.metadata` dict** — mirrors the exact approach used by `openai_agents/extractors.py` for `cached_input_tokens`; promotes consistency across extractors and avoids touching the `LlmSpan` type (which would require a larger schema change and a server-side migration).
- **Skip-when-None** — cache tokens are absent on non-caching requests; metadata is only written when at least one field is non-None.

## Changes

| File | What changed |
|------|-------------|
| `deepeval/model_integrations/types.py` | Added `cache_creation_input_tokens` and `cache_read_input_tokens` optional fields to `OutputParameters` |
| `deepeval/anthropic/extractors.py` | Extracts both fields via `getattr` from `message_response.usage` and returns them in `OutputParameters` |
| `deepeval/model_integrations/utils.py` | Writes both fields to `current_span.metadata` in `_update_all_attributes` when non-None |
| `tests/test_core/test_models/test_anthropic_cache_tokens.py` | 7 new tests: cache-create-only, cache-read-only, both together, none set, regular counts unaffected, `safe_extract` round-trip, `getattr` guard for older SDK |

## Testing

- [x] 7 new tests — all pass
- [x] `test_openai_extractors.py` (1) and `test_models_utils.py` (15) — still pass (16 total)
- [x] `black --check --line-length 80` — clean on all 4 files
- [x] Manually verified: `getattr(usage, 'cache_creation_input_tokens', None)` returns `None` on a MagicMock with restricted spec (`spec=['input_tokens', 'output_tokens']`), confirming backwards-compat guard works

## Note on PR #2914

PR #2914 (currently open) also modifies `deepeval/anthropic/extractors.py` to fix the `content[0].text` bug. The two changes are on different lines and address orthogonal issues — the cache-token extraction is unchanged by either the old or the new `content[0]` logic. If #2914 merges before this PR, a trivial rebase on `extractors.py` is all that's needed.

## Impact

Users who use Anthropic prompt caching in their evaluations now see accurate per-call cache token counts in the LLM span metadata, enabling correct cost attribution and cache-hit monitoring through the DeepEval tracing UI.