### PR TITLE
docs: fix typo in tool name on metrics step efficiency doc

### DIFF
--- a/docs/content/docs/(agentic)/metrics-step-efficiency.mdx
+++ b/docs/content/docs/(agentic)/metrics-step-efficiency.mdx
@@ -26,7 +26,7 @@ from deepeval.test_case import ToolCall
 @observe
 def tool_call(input):
     ...
-    return [ToolCall(name="CheckWhether")]
+    return [ToolCall(name="CheckWeather")]
 
 @observe
 def agent(input):


### PR DESCRIPTION
This PR fixes a small typo in the tool name the code example on the metrics step efficiency doc page.
Changes the tool name from `CheckWhether` to `CheckWeather`