### PR TITLE
fix: stamp utm_content first so GA4's 100-char link_url keeps the label

### DIFF
--- a/docs/src/layouts/UtmCapture/UtmCapture.tsx
+++ b/docs/src/layouts/UtmCapture/UtmCapture.tsx
@@ -103,13 +103,15 @@ function stampAnchor(anchor: HTMLAnchorElement | null): void {
     (anchor.getAttribute("data-utm-medium") as UtmMedium | null) ??
     DEFAULT_MEDIUM;
 
+  // utm_content first - GA4's link_url truncates at 100 chars; see the
+  // matching comment in src/utils/utm.ts.
+  if (content && !u.searchParams.has("utm_content")) {
+    u.searchParams.set("utm_content", content);
+  }
   if (!u.searchParams.has("utm_source"))
     u.searchParams.set("utm_source", SOURCE);
   if (!u.searchParams.has("utm_medium"))
     u.searchParams.set("utm_medium", medium);
-  if (content && !u.searchParams.has("utm_content")) {
-    u.searchParams.set("utm_content", content);
-  }
 
   const last = getLastTouchParams();
   if (last) {

--- a/docs/src/utils/utm.ts
+++ b/docs/src/utils/utm.ts
@@ -100,11 +100,15 @@ export function appendDeepEvalAttribution(
 
   const { content, medium = DEFAULT_MEDIUM } = opts;
 
-  if (!u.searchParams.has('utm_source')) u.searchParams.set('utm_source', SOURCE);
-  if (!u.searchParams.has('utm_medium')) u.searchParams.set('utm_medium', medium);
+  // utm_content goes FIRST: GA4's link_url dimension truncates at 100 chars,
+  // and with content in third position even a short destination like
+  // /book-a-demo cuts the label mid-value ("enterprise_hero_demo" recorded as
+  // "enterprise_"). Param order carries no meaning to the destination.
   if (content && !u.searchParams.has('utm_content')) {
     u.searchParams.set('utm_content', content);
   }
+  if (!u.searchParams.has('utm_source')) u.searchParams.set('utm_source', SOURCE);
+  if (!u.searchParams.has('utm_medium')) u.searchParams.set('utm_medium', medium);
 
   const last = getLastTouchParams();
   if (last) {


### PR DESCRIPTION
## Problem

GA4 enhanced measurement truncates the `link_url` dimension at **100 characters**. The docs' UTM stamping appends `utm_content` third (after source and medium), so even a short destination overflows: `https://www.confident-ai.com/book-a-demo?utm_source=deepeval&utm_medium=docs&utm_content=enterprise_` is exactly 100 characters — and that literal truncated fragment `enterprise_` (and `introduction_ecosy`) is what shows up in DeepEval's GA4 click data today. Result: per-label outbound-click counts are wrong or missing for any label past the cutoff, which breaks the docs→Confident CTR analysis.

## Change

Two stamp sites (`docs/src/utils/utm.ts` and `docs/src/layouts/UtmCapture/UtmCapture.tsx`) now append `utm_content` **first**, then source/medium, then the visitor-derived campaign/term and `ref_page` as before. Query-param order carries no meaning to the destination — Confident AI's GA4 receives the full URL regardless — this only changes what survives inside GA4's own 100-char snapshot on the deepeval side.

No behavioral change otherwise: existing params are still never clobbered, and the never-break-navigation guarantees are untouched.

## Verification

Observed evidence: the `enterprise_` fragment in DeepEval GA4 ends at exactly character 100 of the decorated book-a-demo URL. After deploy, new clicks on the enterprise CTAs should record `utm_content=enterprise_hero_demo` / `enterprise_bottom_demo` in full (visible in GA4 Realtime under the click event's link_url).

🤖 Generated with [Claude Code](https://claude.com/claude-code)