### PR TITLE
fix: recursively set additionalProperties for nested gateway schemas

### DIFF
--- a/deepeval/models/llms/gateway_model.py
+++ b/deepeval/models/llms/gateway_model.py
@@ -363,13 +363,16 @@ class DeepEvalOpenAICompatibleModel(DeepEvalBaseGatewayModel):
         schema: Union[Type[BaseModel], BaseModel],
     ) -> Dict:
         json_schema = schema.model_json_schema()
+        DeepEvalOpenAICompatibleModel._set_additional_properties_false(
+            json_schema
+        )
+
         schema_name = (
             schema.__name__
             if inspect.isclass(schema)
             else schema.__class__.__name__
         )
-        # `strict: true` requires additionalProperties to be set at the root.
-        json_schema.setdefault("additionalProperties", False)
+
         return {
             "type": "json_schema",
             "json_schema": {
@@ -420,3 +423,20 @@ class DeepEvalOpenAICompatibleModel(DeepEvalBaseGatewayModel):
                 kw.pop("max_retries", None)
                 return cls(**kw)
             raise
+
+    @staticmethod
+    def _set_additional_properties_false(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                node.setdefault("additionalProperties", False)
+
+            for value in node.values():
+                DeepEvalOpenAICompatibleModel._set_additional_properties_false(
+                    value
+                )
+
+        elif isinstance(node, list):
+            for value in node:
+                DeepEvalOpenAICompatibleModel._set_additional_properties_false(
+                    value
+                )

--- a/deepeval/models/llms/gateway_model.py
+++ b/deepeval/models/llms/gateway_model.py
@@ -27,7 +27,7 @@ Two layers live here:
 
 import inspect
 import warnings
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from openai import OpenAI, AsyncOpenAI
 from pydantic import BaseModel, SecretStr

--- a/tests/test_core/test_models/test_openrouter_model.py
+++ b/tests/test_core/test_models/test_openrouter_model.py
@@ -5,6 +5,10 @@ from pydantic import BaseModel
 
 from deepeval.models.llms.constants import DEFAULT_OPENROUTER_MODEL
 from deepeval.models.llms.openrouter_model import OpenRouterModel
+from typing import List
+from deepeval.models.llms.gateway_model import (
+    DeepEvalOpenAICompatibleModel,
+)
 
 
 class SampleSchema(BaseModel):
@@ -12,6 +16,14 @@ class SampleSchema(BaseModel):
 
     field1: str
     field2: int
+
+
+class Item(BaseModel):
+    name: str
+
+
+class NestedSchema(BaseModel):
+    items: List[Item]
 
 
 class TestOpenRouterModel:
@@ -399,3 +411,14 @@ class TestOpenRouterModel:
         returned_model, using_native = initialize_model(model)
         assert using_native is True
         assert returned_model is model
+
+    @staticmethod
+    def test_schema_response_format_sets_additional_properties_on_nested_models():
+        response_format = DeepEvalOpenAICompatibleModel._schema_response_format(
+            NestedSchema
+        )
+
+        schema = response_format["json_schema"]["schema"]
+
+        assert schema["additionalProperties"] is False
+        assert schema["$defs"]["Item"]["additionalProperties"] is False


### PR DESCRIPTION
Fixes #2929.

## Summary

This PR fixes JSON schema generation for gateway-based models by recursively applying `additionalProperties: false` to all object schemas generated by `_schema_response_format()`.

Previously, `additionalProperties: false` was only applied to the root schema. For nested Pydantic models, object definitions under `$defs` were left unchanged, causing providers enforcing OpenAI's strict structured output requirements to reject the schema.

## Changes

- Added `_set_additional_properties_false()` to recursively apply `additionalProperties: false` to all object schemas.
- Updated `_schema_response_format()` to use the recursive helper before constructing the response format.
- Added a regression test to verify that both the root schema and nested models under `$defs` include `additionalProperties: false`.

## Testing

- Added `test_schema_response_format_sets_additional_properties_on_nested_models`.
- Verified that the new regression test passes.
- Verified that the existing model tests continue to pass.