### PR TITLE
fix: serialize tool call enums in datasets

### DIFF
--- a/deepeval/dataset/utils.py
+++ b/deepeval/dataset/utils.py
@@ -187,7 +187,9 @@ def format_turns(turns: List[Turn]) -> str:
             for m in models:
                 if hasattr(m, "model_dump"):
                     dumped.append(
-                        m.model_dump(by_alias=True, exclude_none=True)
+                        m.model_dump(
+                            mode="json", by_alias=True, exclude_none=True
+                        )
                     )
                 elif hasattr(m, "dict"):
                     dumped.append(m.dict(exclude_none=True))

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -351,6 +351,7 @@ class TestSaveAndLoad:
                 turns = data["turns"]
                 assert isinstance(turns, list) and turns[0]["user_id"] == "u1"
                 assert isinstance(turns[0]["tools_called"], list)
+                assert turns[0]["tools_called"][0]["type"] == "FUNCTION"
                 assert data["additional_metadata"]["gk"] == "gv"
                 assert data["custom_column_key_values"]["col"] == "val"
 
@@ -362,6 +363,7 @@ class TestSaveAndLoad:
                 turns = rec["turns"]
                 assert isinstance(turns, list) and turns[0]["user_id"] == "u1"
                 assert isinstance(turns[0]["tools_called"], list)
+                assert turns[0]["tools_called"][0]["type"] == "FUNCTION"
 
     def test_add_goldens_from_jsonl_file_loads_single_turn_goldens(self):
         """Load single-turn goldens from JSONL and preserve extra fields."""


### PR DESCRIPTION
## Summary

- serialize nested Pydantic models in JSON mode when formatting conversational turns
- convert `ToolCallType` enum values to JSON-safe strings before the final `json.dumps`
- strengthen both JSON and JSONL export coverage to assert the persisted enum value

## Problem

`EvaluationDataset.save_as(...)` raises `ValueError: Object of type ToolCallType is not JSON serializable` for conversational goldens containing tool calls. The nested model was dumped in Python mode, which preserves enum objects that the standard JSON encoder cannot serialize.

## Validation

- `uvx poetry run pytest tests/test_core -q --maxfail=1` — 1111 passed, 56 skipped
- `uvx ruff check deepeval/dataset/utils.py tests/test_core/test_datasets/test_dataset.py`
- `uvx ruff format --check deepeval/dataset/utils.py tests/test_core/test_datasets/test_dataset.py`
- `uvx poetry run black --check deepeval/dataset/utils.py tests/test_core/test_datasets/test_dataset.py`
