### PR TITLE
fix: trim_and_load_json in models/llms/utils.py corrupts valid JSON s…

### DIFF
--- a/deepeval/models/llms/utils.py
+++ b/deepeval/models/llms/utils.py
@@ -17,12 +17,17 @@ def trim_and_load_json(
         input_string = input_string + "}"
         end = len(input_string)
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
-    jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
     try:
         return json.loads(jsonStr)
     except json.JSONDecodeError:
-        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
-        raise DeepEvalError(error_str)
+        # Some models emit a trailing comma before a closing ] or }. Strip it
+        # and retry, but only after a direct parse fails, so valid JSON string
+        # values containing ", ]" or ", }" are never corrupted.
+        try:
+            return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
+        except json.JSONDecodeError:
+            error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+            raise DeepEvalError(error_str)
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
 

--- a/tests/test_core/test_trim_and_load_json.py
+++ b/tests/test_core/test_trim_and_load_json.py
@@ -1,9 +1,9 @@
 """Regression tests for trimAndLoadJson trailing-comma handling.
 
-Both the metrics and dataset copies stripped ``,\\s*`` before a closing ``]``/``}``
-unconditionally, which corrupted valid JSON whose string values happened to
-contain ``", ]"`` or ``", }"``. The cleanup must only run as a fallback when a
-direct parse fails.
+The metrics, dataset, and models/llms copies all stripped ``,\\s*`` before a
+closing ``]``/``}`` unconditionally, which corrupted valid JSON whose string
+values happened to contain ``", ]"`` or ``", }"``. The cleanup must only run
+as a fallback when a direct parse fails.
 """
 
 import json
@@ -11,9 +11,11 @@ import json
 import pytest
 
 from deepeval.dataset.utils import trimAndLoadJson as trim_dataset
+from deepeval.errors import DeepEvalError
 from deepeval.metrics.utils import trimAndLoadJson as trim_metrics
+from deepeval.models.llms.utils import trim_and_load_json as trim_llms
 
-TRIM_FNS = [trim_metrics, trim_dataset]
+TRIM_FNS = [trim_metrics, trim_dataset, trim_llms]
 
 
 @pytest.mark.parametrize("trim", TRIM_FNS)
@@ -35,5 +37,5 @@ def test_trailing_comma_is_still_stripped(trim):
 
 @pytest.mark.parametrize("trim", TRIM_FNS)
 def test_invalid_json_still_raises(trim):
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, DeepEvalError)):
         trim("not json at all {[")


### PR DESCRIPTION
Fixes #2770.

## Problem
`deepeval.models.llms.utils.trim_and_load_json` unconditionally ran the trailing-comma cleanup regex (`re.sub(r",\s*([\]}])", r"\1", jsonStr)`) *before* attempting to parse, so JSON whose string values contained `", ]"` or `", }"` got silently corrupted — e.g. `trim_and_load_json('{"reason": "score is 1,} good"}')` returned `{'reason': 'score is 1} good'}` instead of the correct value.

This function is imported by every concrete model backend (OpenAI, Azure, Anthropic, Bedrock, DeepSeek, Grok, Kimi, LiteLLM, Local, Gateway) to parse generated output, so the corruption affects any evaluation LLM output containing a comma near a closing brace/bracket inside a string.

PR #2701 fixed the identical bug in the two other copies of this logic (`deepeval/metrics/utils.py` and `deepeval/dataset/utils.py`) by only falling back to the regex-stripping retry after a direct `json.loads` fails. This third copy was missed.

## Changes
- Applied the same try-direct-parse-then-regex-fallback approach to `deepeval/models/llms/utils.py::trim_and_load_json`.
- Extended `tests/test_core/test_trim_and_load_json.py` (originally added by PR #2701) to also cover this third copy, so all three implementations now share the same regression suite: valid JSON with commas-near-brackets in string values is preserved, genuine trailing commas are still cleaned up, and invalid JSON still raises.

## Testing
Ran the updated test file locally in an isolated venv — all 12 cases pass (4 per copy × 3 copies), and confirmed the 2 new cases fail against the pre-fix code (proving the regression is real). Also confirmed `black --check` is clean on both changed files.