### PR TITLE
fix(dataset): load CSV additional_metadata as JSON to match save_as

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -594,8 +594,20 @@ class EvaluationDataset:
         comments = get_column_data(df, comments_key_name)
         name = get_column_data(df, name_key_name)
         source_files = get_column_data(df, source_file_col_name)
+
+        def parse_metadata(metadata):
+            if not metadata:
+                return None
+            # save_as("csv") serializes additional_metadata with json.dumps,
+            # so parse it as JSON first. Fall back to ast.literal_eval for
+            # metadata written as a Python literal.
+            try:
+                return json.loads(metadata)
+            except (ValueError, SyntaxError):
+                return ast.literal_eval(metadata)
+
         metadatas = [
-            ast.literal_eval(metadata) if metadata else None
+            parse_metadata(metadata)
             for metadata in get_column_data(
                 df, additional_metadata_col_name, default=""
             )

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -288,6 +288,22 @@ class TestSaveAndLoad:
                 assert rc[0].source == "s" and rc[0].context == "c"
                 assert rc[1] == "plain"
 
+    def test_save_as_round_trips_additional_metadata(self):
+        """save_as('csv') serializes additional_metadata with json.dumps, so
+        add_goldens_from_csv_file must parse it as JSON. Booleans and None
+        (JSON true/false/null) used to crash the loader, which parsed the
+        column with ast.literal_eval. They now round-trip losslessly."""
+        meta = {"passed": True, "skipped": False, "note": None, "score": 5}
+        goldens = [Golden(input="q", additional_metadata=meta)]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = EvaluationDataset(goldens).save_as(
+                "csv", directory=tmpdir, file_name="meta_csv"
+            )
+            reloaded = EvaluationDataset()
+            reloaded.add_goldens_from_csv_file(csv_path)
+            assert reloaded.goldens[0].additional_metadata == meta
+
     def test_save_as_round_trips_turn_retrieval_context_data(self):
         """Multi-turn goldens serialize through format_turns, which previously
         dropped the source of a Turn's RetrievedContextData. It now round-trips


### PR DESCRIPTION
### Summary

`EvaluationDataset.save_as("csv")` serializes `additional_metadata` with `json.dumps`, but `add_goldens_from_csv_file` parses that column back with `ast.literal_eval`. `ast.literal_eval` cannot read the JSON tokens `true`, `false` and `null`, so a golden whose `additional_metadata` contains a bool or `None` crashes the whole CSV load with `ValueError`. Metadata made only of strings and numbers happens to survive (double-quoted JSON strings and numbers are also valid Python literals), which masks the bug.

### Root cause

The save path writes JSON (`deepeval/dataset/dataset.py`):

```python
additional_metadata = (
    json.dumps(golden.additional_metadata, ensure_ascii=False)
    if golden.additional_metadata is not None
    else None
)
```

so `{"ok": True, "missing": None}` is written to the CSV as `{"ok": true, "missing": null}`. The load path then does:

```python
ast.literal_eval(metadata) if metadata else None
```

`ast.literal_eval("{\"ok\": true, \"missing\": null}")` raises `ValueError: malformed node or string`, because `true`/`null` are not Python literals. The two sides use different codecs for the same column.

### Fix

Parse the column with `json.loads` (matching `save_as`), falling back to `ast.literal_eval` so any metadata previously written as a Python literal still loads:

```python
def parse_metadata(metadata):
    if not metadata:
        return None
    try:
        return json.loads(metadata)
    except (ValueError, SyntaxError):
        return ast.literal_eval(metadata)
```

Scope is the goldens round trip only (`save_as("csv")` -> `add_goldens_from_csv_file`). `add_test_cases_from_csv_file` uses the same parser but is not fed by `save_as`, so it is left unchanged.

### Verification

Ran in a clean `python:3.12-slim` container, module provenance confirmed via `__file__`:

- Before: a golden with `additional_metadata={"ok": True, "missing": None, ...}`, saved to CSV and reloaded, raises `ValueError: malformed node or string`.
- After: the round trip returns the metadata unchanged.

Added `test_save_as_round_trips_additional_metadata`, which saves a golden whose metadata mixes `True`, `False`, `None` and an int, reloads it and asserts equality. It fails on `main` (`ValueError` from `ast.literal_eval`) and passes on this branch. `pytest tests/test_core/test_datasets/test_dataset.py` is green (19 passed). `black --check` passes on both changed files.

Not verified: the Confident AI push/pull paths, which are separate from local file save and load.
