### PR TITLE
fix(gemini): count thoughts_token_count in output tokens and cost

### DIFF
--- a/deepeval/models/llms/gemini_model.py
+++ b/deepeval/models/llms/gemini_model.py
@@ -352,6 +352,13 @@ class GeminiModel(DeepEvalBaseLLM):
         usage = getattr(response, "usage_metadata", None)
         input_tokens = getattr(usage, "prompt_token_count", None)
         output_tokens = getattr(usage, "candidates_token_count", None)
+        if output_tokens is not None:
+            # Gemini 2.5/3.x thinking models report reasoning tokens separately
+            # in thoughts_token_count (total_token_count = prompt + candidates +
+            # thoughts), and Google bills them at the output rate. Fold them into
+            # output_tokens so cost is not undercounted, matching the OpenAI
+            # adapter whose completion_tokens already includes reasoning tokens.
+            output_tokens += getattr(usage, "thoughts_token_count", 0) or 0
         if input_tokens is not None and output_tokens is not None:
             cost = self.calculate_cost(input_tokens, output_tokens)
             if cost is not None:

--- a/tests/test_core/test_models/test_gemini_model.py
+++ b/tests/test_core/test_models/test_gemini_model.py
@@ -248,6 +248,44 @@ def test_gemini_generate_computes_cost_from_tokens_and_registry_prices(
 
 
 @patch("deepeval.models.llms.gemini_model.require_dependency")
+def test_gemini_generate_folds_thinking_tokens_into_output_cost(
+    mock_require_dep, settings
+):
+    """
+    Gemini 2.5/3.x thinking models report reasoning tokens in a separate
+    ``thoughts_token_count`` field (``total_token_count`` = prompt + candidates
+    + thoughts), and Google bills them at the output rate. They must be folded
+    into ``output_tokens`` so the reported output count and the derived cost
+    reflect what was billed. Counting only ``candidates_token_count`` (the
+    pre-fix behavior) undercounts every thinking-model call.
+    """
+    fake_response = SimpleNamespace(
+        text="Hello world",
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=1000,
+            candidates_token_count=500,
+            thoughts_token_count=300,
+        ),
+    )
+
+    model = _build_gemini_model_with_fake_client(
+        mock_require_dep, settings, fake_response, model_name="gemini-2.5-flash"
+    )
+
+    output, cost = model.generate("test prompt")
+
+    registry = GEMINI_MODELS_DATA.get("gemini-2.5-flash")
+    # output billed = candidates (500) + thoughts (300)
+    expected = 1000 * registry.input_price + 800 * registry.output_price
+
+    assert output == "Hello world"
+    assert isinstance(cost, EvaluationCost)
+    assert cost.output_tokens == 800
+    assert cost.input_tokens == 1000
+    assert cost == expected
+
+
+@patch("deepeval.models.llms.gemini_model.require_dependency")
 def test_gemini_generate_returns_unknown_cost_when_usage_metadata_missing(
     mock_require_dep, settings
 ):


### PR DESCRIPTION
## Root cause

`GeminiModel._token_cost` (`deepeval/models/llms/gemini_model.py`) takes output tokens from `candidates_token_count` alone:

```python
output_tokens = getattr(usage, "candidates_token_count", None)
```

Gemini 2.5/3.x thinking models report their reasoning tokens in a separate `thoughts_token_count` field, not inside `candidates_token_count`. Google's `GenerateContentResponseUsageMetadata` keeps them apart: `total_token_count = prompt_token_count + candidates_token_count + thoughts_token_count`. Thinking tokens are billed at the output rate, so dropping `thoughts_token_count` undercounts both the reported `output_tokens` and the derived cost on every thinking-model call. `calculate_cost` multiplies the short `output_tokens` by `output_price`, so the cost is low by `thoughts_token_count * output_price`.

The OpenAI adapter does not have this gap: it uses `completion.usage.completion_tokens`, which already includes reasoning tokens.

## Invariant

For a Gemini response, `output_tokens` should be the count billed at the output rate, which is `candidates_token_count + thoughts_token_count` (thoughts are 0 on non-thinking models and on responses that omit the field).

## Fix

Fold `thoughts_token_count` into `output_tokens` when a candidate count is present, leaving the None handling untouched so a missing `usage_metadata` still yields an unknown cost:

```python
output_tokens = getattr(usage, "candidates_token_count", None)
if output_tokens is not None:
    output_tokens += getattr(usage, "thoughts_token_count", 0) or 0
```

`_token_cost` is the single token-counting site; both `generate` and `a_generate` route through it, so the sync and async paths are covered by the one change.

## Verification

Reproduced and tested in a clean `python:3.12-slim` container against this branch.

- Confirmed against the installed `google-genai` SDK that `thoughts_token_count` is a field on `GenerateContentResponseUsageMetadata`, and that `total_token_count == prompt_token_count + candidates_token_count + thoughts_token_count`, i.e. candidates does not already include thoughts.
- Added `test_gemini_generate_folds_thinking_tokens_into_output_cost`: a response with `candidates_token_count=500, thoughts_token_count=300` must report `output_tokens == 800` and a cost of `1000*input_price + 800*output_price`. It fails on `main` (`output_tokens == 500`, cost short by `300*output_price`) and passes with this change.
- Full `tests/test_core/test_models/test_gemini_model.py` passes (13 tests). Existing mocks carry no `thoughts_token_count`, so they are unaffected (thoughts default to 0).
- `black --line-length 80` and `ruff check` are clean on both changed files.

## Not verified

I did not call the live Gemini API. The accounting is exercised with the SDK's own usage-metadata type and mock responses. The premise that thoughts are billed at the output rate is Google's documented pricing behavior, not something measured here.
