### PR TITLE
fix(models): extract Anthropic text block by type, not content[0]

### DIFF
--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -160,10 +160,11 @@ class AnthropicModel(DeepEvalBaseLLM):
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )
+        text = self._extract_text(message)
         if schema is None:
-            return message.content[0].text, cost
+            return text, cost
         else:
-            json_output = trim_and_load_json(message.content[0].text)
+            json_output = trim_and_load_json(text)
             return schema.model_validate(json_output), cost
 
     @retry_anthropic
@@ -200,12 +201,24 @@ class AnthropicModel(DeepEvalBaseLLM):
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )
+        text = self._extract_text(message)
         if schema is None:
-            return message.content[0].text, cost
+            return text, cost
         else:
-            json_output = trim_and_load_json(message.content[0].text)
+            json_output = trim_and_load_json(text)
 
             return schema.model_validate(json_output), cost
+
+    def _extract_text(self, message) -> str:
+        # With extended thinking enabled, content starts with thinking blocks;
+        # the text block is not guaranteed to be first.
+        for block in message.content:
+            if getattr(block, "type", None) == "text":
+                return block.text
+        raise DeepEvalError(
+            f"Anthropic response from `{self.name}` contained no text block "
+            f"(content types: {[getattr(b, 'type', '?') for b in message.content]})."
+        )
 
     def generate_content(self, multimodal_input: List[Union[str, MLLMImage]]):
         content = []

--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -163,10 +163,11 @@ class AnthropicModel(DeepEvalBaseLLM):
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )
+        text = self._extract_text(message)
         if schema is None:
-            return message.content[0].text, cost
+            return text, cost
         else:
-            json_output = trim_and_load_json(message.content[0].text)
+            json_output = trim_and_load_json(text)
             return schema.model_validate(json_output), cost
 
     @retry_anthropic
@@ -203,12 +204,24 @@ class AnthropicModel(DeepEvalBaseLLM):
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )
+        text = self._extract_text(message)
         if schema is None:
-            return message.content[0].text, cost
+            return text, cost
         else:
-            json_output = trim_and_load_json(message.content[0].text)
+            json_output = trim_and_load_json(text)
 
             return schema.model_validate(json_output), cost
+
+    def _extract_text(self, message) -> str:
+        # With extended thinking enabled, content starts with thinking blocks;
+        # the text block is not guaranteed to be first.
+        for block in message.content:
+            if getattr(block, "type", None) == "text":
+                return block.text
+        raise DeepEvalError(
+            f"Anthropic response from `{self.name}` contained no text block "
+            f"(content types: {[getattr(b, 'type', '?') for b in message.content]})."
+        )
 
     def generate_content(self, multimodal_input: List[Union[str, MLLMImage]]):
         content = []

--- a/tests/test_core/test_models/test_anthropic_model.py
+++ b/tests/test_core/test_models/test_anthropic_model.py
@@ -311,3 +311,107 @@ def test_anthropic_calculate_cost_with_zero_tokens(mock_require_dep, settings):
     model = AnthropicModel(model="claude-3-7-sonnet-latest")
     cost = model.calculate_cost(input_tokens=0, output_tokens=0)
     assert cost == 0.0
+
+
+#####################################################
+# Extended thinking (thinking-first content blocks) #
+#####################################################
+
+
+def _make_thinking_first_message():
+    from anthropic.types import Message, TextBlock, ThinkingBlock, Usage
+
+    return Message(
+        id="msg_thinking",
+        model="claude-3-7-sonnet-latest",
+        role="assistant",
+        stop_reason="end_turn",
+        type="message",
+        usage=Usage(input_tokens=10, output_tokens=20),
+        content=[
+            ThinkingBlock(
+                type="thinking",
+                thinking="Reasoning about the answer...",
+                signature="sig",
+            ),
+            TextBlock(type="text", text="final answer"),
+        ],
+    )
+
+
+class _ThinkingResponseClient(_RecordingClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.messages = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs):
+        return _make_thinking_first_message()
+
+
+class _AsyncThinkingResponseClient(_RecordingClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.messages = SimpleNamespace(create=self._create)
+
+    async def _create(self, **kwargs):
+        return _make_thinking_first_message()
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_model_generate_returns_text_when_thinking_block_first(
+    mock_require_dep,
+    settings,
+):
+    """
+    With extended thinking enabled (via generation_kwargs), the API returns
+    content=[ThinkingBlock, TextBlock]. generate() must return the text
+    block instead of assuming content[0] is text.
+    """
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 1e-6
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 1e-6
+
+    fake_anthropic_module = SimpleNamespace(
+        Anthropic=_ThinkingResponseClient,
+        AsyncAnthropic=_AsyncThinkingResponseClient,
+    )
+    mock_require_dep.return_value = fake_anthropic_module
+
+    model = AnthropicModel(
+        model="claude-3-7-sonnet-latest",
+        generation_kwargs={
+            "thinking": {"type": "enabled", "budget_tokens": 1024}
+        },
+    )
+
+    output, _ = model.generate("what is the answer?")
+    assert output == "final answer"
+
+
+@pytest.mark.asyncio
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+async def test_anthropic_model_a_generate_returns_text_when_thinking_block_first(
+    mock_require_dep,
+    settings,
+):
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 1e-6
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 1e-6
+
+    fake_anthropic_module = SimpleNamespace(
+        Anthropic=_ThinkingResponseClient,
+        AsyncAnthropic=_AsyncThinkingResponseClient,
+    )
+    mock_require_dep.return_value = fake_anthropic_module
+
+    model = AnthropicModel(
+        model="claude-3-7-sonnet-latest",
+        generation_kwargs={
+            "thinking": {"type": "enabled", "budget_tokens": 1024}
+        },
+    )
+
+    output, _ = await model.a_generate("what is the answer?")
+    assert output == "final answer"

--- a/tests/test_core/test_models/test_anthropic_model.py
+++ b/tests/test_core/test_models/test_anthropic_model.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from deepeval.errors import DeepEvalError
 from deepeval.models.llms.anthropic_model import AnthropicModel
 from deepeval.config.settings import reset_settings, get_settings
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 
 from tests.test_core.stubs import _RecordingClient
 
@@ -318,7 +318,11 @@ def test_anthropic_calculate_cost_with_zero_tokens(mock_require_dep, settings):
 #####################################################
 
 
-def _make_thinking_first_message():
+class _Verdict(BaseModel):
+    verdict: str
+
+
+def _make_thinking_first_message(text="final answer"):
     from anthropic.types import Message, TextBlock, ThinkingBlock, Usage
 
     return Message(
@@ -334,27 +338,33 @@ def _make_thinking_first_message():
                 thinking="Reasoning about the answer...",
                 signature="sig",
             ),
-            TextBlock(type="text", text="final answer"),
+            TextBlock(type="text", text=text),
         ],
     )
 
 
 class _ThinkingResponseClient(_RecordingClient):
+    text = "final answer"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.messages = SimpleNamespace(create=self._create)
 
     def _create(self, **kwargs):
-        return _make_thinking_first_message()
+        return _make_thinking_first_message(self.text)
 
 
-class _AsyncThinkingResponseClient(_RecordingClient):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.messages = SimpleNamespace(create=self._create)
-
+class _AsyncThinkingResponseClient(_ThinkingResponseClient):
     async def _create(self, **kwargs):
-        return _make_thinking_first_message()
+        return _make_thinking_first_message(self.text)
+
+
+class _ThinkingJSONResponseClient(_ThinkingResponseClient):
+    text = '{"verdict": "yes"}'
+
+
+class _AsyncThinkingJSONResponseClient(_AsyncThinkingResponseClient):
+    text = '{"verdict": "yes"}'
 
 
 @patch("deepeval.models.llms.anthropic_model.require_dependency")
@@ -380,6 +390,7 @@ def test_anthropic_model_generate_returns_text_when_thinking_block_first(
 
     model = AnthropicModel(
         model="claude-3-7-sonnet-latest",
+        max_tokens=2048,
         generation_kwargs={
             "thinking": {"type": "enabled", "budget_tokens": 1024}
         },
@@ -408,6 +419,7 @@ async def test_anthropic_model_a_generate_returns_text_when_thinking_block_first
 
     model = AnthropicModel(
         model="claude-3-7-sonnet-latest",
+        max_tokens=2048,
         generation_kwargs={
             "thinking": {"type": "enabled", "budget_tokens": 1024}
         },
@@ -415,3 +427,65 @@ async def test_anthropic_model_a_generate_returns_text_when_thinking_block_first
 
     output, _ = await model.a_generate("what is the answer?")
     assert output == "final answer"
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_model_generate_parses_schema_when_thinking_block_first(
+    mock_require_dep,
+    settings,
+):
+    """
+    Metrics call generate() with a schema, so the JSON branch is the one
+    scoring depends on. A fix that only repaired the schema-less return
+    would leave every metric crashing.
+    """
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 1e-6
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 1e-6
+
+    fake_anthropic_module = SimpleNamespace(
+        Anthropic=_ThinkingJSONResponseClient,
+        AsyncAnthropic=_AsyncThinkingJSONResponseClient,
+    )
+    mock_require_dep.return_value = fake_anthropic_module
+
+    model = AnthropicModel(
+        model="claude-3-7-sonnet-latest",
+        max_tokens=2048,
+        generation_kwargs={
+            "thinking": {"type": "enabled", "budget_tokens": 1024}
+        },
+    )
+
+    output, _ = model.generate("what is the answer?", schema=_Verdict)
+    assert output == _Verdict(verdict="yes")
+
+
+@pytest.mark.asyncio
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+async def test_anthropic_model_a_generate_parses_schema_when_thinking_block_first(
+    mock_require_dep,
+    settings,
+):
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 1e-6
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 1e-6
+
+    fake_anthropic_module = SimpleNamespace(
+        Anthropic=_ThinkingJSONResponseClient,
+        AsyncAnthropic=_AsyncThinkingJSONResponseClient,
+    )
+    mock_require_dep.return_value = fake_anthropic_module
+
+    model = AnthropicModel(
+        model="claude-3-7-sonnet-latest",
+        max_tokens=2048,
+        generation_kwargs={
+            "thinking": {"type": "enabled", "budget_tokens": 1024}
+        },
+    )
+
+    output, _ = await model.a_generate("what is the answer?", schema=_Verdict)
+    assert output == _Verdict(verdict="yes")


### PR DESCRIPTION
Fixes #2946

## Summary

- `AnthropicModel.generate()` and `a_generate()` now pick the first `text` block from `message.content` instead of assuming `content[0]` is it.
- Raises a clear `DeepEvalError` (listing the block types received) when a response has no text block, instead of a raw `AttributeError`.
- Adds sync and async regression tests built from real `anthropic.types` objects with a thinking-first content list.

## Why

Enabling extended thinking through `generation_kwargs={"thinking": {...}}` makes the API return `content=[ThinkingBlock, TextBlock]`. `content[0].text` then raises `AttributeError: 'ThinkingBlock' object has no attribute 'text'` and every metric using that judge fails. Same `content[0]` assumption as #2913, different file: that one is the tracing integration, this one is the judge model wrapper.

## Test plan

- [x] New tests fail on `main` with `AttributeError: 'ThinkingBlock' object has no attribute 'text'`, pass with the fix
- [x] `pytest tests/test_core/test_models/` passes (211 tests)
- [x] `black --check` clean on both files
