### PR TITLE
fix(models): send temperature on non-schema path for DeepSeek and Kimi

### DIFF
--- a/deepeval/models/llms/deepseek_model.py
+++ b/deepeval/models/llms/deepseek_model.py
@@ -128,6 +128,7 @@ class DeepSeekModel(DeepEvalBaseLLM):
             completion = client.chat.completions.create(
                 model=self.name,
                 messages=[{"role": "user", "content": prompt}],
+                temperature=self.temperature,
                 **self.generation_kwargs,
             )
             output = completion.choices[0].message.content
@@ -163,6 +164,7 @@ class DeepSeekModel(DeepEvalBaseLLM):
             completion = await client.chat.completions.create(
                 model=self.name,
                 messages=[{"role": "user", "content": prompt}],
+                temperature=self.temperature,
                 **self.generation_kwargs,
             )
             output = completion.choices[0].message.content

--- a/deepeval/models/llms/kimi_model.py
+++ b/deepeval/models/llms/kimi_model.py
@@ -134,6 +134,7 @@ class KimiModel(DeepEvalBaseLLM):
         completion = client.chat.completions.create(
             model=self.name,
             messages=[{"role": "user", "content": content}],
+            temperature=self.temperature,
             **self.generation_kwargs,
         )
         output = completion.choices[0].message.content
@@ -179,6 +180,7 @@ class KimiModel(DeepEvalBaseLLM):
         completion = await client.chat.completions.create(
             model=self.name,
             messages=[{"role": "user", "content": content}],
+            temperature=self.temperature,
             **self.generation_kwargs,
         )
         output = completion.choices[0].message.content

--- a/tests/test_core/test_models/test_deepseek_model.py
+++ b/tests/test_core/test_models/test_deepseek_model.py
@@ -2,7 +2,7 @@
 
 import deepeval.models.llms.deepseek_model as deepseek_mod
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from pydantic import BaseModel, SecretStr
 
@@ -227,6 +227,57 @@ def test_deepseek_calculate_cost_with_zero_tokens():
     model.model_data.output_price = 0.002
     cost = model.calculate_cost(input_tokens=0, output_tokens=0)
     assert cost == 0.0
+
+
+##############################
+# temperature forwarding      #
+##############################
+
+
+def _mock_completion(text: str) -> Mock:
+    """Build a completion object shaped the way DeepSeekModel expects."""
+    completion = Mock()
+    choice = Mock()
+    choice.message.content = text
+    completion.choices = [choice]
+    completion.usage.prompt_tokens = 10
+    completion.usage.completion_tokens = 5
+    return completion
+
+
+@patch("deepeval.models.llms.deepseek_model.OpenAI")
+def test_generate_forwards_temperature_without_schema(mock_openai):
+    """generate() must send the configured temperature on the no-schema path."""
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = _mock_completion("hi")
+    mock_openai.return_value = mock_client
+
+    model = DeepSeekModel(
+        api_key="test-key", model="deepseek-chat", temperature=0.3
+    )
+    model.generate("hello there")
+
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 0.3
+
+
+async def test_a_generate_forwards_temperature_without_schema(monkeypatch):
+    """a_generate() must send the configured temperature on the no-schema path."""
+    mock_client = Mock()
+    mock_client.chat.completions.create = AsyncMock(
+        return_value=_mock_completion("hi")
+    )
+    monkeypatch.setattr(
+        deepseek_mod, "AsyncOpenAI", lambda *a, **k: mock_client, raising=True
+    )
+
+    model = DeepSeekModel(
+        api_key="test-key", model="deepseek-chat", temperature=0.3
+    )
+    await model.a_generate("hello there")
+
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 0.3
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_models/test_kimi_model.py
+++ b/tests/test_core/test_models/test_kimi_model.py
@@ -2,6 +2,7 @@
 
 import deepeval.models.llms.kimi_model as kimi_mod
 
+from unittest.mock import AsyncMock, Mock
 from pydantic import SecretStr
 
 from deepeval.config.settings import get_settings, reset_settings
@@ -174,3 +175,58 @@ def test_kimi_calculate_cost_with_zero_tokens(monkeypatch):
     model.model_data.output_price = 0.008
     cost = model.calculate_cost(input_tokens=0, output_tokens=0)
     assert cost == 0.0
+
+
+##############################
+# temperature forwarding      #
+##############################
+
+
+def _mock_completion(text: str) -> Mock:
+    """Build a completion object shaped the way KimiModel expects."""
+    completion = Mock()
+    choice = Mock()
+    choice.message.content = text
+    completion.choices = [choice]
+    completion.usage.prompt_tokens = 10
+    completion.usage.completion_tokens = 5
+    return completion
+
+
+def test_generate_forwards_temperature_without_schema(monkeypatch):
+    """generate() must send the configured temperature on the no-schema path."""
+    mock_client = Mock()
+    mock_client.chat.completions.create.return_value = _mock_completion("hi")
+    monkeypatch.setattr(
+        kimi_mod, "OpenAI", lambda *a, **k: mock_client, raising=True
+    )
+
+    model = KimiModel(
+        model="moonshot-v1-8k", api_key="test-key", temperature=0.3
+    )
+    model.generate("hello there")
+
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 0.3
+
+
+async def test_a_generate_forwards_temperature_without_schema(monkeypatch):
+    """a_generate() must send the configured temperature on the no-schema path."""
+    mock_client = Mock()
+    mock_client.chat.completions.create = AsyncMock(
+        return_value=_mock_completion("hi")
+    )
+    monkeypatch.setattr(
+        kimi_mod, "OpenAI", lambda *a, **k: mock_client, raising=True
+    )
+    monkeypatch.setattr(
+        kimi_mod, "AsyncOpenAI", lambda *a, **k: mock_client, raising=True
+    )
+
+    model = KimiModel(
+        model="moonshot-v1-8k", api_key="test-key", temperature=0.3
+    )
+    await model.a_generate("hello there")
+
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 0.3


### PR DESCRIPTION
## Summary

`DeepSeekModel` and `KimiModel` only forward the configured `temperature` on their **schema / JSON** generation path. On the plain-text path — `generate()`/`a_generate()` called without a `schema` (and, for Kimi, also when `supports_json_mode()` is `False`) — the `chat.completions.create()` call omits `temperature`, so the request silently runs at the provider's server-side default instead of the value the user set.

This makes `DeepSeekModel(temperature=0.0)` / `KimiModel(temperature=0.0)` behave inconsistently: deterministic when a schema is passed, non-deterministic for a plain prompt.

The sibling `GrokModel` already applies `temperature` uniformly (set once on `chat.create(...)`, used by both paths), and both DeepSeek and Kimi already send `temperature` unconditionally on their schema path — so aligning the plain path introduces no new behavior for any model.

## Changes

- Add `temperature=self.temperature` to the non-schema `create()` calls in `DeepSeekModel.generate`/`a_generate` and `KimiModel.generate`/`a_generate` (4 call sites).
- Regression tests (sync + async, both models) that mock the client and assert `temperature` is forwarded on the no-schema path.

## Testing

```
pytest tests/test_core/test_models/test_deepseek_model.py tests/test_core/test_models/test_kimi_model.py
```

All pass; the new tests fail on `main` (the kwarg is absent) and pass with the fix. `black --line-length 80` clean.
