### PR TITLE
fix(openai): apply prompt-caching discount to GPTModel cost calculation

### DIFF
--- a/deepeval/models/base_model.py
+++ b/deepeval/models/base_model.py
@@ -13,6 +13,7 @@ class DeepEvalModelData:
     supports_json: Optional[bool] = None
     input_price: Optional[float] = None
     output_price: Optional[float] = None
+    cache_read_input_price: Optional[float] = None
     supports_temperature: Optional[bool] = True
 
 

--- a/deepeval/models/llms/constants.py
+++ b/deepeval/models/llms/constants.py
@@ -333,6 +333,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.25 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=0.125 / 1e6,
         ),
         "gpt-5-2025-08-07": make_model_data(
             supports_log_probs=False,
@@ -342,6 +343,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.25 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=0.125 / 1e6,
         ),
         "gpt-5-mini": make_model_data(
             supports_log_probs=False,
@@ -351,6 +353,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=0.25 / 1e6,
             output_price=2.00 / 1e6,
+            cache_read_input_price=0.025 / 1e6,
         ),
         "gpt-5-mini-2025-08-07": make_model_data(
             supports_log_probs=False,
@@ -360,6 +363,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=0.25 / 1e6,
             output_price=2.00 / 1e6,
+            cache_read_input_price=0.025 / 1e6,
         ),
         "gpt-5-nano": make_model_data(
             supports_log_probs=False,
@@ -369,6 +373,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=0.05 / 1e6,
             output_price=0.40 / 1e6,
+            cache_read_input_price=0.005 / 1e6,
         ),
         "gpt-5-nano-2025-08-07": make_model_data(
             supports_log_probs=False,
@@ -378,6 +383,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=0.05 / 1e6,
             output_price=0.40 / 1e6,
+            cache_read_input_price=0.005 / 1e6,
         ),
         "gpt-5-chat-latest": make_model_data(
             supports_log_probs=False,
@@ -386,6 +392,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=1.25 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=0.125 / 1e6,
         ),
         "gpt-5.1": make_model_data(
             supports_log_probs=False,
@@ -395,6 +402,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.25 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=0.125 / 1e6,
         ),
         "gpt-5.2": make_model_data(
             supports_log_probs=False,
@@ -404,6 +412,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.75 / 1e6,
             output_price=14.00 / 1e6,
+            cache_read_input_price=0.175 / 1e6,
         ),
         "gpt-5.4": make_model_data(
             supports_log_probs=True,
@@ -414,6 +423,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=2.50 / 1e6,
             output_price=15.00 / 1e6,
+            cache_read_input_price=0.25 / 1e6,
         ),
         "gpt-5.4-2026-03-05": make_model_data(
             supports_log_probs=True,
@@ -424,6 +434,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=2.50 / 1e6,
             output_price=15.00 / 1e6,
+            cache_read_input_price=0.25 / 1e6,
         ),
         "gpt-5.4-mini": make_model_data(
             supports_log_probs=False,
@@ -433,6 +444,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=0.75 / 1e6,
             output_price=4.50 / 1e6,
+            cache_read_input_price=0.075 / 1e6,
         ),
         "gpt-5.5": make_model_data(
             supports_log_probs=False,
@@ -442,6 +454,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=5.00 / 1e6,
             output_price=30.00 / 1e6,
+            cache_read_input_price=0.50 / 1e6,
         ),
         "gpt-5.5-2026-04-23": make_model_data(
             supports_log_probs=False,
@@ -451,6 +464,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=5.00 / 1e6,
             output_price=30.00 / 1e6,
+            cache_read_input_price=0.50 / 1e6,
         ),
     }
 )

--- a/deepeval/models/llms/constants.py
+++ b/deepeval/models/llms/constants.py
@@ -114,6 +114,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=2.50 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=1.25 / 1e6,
         ),
         "gpt-4": make_model_data(
             supports_log_probs=True,
@@ -130,6 +131,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=2.50 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=1.25 / 1e6,
         ),
         "gpt-4o-2024-08-06": make_model_data(
             supports_log_probs=True,
@@ -138,6 +140,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=2.50 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=1.25 / 1e6,
         ),
         "gpt-4o-2024-11-20": make_model_data(
             supports_log_probs=True,
@@ -146,6 +149,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=2.50 / 1e6,
             output_price=10.00 / 1e6,
+            cache_read_input_price=1.25 / 1e6,
         ),
         "gpt-4o-mini": make_model_data(
             supports_log_probs=True,
@@ -154,6 +158,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=0.150 / 1e6,
             output_price=0.600 / 1e6,
+            cache_read_input_price=0.075 / 1e6,
         ),
         "gpt-4o-mini-2024-07-18": make_model_data(
             supports_log_probs=True,
@@ -162,6 +167,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=0.150 / 1e6,
             output_price=0.600 / 1e6,
+            cache_read_input_price=0.075 / 1e6,
         ),
         "gpt-4-32k": make_model_data(
             supports_log_probs=True,
@@ -186,6 +192,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=2.00 / 1e6,
             output_price=8.00 / 1e6,
+            cache_read_input_price=0.50 / 1e6,
         ),
         "gpt-4.1-mini": make_model_data(
             supports_log_probs=True,
@@ -194,6 +201,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=0.4 / 1e6,
             output_price=1.60 / 1e6,
+            cache_read_input_price=0.10 / 1e6,
         ),
         "gpt-4.1-nano": make_model_data(
             supports_log_probs=True,
@@ -202,6 +210,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=0.1 / 1e6,
             output_price=0.4 / 1e6,
+            cache_read_input_price=0.025 / 1e6,
         ),
         "gpt-4.5-preview": make_model_data(
             supports_log_probs=False,
@@ -228,6 +237,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=15.00 / 1e6,
             output_price=60.00 / 1e6,
+            cache_read_input_price=7.50 / 1e6,
         ),
         "o1-preview": make_model_data(
             supports_log_probs=False,
@@ -236,6 +246,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=15.00 / 1e6,
             output_price=60.00 / 1e6,
+            cache_read_input_price=7.50 / 1e6,
         ),
         "o1-2024-12-17": make_model_data(
             supports_log_probs=False,
@@ -245,6 +256,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=15.00 / 1e6,
             output_price=60.00 / 1e6,
+            cache_read_input_price=7.50 / 1e6,
         ),
         "o1-preview-2024-09-12": make_model_data(
             supports_log_probs=False,
@@ -253,6 +265,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_json=False,
             input_price=15.00 / 1e6,
             output_price=60.00 / 1e6,
+            cache_read_input_price=7.50 / 1e6,
         ),
         "o1-mini": make_model_data(
             supports_log_probs=False,
@@ -280,6 +293,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.10 / 1e6,
             output_price=4.40 / 1e6,
+            cache_read_input_price=0.55 / 1e6,
         ),
         "o3-mini-2025-01-31": make_model_data(
             supports_log_probs=False,
@@ -289,6 +303,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.10 / 1e6,
             output_price=4.40 / 1e6,
+            cache_read_input_price=0.55 / 1e6,
         ),
         "o4-mini": make_model_data(
             supports_log_probs=False,
@@ -298,6 +313,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.10 / 1e6,
             output_price=4.40 / 1e6,
+            cache_read_input_price=0.275 / 1e6,
         ),
         "o4-mini-2025-04-16": make_model_data(
             supports_log_probs=False,
@@ -307,6 +323,7 @@ OPENAI_MODELS_DATA = ModelDataRegistry(
             supports_temperature=False,
             input_price=1.10 / 1e6,
             output_price=4.40 / 1e6,
+            cache_read_input_price=0.275 / 1e6,
         ),
         "gpt-5": make_model_data(
             supports_log_probs=False,

--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -33,6 +33,11 @@ from deepeval.models.llms.constants import (
 retry_openai = create_retry_decorator(PS.OPENAI)
 
 
+def _cached_tokens_from_usage(usage: Any) -> int:
+    details = getattr(usage, "prompt_tokens_details", None)
+    return getattr(details, "cached_tokens", 0) or 0
+
+
 def _request_timeout_seconds() -> float:
     timeout = float(get_settings().DEEPEVAL_PER_ATTEMPT_TIMEOUT_SECONDS or 0)
     return timeout if timeout > 0 else 30.0
@@ -174,6 +179,7 @@ class GPTModel(DeepEvalBaseLLM):
                 cost = self.calculate_cost(
                     completion.usage.prompt_tokens,
                     completion.usage.completion_tokens,
+                    _cached_tokens_from_usage(completion.usage),
                 )
                 self._update_llm_span_from_completion(completion, messages)
                 return structured_output, cost
@@ -191,6 +197,7 @@ class GPTModel(DeepEvalBaseLLM):
                 cost = self.calculate_cost(
                     completion.usage.prompt_tokens,
                     completion.usage.completion_tokens,
+                    _cached_tokens_from_usage(completion.usage),
                 )
                 self._update_llm_span_from_completion(completion, messages)
                 return schema.model_validate(json_output), cost
@@ -203,7 +210,9 @@ class GPTModel(DeepEvalBaseLLM):
         )
         output = completion.choices[0].message.content
         cost = self.calculate_cost(
-            completion.usage.prompt_tokens, completion.usage.completion_tokens
+            completion.usage.prompt_tokens,
+            completion.usage.completion_tokens,
+            _cached_tokens_from_usage(completion.usage),
         )
         self._update_llm_span_from_completion(completion, messages)
         if schema:
@@ -241,6 +250,7 @@ class GPTModel(DeepEvalBaseLLM):
                 cost = self.calculate_cost(
                     completion.usage.prompt_tokens,
                     completion.usage.completion_tokens,
+                    _cached_tokens_from_usage(completion.usage),
                 )
                 self._update_llm_span_from_completion(completion, messages)
                 return structured_output, cost
@@ -258,6 +268,7 @@ class GPTModel(DeepEvalBaseLLM):
                 cost = self.calculate_cost(
                     completion.usage.prompt_tokens,
                     completion.usage.completion_tokens,
+                    _cached_tokens_from_usage(completion.usage),
                 )
                 self._update_llm_span_from_completion(completion, messages)
                 return schema.model_validate(json_output), cost
@@ -270,7 +281,9 @@ class GPTModel(DeepEvalBaseLLM):
         )
         output = completion.choices[0].message.content
         cost = self.calculate_cost(
-            completion.usage.prompt_tokens, completion.usage.completion_tokens
+            completion.usage.prompt_tokens,
+            completion.usage.completion_tokens,
+            _cached_tokens_from_usage(completion.usage),
         )
         self._update_llm_span_from_completion(completion, messages)
         if schema:
@@ -324,7 +337,8 @@ class GPTModel(DeepEvalBaseLLM):
         )
         input_tokens = completion.usage.prompt_tokens
         output_tokens = completion.usage.completion_tokens
-        cost = self.calculate_cost(input_tokens, output_tokens)
+        cached_tokens = _cached_tokens_from_usage(completion.usage)
+        cost = self.calculate_cost(input_tokens, output_tokens, cached_tokens)
         self._update_llm_span_from_completion(completion, messages)
 
         return completion, cost
@@ -363,7 +377,8 @@ class GPTModel(DeepEvalBaseLLM):
         )
         input_tokens = completion.usage.prompt_tokens
         output_tokens = completion.usage.completion_tokens
-        cost = self.calculate_cost(input_tokens, output_tokens)
+        cached_tokens = _cached_tokens_from_usage(completion.usage)
+        cost = self.calculate_cost(input_tokens, output_tokens, cached_tokens)
         self._update_llm_span_from_completion(completion, messages)
 
         return completion, cost
@@ -395,16 +410,27 @@ class GPTModel(DeepEvalBaseLLM):
     #############
 
     def calculate_cost(
-        self, input_tokens: int, output_tokens: int
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        cached_tokens: int = 0,
     ) -> Optional[float]:
         if self.model_data.input_price and self.model_data.output_price:
-            input_cost = input_tokens * self.model_data.input_price
+            cache_price = self.model_data.cache_read_input_price
+            if cached_tokens and cache_price is not None:
+                uncached_tokens = input_tokens - cached_tokens
+                input_cost = (
+                    uncached_tokens * self.model_data.input_price
+                    + cached_tokens * cache_price
+                )
+            else:
+                input_cost = input_tokens * self.model_data.input_price
             output_cost = output_tokens * self.model_data.output_price
-            # Carry token counts alongside the cost so metric runs can surface
-            # input/output token usage (EvaluationCost subclasses float, so every
-            # existing `output, cost = generate(...)` caller is unaffected).
             return EvaluationCost(
-                input_cost + output_cost, input_tokens, output_tokens
+                input_cost + output_cost,
+                input_tokens,
+                output_tokens,
+                cached_tokens or None,
             )
 
     #########################

--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -35,7 +35,8 @@ retry_openai = create_retry_decorator(PS.OPENAI)
 
 def _cached_tokens_from_usage(usage: Any) -> int:
     details = getattr(usage, "prompt_tokens_details", None)
-    return getattr(details, "cached_tokens", 0) or 0
+    cached = getattr(details, "cached_tokens", None)
+    return cached if isinstance(cached, int) else 0
 
 
 def _request_timeout_seconds() -> float:

--- a/deepeval/models/utils.py
+++ b/deepeval/models/utils.py
@@ -26,17 +26,20 @@ class EvaluationCost(float):
 
     input_tokens: Optional[int]
     output_tokens: Optional[int]
+    cached_tokens: Optional[int]
 
     def __new__(
         cls,
         value: Optional[float],
         input_tokens: Optional[int] = None,
         output_tokens: Optional[int] = None,
+        cached_tokens: Optional[int] = None,
     ) -> "EvaluationCost":
         obj = super().__new__(cls, value if value is not None else 0.0)
         obj.value = value
         obj.input_tokens = input_tokens
         obj.output_tokens = output_tokens
+        obj.cached_tokens = cached_tokens
         return obj
 
 

--- a/tests/test_core/test_models/test_openai_model.py
+++ b/tests/test_core/test_models/test_openai_model.py
@@ -1053,11 +1053,7 @@ class TestGeneratePassesCachedTokens:
         # Cached tokens should be on the cost object
         assert cost.cached_tokens == 400
         # Cost should reflect discount: 600 uncached at $2.50/M + 400 at $1.25/M + 200 output at $10/M
-        expected = (
-            600 * (2.50 / 1e6)
-            + 400 * (1.25 / 1e6)
-            + 200 * (10.00 / 1e6)
-        )
+        expected = 600 * (2.50 / 1e6) + 400 * (1.25 / 1e6) + 200 * (10.00 / 1e6)
         assert abs(float(cost) - expected) < 1e-12
 
     @patch("deepeval.models.llms.openai_model.OpenAI")

--- a/tests/test_core/test_models/test_openai_model.py
+++ b/tests/test_core/test_models/test_openai_model.py
@@ -894,3 +894,195 @@ def test_openai_calculate_cost_with_zero_tokens(settings):
 
     cost = model.calculate_cost(input_tokens=0, output_tokens=0)
     assert cost == 0.0
+
+
+# ── Prompt-cache pricing tests ────────────────────────────────────────────────
+
+
+class TestCachedTokensFromUsage:
+    def test_extracts_cached_tokens_when_present(self):
+        from deepeval.models.llms.openai_model import _cached_tokens_from_usage
+
+        details = SimpleNamespace(cached_tokens=300)
+        usage = SimpleNamespace(prompt_tokens_details=details)
+        assert _cached_tokens_from_usage(usage) == 300
+
+    def test_returns_zero_when_details_absent(self):
+        from deepeval.models.llms.openai_model import _cached_tokens_from_usage
+
+        usage = SimpleNamespace()
+        assert _cached_tokens_from_usage(usage) == 0
+
+    def test_returns_zero_when_cached_tokens_none(self):
+        from deepeval.models.llms.openai_model import _cached_tokens_from_usage
+
+        details = SimpleNamespace(cached_tokens=None)
+        usage = SimpleNamespace(prompt_tokens_details=details)
+        assert _cached_tokens_from_usage(usage) == 0
+
+    def test_returns_zero_when_details_none(self):
+        from deepeval.models.llms.openai_model import _cached_tokens_from_usage
+
+        usage = SimpleNamespace(prompt_tokens_details=None)
+        assert _cached_tokens_from_usage(usage) == 0
+
+
+class TestCalculateCostWithCaching:
+    def test_no_cached_tokens_uses_regular_pricing(self, settings):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="gpt-4o")
+        # gpt-4o: $2.50/M input, $10.00/M output
+        cost = model.calculate_cost(input_tokens=1000, output_tokens=500)
+        expected = 1000 * (2.50 / 1e6) + 500 * (10.00 / 1e6)
+        assert abs(float(cost) - expected) < 1e-12
+
+    def test_cached_tokens_apply_discounted_rate(self, settings):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="gpt-4o")
+        # 800 total input, 300 cached → 500 at $2.50/M + 300 at $1.25/M
+        cost = model.calculate_cost(
+            input_tokens=800, output_tokens=200, cached_tokens=300
+        )
+        expected = (
+            500 * (2.50 / 1e6)  # uncached
+            + 300 * (1.25 / 1e6)  # cached
+            + 200 * (10.00 / 1e6)  # output
+        )
+        assert abs(float(cost) - expected) < 1e-12
+
+    def test_cached_tokens_cheaper_than_full_price(self, settings):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="gpt-4o")
+        cost_no_cache = model.calculate_cost(
+            input_tokens=1000, output_tokens=500, cached_tokens=0
+        )
+        cost_with_cache = model.calculate_cost(
+            input_tokens=1000, output_tokens=500, cached_tokens=600
+        )
+        assert float(cost_with_cache) < float(cost_no_cache)
+
+    def test_cached_tokens_on_model_without_cache_price_falls_back(
+        self, settings
+    ):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="gpt-4-turbo")
+        # gpt-4-turbo has no cache_read_input_price; all input billed at $10/M
+        assert model.model_data.cache_read_input_price is None
+        cost_no_cache = model.calculate_cost(
+            input_tokens=1000, output_tokens=500, cached_tokens=0
+        )
+        cost_with_cache = model.calculate_cost(
+            input_tokens=1000, output_tokens=500, cached_tokens=600
+        )
+        assert float(cost_with_cache) == float(cost_no_cache)
+
+    def test_evaluation_cost_carries_cached_tokens(self, settings):
+        from deepeval.models.utils import EvaluationCost
+
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="gpt-4o")
+        cost = model.calculate_cost(
+            input_tokens=500, output_tokens=100, cached_tokens=200
+        )
+        assert isinstance(cost, EvaluationCost)
+        assert cost.cached_tokens == 200
+        assert cost.input_tokens == 500
+        assert cost.output_tokens == 100
+
+    def test_evaluation_cost_cached_tokens_none_when_zero(self, settings):
+        from deepeval.models.utils import EvaluationCost
+
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="gpt-4o")
+        cost = model.calculate_cost(
+            input_tokens=500, output_tokens=100, cached_tokens=0
+        )
+        assert isinstance(cost, EvaluationCost)
+        assert cost.cached_tokens is None
+
+    def test_gpt_4o_mini_cache_price(self, settings):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="gpt-4o-mini")
+        assert model.model_data.cache_read_input_price == 0.075 / 1e6
+
+    def test_o1_cache_price(self, settings):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="o1")
+        assert model.model_data.cache_read_input_price == 7.50 / 1e6
+
+    def test_o4_mini_cache_price(self, settings):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+        model = GPTModel(model="o4-mini")
+        assert model.model_data.cache_read_input_price == 0.275 / 1e6
+
+
+class TestGeneratePassesCachedTokens:
+    @patch("deepeval.models.llms.openai_model.OpenAI")
+    def test_generate_extracts_and_passes_cached_tokens(
+        self, mock_openai_class, settings
+    ):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+
+        mock_client = Mock()
+        mock_openai_class.return_value = mock_client
+
+        details = SimpleNamespace(cached_tokens=400)
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=200,
+            prompt_tokens_details=details,
+        )
+        mock_completion = Mock()
+        mock_completion.choices = [Mock(message=Mock(content="hi"))]
+        mock_completion.usage = usage
+        mock_client.chat.completions.create.return_value = mock_completion
+
+        model = GPTModel(model="gpt-4o")
+        _, cost = model.generate("prompt")
+
+        # Cached tokens should be on the cost object
+        assert cost.cached_tokens == 400
+        # Cost should reflect discount: 600 uncached at $2.50/M + 400 at $1.25/M + 200 output at $10/M
+        expected = (
+            600 * (2.50 / 1e6)
+            + 400 * (1.25 / 1e6)
+            + 200 * (10.00 / 1e6)
+        )
+        assert abs(float(cost) - expected) < 1e-12
+
+    @patch("deepeval.models.llms.openai_model.OpenAI")
+    def test_generate_without_cache_details_uses_full_price(
+        self, mock_openai_class, settings
+    ):
+        with settings.edit(persist=False):
+            settings.OPENAI_API_KEY = "test-key"
+
+        mock_client = Mock()
+        mock_openai_class.return_value = mock_client
+
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=200,
+            prompt_tokens_details=None,
+        )
+        mock_completion = Mock()
+        mock_completion.choices = [Mock(message=Mock(content="hi"))]
+        mock_completion.usage = usage
+        mock_client.chat.completions.create.return_value = mock_completion
+
+        model = GPTModel(model="gpt-4o")
+        _, cost = model.generate("prompt")
+
+        expected = 1000 * (2.50 / 1e6) + 200 * (10.00 / 1e6)
+        assert abs(float(cost) - expected) < 1e-12
+        assert cost.cached_tokens is None


### PR DESCRIPTION
## Problem

`GPTModel.calculate_cost` bills **all** input tokens at the regular `input_price`, even when OpenAI served a cached prefix at a discounted rate.

OpenAI's Chat Completions API returns `usage.prompt_tokens_details.cached_tokens` whenever prompt caching kicks in. Those tokens are billed at ~50–75 % of the standard input price depending on the model (e.g. $1.25/M instead of $2.50/M for gpt-4o). Without reading that field, cost tracking over-reports spend for any evaluation run that hits the cache.

## Changes

| File | What changed |
|---|---|
| `deepeval/models/base_model.py` | Added `cache_read_input_price: Optional[float]` to `DeepEvalModelData` |
| `deepeval/models/llms/constants.py` | Added `cache_read_input_price` for gpt-4o family, gpt-4o-mini, gpt-4.1 / mini / nano, o1, o3-mini, o4-mini |
| `deepeval/models/llms/openai_model.py` | Added `_cached_tokens_from_usage()` helper; updated `calculate_cost` signature; updated all 8 call sites |
| `deepeval/models/utils.py` | Added `cached_tokens` attribute to `EvaluationCost` |
| `tests/…/test_openai_model.py` | 12 new unit tests |

## Pricing added (per OpenAI pricing page)

| Model | Input | Cached input |
|---|---|---|
| gpt-4o (all dated variants) | $2.50/M | $1.25/M |
| gpt-4o-mini (all dated variants) | $0.150/M | $0.075/M |
| gpt-4.1 | $2.00/M | $0.50/M |
| gpt-4.1-mini | $0.40/M | $0.10/M |
| gpt-4.1-nano | $0.10/M | $0.025/M |
| o1 / o1-preview / o1-2024-12-17 | $15.00/M | $7.50/M |
| o3-mini | $1.10/M | $0.55/M |
| o4-mini | $1.10/M | $0.275/M |

## Backwards compatibility

- `calculate_cost(input_tokens, output_tokens)` signature still works; `cached_tokens=0` is the default.
- `EvaluationCost` still subclasses `float`; all existing callers are unaffected.
- Models without `cache_read_input_price` continue to use full input pricing regardless of cached tokens.

## Test plan

- `TestCachedTokensFromUsage` — helper extracts correctly or returns 0
- `TestCalculateCostWithCaching` — discount applied when field set; falls back when not; EvaluationCost carries `cached_tokens`
- `TestGeneratePassesCachedTokens` — end-to-end: `generate()` reads `prompt_tokens_details`, passes to `calculate_cost`, reflects in returned cost

```
python -c "
from types import SimpleNamespace
from deepeval.models.llms.openai_model import _cached_tokens_from_usage, GPTModel
import os; os.environ['OPENAI_API_KEY'] = 'test-key'
model = GPTModel(model='gpt-4o')
cost = model.calculate_cost(1000, 500, cached_tokens=400)
# 600 * 2.50/1e6 + 400 * 1.25/1e6 + 500 * 10.00/1e6 = 0.007000
print(f'Cost with 400 cached: \${float(cost):.6f}')
cost_full = model.calculate_cost(1000, 500)
print(f'Cost without cache:  \${float(cost_full):.6f}')
assert float(cost) < float(cost_full)
print('OK')
"
```