### PR TITLE
docs(ragas): correct RagasMetric default threshold to 0.3

### DIFF
--- a/docs/content/docs/(metrics-others)/metrics-ragas.mdx
+++ b/docs/content/docs/(metrics-others)/metrics-ragas.mdx
@@ -76,7 +76,7 @@ evaluate([test_case], [metric])
 
 There are **THREE** optional parameters when creating a `RagasMetric`:
 
-- [Optional] `threshold`: a float representing the minimum passing threshold, defaulted to 0.5.
+- [Optional] `threshold`: a float representing the minimum passing threshold, defaulted to 0.3.
 - [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** any one of langchain's [chat models](https://python.langchain.com/docs/integrations/chat/) of type `BaseChatModel`. Defaulted to 'gpt-3.5-turbo'.
 - [Optional] `embeddings`: any one of langchain's [embedding models](https://python.langchain.com/docs/integrations/text_embedding) of type `Embeddings`. Custom `embeddings` provided to the `RagasMetric` will only be used in the `RAGASAnswerRelevancyMetric`, since it is the only metric that requires embeddings for calculating cosine similarity.
 


### PR DESCRIPTION
The `RagasMetric` parameter list documents the default `threshold` as `0.5`, but `RagasMetric.__init__` in `deepeval/metrics/ragas.py` defaults it to `0.3`. This updates the docs to match the source.
