### PR TITLE
fix(metrics): preserve whitespace in exact and pattern matching

### DIFF
--- a/deepeval/metrics/exact_match/exact_match.py
+++ b/deepeval/metrics/exact_match/exact_match.py
@@ -45,8 +45,8 @@ class ExactMatchMetric(BaseMetric):
         with metric_progress_indicator(
             self, _show_indicator=_show_indicator, _in_component=_in_component
         ):
-            expected = test_case.expected_output.strip()
-            actual = test_case.actual_output.strip()
+            expected = test_case.expected_output
+            actual = test_case.actual_output
 
             if expected == actual:
                 self.score = self.precision = self.recall = self.f1 = 1.0

--- a/deepeval/metrics/pattern_match/pattern_match.py
+++ b/deepeval/metrics/pattern_match/pattern_match.py
@@ -24,7 +24,7 @@ class PatternMatchMetric(BaseMetric):
         verbose_mode: bool = False,
         flaky: bool = False,
     ):
-        self.pattern = pattern.strip()
+        self.pattern = pattern
         self.ignore_case = ignore_case
         self.verbose_mode = verbose_mode
         self.flaky = flaky
@@ -55,7 +55,7 @@ class PatternMatchMetric(BaseMetric):
         with metric_progress_indicator(
             self, _show_indicator=_show_indicator, _in_component=_in_component
         ):
-            actual = test_case.actual_output.strip()
+            actual = test_case.actual_output
             full_match = self._compiled_pattern.fullmatch(actual)
 
             self.score = 1.0 if full_match else 0.0

--- a/docs/content/docs/(non-llm)/metrics-pattern-match.mdx
+++ b/docs/content/docs/(non-llm)/metrics-pattern-match.mdx
@@ -88,7 +88,7 @@ await evaluate([testCase], [metric]);
 There is **ONE** mandatory and **FOUR** optional parameters when creating a `PatternMatchMetric`:
 
 - `pattern`: a string representing the regular expression pattern that the <Term py="actual_output" ts="actualOutput"/> must match.
-- [Optional] <Term py="ignore_case" ts="ignoreCase"/>: a boolean which when set to <Term py="True" ts="true"/>, performs case-sensitive pattern matching. Defaulted to <Term py="False" ts="false"/>.
+- [Optional] <Term py="ignore_case" ts="ignoreCase"/>: a boolean which when set to <Term py="True" ts="true"/>, performs case-insensitive pattern matching. Defaulted to <Term py="False" ts="false"/>.
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `1.0`.
 - [Optional] <Term py="verbose_mode" ts="verboseMode"/>: a boolean which when set to <Term py="True" ts="true"/>, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to <Term py="False" ts="false"/>.
 - [Optional] `flaky`: a boolean which when set to <Term py="True" ts="true"/>, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics). Defaulted to <Term py="False" ts="false"/>.

--- a/tests/test_metrics/test_match_whitespace.py
+++ b/tests/test_metrics/test_match_whitespace.py
@@ -1,0 +1,60 @@
+"""Whitespace and case behavior of the two deterministic matchers.
+
+These need no API key: both metrics are pure string comparison.
+"""
+
+import pytest
+
+from deepeval.metrics import ExactMatchMetric, PatternMatchMetric
+from deepeval.test_case import LLMTestCase
+
+
+@pytest.mark.parametrize(
+    ("actual_output", "expected_output", "expected_score"),
+    [
+        ("act", "act", 1.0),
+        ("act ", "act", 0.0),
+        (" act", "act", 0.0),
+        ("act\n", "act", 0.0),
+        ("act", "act ", 0.0),
+        ("ACT", "act", 0.0),
+    ],
+)
+def test_exact_match_compares_complete_strings(
+    actual_output, expected_output, expected_score
+):
+    metric = ExactMatchMetric()
+    metric.measure(
+        LLMTestCase(
+            input="classify",
+            actual_output=actual_output,
+            expected_output=expected_output,
+        ),
+        _show_indicator=False,
+    )
+
+    assert metric.score == expected_score
+
+
+@pytest.mark.parametrize(
+    ("pattern", "actual_output", "ignore_case", "expected_score"),
+    [
+        ("act", "act", False, 1.0),
+        ("act", " act ", False, 0.0),
+        ("act", "act\n", False, 0.0),
+        (r"\s*act\s*", " act ", False, 1.0),
+        (" act ", "act", False, 0.0),
+        ("act", "ACT", False, 0.0),
+        ("act", "ACT", True, 1.0),
+    ],
+)
+def test_pattern_match_uses_complete_pattern_and_output(
+    pattern, actual_output, ignore_case, expected_score
+):
+    metric = PatternMatchMetric(pattern=pattern, ignore_case=ignore_case)
+    metric.measure(
+        LLMTestCase(input="classify", actual_output=actual_output),
+        _show_indicator=False,
+    )
+
+    assert metric.score == expected_score


### PR DESCRIPTION
## Summary

- Compare the supplied strings as given in `ExactMatchMetric`.
- Compile the supplied regex unchanged and match it against the complete `actual_output` in `PatternMatchMetric`.
- Add keyless regression tests for the whitespace and case behavior.
- Correct an adjacent `ignore_case=True` documentation typo.

Rebased onto current `main`. **No existing test is modified or removed** — the new tests are a separate file, and the four existing tests in `tests/test_metrics/test_exact_match_metric.py` and `test_pattern_match_metric.py` still pass unchanged under this change.

## Problem

`ExactMatchMetric` is documented as a strict, whitespace-sensitive string equality check, but it strips both values:

```python
expected = test_case.expected_output.strip()
actual = test_case.actual_output.strip()
```

So `actual_output="act "` passes against `expected_output="act"`.

`PatternMatchMetric` strips both its pattern and the actual output before `re.fullmatch`, so `pattern="act"` passes on `actual_output=" act "` even though the docs say the regex applies to the entire output.

Reproduced on `0d100e37d` with no API key:

```text
ExactMatch:   actual="act ",  expected="act"  -> score 1.0
ExactMatch:   actual=" act",  expected="act"  -> score 1.0
PatternMatch: pattern="act",  actual=" act "  -> score 1.0
```

This hides representation defects in enum, classification, protocol-token, and structured-output tests — the cases the docs recommend deterministic matching for.

## Behavior after this change

- `"act"` exactly equals `"act"`; `"act "` does not.
- regex `"act"` does not full-match `" act "`; regex `r"\s*act\s*"` does.
- callers can still normalize before evaluation when that is their intended contract.

## Compatibility

**This changes results for callers relying on the current undocumented trimming.** The most likely breakage is a trailing newline: a suite comparing `"yes\n"` against `"yes"` passes today and fails after this change.

The change restores the published whitespace-sensitive and `re.fullmatch` contracts, and tolerant behavior stays expressible through caller preprocessing or an explicit `r"\s*...\s*"` regex.

If that trade isn't one you want to make, two smaller positions are available and I'm happy to cut this down to either:

1. **Output-side only** — keep the constructor's `pattern.strip()` (patterns come from source code, where a stray space is likelier a typo than intent) and remove only the `actual_output` strip.
2. **Docs only** — drop the behavior change and just document the trimming as intended.

Say which contract you want and I'll adjust the tests to match.

## Scope

No thresholds, scoring formulas, public types, or model-backed metrics change. This intentionally adds no normalization option — callers can normalize before evaluation or express accepted whitespace in the regex.

## Verification

- [x] `pytest tests/test_metrics/test_match_whitespace.py` — 13 passed with `OPENAI_API_KEY` unset; 7 of the 13 fail on unpatched `main`, so they're real regression tests
- [x] the four pre-existing tests in the two matcher test files pass unchanged under this change (verified with the key set, so the `skipif` doesn't hide them)
- [x] `black --check` on all changed files — clean

One note on what I did not verify: `black --check .` across the repo reports pre-existing files needing reformatting on unmodified `main`, unrelated to this PR, so I checked only the files this PR touches. The `lint` job appears red for that reason on other open PRs too. I left the repo-wide reformat out deliberately to keep this diff at 4 files — happy to add it if you'd like.
