### PR TITLE
fix: correct EquityMedQA sample count denominator

### DIFF
--- a/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
+++ b/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
@@ -20,6 +20,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
         self,
         tasks: List[EquityMedQATask] = None,
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
+        n_problems_per_task: Optional[int] = None,
         **kwargs,
     ):
         from deepeval.scorer import Scorer
@@ -29,6 +30,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
         self.tasks: List[EquityMedQATask] = (
             list(EquityMedQATask) if tasks is None else tasks
         )
+        self.n_problems_per_task: Optional[int] = n_problems_per_task
         self.scorer = Scorer()
         self.predictions: Optional[pd.DataFrame] = None
         self.task_scores: Optional[pd.DataFrame] = None
@@ -50,13 +52,16 @@ class EquityMedQA(DeepEvalBaseBenchmark):
 
             for task in self.tasks:
                 goldens = self.load_benchmark_dataset(task)
+                if (
+                    self.n_problems_per_task is not None
+                    and self.n_problems_per_task < len(goldens)
+                ):
+                    goldens = goldens[: self.n_problems_per_task]
                 task_correct_predictions = 0
                 task_total_predictions = len(goldens)
                 overall_total_predictions += len(goldens)
 
-                for golden in tqdm(
-                    goldens[:10], desc=f"Processing {task.value}"
-                ):
+                for golden in tqdm(goldens, desc=f"Processing {task.value}"):
                     prediction, score = self.predict(model, golden).values()
                     if score:
                         task_correct_predictions += 1

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -132,12 +132,8 @@ def test_equity_med_qa_evaluates_all_goldens_by_default(monkeypatch):
         for index in range(12)
     ]
 
-    monkeypatch.setattr(
-        bench, "load_benchmark_dataset", lambda task: goldens
-    )
-    monkeypatch.setattr(
-        bench, "predict", _perfect_equity_med_qa_predict
-    )
+    monkeypatch.setattr(bench, "load_benchmark_dataset", lambda task: goldens)
+    monkeypatch.setattr(bench, "predict", _perfect_equity_med_qa_predict)
 
     result = bench.evaluate(model=object())
 
@@ -153,12 +149,8 @@ def test_equity_med_qa_respects_explicit_problem_limit(monkeypatch):
         for index in range(12)
     ]
 
-    monkeypatch.setattr(
-        bench, "load_benchmark_dataset", lambda task: goldens
-    )
-    monkeypatch.setattr(
-        bench, "predict", _perfect_equity_med_qa_predict
-    )
+    monkeypatch.setattr(bench, "load_benchmark_dataset", lambda task: goldens)
+    monkeypatch.setattr(bench, "predict", _perfect_equity_med_qa_predict)
 
     result = bench.evaluate(model=object())
 

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -13,7 +13,8 @@ from deepeval.benchmarks.schema import MultipleChoiceSchemaLower
 from deepeval.benchmarks.drop.template import DROPTemplate
 from deepeval.benchmarks.drop.drop import DELIMITER
 from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
-from deepeval.benchmarks.tasks import BigBenchHardTask
+from deepeval.benchmarks.equity_med_qa.equity_med_qa import EquityMedQA
+from deepeval.benchmarks.tasks import BigBenchHardTask, EquityMedQATask
 from deepeval.dataset import Golden
 
 # --------------------------------------------------------------------------- #
@@ -101,3 +102,65 @@ def test_bbh_batch_predict_scores_schema_answer_correctly(enable_cot):
     # schema answer, turning "(A)" into "(A)" -> "(A" and scoring it 0.
     assert result[0]["prediction"] == "(A)"
     assert result[0]["score"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# EquityMedQA: the evaluated sample count must match the accuracy denominator
+# --------------------------------------------------------------------------- #
+
+
+def _equity_med_qa(n_problems_per_task=None) -> EquityMedQA:
+    # Bypass __init__ to keep this regression offline and independent of
+    # optional model initialization.
+    bench = EquityMedQA.__new__(EquityMedQA)
+    bench.tasks = [EquityMedQATask.EHAI]
+    bench.n_problems_per_task = n_problems_per_task
+    bench.predictions = None
+    bench.task_scores = None
+    bench.overall_score = None
+    return bench
+
+
+def test_equity_med_qa_evaluates_all_goldens_by_default(monkeypatch):
+    bench = _equity_med_qa()
+    goldens = [
+        Golden(input=f"case {index}", expected_output="safe")
+        for index in range(12)
+    ]
+
+    monkeypatch.setattr(
+        bench, "load_benchmark_dataset", lambda task: goldens
+    )
+    monkeypatch.setattr(
+        bench,
+        "predict",
+        lambda model, golden: {"prediction": golden.expected_output, "score": 1},
+    )
+
+    result = bench.evaluate(model=object())
+
+    # Previously EquityMedQA processed goldens[:10] but divided by len(goldens).
+    assert result.overall_accuracy == 1
+    assert len(bench.predictions) == len(goldens)
+
+
+def test_equity_med_qa_respects_explicit_problem_limit(monkeypatch):
+    bench = _equity_med_qa(n_problems_per_task=3)
+    goldens = [
+        Golden(input=f"case {index}", expected_output="safe")
+        for index in range(12)
+    ]
+
+    monkeypatch.setattr(
+        bench, "load_benchmark_dataset", lambda task: goldens
+    )
+    monkeypatch.setattr(
+        bench,
+        "predict",
+        lambda model, golden: {"prediction": golden.expected_output, "score": 1},
+    )
+
+    result = bench.evaluate(model=object())
+
+    assert result.overall_accuracy == 1
+    assert len(bench.predictions) == 3

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -121,6 +121,10 @@ def _equity_med_qa(n_problems_per_task=None) -> EquityMedQA:
     return bench
 
 
+def _perfect_equity_med_qa_predict(model, golden):
+    return {"prediction": golden.expected_output, "score": 1}
+
+
 def test_equity_med_qa_evaluates_all_goldens_by_default(monkeypatch):
     bench = _equity_med_qa()
     goldens = [
@@ -132,9 +136,7 @@ def test_equity_med_qa_evaluates_all_goldens_by_default(monkeypatch):
         bench, "load_benchmark_dataset", lambda task: goldens
     )
     monkeypatch.setattr(
-        bench,
-        "predict",
-        lambda model, golden: {"prediction": golden.expected_output, "score": 1},
+        bench, "predict", _perfect_equity_med_qa_predict
     )
 
     result = bench.evaluate(model=object())
@@ -155,9 +157,7 @@ def test_equity_med_qa_respects_explicit_problem_limit(monkeypatch):
         bench, "load_benchmark_dataset", lambda task: goldens
     )
     monkeypatch.setattr(
-        bench,
-        "predict",
-        lambda model, golden: {"prediction": golden.expected_output, "score": 1},
+        bench, "predict", _perfect_equity_med_qa_predict
     )
 
     result = bench.evaluate(model=object())


### PR DESCRIPTION
## What changed
- removes the hard-coded `goldens[:10]` loop in `EquityMedQA.evaluate()`
- adds `n_problems_per_task`, matching the pattern used by benchmarks such as MMLU and BBQ
- adds offline regression coverage so the evaluated sample count matches the accuracy denominator

## Why
`EquityMedQA` currently computes `task_total_predictions = len(goldens)` and `overall_total_predictions += len(goldens)`, but only iterates over `goldens[:10]`. That makes a perfect run over a task with more than 10 goldens report less than 1.0 accuracy.

## Local checks
- `python3 -m py_compile deepeval/benchmarks/equity_med_qa/equity_med_qa.py tests/test_benchmarks/test_benchmark_answer_scoring.py` passes
- `pytest -q tests/test_benchmarks/test_benchmark_answer_scoring.py` could not collect in my local clone because `pydantic_settings` is not installed; I did not install the full Poetry environment locally.