### PR TITLE
fix(metrics): is_successful() discards recomputed verdict in TurnRelevancy/TopicAdherence

### DIFF
--- a/deepeval/metrics/topic_adherence/topic_adherence.py
+++ b/deepeval/metrics/topic_adherence/topic_adherence.py
@@ -383,7 +383,7 @@ class TopicAdherenceMetric(BaseConversationalMetric):
             self.success = False
         else:
             try:
-                self.score >= self.threshold
+                self.success = self.score >= self.threshold
             except TypeError:
                 self.success = False
         return self.success

--- a/deepeval/metrics/turn_relevancy/turn_relevancy.py
+++ b/deepeval/metrics/turn_relevancy/turn_relevancy.py
@@ -282,7 +282,7 @@ class TurnRelevancyMetric(BaseConversationalMetric):
             self.success = False
         else:
             try:
-                self.score >= self.threshold
+                self.success = self.score >= self.threshold
             except TypeError:
                 self.success = False
         return self.success

--- a/tests/test_metrics/test_is_successful_recompute.py
+++ b/tests/test_metrics/test_is_successful_recompute.py
@@ -1,0 +1,73 @@
+"""is_successful() must recompute the verdict from score/threshold, not discard it.
+
+TurnRelevancyMetric and TopicAdherenceMetric evaluated `self.score >= self.threshold`
+as a bare expression, so the computed pass/fail was thrown away and the method returned
+whatever `self.success` already held (the class default None, or a stale value from an
+earlier run). Every other metric assigns `self.success = self.score >= self.threshold`.
+
+These tests build the metric with a no-op judge, so they run without any API key and
+never call a model: is_successful() is pure score/threshold arithmetic.
+"""
+
+import pytest
+
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics import TurnRelevancyMetric, TopicAdherenceMetric
+
+
+class _NoOpJudge(DeepEvalBaseLLM):
+    """Satisfies construction without touching a provider; never invoked by is_successful()."""
+
+    def __init__(self):
+        super().__init__(model="noop")
+
+    def load_model(self):
+        return self
+
+    def generate(self, *args, **kwargs):
+        return None
+
+    async def a_generate(self, *args, **kwargs):
+        return None
+
+    def get_model_name(self):
+        return "noop"
+
+
+def _metrics():
+    return [
+        TurnRelevancyMetric(model=_NoOpJudge(), async_mode=False),
+        TopicAdherenceMetric(
+            model=_NoOpJudge(), relevant_topics=["x"], async_mode=False
+        ),
+    ]
+
+
+@pytest.mark.parametrize("metric", _metrics())
+def test_is_successful_recomputes_pass_when_never_measured(metric):
+    # success left at its class default (None): a passing score must yield True.
+    metric.threshold = 0.5
+    metric.score = 0.9
+    metric.error = None
+    assert metric.is_successful() is True
+    assert metric.success is True
+
+
+@pytest.mark.parametrize("metric", _metrics())
+def test_is_successful_recomputes_fail(metric):
+    metric.threshold = 0.5
+    metric.score = 0.1
+    metric.error = None
+    assert metric.is_successful() is False
+    assert metric.success is False
+
+
+@pytest.mark.parametrize("metric", _metrics())
+def test_is_successful_overwrites_stale_success(metric):
+    # a prior failing run left success=False; score/threshold now describe a pass.
+    metric.threshold = 0.5
+    metric.score = 0.9
+    metric.error = None
+    metric.success = False
+    assert metric.is_successful() is True
+    assert metric.success is True


### PR DESCRIPTION
### Root cause

`TurnRelevancyMetric.is_successful()` and `TopicAdherenceMetric.is_successful()` recompute the pass/fail verdict from `score` and `threshold`, but do so with a bare expression:

```python
def is_successful(self) -> bool:
    if self.error is not None:
        self.success = False
    else:
        try:
            self.score >= self.threshold   # result discarded
        except TypeError:
            self.success = False
    return self.success
```

The comparison is evaluated and thrown away. On the success path `self.success` is never assigned, so the method returns whatever `self.success` already held: the class default `None` when the metric was never measured, or a stale value carried over from an earlier run. Every other metric assigns it, for example `ExactMatchMetric`:

```python
self.success = self.score >= self.threshold
```

An AST scan of `deepeval/metrics/` finds 47 `is_successful` methods using the assign form and exactly these 2 using the bare form.

### Impact

`is_successful()` is documented as the recompute-from-score accessor, so callers reach it independently of `measure()`. It returns a wrong verdict whenever `self.success` is not already correct:

- called before `measure()` on a fresh metric, returns `None`;
- a metric object reused or copied with a stale `success`, then a new `score`/`threshold`, returns the old verdict;
- `threshold` mutated after `measure()`, the change is ignored.

The common `measure()`-then-`is_successful()` path is unaffected, because `measure()` already sets `success`, which is why this was easy to miss.

### Fix

Assign the comparison to `self.success` in both methods, matching the canonical pattern. Two lines.

### Invariant

After `is_successful()` returns, `self.success == (self.score >= self.threshold)` on the no-error path (and `False` on a `TypeError` or when `error` is set), and the return value equals `self.success`. This is a property of the method itself, not a claim about other writers of `self.success`.

### Verification

Reproduced and fixed in a clean `python:3.11-slim` container against this HEAD, source-tree provenance confirmed (`is_successful.__module__.__file__` under the checked-out tree). Judge model is a no-op stub, so `is_successful()` runs pure arithmetic with no API key.

Before, for `score=0.9, threshold=0.5, error=None`:

```
TurnRelevancyMetric.is_successful()  -> None    (never measured)
TurnRelevancyMetric.is_successful()  -> False   (stale success=False, now a pass)
TopicAdherenceMetric.is_successful() -> None
TopicAdherenceMetric.is_successful() -> False
ExactMatchMetric.is_successful()     -> True    (canonical sibling)
```

After the fix all four return `True`, matching the sibling.

The added test `tests/test_metrics/test_is_successful_recompute.py` covers three cases per metric (pass when never measured, fail, and overwrite of a stale `success`), asserting both the return value and the final `self.success`. It fails on `main` (6 failed) and passes on this branch (6 passed); it needs no API key. `black --check` is clean on the changed files.

I did not run the API-key-gated metric suites (`tests/test_metrics/*` gated on `OPENAI_API_KEY`), as they exercise live model calls unrelated to this method.
