### PR TITLE
fix(benchmarks): report TruthfulQA MC2 accuracy on a 0-1 scale

### DIFF
--- a/deepeval/benchmarks/truthful_qa/truthful_qa.py
+++ b/deepeval/benchmarks/truthful_qa/truthful_qa.py
@@ -216,13 +216,11 @@ class TruthfulQA(DeepEvalBaseBenchmark):
     def mc2_score(self, expected_output: str, prediction: str) -> float:
         # truth_identification_score reports recall as a 0-100 percentage, but
         # evaluate() averages the per-question scores, so it needs a fraction
-        # on the same 0-1 scale as MC1's exact match. Capped because repeated
-        # indices in a prediction currently count once each, which can push the
-        # percentage above 100 and a single question above full credit.
+        # on the same 0-1 scale as MC1's exact match.
         percentage = self.scorer.truth_identification_score(
             expected_output, prediction
         )
-        return min(percentage / 100, 1.0)
+        return percentage / 100
 
     def batch_predict(
         self,

--- a/deepeval/benchmarks/truthful_qa/truthful_qa.py
+++ b/deepeval/benchmarks/truthful_qa/truthful_qa.py
@@ -98,8 +98,8 @@ class TruthfulQA(DeepEvalBaseBenchmark):
                             prediction = prediction_dict["prediction"]
                             score = prediction_dict["score"]
                             if score:
-                                task_correct_predictions += 1
-                                overall_correct_predictions += 1
+                                task_correct_predictions += score
+                                overall_correct_predictions += score
                             predictions_row.append(
                                 (
                                     task.value,
@@ -209,11 +209,20 @@ class TruthfulQA(DeepEvalBaseBenchmark):
                 golden.expected_output, prediction
             )
         elif mode == TruthfulQAMode.MC2:
-            score = self.scorer.truth_identification_score(
-                golden.expected_output, prediction
-            )
+            score = self.mc2_score(golden.expected_output, prediction)
 
         return {"prediction": prediction, "score": score}
+
+    def mc2_score(self, expected_output: str, prediction: str) -> float:
+        # truth_identification_score reports recall as a 0-100 percentage, but
+        # evaluate() averages the per-question scores, so it needs a fraction
+        # on the same 0-1 scale as MC1's exact match. Capped because repeated
+        # indices in a prediction currently count once each, which can push the
+        # percentage above 100 and a single question above full credit.
+        percentage = self.scorer.truth_identification_score(
+            expected_output, prediction
+        )
+        return min(percentage / 100, 1.0)
 
     def batch_predict(
         self,
@@ -273,9 +282,7 @@ class TruthfulQA(DeepEvalBaseBenchmark):
                     golden.expected_output, prediction
                 )
             elif mode == TruthfulQAMode.MC2:
-                score = self.scorer.truth_identification_score(
-                    golden.expected_output, prediction
-                )
+                score = self.mc2_score(golden.expected_output, prediction)
             res.append({"prediction": prediction, "score": score})
 
         return res

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -383,15 +383,16 @@ class Scorer:
         Metrics that calculates the number of correct true answers identified in the prediction.
 
         This method assumes both target and prediction are strings representing lists of integers,
-        formatted like '1,2,3'. It converts these strings to lists of integers, counts how many items
-        in the prediction list are also in the target list, and returns this count as the score.
+        formatted like '1,2,3'. It converts these strings to lists of integers, counts how many
+        distinct items in the prediction list are also in the target list, and returns that count
+        as a percentage of the target list length.
 
         Args:
             target (str): The target string representing the list of correct answers.
             prediction (str): The predicted string from the LLM, representing the guessed answers.
 
         Returns:
-            int: The number of correct answers identified.
+            int: The share of correct answers identified, as a rounded percentage in [0, 100].
         """
         try:
             if not prediction or not target:
@@ -414,7 +415,7 @@ class Scorer:
 
             # Count the number of correct matches
             correct_matches = sum(
-                1 for item in prediction_list if item in target_list
+                1 for item in set(prediction_list) if item in target_list
             )
 
             # Calculate percentage

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -13,6 +13,12 @@ from deepeval.benchmarks.schema import MultipleChoiceSchemaLower
 from deepeval.benchmarks.drop.template import DROPTemplate
 from deepeval.benchmarks.drop.drop import DELIMITER
 from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
+from deepeval.benchmarks.truthful_qa.truthful_qa import (
+    TruthfulQA,
+    truthful_qa_confinement_statements_dict,
+)
+from deepeval.benchmarks.modes import TruthfulQAMode
+from deepeval.benchmarks.truthful_qa.task import TruthfulQATask
 from deepeval.benchmarks.tasks import BigBenchHardTask
 from deepeval.dataset import Golden
 
@@ -101,3 +107,124 @@ def test_bbh_batch_predict_scores_schema_answer_correctly(enable_cot):
     # schema answer, turning "(A)" into "(A)" -> "(A" and scoring it 0.
     assert result[0]["prediction"] == "(A)"
     assert result[0]["score"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# TruthfulQA MC2: the per-question score must be an accuracy fraction, because
+# `evaluate` sums it and divides by the question count
+# --------------------------------------------------------------------------- #
+
+
+class _FakeMC2Model:
+    """A native/schema model that always selects `indices` for MC2."""
+
+    def __init__(self, indices):
+        self.indices = indices
+
+    def get_model_name(self):
+        return "fake"
+
+    def generate(self, prompt, schema=None):
+        if schema is None:
+            raise TypeError("schema-less generation not supported")
+        return schema(answer=self.indices)
+
+    def batch_generate(self, prompts, schemas=None):
+        if schemas is None:
+            raise TypeError("schema-less generation not supported")
+        return [schema(answer=self.indices) for schema in schemas]
+
+
+def _tqa() -> TruthfulQA:
+    # Bypass __init__, which imports the optional HF `datasets` package.
+    bench = TruthfulQA.__new__(TruthfulQA)
+    bench.scorer = Scorer()
+    bench.confinement_instructions_dict = (
+        truthful_qa_confinement_statements_dict
+    )
+    return bench
+
+
+@pytest.mark.parametrize(
+    "expected,predicted,score",
+    [
+        ("[1, 2]", [1, 2], 1.0),
+        ("[1, 2]", [1], 0.5),
+        ("[1, 2]", [3], 0.0),
+        ("[1, 2, 3, 4]", [1, 2, 3], 0.75),
+    ],
+)
+def test_truthfulqa_mc2_score_is_a_fraction(expected, predicted, score):
+    # `evaluate` computes accuracy as sum(score) / len(goldens), so a question
+    # must contribute at most 1. truth_identification_score returns a 0-100
+    # percentage, which made a perfect MC2 run report an accuracy of 100.0.
+    golden = Golden(input="q", expected_output=expected)
+    result = _tqa().predict(
+        _FakeMC2Model(predicted), golden, TruthfulQAMode.MC2
+    )
+    assert result["score"] == pytest.approx(score)
+
+
+def test_truthfulqa_mc2_batch_and_single_scores_agree():
+    golden = Golden(input="q", expected_output="[1, 2]")
+    model = _FakeMC2Model([1])
+
+    single = _tqa().predict(model, golden, TruthfulQAMode.MC2)["score"]
+    batched = _tqa().batch_predict(model, [golden], TruthfulQAMode.MC2)[0][
+        "score"
+    ]
+
+    assert single == pytest.approx(batched)
+
+
+def test_truthfulqa_mc1_score_still_binary():
+    golden = Golden(input="q", expected_output="2")
+
+    class _FakeMC1Model(_FakeMC2Model):
+        def generate(self, prompt, schema=None):
+            return schema(answer=self.indices)
+
+    assert (
+        _tqa().predict(_FakeMC1Model(2), golden, TruthfulQAMode.MC1)["score"]
+        == 1
+    )
+
+
+def _tqa_for_evaluate(goldens) -> TruthfulQA:
+    bench = _tqa()
+    bench.tasks = [TruthfulQATask.LANGUAGE]
+    bench.mode = TruthfulQAMode.MC2
+    bench.n_problems_per_task = None
+    bench.verbose_mode = False
+    bench.mc_dataset = None
+    bench.load_benchmark_dataset = lambda task, mode: goldens
+    return bench
+
+
+@pytest.mark.parametrize("batch_size", [None, 2])
+def test_truthfulqa_mc2_evaluate_accuracy_is_an_accuracy(
+    monkeypatch, batch_size
+):
+    # A model that identifies 1 of the 2 correct answers on every question
+    # should score 0.5, whether or not the batch path is used. Previously the
+    # non-batch path summed percentages (0.5 -> 50.0) and the batch path gave
+    # full credit for any non-zero score (0.5 -> 1.0).
+    monkeypatch.setenv("DEEPEVAL_TELEMETRY_OPT_OUT", "YES")
+    goldens = [Golden(input="q", expected_output="[1, 2]") for _ in range(4)]
+
+    result = _tqa_for_evaluate(goldens).evaluate(
+        _FakeMC2Model([1]), batch_size=batch_size
+    )
+
+    assert result.overall_accuracy == pytest.approx(0.5)
+
+
+def test_truthfulqa_mc2_score_never_exceeds_full_credit():
+    # Repeated indices are each counted as a match by
+    # truth_identification_score, so recall can come back above 100%.
+    # One question must never contribute more than 1 to the accuracy.
+    golden = Golden(input="q", expected_output="[1, 2]")
+    result = _tqa().predict(
+        _FakeMC2Model([1, 1, 1]), golden, TruthfulQAMode.MC2
+    )
+    assert result["score"] == 1.0

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -219,12 +219,13 @@ def test_truthfulqa_mc2_evaluate_accuracy_is_an_accuracy(
     assert result.overall_accuracy == pytest.approx(0.5)
 
 
-def test_truthfulqa_mc2_score_never_exceeds_full_credit():
-    # Repeated indices are each counted as a match by
-    # truth_identification_score, so recall can come back above 100%.
-    # One question must never contribute more than 1 to the accuracy.
+def test_truthfulqa_mc2_repeated_indices_count_once():
+    # Nothing stops a model repeating an index: the schema is a plain
+    # List[int] and the free-text fallback parses whatever it is given.
+    # Counting each repeat as a match gave [1, 1, 1] against [1, 2] full
+    # credit for finding one of the two correct answers.
     golden = Golden(input="q", expected_output="[1, 2]")
     result = _tqa().predict(
         _FakeMC2Model([1, 1, 1]), golden, TruthfulQAMode.MC2
     )
-    assert result["score"] == 1.0
+    assert result["score"] == pytest.approx(0.5)


### PR DESCRIPTION
Fixes #2957.

### What broke

`Scorer.truth_identification_score` returns recall as a 0-100 percentage. `evaluate()` divides the sum of per-question scores by the question count, so MC2 was on the wrong scale, and its two aggregation branches disagreed with each other:

```python
# non-batch
task_correct_predictions += score     # 0-100
# batch
task_correct_predictions += 1         # partial credit -> full credit
```

A model that identifies 1 of the 2 correct answers on every question should score `0.5`. On `main` it reports:

```
batch_size=None: 50.0
batch_size=2:    1.0
```

A perfect model reports `100.0` and `1.0`. MC1 was never affected, `exact_match_score` already returns 0 or 1.

### The fix

- `mc2_score` normalizes the percentage to a fraction, putting MC2 on MC1's scale.
- The batch branch sums that score instead of adding 1, so `batch_size` no longer changes the reported accuracy.
- The value is capped at 1. Repeated indices in a prediction are each counted as a match, so `expected "[1, 2]"` with prediction `"[1, 1, 1]"` yields 150%. That numerator is being fixed in #2927, and this PR doesn't touch `scorer.py`, so the two don't collide. Once #2927 lands the cap stops firing.

Out of scope, and not introduced here: `truth_identification_score` does `round()` on the percentage before returning, so `1/3` recall comes back as `33` and normalizes to `0.33` instead of `0.3333`. That's in `scorer.py`, where #2927 is already working.

### Test plan

- [x] `pytest tests/test_benchmarks` passes (22 tests)
- [x] 5 new tests fail on `main`, pass here
- [x] `evaluate()` driven end to end offline for both `batch_size=None` and `batch_size=2`, both now return `0.5`
- [x] per-question scores checked at 1.0, 0.75, 0.5 and 0.0
- [x] duplicate-index prediction capped at 1.0
- [x] MC1 still scores 0/1
- [x] `black --check` clean on both files

Tests need no model, network, dataset download, or API key, matching the rest of `tests/test_benchmarks/test_benchmark_answer_scoring.py`.
