### PR TITLE
fix: make safe_asyncio_run loop-safe for Jupyter/FastAPI/pytest-asyncio (#2952)

### DIFF
--- a/deepeval/models/llms/utils.py
+++ b/deepeval/models/llms/utils.py
@@ -29,20 +29,25 @@ def trim_and_load_json(
 
 def safe_asyncio_run(coro):
     """
-    Run an async coroutine safely.
-    Falls back to run_until_complete if already in a running event loop.
+    Run an async coroutine safely, regardless of whether an event loop is
+    already running (e.g. inside Jupyter notebooks, FastAPI, pytest-asyncio).
+
+    Strategy:
+    - If a loop IS running: apply nest_asyncio (idempotent) so the coroutine
+      can be driven on the existing loop without a nested-loop RuntimeError.
+    - If no loop is running: use the standard asyncio.run() path.
     """
     try:
-        return asyncio.run(coro)
+        running_loop = asyncio.get_running_loop()
     except RuntimeError:
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                future = asyncio.ensure_future(coro)
-                return loop.run_until_complete(future)
-            else:
-                return loop.run_until_complete(coro)
-        except Exception:
-            raise
-    except Exception:
-        raise
+        running_loop = None
+
+    if running_loop is not None:
+        # A loop is already active — patch it with nest_asyncio so we can
+        # call run_until_complete from within it, then schedule the coroutine.
+        import nest_asyncio
+
+        nest_asyncio.apply(running_loop)
+        return running_loop.run_until_complete(coro)
+    else:
+        return asyncio.run(coro)

--- a/deepeval/simulator/controller/controller.py
+++ b/deepeval/simulator/controller/controller.py
@@ -1,4 +1,4 @@
-import asyncio
+from deepeval.models.llms.utils import safe_asyncio_run
 import inspect
 from typing import Awaitable, Callable, List, Optional
 
@@ -59,7 +59,7 @@ class SimulationController:
         )
         decision = self._invoke_controller(ctx)
         if inspect.isawaitable(decision):
-            decision = asyncio.run(decision)
+            decision = safe_asyncio_run(decision)
 
         return self._should_end(decision, progress, pbar_turns_id)
 

--- a/deepeval/simulator/conversation_simulator.py
+++ b/deepeval/simulator/conversation_simulator.py
@@ -6,6 +6,8 @@ import asyncio
 import uuid
 import warnings
 
+from deepeval.models.llms.utils import safe_asyncio_run
+
 from deepeval.utils import (
     get_or_create_event_loop,
     update_pbar,
@@ -298,7 +300,7 @@ class ConversationSimulator:
 
             # Generate turn from assistant
             if self.is_callback_async:
-                assistant_turn = asyncio.run(
+                assistant_turn = safe_asyncio_run(
                     self.a_generate_turn_from_callback(
                         user_input,
                         model_callback=self.model_callback,

--- a/deepeval/simulator/simulation_graph/runner.py
+++ b/deepeval/simulator/simulation_graph/runner.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from deepeval.models.llms.utils import safe_asyncio_run
 
 from deepeval.dataset import ConversationalGolden
 from deepeval.simulator.simulation_graph.node import SimulationNode
@@ -87,10 +88,9 @@ class _SimulationGraphRunner:
             async_mode=False,
         )
         if inspect.isawaitable(result):
-            # Action is async but we're in sync mode: run it via asyncio,
-            # matching the existing `is_callback_async` shim used by
-            # `model_callback`.
-            result = asyncio.run(result)
+            # Action is async but we're in sync mode: run it via safe_asyncio_run
+            # so it works correctly even in already-running event loops.
+            result = safe_asyncio_run(result)
 
         turn = _normalize_user_turn(result, node)
         state.visits[id(node)] = visits + 1

--- a/tests/test_event_loop_safety.py
+++ b/tests/test_event_loop_safety.py
@@ -1,0 +1,128 @@
+"""
+Regression tests for issue #2952 – event-loop safety in deepeval.
+
+The safe_asyncio_run function is tested in isolation (without importing the
+full deepeval package) so these tests have no heavy dependency requirements.
+
+Covers:
+  1. Plain sync Python process (no loop running)
+  2. Async context via pytest-asyncio (loop already running)
+  3. Simulated "Jupyter / FastAPI" scenario (nest_asyncio + running loop)
+  4. Multiple sequential calls don't deadlock
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import safe_asyncio_run directly from the source file, bypassing the full
+# deepeval __init__.py chain (which requires sentry_sdk and other heavy deps).
+# ---------------------------------------------------------------------------
+_utils_path = (
+    Path(__file__).parents[1] / "deepeval" / "models" / "llms" / "utils.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "deepeval_llm_utils", _utils_path
+)
+_utils_mod = importlib.util.module_from_spec(_spec)
+
+# Stub out deepeval.errors so the lone `from deepeval.errors import ...` line
+# inside utils.py doesn't trigger the full package import chain.
+_fake_errors = _types.ModuleType("deepeval.errors")
+
+
+class _DeepEvalError(Exception):
+    pass
+
+
+_fake_errors.DeepEvalError = _DeepEvalError
+sys.modules.setdefault("deepeval", _types.ModuleType("deepeval"))
+sys.modules["deepeval.errors"] = _fake_errors
+_spec.loader.exec_module(_utils_mod)
+safe_asyncio_run = _utils_mod.safe_asyncio_run
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _add(a: int, b: int) -> int:
+    """Trivial async coroutine used as a test fixture."""
+    await asyncio.sleep(0)  # yield once to exercise real async scheduling
+    return a + b
+
+
+# ---------------------------------------------------------------------------
+# 1. Sync execution in a plain Python process (no loop running)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_asyncio_run_no_loop():
+    """safe_asyncio_run works when called from a plain sync context."""
+    result = safe_asyncio_run(_add(1, 2))
+    assert result == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Async execution under pytest-asyncio (loop is already running)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_asyncio_run_inside_running_loop():
+    """safe_asyncio_run must NOT raise RuntimeError when a loop is active."""
+    # This exercises the nest_asyncio branch that was broken in the original
+    # implementation (it tried asyncio.run() first, which raises here).
+    result = safe_asyncio_run(_add(3, 4))
+    assert result == 7
+
+
+# ---------------------------------------------------------------------------
+# 3. Notebook / FastAPI-like scenario: nest_asyncio pre-applied, loop active
+# ---------------------------------------------------------------------------
+
+
+def test_safe_asyncio_run_with_nest_asyncio_pre_applied():
+    """
+    Simulate the Jupyter / FastAPI scenario where nest_asyncio is already
+    applied and a loop is running.
+
+    We spin up a fresh event loop, apply nest_asyncio to it, and call
+    safe_asyncio_run from *within* that running loop – exactly the pattern
+    that triggered the original RuntimeError.
+    """
+    import nest_asyncio
+
+    loop = asyncio.new_event_loop()
+    nest_asyncio.apply(loop)
+
+    async def _inner():
+        return safe_asyncio_run(_add(10, 20))
+
+    result = loop.run_until_complete(_inner())
+    loop.close()
+    assert result == 30
+
+
+# ---------------------------------------------------------------------------
+# 4. Multiple sequential calls don't deadlock
+# ---------------------------------------------------------------------------
+
+
+def test_safe_asyncio_run_multiple_calls_no_deadlock():
+    """Calling safe_asyncio_run repeatedly in the same process doesn't hang."""
+    for i in range(5):
+        assert safe_asyncio_run(_add(i, i)) == i * 2
+
+
+@pytest.mark.asyncio
+async def test_safe_asyncio_run_multiple_calls_inside_running_loop():
+    """Same check but from within a running async context."""
+    for i in range(5):
+        assert safe_asyncio_run(_add(i, i)) == i * 2


### PR DESCRIPTION
Fixes #2952.

In async-hosted environments (Jupyter notebooks, FastAPI apps, \`pytest-asyncio\` tests), running evals failed with:

\`\`\`
RuntimeError: This event loop is already running
\`\`\`

**Two root causes:**

1. \`safe_asyncio_run()\` in \`deepeval/models/llms/utils.py\` tried \`asyncio.run()\` first and caught \`RuntimeError\` *after the fact*. But \`asyncio.run()\` raises **before** any fallback ran — so the catch block was never reached.

2. Three simulator call sites used **bare \`asyncio.run()\`** with no protection at all:
   - \`deepeval/simulator/controller/controller.py:62\`
   - \`deepeval/simulator/simulation_graph/runner.py:93\`
   - \`deepeval/simulator/conversation_simulator.py:301\`

---

## Fix

### \`deepeval/models/llms/utils.py\`
Rewrote \`safe_asyncio_run()\` to **check first** using \`asyncio.get_running_loop()\` (Python 3.7+, raises only when no loop is active — a clean signal, not an error path):

- **Loop is running** → apply \`nest_asyncio\` (idempotent) + \`run_until_complete()\`
- **No loop running** → standard \`asyncio.run()\`

### \`deepeval/simulator/\` (3 files)
Replaced bare \`asyncio.run()\` calls with \`safe_asyncio_run()\`.

---

## Tests

Added \`tests/test_event_loop_safety.py\` with **5 regression tests** — all pass:

| Test | Scenario |
|---|---|
| \`test_safe_asyncio_run_no_loop\` | Plain sync Python process |
| \`test_safe_asyncio_run_inside_running_loop\` | \`pytest-asyncio\` (loop already running) |
| \`test_safe_asyncio_run_with_nest_asyncio_pre_applied\` | Jupyter/FastAPI (nest_asyncio + running loop) |
| \`test_safe_asyncio_run_multiple_calls_no_deadlock\` | Repeated sync calls |
| \`test_safe_asyncio_run_multiple_calls_inside_running_loop\` | Repeated calls from async context |

---

## Files Changed
- \`deepeval/models/llms/utils.py\` — core fix to \`safe_asyncio_run()\`
- \`deepeval/simulator/controller/controller.py\`
- \`deepeval/simulator/simulation_graph/runner.py\`
- \`deepeval/simulator/conversation_simulator.py\`
- \`tests/test_event_loop_safety.py\` *(new)*"
