### PR TITLE
fix(benchmarks): correct the accuracy denominators in EquityMedQA and GSM8K

### DIFF
--- a/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
+++ b/deepeval/benchmarks/equity_med_qa/equity_med_qa.py
@@ -20,6 +20,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
         self,
         tasks: List[EquityMedQATask] = None,
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
+        n_problems_per_task: Optional[int] = 10,
         **kwargs,
     ):
         from deepeval.scorer import Scorer
@@ -29,6 +30,7 @@ class EquityMedQA(DeepEvalBaseBenchmark):
         self.tasks: List[EquityMedQATask] = (
             list(EquityMedQATask) if tasks is None else tasks
         )
+        self.n_problems_per_task: Optional[int] = n_problems_per_task
         self.scorer = Scorer()
         self.predictions: Optional[pd.DataFrame] = None
         self.task_scores: Optional[pd.DataFrame] = None
@@ -50,13 +52,16 @@ class EquityMedQA(DeepEvalBaseBenchmark):
 
             for task in self.tasks:
                 goldens = self.load_benchmark_dataset(task)
+                if (
+                    self.n_problems_per_task is not None
+                    and self.n_problems_per_task < len(goldens)
+                ):
+                    goldens = goldens[: self.n_problems_per_task]
                 task_correct_predictions = 0
                 task_total_predictions = len(goldens)
                 overall_total_predictions += len(goldens)
 
-                for golden in tqdm(
-                    goldens[:10], desc=f"Processing {task.value}"
-                ):
+                for golden in tqdm(goldens, desc=f"Processing {task.value}"):
                     prediction, score = self.predict(model, golden).values()
                     if score:
                         task_correct_predictions += 1

--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -26,6 +26,7 @@ class GSM8K(DeepEvalBaseBenchmark):
         import pandas as pd
 
         assert n_shots <= 15, "GSM8K only supports n_shots <= 15"
+        assert n_problems <= 1319, "GSM8K only supports n_problems <= 1319"
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.shots_dataset: List[Dict] = None
@@ -49,11 +50,11 @@ class GSM8K(DeepEvalBaseBenchmark):
 
         with capture_benchmark_run("GSM8K", len(self.tasks)):
             overall_correct_predictions = 0
-            overall_total_predictions = self.n_problems
             predictions_row = []
 
             # Solving each problem
             goldens = self.load_benchmark_dataset()[: self.n_problems]
+            overall_total_predictions = len(goldens)
             for idx, golden in enumerate(
                 tqdm(goldens, desc=f"Processing {self.n_problems} problems")
             ):

--- a/tests/test_benchmarks/test_benchmark_accuracy_denominator.py
+++ b/tests/test_benchmarks/test_benchmark_accuracy_denominator.py
@@ -1,0 +1,124 @@
+"""
+Regression tests for benchmarks whose reported accuracy was divided by a
+denominator that did not match the goldens actually scored.
+
+They are offline: no model, network, dataset download, or API key required.
+The benchmarks are subclassed so that ``__init__`` (which imports the optional
+HF ``datasets`` package) is bypassed and ``load_benchmark_dataset``/``predict``
+are replaced by scripted fakes.
+"""
+
+import pytest
+
+from deepeval.dataset import Golden
+from deepeval.benchmarks.equity_med_qa.equity_med_qa import EquityMedQA
+from deepeval.benchmarks.equity_med_qa.task import EquityMedQATask
+from deepeval.benchmarks.gsm8k.gsm8k import GSM8K
+
+# --------------------------------------------------------------------------- #
+# EquityMedQA: only the first n_problems_per_task goldens of a task are scored,
+# so the accuracy has to be divided by that many and not by the full task size.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeEquityMedQA(EquityMedQA):
+    """A single task with `n_goldens` goldens and a model that is always right."""
+
+    def __init__(self, n_goldens, n_problems_per_task=10):
+        self.tasks = [EquityMedQATask.OMAQ]
+        self.n_problems_per_task = n_problems_per_task
+        self.n_goldens = n_goldens
+        self.dataset = None
+
+    def load_benchmark_dataset(self, task):
+        return [Golden(input=f"q{i}") for i in range(self.n_goldens)]
+
+    def predict(self, model, golden):
+        return {"prediction": "answer", "score": 1}
+
+
+def test_equity_med_qa_accuracy_is_over_the_goldens_actually_scored():
+    # A model that answers every scored golden correctly must score 1.0.
+    # Previously only goldens[:10] were scored but the accuracy was divided by
+    # len(goldens), so a perfect model on a 40-golden task reported 0.25.
+    benchmark = _FakeEquityMedQA(n_goldens=40)
+    result = benchmark.evaluate(model=None)
+
+    assert result.overall_accuracy == 1.0
+    assert benchmark.task_scores["Score"].tolist() == [1.0]
+
+
+def test_equity_med_qa_default_still_caps_each_task_at_ten_goldens():
+    benchmark = _FakeEquityMedQA(n_goldens=40)
+    benchmark.evaluate(model=None)
+
+    assert len(benchmark.predictions) == 10
+
+
+def test_equity_med_qa_cap_can_be_disabled():
+    benchmark = _FakeEquityMedQA(n_goldens=40, n_problems_per_task=None)
+    result = benchmark.evaluate(model=None)
+
+    assert len(benchmark.predictions) == 40
+    assert result.overall_accuracy == 1.0
+
+
+def test_equity_med_qa_task_smaller_than_the_cap_is_not_padded():
+    benchmark = _FakeEquityMedQA(n_goldens=3)
+    result = benchmark.evaluate(model=None)
+
+    assert len(benchmark.predictions) == 3
+    assert result.overall_accuracy == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# GSM8K: accuracy must be divided by the goldens actually loaded, and
+# n_problems must be bounded by the dataset size like its sibling benchmarks.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeGSM8K(GSM8K):
+    """`n_available` goldens in the dataset and a model that is always right."""
+
+    def __init__(self, n_problems, n_available):
+        self.n_problems = n_problems
+        self.n_available = n_available
+        self.verbose_mode = False
+        self.tasks = []
+        self.dataset = None
+
+    def load_benchmark_dataset(self):
+        return [
+            Golden(input=f"q{i}", expected_output="1")
+            for i in range(self.n_available)
+        ]
+
+    def predict(self, model, golden):
+        return {"prediction": "1", "score": 1}
+
+
+def test_gsm8k_accuracy_is_over_the_goldens_actually_loaded():
+    # A perfect model must score 1.0 even when the dataset yields fewer goldens
+    # than n_problems. Previously the denominator was n_problems, so 4 loaded
+    # goldens against the default n_problems=1319 reported 0.003.
+    benchmark = _FakeGSM8K(n_problems=1319, n_available=4)
+    result = benchmark.evaluate(model=None)
+
+    assert result.overall_accuracy == 1.0
+    assert len(benchmark.predictions) == 4
+
+
+def test_gsm8k_accuracy_unchanged_when_enough_goldens_are_available():
+    benchmark = _FakeGSM8K(n_problems=5, n_available=100)
+    result = benchmark.evaluate(model=None)
+
+    assert result.overall_accuracy == 1.0
+    assert len(benchmark.predictions) == 5
+
+
+@pytest.mark.parametrize("n_problems", [1320, 5000])
+def test_gsm8k_rejects_n_problems_larger_than_the_dataset(n_problems):
+    # BoolQ, LAMBADA, Winogrande and ARC all bound n_problems this way; without
+    # it GSM8K silently deflated the accuracy by len(goldens) / n_problems.
+    with pytest.raises(AssertionError):
+        GSM8K(n_problems=n_problems)


### PR DESCRIPTION
Two benchmarks report an accuracy divided by a denominator that does not match the goldens they actually scored. Both fail silently -- no error, just a wrong number.

## EquityMedQA

`EquityMedQA.evaluate()` scores only the first 10 goldens of each task:

```python
for golden in tqdm(goldens[:10], desc=f"Processing {task.value}"):
```

but sets the denominator from the full task:

```python
task_total_predictions = len(goldens)
overall_total_predictions += len(goldens)
```

So the reported accuracy is scaled by `10 / len(goldens)`. A model that answers every scored golden correctly on a 40-golden task reports 0.25. On `fbrt_llm_661_sampled` (661 goldens) a perfect run reports 0.015. Only tasks with 10 or fewer goldens are correct today.

The `[:10]` cap was also hard-coded, so there was no way to run the full benchmark.

Fix: divide by the goldens actually scored, and expose the cap as `n_problems_per_task`, the same argument BBQ, MMLU, HellaSwag, DROP, SQuAD, LogiQA, MathQA and TruthfulQA already take. The default is 10, so an existing run scores exactly the same goldens as before and only the denominator changes. `n_problems_per_task=None` scores the whole task.

## GSM8K

`GSM8K.evaluate()` divides by the requested `n_problems` rather than the goldens actually loaded:

```python
overall_total_predictions = self.n_problems
goldens = self.load_benchmark_dataset()[: self.n_problems]
```

and unlike BoolQ, LAMBADA, Winogrande and ARC it has no bound on `n_problems`. `GSM8K(n_problems=5000)` is accepted, runs the 1319 problems that exist, and deflates the accuracy by `1319/5000` -- a perfect model reports 0.264.

Fix: add the bound assert the sibling benchmarks all have, and use `len(goldens)` as the denominator. With `n_problems <= 1319` the two are equal, so runs that were already correct are unaffected.

## Tests

`tests/test_benchmarks/test_benchmark_accuracy_denominator.py`. The dataset and the predictions are scripted fakes, so the tests need no model, network or API key.

On main, 5 of the 8 fail:

```
$ python -m pytest tests/test_benchmarks/test_benchmark_accuracy_denominator.py -q

___________ test_equity_med_qa_accuracy_is_over_the_goldens_actually_scored ____________

    benchmark = _FakeEquityMedQA(n_goldens=40)
    result = benchmark.evaluate(model=None)

>   assert result.overall_accuracy == 1.0
E   assert 0.25 == 1.0
E    +  where 0.25 = DeepEvalBaseBenchmarkResult(overall_accuracy=0.25).overall_accuracy

_______________________ test_equity_med_qa_cap_can_be_disabled ________________________

    benchmark = _FakeEquityMedQA(n_goldens=40, n_problems_per_task=None)
    result = benchmark.evaluate(model=None)

>   assert len(benchmark.predictions) == 40
E   assert 10 == 40

_______________ test_gsm8k_accuracy_is_over_the_goldens_actually_loaded _______________

    benchmark = _FakeGSM8K(n_problems=1319, n_available=4)
    result = benchmark.evaluate(model=None)

>   assert result.overall_accuracy == 1.0
E   assert 0.003032600454890068 == 1.0
E    +  where 0.003032600454890068 = DeepEvalBaseBenchmarkResult(overall_accuracy=0.003032600454890068).overall_accuracy

_____________ test_gsm8k_rejects_n_problems_larger_than_the_dataset[1320] _____________

>   with pytest.raises(AssertionError):
E   Failed: DID NOT RAISE <class 'AssertionError'>

_____________ test_gsm8k_rejects_n_problems_larger_than_the_dataset[5000] _____________

>   with pytest.raises(AssertionError):
E   Failed: DID NOT RAISE <class 'AssertionError'>

5 failed, 3 passed in 19.92s
```

With the fix, `tests/test_benchmarks/` is 21 passed. `black` was run over the changed files.

Related but independent of #2965, which fixes a scoring bug in `ConversationalGEval`. No shared code or branch.
