### PR TITLE
fix(benchmarks): stop HumanEval from collapsing pass@k into pass@n

### DIFF
--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -122,22 +122,20 @@ class HumanEval(DeepEvalBaseBenchmark):
 
             for task in self.tasks:
                 golden: Golden = self.load_benchmark_dataset(task)
-                task_correct = 0
                 overall_total_predictions += 1
 
-                # Calculate task accuracy
+                # Calculate task accuracy. pass@k is a probability in [0, 1],
+                # not a pass/fail flag, so it is accumulated as-is.
                 prediction, score = self.predict(
                     model, task, golden, k
                 ).values()
-                if score:
-                    task_correct = 1
-                    overall_correct_predictions += 1
+                overall_correct_predictions += score
                 predictions_row.append(
                     (
                         task.value,
                         golden.input,
                         prediction,
-                        task_correct,
+                        score,
                         golden.expected_output,
                         score,
                     )
@@ -146,10 +144,8 @@ class HumanEval(DeepEvalBaseBenchmark):
                     self.print_verbose_logs(
                         task.value, golden.input, prediction, score
                     )
-                print(
-                    f"HumanEval Task Accuracy (task={task.value}): {task_correct}"
-                )
-                scores_row.append((task.value, task_correct))
+                print(f"HumanEval Task Accuracy (task={task.value}): {score}")
+                scores_row.append((task.value, score))
 
             # Calculate overall accuracy
             overall_accuracy = (

--- a/tests/test_benchmarks/test_human_eval_pass_at_k.py
+++ b/tests/test_benchmarks/test_human_eval_pass_at_k.py
@@ -1,0 +1,75 @@
+"""
+Regression tests for HumanEval collapsing pass@k into pass@n.
+
+pass@k is a probability in [0, 1]. `evaluate()` used to fold it through
+`if score:`, which is true for every non-zero probability, so a task counted as
+a full pass whenever at least one of the n samples passed -- that is pass@n,
+regardless of the k that was asked for.
+
+Offline: no model, network, dataset download, or API key required.
+"""
+
+import pytest
+
+from deepeval.dataset import Golden
+from deepeval.scorer import Scorer
+from deepeval.benchmarks.human_eval.human_eval import HumanEval
+from deepeval.benchmarks.human_eval.task import HumanEvalTask
+
+
+class _FakeHumanEval(HumanEval):
+    """`n` samples per task of which `c` pass, over `n_tasks` tasks."""
+
+    def __init__(self, n, c, n_tasks=1):
+        self.tasks = list(HumanEvalTask)[:n_tasks]
+        self.n = n
+        self.n_correct = c
+        self.verbose_mode = False
+        self.scorer = Scorer()
+        self.dataset = None
+
+    def load_benchmark_dataset(self, task):
+        return Golden(input="prompt", expected_output="assert True")
+
+    def predict(self, model, task, golden, k):
+        return {
+            "prediction": ["sample"] * self.n,
+            "score": self.scorer.pass_at_k(self.n, self.n_correct, k),
+        }
+
+
+def test_pass_at_1_of_one_correct_sample_in_two_hundred_is_not_a_full_pass():
+    # 1 of 200 samples passes: pass@1 is 0.005, not 1.0. `if score:` used to
+    # round that up to a full pass and report an overall accuracy of 1.0.
+    benchmark = _FakeHumanEval(n=200, c=1)
+    result = benchmark.evaluate(model=None, k=1)
+
+    assert result.overall_accuracy == pytest.approx(0.005)
+
+
+@pytest.mark.parametrize("c, k, expected", [(2, 1, 0.02), (10, 1, 0.1)])
+def test_overall_accuracy_is_the_mean_pass_at_k(c, k, expected):
+    benchmark = _FakeHumanEval(n=100, c=c, n_tasks=4)
+    result = benchmark.evaluate(model=None, k=k)
+
+    assert result.overall_accuracy == pytest.approx(expected)
+    assert benchmark.task_scores["Score"].tolist() == pytest.approx(
+        [expected] * 4
+    )
+
+
+def test_zero_correct_samples_still_scores_zero():
+    benchmark = _FakeHumanEval(n=200, c=0)
+    result = benchmark.evaluate(model=None, k=1)
+
+    assert result.overall_accuracy == 0.0
+
+
+@pytest.mark.parametrize("c", [1, 5, 200])
+def test_pass_at_n_is_unchanged(c):
+    # With k == n, pass@k is exactly 1.0 whenever any sample passes, so runs
+    # that were already correct report the same number as before.
+    benchmark = _FakeHumanEval(n=200, c=c)
+    result = benchmark.evaluate(model=None, k=200)
+
+    assert result.overall_accuracy == 1.0


### PR DESCRIPTION
`HumanEval.evaluate()` folds the pass@k score through a truthiness check:

```python
prediction, score = self.predict(model, task, golden, k).values()
if score:
    task_correct = 1
    overall_correct_predictions += 1
```

pass@k is a probability in `[0, 1]`, not a pass/fail flag. `Scorer.pass_at_k(n, c, k)` returns a non-zero value whenever `c >= 1`, i.e. whenever at least one of the `n` samples passes. So `if score:` counts every such task as a full pass, which is pass@n -- regardless of the `k` that was requested. The `k` argument to `evaluate()` has no effect on the reported number.

With the default `n=200` and `k=1`, a task where 1 of 200 samples passes has `pass@1 = 0.005` but is reported as `1.0`. A model that happens to solve each task once in 200 attempts scores 100% on HumanEval.

Fix: accumulate the score itself. `overall_accuracy` becomes the mean pass@k over the tasks and the per-task score becomes that task's pass@k, which is what the standard metric is.

This changes the reported number for `k < n`, which is the case that was wrong. For `k == n`, `pass_at_k` returns exactly 1.0 for any task with a passing sample and 0.0 otherwise, so runs at `k == n` report the same number as before.

## Tests

`tests/test_benchmarks/test_human_eval_pass_at_k.py`. `evaluate()` is driven with scripted `(n, c)` pairs, so no model, network or API key is needed. The last test pins the `k == n` case that must not change.

On main, 3 of the 7 fail:

```
$ python -m pytest tests/test_benchmarks/test_human_eval_pass_at_k.py -q

_______ test_pass_at_1_of_one_correct_sample_in_two_hundred_is_not_a_full_pass _______

    benchmark = _FakeHumanEval(n=200, c=1)
    result = benchmark.evaluate(model=None, k=1)

>   assert result.overall_accuracy == pytest.approx(0.005)
E   assert 1.0 == 0.005 +- 5.0e-09
E     comparison failed
E     Obtained: 1.0
E     Expected: 0.005 +- 5.0e-09

________________ test_overall_accuracy_is_the_mean_pass_at_k[2-1-0.02] ________________

c = 2, k = 1, expected = 0.02

    benchmark = _FakeHumanEval(n=100, c=c, n_tasks=4)
    result = benchmark.evaluate(model=None, k=k)

>   assert result.overall_accuracy == pytest.approx(expected)
E   assert 1.0 == 0.02 +- 2.0e-08
E     comparison failed
E     Obtained: 1.0
E     Expected: 0.02 +- 2.0e-08

________________ test_overall_accuracy_is_the_mean_pass_at_k[10-1-0.1] ________________

c = 10, k = 1, expected = 0.1

    benchmark = _FakeHumanEval(n=100, c=c, n_tasks=4)
    result = benchmark.evaluate(model=None, k=k)

>   assert result.overall_accuracy == pytest.approx(expected)
E   assert 1.0 == 0.1 +- 1.0e-07
E     comparison failed
E     Obtained: 1.0
E     Expected: 0.1 +- 1.0e-07

3 failed, 4 passed in 12.21s
```

With the fix, `tests/test_benchmarks/` is 20 passed. `black` was run over the changed files.

Related but independent of #2965 (`ConversationalGEval` rubric range) and #2966 (`EquityMedQA`/`GSM8K` accuracy denominators). No shared code or branches.
