### PR TITLE
fix(metrics): score ToolUseMetric correctly when no tool is needed

### DIFF
--- a/deepeval/metrics/tool_use/tool_use.py
+++ b/deepeval/metrics/tool_use/tool_use.py
@@ -351,16 +351,17 @@ class ToolUseMetric(BaseConversationalMetric):
         tool_selections_scores_divisor = (
             len(tool_use_scores) if len(tool_use_scores) > 0 else 1
         )
-        argument_correctness_score_divisor = (
-            len(argument_correctness_scores)
-            if len(argument_correctness_scores) > 0
-            else 1
-        )
         tools_selction_score = tools_scores_sum / tool_selections_scores_divisor
-        argument_correctness_score = (
-            arguments_scores_sum / argument_correctness_score_divisor
-        )
-        score = min(tools_selction_score, argument_correctness_score)
+        if argument_correctness_scores:
+            argument_correctness_score = arguments_scores_sum / len(
+                argument_correctness_scores
+            )
+            score = min(tools_selction_score, argument_correctness_score)
+        else:
+            # No turn called a tool, so there are no arguments to be correct
+            # about. Scoring that 0 would fail a conversation that correctly
+            # needed no tools; the tool selection score already covers it.
+            score = tools_selction_score
         return 0 if self.strict_mode and score < self.threshold else score
 
     def _generate_reason_for_tool_selection(

--- a/tests/test_metrics/test_tool_use_metric_score.py
+++ b/tests/test_metrics/test_tool_use_metric_score.py
@@ -1,0 +1,82 @@
+"""
+Regression tests for ToolUseMetric._calculate_score().
+
+Argument correctness is only scored for interactions that actually called a
+tool. When none did, the empty list used to be averaged as 0.0 and folded into
+a min(), so a conversation that correctly needed no tools scored 0 -- the same
+score as a model that picked every tool wrong.
+
+Offline: `__init__` is bypassed so no model, network or API key is required.
+"""
+
+import pytest
+
+from deepeval.metrics.tool_use.tool_use import ToolUseMetric
+from deepeval.metrics.tool_use.schema import (
+    ToolSelectionScore,
+    ArgumentCorrectnessScore,
+)
+
+
+def _metric(strict_mode=False, threshold=0.5):
+    # Bypass __init__, which builds an LLM client; _calculate_score only needs
+    # these two attributes.
+    metric = ToolUseMetric.__new__(ToolUseMetric)
+    metric.strict_mode = strict_mode
+    metric.threshold = threshold
+    return metric
+
+
+def _selection(*scores):
+    return [ToolSelectionScore(score=s, reason="reason") for s in scores]
+
+
+def _arguments(*scores):
+    return [ArgumentCorrectnessScore(score=s, reason="reason") for s in scores]
+
+
+def test_no_tools_used_falls_back_to_the_tool_selection_score():
+    # The model correctly decided no tool was needed. There are no tool
+    # arguments to judge, so the score is the tool selection score.
+    assert _metric()._calculate_score(_selection(1.0), []) == 1.0
+
+
+@pytest.mark.parametrize("selection_score", [0.0, 0.25, 0.5, 1.0])
+def test_no_tools_used_preserves_a_bad_tool_selection_score(selection_score):
+    # Falling back must not mask a wrong selection decision, e.g. the model
+    # should have called a tool and did not.
+    assert (
+        _metric()._calculate_score(_selection(selection_score), [])
+        == selection_score
+    )
+
+
+def test_tools_used_still_takes_the_minimum():
+    assert _metric()._calculate_score(_selection(1.0), _arguments(0.4)) == 0.4
+    assert _metric()._calculate_score(_selection(0.2), _arguments(0.9)) == 0.2
+
+
+def test_argument_correctness_is_averaged_over_the_turns_that_used_tools():
+    # Two of three interactions used a tool; the average is over those two.
+    score = _metric()._calculate_score(
+        _selection(1.0, 1.0, 1.0), _arguments(1.0, 0.5)
+    )
+    assert score == 0.75
+
+
+def test_strict_mode_still_zeroes_a_below_threshold_score():
+    assert (
+        _metric(strict_mode=True, threshold=1)._calculate_score(
+            _selection(0.9), []
+        )
+        == 0
+    )
+
+
+def test_strict_mode_passes_a_perfect_no_tool_conversation():
+    assert (
+        _metric(strict_mode=True, threshold=1)._calculate_score(
+            _selection(1.0), []
+        )
+        == 1.0
+    )


### PR DESCRIPTION
`ToolUseMetric` scores argument correctness only for interactions that actually called a tool:

```python
argument_correctness_scores = [
    self._get_argument_correctness_score(...)
    for user_and_tools in user_input_and_tools
    if user_and_tools.tools_used
]
```

When no turn calls a tool, that list is empty. `_calculate_score` still averages it -- a sum of 0 over a divisor forced to 1 -- and folds the resulting `0.0` into the `min()`:

```python
argument_correctness_score_divisor = (
    len(argument_correctness_scores)
    if len(argument_correctness_scores) > 0
    else 1
)
argument_correctness_score = arguments_scores_sum / argument_correctness_score_divisor
score = min(tools_selction_score, argument_correctness_score)
```

So a conversation where the model correctly answered without needing any tool scores 0, whatever the tool selection score says. That is the same score a model gets for picking every tool wrong. Any multi-turn suite with a mix of tool-requiring and conversational turns gets the conversational ones scored 0 and the aggregate dragged down, with no error and a reason string that reads as if tool use failed.

Fix: when there are no argument correctness scores, use the tool selection score alone. Whether a tool *should* have been called is already judged by the tool selection score, so a model that should have called one and did not still scores low -- the fallback does not mask it, and the second test below pins that.

Behaviour is unchanged whenever any tool was called: the same `min()` of the same two averages.

## Tests

`tests/test_metrics/test_tool_use_metric_score.py`. `_calculate_score` is called directly with scripted score lists and `__init__` is bypassed, so no model, network or API key is needed. The existing `tests/test_metrics/test_tool_use_metric.py` is skipped without `OPENAI_API_KEY` and does not assert on values.

On main, 5 of the 9 fail:

```
$ python -m pytest tests/test_metrics/test_tool_use_metric_score.py -q

______________ test_no_tools_used_falls_back_to_the_tool_selection_score ______________

>   assert _metric()._calculate_score(_selection(1.0), []) == 1.0
E   AssertionError: assert 0.0 == 1.0
E    +  where 0.0 = _calculate_score([ToolSelectionScore(score=1.0, reason='reason')], [])

______________ test_no_tools_used_preserves_a_bad_tool_selection_score[1.0] ___________

selection_score = 1.0

>   assert (
        _metric()._calculate_score(_selection(selection_score), [])
        == selection_score
    )
E   AssertionError: assert 0.0 == 1.0

_________________ test_strict_mode_passes_a_perfect_no_tool_conversation ______________

>   assert (
        _metric(strict_mode=True, threshold=1)._calculate_score(
            _selection(1.0), []
        )
        == 1.0
    )
E   AssertionError: assert 0 == 1.0

FAILED test_no_tools_used_falls_back_to_the_tool_selection_score
FAILED test_no_tools_used_preserves_a_bad_tool_selection_score[0.25]
FAILED test_no_tools_used_preserves_a_bad_tool_selection_score[0.5]
FAILED test_no_tools_used_preserves_a_bad_tool_selection_score[1.0]
FAILED test_strict_mode_passes_a_perfect_no_tool_conversation
5 failed, 4 passed in 11.61s
```

`test_no_tools_used_preserves_a_bad_tool_selection_score[0.0]` passes on main and after the fix -- a selection score of 0 stays 0 either way.

With the fix, 9 passed. `black` was run over the changed files.

Related but independent of #2965 (`ConversationalGEval` rubric range), #2966 (`EquityMedQA`/`GSM8K` accuracy denominators) and #2967 (`HumanEval` pass@k). No shared code or branches.
