### PR TITLE
fix(models): try direct JSON parse before trailing-comma regex (closes #2770)

### DIFF
--- a/deepeval/models/llms/utils.py
+++ b/deepeval/models/llms/utils.py
@@ -17,12 +17,17 @@ def trim_and_load_json(
         input_string = input_string + "}"
         end = len(input_string)
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
-    jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
     try:
         return json.loads(jsonStr)
     except json.JSONDecodeError:
-        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
-        raise DeepEvalError(error_str)
+        # Some models emit a trailing comma before a closing ] or }. Strip it
+        # and retry, but only after a direct parse fails, so valid JSON string
+        # values containing ", ]" or ", }" are never corrupted.
+        try:
+            return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
+        except json.JSONDecodeError:
+            error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+            raise DeepEvalError(error_str)
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
 

--- a/tests/test_models/test_trim_and_load_json.py
+++ b/tests/test_models/test_trim_and_load_json.py
@@ -1,0 +1,64 @@
+"""
+Regression tests for trim_and_load_json corrupting valid JSON string values
+(GitHub issue #2770).
+
+The function unconditionally ran ``re.sub(r",\\s*([\\]}])", r"\\1", jsonStr)``
+on the entire JSON string *before* parsing, so it could not distinguish a
+structural trailing comma from a comma that legitimately appears inside a
+string value.  PR #2701 fixed this in ``deepeval/metrics/utils.py`` and
+``deepeval/dataset/utils.py``, but the third copy in
+``deepeval/models/llms/utils.py`` was missed.
+
+The fix: try ``json.loads`` first; only fall back to the trailing-comma
+regex when the direct parse raises ``JSONDecodeError``.
+"""
+
+import pytest
+
+from deepeval.models.llms.utils import trim_and_load_json
+from deepeval.errors import DeepEvalError
+
+
+class TestTrimAndLoadJsonPreservesStringValues:
+    """Valid JSON must parse unchanged — commas inside strings are safe."""
+
+    def test_comma_before_brace_in_string_value(self):
+        """The exact reproduction from issue #2770."""
+        result = trim_and_load_json('{"reason": "score is 1,} good"}')
+        assert result == {"reason": "score is 1,} good"}
+
+    def test_comma_before_bracket_in_string_value(self):
+        result = trim_and_load_json('{"reason": "items: a,] done"}')
+        assert result == {"reason": "items: a,] done"}
+
+    def test_multiple_commas_in_string(self):
+        result = trim_and_load_json('{"verdict": "x, y, z]", "score": 0.8}')
+        assert result == {"verdict": "x, y, z]", "score": 0.8}
+
+    def test_clean_json_still_works(self):
+        result = trim_and_load_json('{"score": 1, "reason": "good"}')
+        assert result == {"score": 1, "reason": "good"}
+
+
+class TestTrimAndLoadJsonTrailingCommaFallback:
+    """The trailing-comma regex must still work as a fallback."""
+
+    def test_trailing_comma_before_brace(self):
+        result = trim_and_load_json('{"score": 1, "reason": "ok",}')
+        assert result == {"score": 1, "reason": "ok"}
+
+    def test_trailing_comma_before_bracket(self):
+        result = trim_and_load_json('{"items": [1, 2, 3,]}')
+        assert result == {"items": [1, 2, 3]}
+
+
+class TestTrimAndLoadJsonInvalidInput:
+    """Truly invalid JSON must raise DeepEvalError."""
+
+    def test_garbage_input(self):
+        with pytest.raises(DeepEvalError):
+            trim_and_load_json("not json at all")
+
+    def test_empty_string(self):
+        with pytest.raises(DeepEvalError):
+            trim_and_load_json("")


### PR DESCRIPTION
## Root Cause

`trim_and_load_json` in `deepeval/models/llms/utils.py` **unconditionally** ran `re.sub(r",\s*([\]}])", r"\1", jsonStr)` on the entire string before parsing. This corrupted valid JSON whose **string values** contained `, ]` or `, }` — e.g. `{"reason": "score is 1,} good"}` silently lost the comma inside the string.

PR #2701 fixed this in `deepeval/metrics/utils.py` and `deepeval/dataset/utils.py`, but the **third copy** in `models/llms/utils.py` was missed. This copy is imported by **every concrete model backend** (openai, anthropic, azure, bedrock, gemini, deepseek, litellm, grok, kimi, gateway), so any metric whose JSON `reason`/`verdict` free-text contains `, }` or `, ]` was silently corrupted.

## Fix

Try `json.loads()` first; only fall back to the trailing-comma regex when the direct parse raises `JSONDecodeError`. This is the exact same pattern already established by PR #2701 in the other two copies.

```python
# Before (buggy):
jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)  # ALWAYS strips
try:
    return json.loads(jsonStr)

# After (fixed):
try:
    return json.loads(jsonStr)  # Try direct parse first
except json.JSONDecodeError:
    try:
        return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))  # Fallback
    except json.JSONDecodeError:
        raise DeepEvalError(...)
```

## Test

- [x] 8 regression tests (`tests/test_models/test_trim_and_load_json.py`)
  - String value preservation (exact #2770 reproduction)
  - Comma before `}` and `]` in string values
  - Trailing-comma fallback still works
  - Invalid input error handling
- [x] ruff clean

## Diff scope

2 files changed, +74/-3 lines (8 lines fix + 67 lines tests)

## AI Disclosure

AI-assisted debug/initial draft/testing. Root cause from issue #2770 analysis + cross-reference with PR #2701 fix pattern. Tests verified locally. Human review of diff scope and correctness.