### PR TITLE
fix: replace PEP 604 unions that break imports on Python 3.9

### DIFF
--- a/deepeval/models/detoxify_model.py
+++ b/deepeval/models/detoxify_model.py
@@ -1,10 +1,12 @@
+from typing import Optional
+
 import torch
 from deepeval.models.base_model import DeepEvalBaseModel
 from detoxify import Detoxify
 
 
 class DetoxifyModel(DeepEvalBaseModel):
-    def __init__(self, model_name: str | None = None, *args, **kwargs):
+    def __init__(self, model_name: Optional[str] = None, *args, **kwargs):
         if model_name is not None:
             assert model_name in [
                 "original",

--- a/deepeval/models/unbias_model.py
+++ b/deepeval/models/unbias_model.py
@@ -3,7 +3,7 @@ from deepeval.models.base_model import DeepEvalBaseModel
 
 
 class UnBiasedModel(DeepEvalBaseModel):
-    def __init__(self, model_name: str | None = None, *args, **kwargs):
+    def __init__(self, model_name: Optional[str] = None, *args, **kwargs):
         model_name = "original" if model_name is None else model_name
         super().__init__(model_name, *args, **kwargs)
 

--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -1,7 +1,7 @@
 import json
 from threading import Lock
 
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any, Union
 from opentelemetry.sdk.trace.export import ReadableSpan
 
 from deepeval.test_case.api import create_api_test_case
@@ -38,7 +38,7 @@ def pop_pending_metrics(uuid: str) -> Optional[List[Any]]:
         return _pending_metrics_overlay.pop(uuid, None)
 
 
-def to_hex_string(id_value: int | bytes, length: int = 32) -> str:
+def to_hex_string(id_value: Union[int, bytes], length: int = 32) -> str:
     """
     Convert a trace ID or span ID to a hex string.
 

--- a/tests/test_core/test_py39_annotations.py
+++ b/tests/test_core/test_py39_annotations.py
@@ -1,0 +1,72 @@
+"""Guard against `X | Y` annotations that break imports on Python 3.9.
+
+PEP 604 unions in runtime-evaluated positions (function signatures, class
+attributes) raise TypeError at import time on 3.9 unless the module has
+`from __future__ import annotations`. This has been fixed twice (#2049,
+#2972); this test keeps new instances out regardless of the Python version
+running the suite.
+"""
+
+import ast
+from pathlib import Path
+
+import deepeval
+
+PACKAGE_ROOT = Path(deepeval.__file__).parent
+
+
+def _has_future_annotations(tree):
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == "annotations" for alias in node.names):
+                return True
+    return False
+
+
+def _contains_union(annotation):
+    return any(
+        isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr)
+        for node in ast.walk(annotation)
+    )
+
+
+def _runtime_union_annotation_lines(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            annotations = [
+                arg.annotation
+                for arg in (
+                    args.args
+                    + args.posonlyargs
+                    + args.kwonlyargs
+                    + ([args.vararg] if args.vararg else [])
+                    + ([args.kwarg] if args.kwarg else [])
+                )
+                if arg.annotation is not None
+            ]
+            if node.returns is not None:
+                annotations.append(node.returns)
+            for annotation in annotations:
+                if _contains_union(annotation):
+                    yield annotation.lineno
+        elif isinstance(node, ast.AnnAssign):
+            if _contains_union(node.annotation):
+                yield node.lineno
+
+
+def test_no_pep604_unions_in_runtime_annotations():
+    offenders = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        if _has_future_annotations(tree):
+            continue
+        for lineno in _runtime_union_annotation_lines(tree):
+            offenders.append(
+                f"{path.relative_to(PACKAGE_ROOT).as_posix()}:{lineno}"
+            )
+    assert not offenders, (
+        "PEP 604 unions evaluated at runtime break imports on Python 3.9. "
+        "Use typing.Union / typing.Optional, or add `from __future__ "
+        "import annotations` to: " + ", ".join(offenders)
+    )


### PR DESCRIPTION
Fixes #2972.

Follow-up to #2049. Three `X | Y` annotations remained after 0aed6f2, in files without `from __future__ import annotations`. They are evaluated at import time, so on Python 3.9 they raise `TypeError` and make `deepeval.tracing.otel`, `deepeval.instrument()`, and the unbias/detoxify scorer models unimportable. `pyproject.toml` still declares 3.9 support.

Replaced them with `Union` / `Optional` to match the earlier fix. `detoxify_model.py` had no typing import, so one was added. `unbias_model.py` already imported `Optional` unused, it is now used.

Tested on Python 3.9.25: all three modules import cleanly after the change, and an AST scan finds no remaining instances in the package. `black --check` passes at line length 80. No behavior change on 3.10+.

Update: added `tests/test_core/test_py39_annotations.py`, a guard test that AST-scans the whole package for `X | Y` in runtime-evaluated annotation positions in modules without the future import. This class of bug has now been fixed twice (#2049, here), so the test is there to keep it fixed. It lives under `tests/test_core/` so the existing core CI job runs it on every PR, and it works on any Python version since it inspects source rather than importing. Against the unfixed tree it fails naming exactly the three files above; on this branch it passes.
