### PR TITLE
fix: use UTF-8 for prompt template and .env file IO

### DIFF
--- a/deepeval/cli/dotenv_handler.py
+++ b/deepeval/cli/dotenv_handler.py
@@ -25,7 +25,11 @@ class DotenvHandler:
         Idempotently set/replace keys in a dotenv file. Preserves comments/order.
         Creates file if missing. Sets file mode to 0600 when possible.
         """
-        lines = self.path.read_text().splitlines() if self.path.exists() else []
+        lines = (
+            self.path.read_text(encoding="utf-8").splitlines()
+            if self.path.exists()
+            else []
+        )
         seen = set()
 
         # replace existing keys in-place
@@ -50,7 +54,9 @@ class DotenvHandler:
             lines.extend(to_append)
 
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text("\n".join(lines) + ("\n" if lines else ""))
+        self.path.write_text(
+            "\n".join(lines) + ("\n" if lines else ""), encoding="utf-8"
+        )
         try:
             self.path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
         except Exception:
@@ -60,7 +66,7 @@ class DotenvHandler:
         """Remove keys from dotenv file, but leave comments and other lines untouched."""
         if not self.path.exists():
             return
-        lines = self.path.read_text().splitlines()
+        lines = self.path.read_text(encoding="utf-8").splitlines()
         out = []
         keys = set(keys)
         for line in lines:
@@ -68,4 +74,6 @@ class DotenvHandler:
             if m and m.group(1) in keys:
                 continue
             out.append(line)
-        self.path.write_text("\n".join(out) + ("\n" if out else ""))
+        self.path.write_text(
+            "\n".join(out) + ("\n" if out else ""), encoding="utf-8"
+        )

--- a/deepeval/prompt/prompt.py
+++ b/deepeval/prompt/prompt.py
@@ -202,7 +202,7 @@ class Prompt:
 
         file_name = os.path.basename(file_path).split(".")[0]
         self.alias = file_name
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
         try:
             data = json.loads(content)

--- a/tests/test_core/test_cli/test_dotenv_handler.py
+++ b/tests/test_core/test_cli/test_dotenv_handler.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from deepeval.cli.dotenv_handler import DotenvHandler
+
+# Written as bytes so the fixture is the same on every platform, whatever the
+# ANSI codepage happens to be.
+EXISTING_ENV = (
+    "# comentário do usuário\n"
+    'APP_GREETING="Ángel-gpt4"\n'
+    "APP_THANKS=ありがとう\n"
+    "OPENAI_API_KEY=sk-old\n"
+).encode("utf-8")
+
+
+def test_upsert_preserves_unrelated_non_ascii_values(tmp_path: Path):
+    env_path = tmp_path / ".env.local"
+    env_path.write_bytes(EXISTING_ENV)
+
+    DotenvHandler(env_path).upsert({"OPENAI_API_KEY": "sk-new"})
+
+    raw = env_path.read_bytes()
+    assert "# comentário do usuário".encode("utf-8") in raw
+    assert 'APP_GREETING="Ángel-gpt4"'.encode("utf-8") in raw
+    assert "APP_THANKS=ありがとう".encode("utf-8") in raw
+
+    values = dotenv_values(env_path)
+    assert values["OPENAI_API_KEY"] == "sk-new"
+    assert values["APP_GREETING"] == "Ángel-gpt4"
+    assert values["APP_THANKS"] == "ありがとう"
+
+
+def test_upsert_writes_non_ascii_values_readable_by_dotenv(tmp_path: Path):
+    env_path = tmp_path / ".env.local"
+
+    DotenvHandler(env_path).upsert(
+        {
+            "AZURE_DEPLOYMENT": "Ángel-gpt4",
+            "APP_THANKS": "ありがとう",
+            "APP_NOTE": "café au lait",
+        }
+    )
+
+    values = dotenv_values(env_path)
+    assert values["AZURE_DEPLOYMENT"] == "Ángel-gpt4"
+    assert values["APP_THANKS"] == "ありがとう"
+    assert values["APP_NOTE"] == "café au lait"
+
+
+def test_upsert_roundtrips_non_ascii_across_two_calls(tmp_path: Path):
+    env_path = tmp_path / ".env.local"
+    handler = DotenvHandler(env_path)
+
+    handler.upsert({"AZURE_DEPLOYMENT": "Ángel-gpt4"})
+    handler.upsert({"OPENAI_API_KEY": "sk-new"})
+
+    values = dotenv_values(env_path)
+    assert values["AZURE_DEPLOYMENT"] == "Ángel-gpt4"
+    assert values["OPENAI_API_KEY"] == "sk-new"
+
+
+def test_unset_removes_only_its_key(tmp_path: Path):
+    env_path = tmp_path / ".env.local"
+    env_path.write_bytes(EXISTING_ENV)
+
+    DotenvHandler(env_path).unset(["OPENAI_API_KEY"])
+
+    raw = env_path.read_bytes()
+    assert b"OPENAI_API_KEY" not in raw
+    assert "# comentário do usuário".encode("utf-8") in raw
+    assert 'APP_GREETING="Ángel-gpt4"'.encode("utf-8") in raw
+    assert "APP_THANKS=ありがとう".encode("utf-8") in raw
+
+    values = dotenv_values(env_path)
+    assert "OPENAI_API_KEY" not in values
+    assert values["APP_GREETING"] == "Ángel-gpt4"
+    assert values["APP_THANKS"] == "ありがとう"

--- a/tests/test_core/test_prompts/test_load.py
+++ b/tests/test_core/test_prompts/test_load.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 import os
 import tempfile
 from deepeval.prompt.prompt import Prompt
@@ -245,5 +246,65 @@ class TestPromptLoad:
             assert len(prompt.messages_template) == 1
             assert prompt.messages_template[0].role == "system"
             assert prompt.messages_template[0].content == "Test"
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_load_utf8_text_file(self):
+        prompt = Prompt()
+        content = "Don’t guess — answer in 中文 (你好)."
+        with tempfile.NamedTemporaryFile(
+            suffix=".txt", delete=False
+        ) as temp_file:
+            temp_file.write(content.encode("utf-8"))
+            temp_file_path = temp_file.name
+
+        try:
+            prompt.load(temp_file_path)
+            assert prompt.text_template == content
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_load_utf8_json_list_format(self):
+        prompt = Prompt()
+        system_content = "You are a helpful assistant — be concise."
+        user_content = "你好, “what’s the weather”?"
+        json_content = json.dumps(
+            [
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content},
+            ],
+            ensure_ascii=False,
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", delete=False
+        ) as temp_file:
+            temp_file.write(json_content.encode("utf-8"))
+            temp_file_path = temp_file.name
+
+        try:
+            prompt.load(temp_file_path)
+            assert prompt.messages_template is not None
+            assert prompt.messages_template[0].content == system_content
+            assert prompt.messages_template[1].content == user_content
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_load_utf8_json_dict_format(self):
+        prompt = Prompt()
+        content = "한국어 — “quoted”"
+        json_content = json.dumps(
+            {"messages": [{"role": "system", "content": content}]},
+            ensure_ascii=False,
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", delete=False
+        ) as temp_file:
+            temp_file.write(json_content.encode("utf-8"))
+            temp_file_path = temp_file.name
+
+        try:
+            prompt.load(temp_file_path, messages_key="messages")
+            assert prompt.messages_template is not None
+            assert prompt.messages_template[0].content == content
         finally:
             os.unlink(temp_file_path)


### PR DESCRIPTION
Fixes #2975.

`Prompt.load()` opened template files, and `DotenvHandler` read and wrote `.env` files, with no encoding argument, so on Windows both used the ANSI codepage instead of UTF-8. A UTF-8 text template with curly quotes loads as mojibake with no error and gets sent to the model; JSON templates with CJK content raise UnicodeDecodeError; and the dotenv writer produced ANSI files that the UTF-8 read path (`deepeval/config/utils.py:150`, python-dotenv) then fails to parse back, including values it never touched, since `upsert()` rewrites the whole file.

The change is `encoding="utf-8"` on the one `open()` in `Prompt.load` and the four `read_text`/`write_text` calls in `DotenvHandler`. The prompt cache files were left alone on purpose: they go through `json.dump` with `ensure_ascii=True`, so they are ASCII by construction and safe under any codepage.

Tests: three new loads in `test_load.py` covering the silent-mojibake and UnicodeDecodeError cases, and a new `test_dotenv_handler.py` covering upsert/unset round-trips with non-ASCII values next to untouched keys. All seven fail on the unfixed code on cp1252 Windows and pass with the fix. `tests/test_core` minus the CI-ignored dirs: 1174 passed, with 2 pre-existing Windows failures unrelated to this change (one is the expanduser test from #2906). `black --check` clean at line length 80. No behavior change on platforms whose default encoding is already UTF-8.
