### PR TITLE
feat(benchmarks): add MMLU-Pro benchmark

### DIFF
--- a/deepeval/benchmarks/__init__.py
+++ b/deepeval/benchmarks/__init__.py
@@ -1,5 +1,6 @@
 from .big_bench_hard.big_bench_hard import BigBenchHard
 from .mmlu.mmlu import MMLU
+from .mmlu_pro.mmlu_pro import MMLUPro
 from .hellaswag.hellaswag import HellaSwag
 from .drop.drop import DROP
 from .truthful_qa.truthful_qa import TruthfulQA
@@ -19,6 +20,7 @@ from .ifeval.ifeval import IFEval
 __all__ = [
     "BigBenchHard",
     "MMLU",
+    "MMLUPro",
     "HellaSwag",
     "DROP",
     "TruthfulQA",

--- a/deepeval/benchmarks/mmlu_pro/mmlu_pro.py
+++ b/deepeval/benchmarks/mmlu_pro/mmlu_pro.py
@@ -10,7 +10,7 @@ from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.mmlu_pro.task import MMLUProTask
 from deepeval.benchmarks.mmlu_pro.template import MMLUProTemplate
 from deepeval.benchmarks.utils import should_use_batch
-from deepeval.benchmarks.schema import MultipleChoiceSchema
+from deepeval.benchmarks.schema import MultipleChoiceSchemaTenOptions
 from deepeval.telemetry import capture_benchmark_run
 
 
@@ -175,7 +175,9 @@ class MMLUPro(DeepEvalBaseBenchmark):
         )
 
         try:
-            res = model.generate(prompt=prompt, schema=MultipleChoiceSchema)
+            res = model.generate(
+                prompt=prompt, schema=MultipleChoiceSchemaTenOptions
+            )
             if isinstance(res, (tuple, list)):
                 prediction = res[0].answer
             else:
@@ -213,11 +215,11 @@ class MMLUPro(DeepEvalBaseBenchmark):
         try:
             responses = model.batch_generate(
                 prompts=prompts,
-                schemas=[MultipleChoiceSchema for i in prompts],
+                schemas=[MultipleChoiceSchemaTenOptions for i in prompts],
             )
             if not isinstance(responses, list):
                 raise TypeError(
-                    "batch_generate must return List[MultipleChoiceSchema]"
+                    "batch_generate must return List[MultipleChoiceSchemaTenOptions]"
                 )
             predictions = [res.answer for res in responses]
         except TypeError:

--- a/deepeval/benchmarks/mmlu_pro/mmlu_pro.py
+++ b/deepeval/benchmarks/mmlu_pro/mmlu_pro.py
@@ -1,0 +1,287 @@
+from typing import List, Optional, Dict, Union
+from tqdm import tqdm
+
+from deepeval.dataset import Golden
+from deepeval.benchmarks.base_benchmark import (
+    DeepEvalBaseBenchmark,
+    DeepEvalBaseBenchmarkResult,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.benchmarks.mmlu_pro.task import MMLUProTask
+from deepeval.benchmarks.mmlu_pro.template import MMLUProTemplate
+from deepeval.benchmarks.utils import should_use_batch
+from deepeval.benchmarks.schema import MultipleChoiceSchema
+from deepeval.telemetry import capture_benchmark_run
+
+
+class MMLUPro(DeepEvalBaseBenchmark):
+    def __init__(
+        self,
+        tasks: Optional[List[MMLUProTask]] = None,
+        n_shots: int = 5,
+        n_problems_per_task: Optional[int] = None,
+        verbose_mode: bool = False,
+        confinement_instructions: Optional[str] = None,
+        **kwargs,
+    ):
+        from deepeval.scorer import Scorer
+
+        super().__init__(**kwargs)
+        self.tasks: List[MMLUProTask] = (
+            list(MMLUProTask) if tasks is None else tasks
+        )
+        self.n_problems_per_task: Optional[int] = n_problems_per_task
+        self.scorer = Scorer()
+        self.shots_dataset: List[Dict] = None
+        self.n_shots: int = n_shots
+        self.predictions = None
+        self.task_scores = None
+        self.overall_score = None
+        self.verbose_mode: bool = verbose_mode
+        if not confinement_instructions:
+            self.confinement_instructions = (
+                "Output only the letter of your answer: "
+                "'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', or 'J'. "
+                "Full answer not needed."
+            )
+        else:
+            self.confinement_instructions = confinement_instructions
+
+    def evaluate(
+        self,
+        model: DeepEvalBaseLLM,
+        *args,
+        batch_size: Union[int, None] = None,
+        **kwargs,
+    ) -> DeepEvalBaseBenchmarkResult:
+        import pandas as pd
+
+        with capture_benchmark_run("MMLU-Pro", len(self.tasks)):
+            overall_correct_predictions = 0
+            overall_total_predictions = 0
+            predictions_row = []
+            scores_row = []
+            use_batch = should_use_batch(model, batch_size)
+
+            for task in self.tasks:
+                goldens = self.load_benchmark_dataset(task)
+                if (
+                    self.n_problems_per_task is not None
+                    and self.n_problems_per_task < len(goldens)
+                ):
+                    goldens = goldens[: self.n_problems_per_task]
+                task_correct_predictions = 0
+                task_total_predictions = len(goldens)
+                overall_total_predictions += len(goldens)
+
+                if use_batch:
+                    for i in tqdm(
+                        range(0, len(goldens), batch_size),
+                        desc=f"Batch Processing {task.value} (batch_size={batch_size})",
+                    ):
+                        goldens_batch = goldens[i : i + batch_size]
+                        batch_predictions = self.batch_predict(
+                            model, task, goldens_batch
+                        )
+                        for golden, prediction_dict in zip(
+                            goldens_batch, batch_predictions
+                        ):
+                            prediction = prediction_dict["prediction"]
+                            score = prediction_dict["score"]
+                            if score:
+                                task_correct_predictions += 1
+                                overall_correct_predictions += 1
+                            predictions_row.append(
+                                (
+                                    task.value,
+                                    golden.input,
+                                    prediction,
+                                    golden.expected_output,
+                                    score,
+                                )
+                            )
+                else:
+                    for idx, golden in enumerate(
+                        tqdm(goldens, desc=f"Processing {task.value}")
+                    ):
+                        prediction, score = self.predict(
+                            model, task, golden
+                        ).values()
+                        if score:
+                            task_correct_predictions += 1
+                            overall_correct_predictions += 1
+                        predictions_row.append(
+                            (
+                                task.value,
+                                golden.input,
+                                prediction,
+                                golden.expected_output,
+                                score,
+                            )
+                        )
+                        if self.verbose_mode:
+                            self.print_verbose_logs(
+                                idx,
+                                task.value,
+                                golden.input,
+                                golden.expected_output,
+                                prediction,
+                                score,
+                            )
+
+                task_accuracy = (
+                    task_correct_predictions / task_total_predictions
+                )
+                print(
+                    f"MMLU-Pro Task Accuracy (task={task.value}): {task_accuracy}"
+                )
+                scores_row.append((task.value, task_accuracy))
+
+            overall_accuracy = (
+                overall_correct_predictions / overall_total_predictions
+            )
+            print(f"Overall MMLU-Pro Accuracy: {overall_accuracy}")
+
+            self.predictions = pd.DataFrame(
+                predictions_row,
+                columns=[
+                    "Task",
+                    "Input",
+                    "Prediction",
+                    "Expected Output",
+                    "Correct",
+                ],
+            )
+            self.task_scores = pd.DataFrame(
+                scores_row, columns=["Task", "Score"]
+            )
+            self.overall_score = overall_accuracy
+
+            return DeepEvalBaseBenchmarkResult(
+                overall_accuracy=overall_accuracy
+            )
+
+    def predict(
+        self, model: DeepEvalBaseLLM, task: MMLUProTask, golden: Golden
+    ) -> Dict:
+        assert (
+            self.shots_dataset is not None
+        ), "Example dataset is empty. Call load_benchmark_dataset."
+        prompt = MMLUProTemplate.generate_output(
+            train_set=self.shots_dataset,
+            input=golden.input,
+            task=task,
+            n_shots=self.n_shots,
+        )
+
+        try:
+            res = model.generate(prompt=prompt, schema=MultipleChoiceSchema)
+            if isinstance(res, (tuple, list)):
+                prediction = res[0].answer
+            else:
+                prediction = res.answer
+        except TypeError:
+            prompt += f"\n\n{self.confinement_instructions}"
+            prediction = model.generate(prompt)
+
+        if isinstance(prediction, tuple):
+            prediction = prediction[0]
+        prediction = str(prediction)
+
+        score = self.scorer.exact_match_score(
+            golden.expected_output, prediction
+        )
+        return {"prediction": prediction, "score": score}
+
+    def batch_predict(
+        self, model: DeepEvalBaseLLM, task: MMLUProTask, goldens: List[Golden]
+    ) -> List[Dict]:
+        assert (
+            self.shots_dataset is not None
+        ), "Example dataset is empty. Call load_benchmark_dataset."
+
+        prompts = []
+        for golden in goldens:
+            prompt = MMLUProTemplate.generate_output(
+                train_set=self.shots_dataset,
+                input=golden.input,
+                task=task,
+                n_shots=self.n_shots,
+            )
+            prompts.append(prompt)
+
+        try:
+            responses = model.batch_generate(
+                prompts=prompts,
+                schemas=[MultipleChoiceSchema for i in prompts],
+            )
+            if not isinstance(responses, list):
+                raise TypeError(
+                    "batch_generate must return List[MultipleChoiceSchema]"
+                )
+            predictions = [res.answer for res in responses]
+        except TypeError:
+            prompts = [
+                prompt + f"\n\n{self.confinement_instructions}"
+                for prompt in prompts
+            ]
+            predictions = model.batch_generate(prompts)
+
+        if len(predictions) is not len(goldens):
+            raise ValueError(
+                "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
+            )
+
+        res = []
+        for i in range(len(predictions)):
+            score = self.scorer.exact_match_score(
+                goldens[i].expected_output, predictions[i]
+            )
+            res.append({"prediction": predictions[i], "score": score})
+        return res
+
+    def load_benchmark_dataset(self, task: MMLUProTask) -> List[Golden]:
+        from datasets import load_dataset
+
+        if not hasattr(self, "dataset") or self.dataset is None:
+            self.dataset = load_dataset("TIGER-Lab/MMLU-Pro")
+
+        self.shots_dataset = [
+            data
+            for data in self.dataset["validation"]
+            if data["category"] == task.value
+        ]
+
+        goldens: List[Golden] = []
+        for data in self.dataset["test"]:
+            if data["category"] != task.value:
+                continue
+            input = MMLUProTemplate.format_question(data, include_answer=False)
+            goldens.append(Golden(input=input, expected_output=data["answer"]))
+        return goldens
+
+    def print_verbose_logs(
+        self,
+        idx: int,
+        task_value: str,
+        input: str,
+        expected_output: str,
+        prediction: str,
+        score: int,
+    ) -> str:
+        steps = [
+            f"Input:\n{input}",
+            f"Score: {score}\nPrediction: {prediction}\nExpected Output: {expected_output}",
+        ]
+        verbose_logs = steps[0]
+
+        if self.verbose_mode:
+            print("*" * 50)
+            print(f"Problem {idx + 1} (Task = {task_value})")
+            print("*" * 50)
+            print("")
+            print(verbose_logs + f"\n \n{steps[-1]}")
+            print("")
+            print("=" * 70)
+
+        return verbose_logs

--- a/deepeval/benchmarks/mmlu_pro/task.py
+++ b/deepeval/benchmarks/mmlu_pro/task.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class MMLUProTask(Enum):
+    MATH = "math"
+    PHYSICS = "physics"
+    CHEMISTRY = "chemistry"
+    BIOLOGY = "biology"
+    LAW = "law"
+    ENGINEERING = "engineering"
+    OTHER = "other"
+    ECONOMICS = "economics"
+    HEALTH = "health"
+    PSYCHOLOGY = "psychology"
+    BUSINESS = "business"
+    PHILOSOPHY = "philosophy"
+    HISTORY = "history"
+    COMPUTER_SCIENCE = "computer science"

--- a/deepeval/benchmarks/mmlu_pro/template.py
+++ b/deepeval/benchmarks/mmlu_pro/template.py
@@ -1,0 +1,26 @@
+from deepeval.benchmarks.mmlu_pro.task import MMLUProTask
+
+
+class MMLUProTemplate:
+
+    @staticmethod
+    def generate_output(
+        input: str, train_set: object, task: MMLUProTask, n_shots: int
+    ):
+        prompt = "The following are multiple choice questions (with answers) about {}.\n\n"
+        prompt = prompt.format(task.value)
+        for i in range(min(n_shots, len(train_set))):
+            prompt += MMLUProTemplate.format_question(train_set[i])
+        prompt += input
+        return prompt
+
+    @staticmethod
+    def format_question(data: dict, include_answer: bool = True):
+        choices = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+        prompt = data["question"]
+        for j in range(len(data["options"])):
+            prompt += "\n{}. {}".format(choices[j], data["options"][j])
+        prompt += "\nAnswer:"
+        if include_answer:
+            prompt += " {}\n\n".format(data["answer"])
+        return prompt

--- a/deepeval/benchmarks/schema.py
+++ b/deepeval/benchmarks/schema.py
@@ -47,6 +47,17 @@ class MultipleChoiceSchemaLower(BaseModel):
     answer: Literal["a", "b", "c", "d", "e"]
 
 
+# MMLU-Pro Models #############################
+
+
+class MultipleChoiceSchemaTenOptions(BaseModel):
+    # MMLU-Pro expands MMLU's four options to ten (A-J). The four-letter
+    # MultipleChoiceSchema cannot represent the gold answer for the ~55% of
+    # items answered E-J, so schema-constrained models could never emit those
+    # letters and those items were always scored 0.
+    answer: Literal["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+
+
 # DROP Models #############################
 
 

--- a/docs/content/docs/(benchmarks)/benchmarks-mmlu-pro.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-mmlu-pro.mdx
@@ -1,0 +1,127 @@
+---
+id: benchmarks-mmlu-pro
+title: MMLU-Pro
+sidebar_label: MMLU-Pro
+---
+
+**MMLU-Pro** is an enhanced version of MMLU, designed to be more challenging and more robust. It expands the answer set from 4 to **10 options** per question and removes trivial or noisy items, spanning **14 broad categories** such as math, physics, law, and engineering. For more information, [visit the MMLU-Pro dataset page](https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro).
+
+:::tip
+`MMLU-Pro` reduces the chance of a model scoring well by guessing, since random guessing yields roughly **10%** rather than 25%. It is a better choice than `MMLU` when evaluating stronger models that have saturated the original benchmark.
+:::
+
+## Arguments
+
+There are **FOUR** optional arguments when using the `MMLU-Pro` benchmark:
+
+- [Optional] `tasks`: a list of tasks (`MMLUProTask` enums), specifying which of the **14 categories** to evaluate in the language model. By default, this is set to all tasks. Detailed descriptions of the `MMLUProTask` enum can be found [here](#mmlu-pro-tasks).
+- [Optional] `n_shots`: the number of "shots" to use for few-shot learning. This is set to **5 by default**.
+- [Optional] `n_problems_per_task`: the number of problems to evaluate per task. By default, all problems in a category are used.
+- [Optional] `verbose_mode`: a boolean which prints each problem, prediction, and expected output as the benchmark runs. Defaults to `False`.
+
+## Usage
+
+The code below evaluates a custom `mistral_7b` model ([click here to learn how to use **ANY** custom LLM](/docs/benchmarks-introduction#benchmarking-your-llm)) and assesses its performance on Computer Science and Physics using 3-shot learning.
+
+```python
+from deepeval.benchmarks import MMLUPro
+from deepeval.benchmarks.mmlu_pro.task import MMLUProTask
+
+# Define benchmark with specific tasks and shots
+benchmark = MMLUPro(
+    tasks=[MMLUProTask.COMPUTER_SCIENCE, MMLUProTask.PHYSICS],
+    n_shots=3
+)
+
+# Replace 'mistral_7b' with your own custom model
+benchmark.evaluate(model=mistral_7b)
+print(benchmark.overall_score)
+```
+
+The `overall_score` for this benchmark ranges from 0 to 1, where 1 signifies perfect performance and 0 indicates no correct answers. The model's score, based on **exact matching**, is calculated by determining the proportion of multiple-choice questions for which the model produces the precise correct letter answer (e.g. 'A') in relation to the total number of questions.
+
+As a result, utilizing more few-shot prompts (`n_shots`) can greatly improve the model's robustness in generating answers in the exact correct format and boost the overall score.
+
+## MMLU-Pro Tasks
+
+The `MMLUProTask` enum classifies the 14 categories covered in the MMLU-Pro benchmark.
+
+```python
+from deepeval.benchmarks.mmlu_pro.task import MMLUProTask
+
+mmlu_pro_tasks = [MMLUProTask.BIOLOGY]
+```
+
+Below is the comprehensive list of all available tasks:
+
+- `MATH`
+- `PHYSICS`
+- `CHEMISTRY`
+- `BIOLOGY`
+- `LAW`
+- `ENGINEERING`
+- `OTHER`
+- `ECONOMICS`
+- `HEALTH`
+- `PSYCHOLOGY`
+- `BUSINESS`
+- `PHILOSOPHY`
+- `HISTORY`
+- `COMPUTER_SCIENCE`
+
+## FAQs
+
+<FAQs
+  qas={[
+    {
+      question: "How is `MMLU-Pro` different from `MMLU`?",
+      answer: (
+        <>
+          <code>MMLU-Pro</code> expands each question from 4 to{" "}
+          <strong>10 answer options</strong>, removes noisy and trivial
+          questions, and groups content into <strong>14 broad categories</strong>{" "}
+          instead of 57 narrow subjects. This makes it substantially harder and
+          less susceptible to correct answers arrived at by guessing.
+        </>
+      ),
+    },
+    {
+      question: "How is `MMLU-Pro` scored?",
+      answer: (
+        <>
+          The <code>overall_score</code> ranges from 0 to 1 and is based on{" "}
+          <strong>exact matching</strong>: it is the proportion of
+          multiple-choice questions for which the model produces the precise
+          correct letter answer (e.g. 'A'). See the{" "}
+          <a href="/docs/benchmarks-introduction">benchmarks introduction</a> for
+          how scoring works across benchmarks.
+        </>
+      ),
+    },
+    {
+      question: "Do all questions have 10 options?",
+      answer: (
+        <>
+          Most do, but a small number of questions have fewer. The benchmark
+          formats each question using however many options it actually has, so
+          no placeholder choices are shown to the model.
+        </>
+      ),
+    },
+    {
+      question: "How do I run `MMLU-Pro` on a custom LLM?",
+      answer: (
+        <>
+          Wrap your model in <code>DeepEvalBaseLLM</code>, create a benchmark
+          with <code>MMLUPro(tasks=[...], n_shots=3)</code>, and call{" "}
+          <code>benchmark.evaluate(model=mistral_7b)</code>. You can then read{" "}
+          <code>benchmark.overall_score</code>. See the{" "}
+          <a href="/docs/benchmarks-introduction#benchmarking-your-llm">
+            benchmarking guide
+          </a>{" "}
+          for using any custom LLM.
+        </>
+      ),
+    },
+  ]}
+/>

--- a/docs/content/docs/(benchmarks)/meta.json
+++ b/docs/content/docs/(benchmarks)/meta.json
@@ -2,6 +2,7 @@
   "title": "Available Benchmarks",
   "pages": [
     "benchmarks-mmlu",
+    "benchmarks-mmlu-pro",
     "benchmarks-hellaswag",
     "benchmarks-big-bench-hard",
     "benchmarks-drop",


### PR DESCRIPTION
## Summary

Adds the **MMLU-Pro** benchmark, addressing part of #508 and extending Open LLM Leaderboard v2 coverage (`IFEval` and `BigBenchHard` are already supported; MMLU-Pro, GPQA, MuSR and MATH were not).

MMLU-Pro is the harder successor to MMLU: 10 answer options instead of 4, noisy and trivial questions removed, and content grouped into 14 broad categories rather than 57 narrow subjects. Random guessing scores ~10% rather than 25%, which makes it more useful for models that have saturated MMLU.

## Usage

```python
from deepeval.benchmarks import MMLUPro
from deepeval.benchmarks.mmlu_pro.task import MMLUProTask

benchmark = MMLUPro(
    tasks=[MMLUProTask.COMPUTER_SCIENCE, MMLUProTask.PHYSICS],
    n_shots=3,
)
benchmark.evaluate(model=my_model)
print(benchmark.overall_score)
```

## Implementation notes

Modelled closely on the existing `mmlu/` module — same `DeepEvalBaseBenchmark` subclass structure, same `evaluate()` / `predict()` / `batch_predict()` pattern, with schema-constrained generation and a plain-text fallback for models that don't support structured output. MMLU-Pro needs a ten-letter schema rather than the four-letter `MultipleChoiceSchema`, so this adds `MultipleChoiceSchemaTenOptions` alongside the existing `MultipleChoiceSchemaLower` and BBH arity schemas.

Three MMLU-Pro-specific differences worth flagging:

- **Variable option count.** Most questions have 10 options but some have fewer, so the template iterates `len(data["options"])` rather than assuming 10. No placeholder choices are shown to the model.
- **Answers are already letters.** MMLU stores an integer index into the choices list; MMLU-Pro stores the letter directly, so no index lookup is needed.
- **Per-task few-shot examples.** MMLU-Pro keeps all categories in a single `validation` split, so shots are filtered per category on each `load_benchmark_dataset` call — caching globally would feed e.g. physics examples into law questions.

## Testing

Verified end to end against stub models on the `BIOLOGY` task, covering both generation paths:

- **Plain-text fallback** (stub whose `generate()` takes no `schema`): always answering "A" scores 0.0; returning the known-correct answers scores 1.0.
- **Schema path** (stub that accepts a `schema` and returns through it): over 40 items spanning all ten gold letters, the four-letter `MultipleChoiceSchema` rejects gold "I" while `MultipleChoiceSchemaTenOptions` accepts A–J. Both `predict()` and `batch_predict()` (batch_size=10) score 1.0.

Also confirmed questions with fewer than 10 options render without placeholder choices.

Files formatted with `black --line-length 80` per `pyproject.toml`.

## Docs

Added `docs/content/docs/(benchmarks)/benchmarks-mmlu-pro.mdx` and registered it in `meta.json`.