### PR TITLE
fix: add UTF-8 encoding to text file open() calls

### DIFF
--- a/deepeval/models/_summac_model.py
+++ b/deepeval/models/_summac_model.py
@@ -273,7 +273,7 @@ class _SummaCImager:
 
     def save_cache(self):
         cache_cp = {"[///]".join(k): v.tolist() for k, v in self.cache.items()}
-        with open(self.get_cache_file(), "w") as f:
+        with open(self.get_cache_file(), "w", encoding="utf-8") as f:
             json.dump(cache_cp, f)
 
     def load_cache(self):
@@ -281,7 +281,7 @@ class _SummaCImager:
 
         cache_file = self.get_cache_file()
         if os.path.isfile(cache_file):
-            with open(cache_file, "r") as f:
+            with open(cache_file, "r", encoding="utf-8") as f:
                 cache_cp = json.load(f)
                 self.cache = {
                     tuple(k.split("[///]")): np.array(v)

--- a/deepeval/prompt/prompt.py
+++ b/deepeval/prompt/prompt.py
@@ -202,7 +202,7 @@ class Prompt:
 
         file_name = os.path.basename(file_path).split(".")[0]
         self.alias = file_name
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
         try:
             data = json.loads(content)

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -257,7 +257,7 @@ class ToolCall(BaseModel):
         validation_alias=AliasChoices("inputParameters", "input_parameters"),
     )
 
-    @field_serializer('type')
+    @field_serializer("type")
     def serialize_type(self, value: ToolCallType) -> str:
         return value.value
 

--- a/deepeval/utils.py
+++ b/deepeval/utils.py
@@ -692,7 +692,7 @@ def get_freer_gpu():
     os.system("nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp_smi")
     memory_available = [
         int(x.split()[2]) + 5 * i
-        for i, x in enumerate(open("tmp_smi", "r").readlines())
+        for i, x in enumerate(open("tmp_smi", "r", encoding="utf-8").readlines())
     ]
     os.remove("tmp_smi")
     return np.argmax(memory_available)
@@ -702,7 +702,7 @@ def any_gpu_with_space(gb_needed):
     os.system("nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp_smi")
     memory_available = [
         float(x.split()[2]) / 1024.0
-        for i, x in enumerate(open("tmp_smi", "r").readlines())
+        for i, x in enumerate(open("tmp_smi", "r", encoding="utf-8").readlines())
     ]
     os.remove("tmp_smi")
     return any([mem >= gb_needed for mem in memory_available])

--- a/deepeval/utils.py
+++ b/deepeval/utils.py
@@ -692,7 +692,9 @@ def get_freer_gpu():
     os.system("nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp_smi")
     memory_available = [
         int(x.split()[2]) + 5 * i
-        for i, x in enumerate(open("tmp_smi", "r", encoding="utf-8").readlines())
+        for i, x in enumerate(
+            open("tmp_smi", "r", encoding="utf-8").readlines()
+        )
     ]
     os.remove("tmp_smi")
     return np.argmax(memory_available)
@@ -702,7 +704,9 @@ def any_gpu_with_space(gb_needed):
     os.system("nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp_smi")
     memory_available = [
         float(x.split()[2]) / 1024.0
-        for i, x in enumerate(open("tmp_smi", "r", encoding="utf-8").readlines())
+        for i, x in enumerate(
+            open("tmp_smi", "r", encoding="utf-8").readlines()
+        )
     ]
     os.remove("tmp_smi")
     return any([mem >= gb_needed for mem in memory_available])

--- a/tests/test_encoding_consistency.py
+++ b/tests/test_encoding_consistency.py
@@ -42,9 +42,9 @@ class TestFileEncodingConsistency:
             os.path.dirname(__file__), "..", "deepeval", "prompt", "prompt.py"
         )
         issues = self._get_open_calls_without_encoding(filepath)
-        assert not issues, (
-            f"prompt.py has open() calls without encoding at lines: {issues}"
-        )
+        assert (
+            not issues
+        ), f"prompt.py has open() calls without encoding at lines: {issues}"
 
     def test_summac_model_uses_utf8(self):
         """_summac_model.py cache save/load must use UTF-8."""
@@ -56,9 +56,9 @@ class TestFileEncodingConsistency:
             "_summac_model.py",
         )
         issues = self._get_open_calls_without_encoding(filepath)
-        assert not issues, (
-            f"_summac_model.py has open() calls without encoding at lines: {issues}"
-        )
+        assert (
+            not issues
+        ), f"_summac_model.py has open() calls without encoding at lines: {issues}"
 
     def test_utils_uses_utf8(self):
         """utils.py GPU memory readers must use UTF-8."""
@@ -66,6 +66,6 @@ class TestFileEncodingConsistency:
             os.path.dirname(__file__), "..", "deepeval", "utils.py"
         )
         issues = self._get_open_calls_without_encoding(filepath)
-        assert not issues, (
-            f"utils.py has open() calls without encoding at lines: {issues}"
-        )
+        assert (
+            not issues
+        ), f"utils.py has open() calls without encoding at lines: {issues}"

--- a/tests/test_encoding_consistency.py
+++ b/tests/test_encoding_consistency.py
@@ -1,0 +1,71 @@
+"""
+Regression test for file encoding consistency (closes encoding audit).
+
+Several open() calls in deepeval used the locale encoding instead of
+explicitly specifying UTF-8. On hosts with non-UTF-8 locale, this
+could cause UnicodeDecodeError or silent mojibake when reading
+prompt templates, model caches, or GPU memory info.
+"""
+
+import ast
+import os
+import pytest
+
+
+class TestFileEncodingConsistency:
+    """All text file open() calls should specify encoding='utf-8'."""
+
+    def _get_open_calls_without_encoding(self, filepath):
+        """Find open() calls that don't specify encoding."""
+        with open(filepath, "r", encoding="utf-8") as f:
+            source = f.read()
+
+        tree = ast.parse(source)
+        issues = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "open":
+                    # Check if encoding keyword is present
+                    has_encoding = any(
+                        kw.arg == "encoding" for kw in node.keywords
+                    )
+                    if not has_encoding:
+                        issues.append(node.lineno)
+
+        return issues
+
+    def test_prompt_py_uses_utf8(self):
+        """prompt.py load() must use UTF-8."""
+        filepath = os.path.join(
+            os.path.dirname(__file__), "..", "deepeval", "prompt", "prompt.py"
+        )
+        issues = self._get_open_calls_without_encoding(filepath)
+        assert not issues, (
+            f"prompt.py has open() calls without encoding at lines: {issues}"
+        )
+
+    def test_summac_model_uses_utf8(self):
+        """_summac_model.py cache save/load must use UTF-8."""
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "deepeval",
+            "models",
+            "_summac_model.py",
+        )
+        issues = self._get_open_calls_without_encoding(filepath)
+        assert not issues, (
+            f"_summac_model.py has open() calls without encoding at lines: {issues}"
+        )
+
+    def test_utils_uses_utf8(self):
+        """utils.py GPU memory readers must use UTF-8."""
+        filepath = os.path.join(
+            os.path.dirname(__file__), "..", "deepeval", "utils.py"
+        )
+        issues = self._get_open_calls_without_encoding(filepath)
+        assert not issues, (
+            f"utils.py has open() calls without encoding at lines: {issues}"
+        )


### PR DESCRIPTION
## Root Cause

Five `open()` calls across three files used the locale encoding instead of explicitly specifying UTF-8. On hosts with non-UTF-8 locale, this could cause `UnicodeDecodeError` or silent mojibake when reading prompt templates, model caches, or GPU memory info.

## Fix

Add `encoding="utf-8"` to all five `open()` calls:

| File | Line | Purpose |
|------|------|---------|
| `deepeval/prompt/prompt.py` | 205 | Prompt template loading |
| `deepeval/models/_summac_model.py` | 276 | Model cache save |
| `deepeval/models/_summac_model.py` | 284 | Model cache load |
| `deepeval/utils.py` | 695 | GPU memory reader |
| `deepeval/utils.py` | 705 | GPU space checker |

## Test

- [x] 3 regression tests (`tests/test_encoding_consistency.py`)
  - AST-based audit: all `open()` calls in affected files specify `encoding="utf-8"`
- [x] All 3 tests pass

## Diff scope

4 files changed, +76/-5 lines (5 lines fix + 71 lines tests)

## AI Disclosure

AI-assisted code audit/fix/testing. Found via grep for `open()` calls without `encoding` parameter. Tests verified locally.