### PR TITLE
fix(models): remove nonexistent dated Claude 4.6 registry IDs, correct Opus 4.5 date

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -48,7 +48,9 @@ class Edit:
     file: str
     pattern: str
     value: Callable[[str], str]  # new version -> replacement text
-    is_version: bool = True  # False for fields that travel with a release, e.g. a date
+    is_version: bool = (
+        True  # False for fields that travel with a release, e.g. a date
+    )
 
 
 def _version_edit(file: str, pattern: str) -> Edit:
@@ -68,7 +70,9 @@ TARGETS: Dict[str, Target] = {
         name="python",
         edits=[
             _version_edit("pyproject.toml", r'^version\s*=\s*"([^"]+)"'),
-            _version_edit("deepeval/_version.py", r'__version__[^=]*=\s*"([^"]+)"'),
+            _version_edit(
+                "deepeval/_version.py", r'__version__[^=]*=\s*"([^"]+)"'
+            ),
             _version_edit("CITATION.cff", r"^version:\s*(\S+)"),
             Edit(
                 file="CITATION.cff",
@@ -82,7 +86,9 @@ TARGETS: Dict[str, Target] = {
     ),
     "typescript": Target(
         name="typescript",
-        edits=[_version_edit("typescript/package.json", r'"version":\s*"([^"]+)"')],
+        edits=[
+            _version_edit("typescript/package.json", r'"version":\s*"([^"]+)"')
+        ],
         json_key="typescript",
         publish_commands=["cd typescript && npm publish"],
     ),
@@ -125,7 +131,9 @@ def read_version(edit: Edit) -> str:
         fail(f"{edit.file} is missing — run this from a full checkout.")
     match = re.search(edit.pattern, path.read_text(), re.MULTILINE)
     if not match:
-        fail(f"could not find a version in {edit.file} (pattern: {edit.pattern})")
+        fail(
+            f"could not find a version in {edit.file} (pattern: {edit.pattern})"
+        )
     return match.group(1)
 
 
@@ -163,7 +171,9 @@ def write_json_version(key: str, version: str) -> None:
 def current_version(target: Target) -> str:
     """Every declaration must already agree, or the bump would paper over drift."""
     found = [
-        (edit.file, read_version(edit)) for edit in target.edits if edit.is_version
+        (edit.file, read_version(edit))
+        for edit in target.edits
+        if edit.is_version
     ]
     versions = {version for _, version in found}
     if len(versions) > 1:
@@ -189,7 +199,9 @@ def next_version(current: str, bump: str) -> str:
         return f"{major}.{minor}.{patch + 1}"
 
     if not SEMVER.match(bump):
-        raise ValueError(f"'{bump}' is neither major/minor/patch nor a version number.")
+        raise ValueError(
+            f"'{bump}' is neither major/minor/patch nor a version number."
+        )
     return bump
 
 
@@ -198,12 +210,16 @@ def prompt_version(target: Target, current: str) -> Optional[str]:
     try:
         default = next_version(current, "patch")
     except ValueError:
-        default = None  # non-semver current: no bump to offer, so require an answer
+        default = (
+            None  # non-semver current: no bump to offer, so require an answer
+        )
 
     suggestion = f" [{default}]" if default else ""
     while True:
         try:
-            answer = input(f"  {target.name}: {current} ->{suggestion} ").strip()
+            answer = input(
+                f"  {target.name}: {current} ->{suggestion} "
+            ).strip()
         except EOFError:
             raise SystemExit(1)
 
@@ -221,7 +237,9 @@ def prompt_version(target: Target, current: str) -> Optional[str]:
             print(f"    {error}")
             continue
         if version == current:
-            print(f"    {target.name} is already at {version} — pick a higher one.")
+            print(
+                f"    {target.name} is already at {version} — pick a higher one."
+            )
             continue
         return version
 
@@ -277,9 +295,13 @@ def main() -> None:
 
     if not args.dry_run:
         check_clean_tree()
-    currents = {name: current_version(target) for name, target in TARGETS.items()}
+    currents = {
+        name: current_version(target) for name, target in TARGETS.items()
+    }
 
-    say("version to release (enter for the patch bump, or major/minor/patch/skip):")
+    say(
+        "version to release (enter for the patch bump, or major/minor/patch/skip):"
+    )
     plan: Dict[str, str] = {}
     for name, target in TARGETS.items():
         chosen = prompt_version(target, currents[name])

--- a/deepeval/models/llms/constants.py
+++ b/deepeval/models/llms/constants.py
@@ -561,29 +561,13 @@ ANTHROPIC_MODELS_DATA = ModelDataRegistry(
             input_price=1.00 / 1e6,
             output_price=5.00 / 1e6,
         ),
-        "claude-opus-4-5-20251124": make_model_data(
+        "claude-opus-4-5-20251101": make_model_data(
             supports_log_probs=False,
             supports_multimodal=True,
             supports_structured_outputs=True,
             supports_json=True,
             input_price=5.00 / 1e6,
             output_price=25.00 / 1e6,
-        ),
-        "claude-opus-4-6-20250610": make_model_data(
-            supports_log_probs=False,
-            supports_multimodal=True,
-            supports_structured_outputs=True,
-            supports_json=True,
-            input_price=5.00 / 1e6,
-            output_price=25.00 / 1e6,
-        ),
-        "claude-sonnet-4-6-20250514": make_model_data(
-            supports_log_probs=False,
-            supports_multimodal=True,
-            supports_structured_outputs=True,
-            supports_json=True,
-            input_price=3.00 / 1e6,
-            output_price=15.00 / 1e6,
         ),
         "claude-3-opus": make_model_data(
             supports_log_probs=False,

--- a/tests/test_core/test_models/test_anthropic_model.py
+++ b/tests/test_core/test_models/test_anthropic_model.py
@@ -311,3 +311,38 @@ def test_anthropic_calculate_cost_with_zero_tokens(mock_require_dep, settings):
     model = AnthropicModel(model="claude-3-7-sonnet-latest")
     cost = model.calculate_cost(input_tokens=0, output_tokens=0)
     assert cost == 0.0
+
+
+########################################################
+# Default model / registry ID validity                 #
+########################################################
+
+
+def test_no_dated_ids_for_dateless_claude_generations():
+    """From the 4.6 generation on, Anthropic publishes dateless pinned IDs
+    only, so a date-suffixed 4.6+ ID 404s on the first messages.create call.
+
+    Regression test for the fabricated "claude-opus-4-6-20250610" and
+    "claude-sonnet-4-6-20250514" registry entries.
+    """
+    import re
+
+    from deepeval.models.llms.constants import (
+        ANTHROPIC_MODELS_DATA,
+        DEFAULT_ANTHROPIC_MODEL,
+    )
+
+    # claude-{family}-{major}-{minor}-{date} where the generation is 4.6+
+    dated_dateless_gen = re.compile(
+        r"claude-(?:opus|sonnet|haiku|fable|mythos)"
+        r"-(?:4-[6-9]|[5-9](?:-\d+)?)-\d{8}$"
+    )
+
+    offenders = [
+        model_id
+        for model_id in ANTHROPIC_MODELS_DATA
+        if dated_dateless_gen.search(model_id)
+    ]
+    assert offenders == []
+    assert not dated_dateless_gen.search(DEFAULT_ANTHROPIC_MODEL)
+    assert DEFAULT_ANTHROPIC_MODEL in ANTHROPIC_MODELS_DATA

--- a/typescript/src/evaluate/evaluate.ts
+++ b/typescript/src/evaluate/evaluate.ts
@@ -39,11 +39,7 @@ import {
   type Hyperparameters,
 } from "@/evaluate/hyperparameters";
 import { mapWithConcurrency, shouldUseCache } from "@/env-flags";
-import {
-  Entrypoint,
-  captureEvaluationRun,
-  recordTestCase,
-} from "@/telemetry";
+import { Entrypoint, captureEvaluationRun, recordTestCase } from "@/telemetry";
 import {
   cacheMetricData,
   ensureCacheFlushedOnExit,

--- a/typescript/src/models/registry/models.json
+++ b/typescript/src/models/registry/models.json
@@ -490,29 +490,13 @@
       "inputPrice": 1e-06,
       "outputPrice": 5e-06
     },
-    "claude-opus-4-5-20251124": {
+    "claude-opus-4-5-20251101": {
       "supportsLogProbs": false,
       "supportsMultimodal": true,
       "supportsStructuredOutputs": true,
       "supportsJson": true,
       "inputPrice": 5e-06,
       "outputPrice": 2.5e-05
-    },
-    "claude-opus-4-6-20250610": {
-      "supportsLogProbs": false,
-      "supportsMultimodal": true,
-      "supportsStructuredOutputs": true,
-      "supportsJson": true,
-      "inputPrice": 5e-06,
-      "outputPrice": 2.5e-05
-    },
-    "claude-sonnet-4-6-20250514": {
-      "supportsLogProbs": false,
-      "supportsMultimodal": true,
-      "supportsStructuredOutputs": true,
-      "supportsJson": true,
-      "inputPrice": 3e-06,
-      "outputPrice": 1.5e-05
     },
     "claude-3-opus": {
       "supportsLogProbs": false,


### PR DESCRIPTION
## Summary

Rebased on current `main` and re-scoped. The original headline of this PR — the default judge pointing at the nonexistent `claude-sonnet-4-6-20250514` — was fixed on `main` (default is now `claude-opus-5`, which is valid). What remains broken is the model registry in `deepeval/models/llms/constants.py`, which still carries three IDs Anthropic never published:

| Registry entry | Problem |
|---|---|
| `claude-opus-4-6-20250610` | Does not exist — from the 4.6 generation onward Anthropic publishes dateless pinned IDs only (`claude-opus-4-6`) |
| `claude-sonnet-4-6-20250514` | Same — no dated Sonnet 4.6 ID exists |
| `claude-opus-4-5-20251124` | Wrong date — the published dated ID is `claude-opus-4-5-20251101` |

Anyone passing these IDs explicitly (they look canonical, matching the dated 4.5-and-earlier scheme) gets a 404 from the Anthropic API on the first `messages.create` call, and cost tracking maps to phantom models.

## Changes

- Remove the two nonexistent dated 4.6 entries; the valid dateless `claude-opus-4-6` / `claude-sonnet-4-6` entries remain.
- Correct `claude-opus-4-5-20251124` → `claude-opus-4-5-20251101` (same pricing/capabilities).
- Add a regression test asserting no dated 4.6+ IDs appear in the registry and that `DEFAULT_ANTHROPIC_MODEL` is a valid registry entry.

## Testing

- `pytest tests/test_core/test_models/test_anthropic_model.py` — 11 passed
- `black --check` clean

Fixes #2993