### PR TITLE
build(typescript): unbreak npm ci by aligning the ai devDependency with the mastra peer range

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -52,7 +52,7 @@
         "@types/nunjucks": "^3.2.6",
         "@types/papaparse": "^5.3.16",
         "@types/uuid": "^9.0.0",
-        "ai": "^6.0.97",
+        "ai": "^6.0.182",
         "babel-jest": "^29.7.0",
         "eslint": "^9.38.0",
         "eslint-config-prettier": "^10.1.8",
@@ -152,15 +152,47 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.53.tgz",
-      "integrity": "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q==",
+      "version": "3.0.162",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.162.tgz",
+      "integrity": "sha512-Ful2sKX4/5iRIULrbKAN88VSduJKVxEIqub84uBT4SZkhYnu6pfWaFEzZOrjCwMf+ScWuxiFSAkZeXFphTji2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+      "integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^5.29.0"
       },
       "engines": {
         "node": ">=18"
@@ -2409,6 +2441,16 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@google/genai": {
@@ -5583,9 +5625,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5701,16 +5743,48 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.97",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.97.tgz",
-      "integrity": "sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ==",
+      "version": "6.0.240",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.240.tgz",
+      "integrity": "sha512-nVytcmJmHAR+1UU3KlRQJ8Un8gePSAcbTfvShNGfbG9hYnQWKdyFRZWa4QBlKH5yiNLNqSS4Y9u0T0KcbY6FkA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.53",
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.15",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.162",
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+      "integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^5.29.0"
       },
       "engines": {
         "node": ">=18"
@@ -13286,6 +13360,19 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -163,7 +163,7 @@
     "@types/nunjucks": "^3.2.6",
     "@types/papaparse": "^5.3.16",
     "@types/uuid": "^9.0.0",
-    "ai": "^6.0.97",
+    "ai": "^6.0.182",
     "babel-jest": "^29.7.0",
     "eslint": "^9.38.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
`npm ci` has failed on every branch of this repo, including `main`, since at least 21 July. It takes both **TypeScript Lint** and **TypeScript Tests** down at the install step, so neither has run to completion on any PR in that window.

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: ai@7.0.48 from lock file
npm error Missing: @ai-sdk/gateway@4.0.37 from lock file
npm error Missing: @ai-sdk/provider@4.0.4 from lock file
```

## The version number is the clue

CI asked for `ai@7.0.37` on 27 July and asks for `7.0.48` today. The required version tracks whatever npm published most recently, which means something is re-resolving at install time rather than reading the lock.

## Root cause

`@mastra/core` nests a package `chat` that declares:

```json
"peerDependencies": { "ai": "^6.0.182 || ^7.0.0" }
```

The lockfile pins `ai` at **6.0.97**. That satisfies neither branch of the range: it is below `^6.0.182` and it is not `^7`. So npm resolves the peer by reaching for the newest `ai@7`, then fails because that version is not in the lock.

It reproduces only on **npm 10**, which is what `node:22` ships and what these workflows run in. npm 11 changed peer resolution and prefers the `^6.0.97` devDependency, so this passes on a modern local machine and fails in CI. That gap is why it has gone unnoticed.

## The fix

Bump the `ai` devDependency from `^6.0.97` to `^6.0.182`, so the root `ai` falls inside the range `chat` asks for and one copy satisfies the whole tree. The lock regenerates to `6.0.240`.

I also tried simply bounding the `ai` peer range to `<7.0.0`. That does **not** work, because the conflict is with a nested peer requirement, not the root one. Worth recording so nobody repeats it.

## Verification

Run with npm 10 to match the container:

| | before | after |
|---|---|---|
| `npx npm@10 ci` | `EUSAGE`, missing `ai@7.0.48` | **exit 0**, added 978 packages |
| `npm run lint -- .` | never reached | **exit 0**, 0 errors, 2 pre-existing warnings |

## What this does not fix

This unblocks the install step only. Being explicit so the result is not oversold:

- **TypeScript Lint** now gets past `npm ci` and reaches the prettier step, where `npx prettier --check "src/**/*.ts" "test/**/*.ts"` reports **66 files** with style issues. ESLint itself passes (0 errors, 2 pre-existing warnings). That drift is untouched by this PR, which changes only `package.json` and `package-lock.json`, neither of which prettier checks. Happy to send it as a separate mechanical `npm run format` PR if you want it.
- **TypeScript Tests** needs `OPENAI_API_KEY` and `CONFIDENT_API_KEY`, which GitHub does not pass to forked PRs, so those jobs will still not go green from a fork regardless.

## Related, if useful

Four peer ranges in `typescript/package.json` have no upper bound: `ai`, `@google/genai`, `@anthropic-ai/sdk`, `@aws-sdk/client-bedrock-runtime` and `ollama`. The `@mastra/*` entries next to them are bounded (`>=1.16.0-0 <2.0.0-0`), which is the shape that avoids this class of problem. `@google/genai` looks like the next candidate: its peer is `>=1.0.0` while the devDependency is `^2.8.0`. Not touching those here, since this PR should stay minimal.
