### PR TITLE
feat: add DEEPEVAL_DISABLE_PROMOTION to silence Confident AI promo output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,9 @@ CONFIDENT_API_KEY=  # Confident AI cloud
 # DEEPEVAL_TELEMETRY_OPT_OUT=1
 # ERROR_REPORTING=1
 
+# Suppress Confident AI promotional console output after evals (when not logged in)
+# DEEPEVAL_DISABLE_PROMOTION=1
+
 # ===================
 # Test run overrides
 # ===================

--- a/deepeval/config/settings.py
+++ b/deepeval/config/settings.py
@@ -772,6 +772,10 @@ class Settings(BaseSettings):
         None,
         description="Opt in to update warnings in the CLI/runtime when new versions are available.",
     )
+    DEEPEVAL_DISABLE_PROMOTION: Optional[bool] = Field(
+        None,
+        description="Suppress Confident AI promotional console output shown after an evaluation when not logged in (e.g. 'Run deepeval view ...' and related nudges).",
+    )
     DEEPEVAL_GRPC_LOGGING: Optional[bool] = Field(
         None,
         description="Enable extra gRPC logging for Confident transport/debugging.",

--- a/deepeval/evaluate/compare.py
+++ b/deepeval/evaluate/compare.py
@@ -22,6 +22,7 @@ from deepeval.utils import (
     custom_console,
     get_or_create_event_loop,
     open_browser,
+    should_show_promotion,
 )
 from deepeval.test_run.test_run import (
     TestRun,
@@ -502,12 +503,13 @@ def wrap_up_experiment(
     )
 
     if not is_confident():
-        capture_login_prompt_shown(LoginPromptSurface.POST_ARENA)
-        console.print(
-            f"{'=' * 80}\n"
-            f"\n» Want to share experiments with your team? ❤️ 🏟️\n"
-            f"  » Run [bold]'deepeval login'[/bold] to analyze and save arena results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n"
-        )
+        if should_show_promotion():
+            capture_login_prompt_shown(LoginPromptSurface.POST_ARENA)
+            console.print(
+                f"{'=' * 80}\n"
+                f"\n» Want to share experiments with your team? ❤️ 🏟️\n"
+                f"  » Run [bold]'deepeval login'[/bold] to analyze and save arena results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n"
+            )
         return
 
     try:

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -257,7 +257,7 @@ class ToolCall(BaseModel):
         validation_alias=AliasChoices("inputParameters", "input_parameters"),
     )
 
-    @field_serializer('type')
+    @field_serializer("type")
     def serialize_type(self, value: ToolCallType) -> str:
         return value.value
 

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -30,6 +30,7 @@ from deepeval.utils import (
     shorten,
     format_turn,
     len_short,
+    should_show_promotion,
 )
 from deepeval.test_run.cache import global_test_run_cache_manager
 from deepeval.telemetry import (
@@ -907,10 +908,11 @@ class TestRunManager:
             if index < len(test_run.test_cases) - 1:
                 self._add_separator_row(table)
 
-        table.add_row(
-            "[bold red]Note: Use Confident AI with DeepEval to analyze failed test cases for more details[/bold red]",
-            *[""] * (len(table.columns) - 1),
-        )
+        if should_show_promotion():
+            table.add_row(
+                "[bold red]Note: Use Confident AI with DeepEval to analyze failed test cases for more details[/bold red]",
+                *[""] * (len(table.columns) - 1),
+            )
         print(table)
 
     def post_test_run(self, test_run: TestRun) -> Optional[Tuple[str, str]]:
@@ -1173,15 +1175,26 @@ class TestRunManager:
                 if test_run.evaluation_cost
                 else "None"
             )
-            capture_login_prompt_shown(LoginPromptSurface.POST_EVAL)
-            console.print(
+            show_promotion = should_show_promotion()
+            if show_promotion:
+                capture_login_prompt_shown(LoginPromptSurface.POST_EVAL)
+            summary = (
                 f"\n\n[rgb(5,245,141)]✓[/rgb(5,245,141)] Evaluation completed 🎉! (time taken: {round(runDuration, 2)}s | token cost: {token_cost})\n"
-                f"» Test Results ({test_run.test_passed + test_run.test_failed} total tests):\n",
-                f"  » Pass Rate: {round((test_run.test_passed / (test_run.test_passed + test_run.test_failed)) * 100, 2)}% | Passed: [bold green]{test_run.test_passed}[/bold green] | Failed: [bold red]{test_run.test_failed}[/bold red]\n\n",
-                "=" * 80,
-                "\n\n» Want to share evals with your team, or a place for your test cases to live? ❤️ 🏡\n"
-                "  » Run [bold]'deepeval view'[/bold] to analyze and save testing results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n",
+                f"» Test Results ({test_run.test_passed + test_run.test_failed} total tests):\n"
             )
+            pass_rate = (
+                f"  » Pass Rate: {round((test_run.test_passed / (test_run.test_passed + test_run.test_failed)) * 100, 2)}% | Passed: [bold green]{test_run.test_passed}[/bold green] | Failed: [bold red]{test_run.test_failed}[/bold red]\n\n"
+            )
+            if show_promotion:
+                console.print(
+                    summary,
+                    pass_rate,
+                    "=" * 80,
+                    "\n\n» Want to share evals with your team, or a place for your test cases to live? ❤️ 🏡\n"
+                    "  » Run [bold]'deepeval view'[/bold] to analyze and save testing results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n",
+                )
+            else:
+                console.print(summary, pass_rate)
 
     def get_latest_test_run_data(self) -> Optional[TestRun]:
         try:

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -1182,9 +1182,7 @@ class TestRunManager:
                 f"\n\n[rgb(5,245,141)]✓[/rgb(5,245,141)] Evaluation completed 🎉! (time taken: {round(runDuration, 2)}s | token cost: {token_cost})\n"
                 f"» Test Results ({test_run.test_passed + test_run.test_failed} total tests):\n"
             )
-            pass_rate = (
-                f"  » Pass Rate: {round((test_run.test_passed / (test_run.test_passed + test_run.test_failed)) * 100, 2)}% | Passed: [bold green]{test_run.test_passed}[/bold green] | Failed: [bold red]{test_run.test_failed}[/bold red]\n\n"
-            )
+            pass_rate = f"  » Pass Rate: {round((test_run.test_passed / (test_run.test_passed + test_run.test_failed)) * 100, 2)}% | Passed: [bold green]{test_run.test_passed}[/bold green] | Failed: [bold red]{test_run.test_failed}[/bold red]\n\n"
             if show_promotion:
                 console.print(
                     summary,

--- a/deepeval/utils.py
+++ b/deepeval/utils.py
@@ -256,6 +256,15 @@ def should_verbose_print() -> bool:
     return bool(get_settings().DEEPEVAL_VERBOSE_MODE)
 
 
+def should_show_promotion() -> bool:
+    """Whether Confident AI promotional console output should be shown.
+
+    Users can opt out by setting ``DEEPEVAL_DISABLE_PROMOTION=1`` (or any truthy
+    value). Returns ``True`` by default so existing behavior is unchanged.
+    """
+    return not bool(get_settings().DEEPEVAL_DISABLE_PROMOTION)
+
+
 def set_verbose_mode(yes: Optional[bool]):
     s = get_settings()
     with s.edit(persist=False):

--- a/tests/test_core/test_config/test_settings.py
+++ b/tests/test_core/test_config/test_settings.py
@@ -81,7 +81,13 @@ def test_disable_promotion_defaults_to_showing(monkeypatch):
 
 @pytest.mark.parametrize(
     "value, expected_show",
-    [("1", False), ("true", False), ("yes", False), ("0", True), ("false", True)],
+    [
+        ("1", False),
+        ("true", False),
+        ("yes", False),
+        ("0", True),
+        ("false", True),
+    ],
 )
 def test_disable_promotion_opt_out(monkeypatch, value, expected_show):
     from deepeval.utils import should_show_promotion

--- a/tests/test_core/test_config/test_settings.py
+++ b/tests/test_core/test_config/test_settings.py
@@ -70,6 +70,26 @@ def test_env_mutation_after_init_triggers_auto_refresh(monkeypatch):
     assert s2.USE_OPENAI_MODEL is (old is not True)
 
 
+def test_disable_promotion_defaults_to_showing(monkeypatch):
+    # env is cleared by conftest -> promotion shown by default
+    from deepeval.utils import should_show_promotion
+
+    monkeypatch.delenv("DEEPEVAL_DISABLE_PROMOTION", raising=False)
+    assert get_settings().DEEPEVAL_DISABLE_PROMOTION in (None, False)
+    assert should_show_promotion() is True
+
+
+@pytest.mark.parametrize(
+    "value, expected_show",
+    [("1", False), ("true", False), ("yes", False), ("0", True), ("false", True)],
+)
+def test_disable_promotion_opt_out(monkeypatch, value, expected_show):
+    from deepeval.utils import should_show_promotion
+
+    monkeypatch.setenv("DEEPEVAL_DISABLE_PROMOTION", value)
+    assert should_show_promotion() is expected_show
+
+
 def test_invalid_trace_sample_rate_raises(monkeypatch):
     # set env before first construction to trigger the validator
     monkeypatch.setenv("CONFIDENT_TRACE_SAMPLE_RATE", "1.2")


### PR DESCRIPTION

Adds an opt-out env var so evals run without 'deepeval login' can suppress the Confident AI promotional console output (post-eval nudge, arena nudge, and the failed-case note row). Defaults to showing, preserving existing behavior. Closes #1417.