### PR TITLE
fix(optimizer): give each PromptOptimizer its own algorithm instance

### DIFF
--- a/deepeval/optimizer/prompt_optimizer.py
+++ b/deepeval/optimizer/prompt_optimizer.py
@@ -54,7 +54,7 @@ class PromptOptimizer:
         model_callback: ModelCallback,
         metrics: Union[List[BaseMetric], List[BaseConversationalMetric]],
         optimizer_model: Optional[Union[str, DeepEvalBaseLLM]] = None,
-        algorithm: Union[GEPA, MIPROV2, COPRO, SIMBA] = GEPA(),
+        algorithm: Optional[Union[GEPA, MIPROV2, COPRO, SIMBA]] = None,
         async_config: Optional[AsyncConfig] = AsyncConfig(),
         display_config: Optional[DisplayConfig] = DisplayConfig(),
     ):
@@ -71,7 +71,10 @@ class PromptOptimizer:
 
         self.async_config = async_config
         self.display_config = display_config
-        self.algorithm = algorithm
+        # Defaulted here rather than in the signature: `_configure_algorithm`
+        # mutates the algorithm, so a default instance would be shared by every
+        # PromptOptimizer built without an explicit `algorithm`.
+        self.algorithm = algorithm if algorithm is not None else GEPA()
         self.optimization_report = None
         self._configure_algorithm()
 

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -257,7 +257,7 @@ class ToolCall(BaseModel):
         validation_alias=AliasChoices("inputParameters", "input_parameters"),
     )
 
-    @field_serializer('type')
+    @field_serializer("type")
     def serialize_type(self, value: ToolCallType) -> str:
         return value.value
 

--- a/tests/test_core/test_optimization/test_prompt_optimizer_defaults.py
+++ b/tests/test_core/test_optimization/test_prompt_optimizer_defaults.py
@@ -1,0 +1,82 @@
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.optimizer.algorithms import COPRO
+from deepeval.optimizer.configs import DisplayConfig
+from deepeval.optimizer.prompt_optimizer import PromptOptimizer
+from deepeval.optimizer.scorer import Scorer
+
+from tests.test_core.stubs import _DummyMetric
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Keeps `initialize_model` off the GPTModel path so no API key is needed."""
+
+    def load_model(self):
+        return self
+
+    def generate(self, *args, **kwargs):
+        return ""
+
+    async def a_generate(self, *args, **kwargs):
+        return ""
+
+    def get_model_name(self):
+        return "stub"
+
+
+def _callback_one(prompt, golden):
+    return "from-callback-one"
+
+
+def _callback_two(prompt, golden):
+    return "from-callback-two"
+
+
+def _build(model_callback):
+    return PromptOptimizer(
+        model_callback=model_callback,
+        metrics=[_DummyMetric()],
+        optimizer_model=_StubLLM(),
+        display_config=DisplayConfig(show_indicator=False),
+    )
+
+
+def test_default_algorithm_is_not_shared_between_optimizers():
+    first = _build(_callback_one)
+    second = _build(_callback_two)
+
+    assert first.algorithm is not second.algorithm
+    assert first.algorithm.scorer is not second.algorithm.scorer
+
+
+def test_building_a_second_optimizer_does_not_rewire_the_first():
+    first = _build(_callback_one)
+    second = _build(_callback_two)
+
+    # `execute()` runs through `self.scorer`, so a shared algorithm instance
+    # would make `first` optimize against the second optimizer's callback.
+    first_scorer = first.algorithm.scorer
+    second_scorer = second.algorithm.scorer
+    assert isinstance(first_scorer, Scorer)
+    assert isinstance(second_scorer, Scorer)
+    assert first_scorer.model_callback is _callback_one
+    assert second_scorer.model_callback is _callback_two
+
+    # Progress/status callbacks must stay bound to their own optimizer.
+    # Bound methods compare equal only when both the function and the
+    # instance they are bound to match.
+    assert first.algorithm.status_callback == first._on_status
+    assert first.algorithm.step_callback == first._on_step
+    assert second.algorithm.status_callback == second._on_status
+
+
+def test_explicitly_passed_algorithm_instance_is_used_as_is():
+    algorithm = COPRO()
+    optimizer = PromptOptimizer(
+        model_callback=_callback_one,
+        metrics=[_DummyMetric()],
+        optimizer_model=_StubLLM(),
+        algorithm=algorithm,
+        display_config=DisplayConfig(show_indicator=False),
+    )
+
+    assert optimizer.algorithm is algorithm


### PR DESCRIPTION
Closes #2998

### Problem

`PromptOptimizer.__init__` used a mutable default argument (`deepeval/optimizer/prompt_optimizer.py:57`):

```python
algorithm: Union[GEPA, MIPROV2, COPRO, SIMBA] = GEPA(),
```

`GEPA()` is evaluated once at import, so every optimizer built without an explicit `algorithm=` shared a single algorithm object — and `_configure_algorithm()` mutates it (`scorer`, `_rewriter`, `status_callback`, `step_callback`, `optimizer_model`).

Constructing a second optimizer silently rewired the first. Since `execute()` runs through `self.scorer`, `optimizer_a.optimize(...)` would call **optimizer B's** `model_callback` and score with **B's** metrics — no error, no warning, just a confidently wrong optimized prompt. Every documented example is affected, as none pass `algorithm=`.

Before:

```
o1.algorithm is o2.algorithm             : True
o1.model_callback                        : cb1
o1.algorithm.scorer.model_callback       : cb2     <-- wrong
o1.algorithm.status_callback.__self__ is o2: True  <-- wrong
```

After:

```
o1.algorithm is o2.algorithm             : False
o1.model_callback                        : cb1
o1.algorithm.scorer.model_callback       : cb1
o1.algorithm.status_callback.__self__ is o2: False
```

### Fix

Default `algorithm` to `None` and construct a fresh `GEPA()` per instance. Behaviour for existing callers is unchanged — the default is still GEPA — so the docs stay accurate and there is no migration.

I deliberately left `async_config` / `display_config` alone: shared default *config* instances are an established idiom across `evaluate/evaluate.py`, `evaluate/compare.py`, `evaluate/execute/e2e.py` and `evaluate/execute/loop.py`, and those objects are read-only with no per-run state. An `ast` sweep of all 503 package files confirmed `prompt_optimizer.py:57` is the only shared default that is mutated and carries per-run state.

### Tests

Added `tests/test_core/test_optimization/test_prompt_optimizer_defaults.py` covering:

- two optimizers built without `algorithm=` get distinct algorithm and scorer objects
- building a second optimizer does not rewire the first's `model_callback` or status/step callbacks
- an explicitly passed `algorithm=` instance is still used as-is

The new file is intentionally not gated on `OPENAI_API_KEY` (unlike the sibling `test_prompt_optimizer.py`), since the bug is provable with no LLM calls — it uses a stub `DeepEvalBaseLLM` plus the existing `_DummyMetric` stub, so it actually runs in CI.

All three fail on `main` and pass with this change.

```
tests/test_core/test_optimization   81 passed, 7 skipped   (78 passed before this PR)
tests/test_core                   1245 passed, 56 skipped
black --check                     clean
```
