### PR TITLE
fix(g-eval): pick the trailing score token for weighted logprob score (#3000)

### DIFF
--- a/deepeval/metrics/g_eval/utils.py
+++ b/deepeval/metrics/g_eval/utils.py
@@ -338,9 +338,13 @@ def calculate_weighted_summed_score(
 ) -> Union[int, float]:
     try:
         generated_logprobs = raw_response.choices[0].logprobs.content
-        # First, locate the token that we care for logprobs, i.e., the token matching the score
+        # First, locate the token that we care for logprobs, i.e., the token
+        # matching the score. Search from the end: the model emits the JSON as
+        # {"reason": ..., "score": N}, so the score is the last matching token.
+        # Iterating forward would wrongly latch onto an identical digit that
+        # happens to appear earlier in the reasoning text.
         score_logprobs = None
-        for token_logprobs in generated_logprobs:
+        for token_logprobs in reversed(generated_logprobs):
             if token_logprobs.token == str(raw_score):
                 score_logprobs = token_logprobs
                 break

--- a/tests/test_metrics/test_g_eval_utils.py
+++ b/tests/test_metrics/test_g_eval_utils.py
@@ -1,9 +1,13 @@
+import math
+from types import SimpleNamespace
+
 import pytest
 
 from deepeval.errors import MissingTestCaseParamsError
 from deepeval.metrics.g_eval.utils import (
     CONVERSATIONAL_G_EVAL_API_PARAMS,
     G_EVAL_API_PARAMS,
+    calculate_weighted_summed_score,
     construct_geval_upload_payload,
     construct_non_turns_test_case_string,
     construct_test_case_string,
@@ -133,3 +137,36 @@ def test_conversational_geval_requires_tags_when_selected():
             [MultiTurnParams.TAGS],
             DummyConversationalMetric(),
         )
+
+
+def _score_token(token, top_logprobs):
+    return SimpleNamespace(
+        token=token,
+        top_logprobs=[
+            SimpleNamespace(token=tok, logprob=math.log(prob))
+            for tok, prob in top_logprobs
+        ],
+    )
+
+
+def _raw_response(content_tokens):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(logprobs=SimpleNamespace(content=content_tokens))
+        ]
+    )
+
+
+def test_weighted_score_uses_trailing_score_token_not_reasoning_digit():
+    # The model emits {"reason": ..., "score": 8}. The reasoning text happens to
+    # contain the digit "8" (with misleadingly certain logprobs) before the real
+    # score token at the end, whose logprobs are split evenly between 8 and 7.
+    # A forward search latches onto the reasoning token and returns 8.0; the
+    # score token is at the tail, so the correct weighted score is 7.5.
+    reasoning_token = _score_token("8", [("8", 0.99)])
+    score_token = _score_token("8", [("8", 0.5), ("7", 0.5)])
+    raw_response = _raw_response([reasoning_token, score_token])
+
+    result = calculate_weighted_summed_score(8, raw_response)
+
+    assert result == pytest.approx(7.5)


### PR DESCRIPTION
## Summary

Fixes #3000.

`calculate_weighted_summed_score` locates the completion token whose text equals the raw score, then reconstructs a probability-weighted score from that token's `top_logprobs`. It searched **forward** and stopped at the first match:

```python
for token_logprobs in generated_logprobs:
    if token_logprobs.token == str(raw_score):
        score_logprobs = token_logprobs
        break
```

The model emits the completion as a JSON object `{"reason": ..., "score": N}` (see `ReasonScore` in `g_eval/schema.py` — `reason` first, `score` last), so the score digit is the **last** matching token. When the reasoning prose happens to contain the same digit as the final score (e.g. the reason mentions "8" and the score is also 8), the forward search latches onto the reasoning token's logprobs instead of the actual score token, corrupting the weighted score.

## Fix

Iterate from the end so the trailing score token wins (as suggested in the issue):

```python
for token_logprobs in reversed(generated_logprobs):
    ...
```

One-line behavioural change plus a clarifying comment.

## Test

Added a regression test in `tests/test_metrics/test_g_eval_utils.py` that builds a fake `logprobs.content` where the score digit appears earlier in the reasoning (with misleadingly certain logprobs) and again at the tail (split 8/7). With the old forward search the function returns `8.0`; with the fix it correctly returns `7.5`.

## Notes

Scope kept intentionally minimal to the file named in the issue. The same forward-search loop also exists inline in `deepeval/metrics/conversational_g_eval/conversational_g_eval.py::generate_weighted_summed_score`; happy to apply the identical fix there in a follow-up if you'd like it in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
