### PR TITLE
fix: quasi_contains_score doing exact match instead of substring containment

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -118,10 +118,18 @@ class Scorer:
 
     @classmethod
     def quasi_contains_score(cls, targets: List[str], prediction: str) -> int:
-        normalized_targets = [normalize_text(t) for t in targets]
         if not prediction:
             return 0
-        return 1 if normalize_text(prediction) in normalized_targets else 0
+        normalized_prediction = normalize_text(prediction)
+        normalized_targets = [normalize_text(t) for t in targets]
+        return (
+            1
+            if any(
+                target and target in normalized_prediction
+                for target in normalized_targets
+            )
+            else 0
+        )
 
     # Todo: More mode based metrics to be added
 

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -59,6 +59,23 @@ def test_drop_delimiter_is_not_a_character_that_occurs_in_answers():
     assert DELIMITER not in "0123456789,.- abcdefghijklmnopqrstuvwxyz"
 
 
+def test_quasi_contains_score_matches_span_surrounded_by_extra_text():
+    # quasi_contains_score previously checked list *membership* of the whole
+    # normalized prediction (an exact match against one of the targets), not
+    # whether a target span is *contained* in the prediction as its name
+    # promises. A correct DROP answer wrapped in the model's own wording
+    # (e.g. "The answer is Paris.") was silently scored 0.
+    assert Scorer.quasi_contains_score(["Paris"], "The answer is Paris.") == 1
+    assert Scorer.quasi_contains_score(["Paris"], "Paris") == 1
+    assert Scorer.quasi_contains_score(["Paris"], "London") == 0
+
+
+def test_quasi_contains_score_ignores_empty_targets():
+    # An empty normalized target must not trivially "contain" in everything.
+    assert Scorer.quasi_contains_score([""], "anything") == 0
+    assert Scorer.quasi_contains_score([], "anything") == 0
+
+
 # --------------------------------------------------------------------------- #
 # BigBenchHard: the batch path must not corrupt schema-constrained answers
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

`Scorer.quasi_contains_score(targets, prediction)` is used by the DROP benchmark (`deepeval/benchmarks/drop/drop.py`, both `predict` and `batch_predict`) to check whether a model's free-text answer contains one of the acceptable gold answer spans.

Despite its name, the implementation checked list *membership* of the whole normalized prediction against the target list:

```python
return 1 if normalize_text(prediction) in normalized_targets else 0
```

`x in list_of_strings` is exact equality against each element, not substring containment. So a model answer that includes any of its own wording around the correct span — e.g. `"The answer is Paris."` for gold answer `"Paris"` — is silently scored `0`, because `"answer is paris" != "paris"`. Only a bare, word-for-word match of the entire (normalized) prediction to one of the targets ever scored `1`.

```python
>>> from deepeval.scorer.scorer import Scorer
>>> Scorer.quasi_contains_score(["Paris"], "The answer is Paris.")
0  # should be 1 -- the correct answer is right there
>>> Scorer.quasi_contains_score(["Paris"], "Paris")
1
```

This systematically under-scores any model that doesn't reply with the bare answer and nothing else on DROP.

## Fix

Check whether any normalized target is a *substring* of the normalized prediction, matching the function's name and DROP's intended lenient span matching:

```python
normalized_prediction = normalize_text(prediction)
normalized_targets = [normalize_text(t) for t in targets]
return 1 if any(target and target in normalized_prediction for target in normalized_targets) else 0
```

The `target and ...` guard prevents an empty normalized target from trivially matching every prediction (`"" in anything` is always `True` in Python).

## Test plan

Added two tests to the existing `tests/test_benchmarks/test_benchmark_answer_scoring.py`:
- `test_quasi_contains_score_matches_span_surrounded_by_extra_text` — confirms a wrapped correct answer now scores 1, a bare correct answer still scores 1, and a wrong answer still scores 0.
- `test_quasi_contains_score_ignores_empty_targets` — confirms the empty-target guard.

Confirmed the first test fails against the pre-fix implementation (`git stash`) with the exact `0 == 1` assertion shown above, and passes after the fix. Full `tests/test_benchmarks/test_benchmark_answer_scoring.py` suite: 15 passed, 0 regressions (including the existing DROP round-trip and multi-span tests, which still pass unchanged since an exact match is a trivial case of substring containment).
