### PR TITLE
feat: optionally penalize ambiguous answer relevancy verdicts

### DIFF
--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -37,6 +37,7 @@ class AnswerRelevancyMetric(BaseMetric):
         async_mode: bool = True,
         strict_mode: bool = False,
         verbose_mode: bool = False,
+        penalize_ambiguous_statements: bool = False,
         flaky: bool = False,
     ):
         self.threshold = 1 if strict_mode else threshold
@@ -46,6 +47,7 @@ class AnswerRelevancyMetric(BaseMetric):
         self.async_mode = async_mode
         self.strict_mode = strict_mode
         self.verbose_mode = verbose_mode
+        self.penalize_ambiguous_statements = penalize_ambiguous_statements
         self.flaky = flaky
 
     def measure(
@@ -163,8 +165,16 @@ class AnswerRelevancyMetric(BaseMetric):
 
         irrelevant_statements = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "no":
+            normalized_verdict = verdict.verdict.strip().lower()
+
+            if normalized_verdict == "no":
                 irrelevant_statements.append(verdict.reason)
+
+            if (
+                normalized_verdict == "idk"
+                and self.penalize_ambiguous_statements
+            ):
+                irrelevant_statements.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self._get_prompt(
             "generate_reason",
@@ -188,8 +198,16 @@ class AnswerRelevancyMetric(BaseMetric):
 
         irrelevant_statements = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "no":
+            normalized_verdict = verdict.verdict.strip().lower()
+
+            if normalized_verdict == "no":
                 irrelevant_statements.append(verdict.reason)
+
+            if (
+                normalized_verdict == "idk"
+                and self.penalize_ambiguous_statements
+            ):
+                irrelevant_statements.append(f"(Ambiguous) {verdict.reason}")
 
         prompt = self._get_prompt(
             "generate_reason",
@@ -300,10 +318,23 @@ class AnswerRelevancyMetric(BaseMetric):
         if number_of_verdicts == 0:
             return 1
 
+    def _calculate_score(self):
+        number_of_verdicts = len(self.verdicts)
+        if number_of_verdicts == 0:
+            return 1
+
         relevant_count = 0
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() != "no":
+            normalized_verdict = verdict.verdict.strip().lower()
+
+            if normalized_verdict != "no":
                 relevant_count += 1
+
+            if (
+                self.penalize_ambiguous_statements
+                and normalized_verdict == "idk"
+            ):
+                relevant_count -= 1
 
         score = relevant_count / number_of_verdicts
         return 0 if self.strict_mode and score < self.threshold else score

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -318,11 +318,6 @@ class AnswerRelevancyMetric(BaseMetric):
         if number_of_verdicts == 0:
             return 1
 
-    def _calculate_score(self):
-        number_of_verdicts = len(self.verdicts)
-        if number_of_verdicts == 0:
-            return 1
-
         relevant_count = 0
         for verdict in self.verdicts:
             normalized_verdict = verdict.verdict.strip().lower()

--- a/tests/test_metrics/test_answer_relevancy_ambiguous_statements.py
+++ b/tests/test_metrics/test_answer_relevancy_ambiguous_statements.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+
+import pytest
+
+from deepeval.metrics import AnswerRelevancyMetric
+from deepeval.metrics.answer_relevancy.schema import (
+    AnswerRelevancyVerdict,
+)
+from tests.test_core.stubs import DummyModel
+
+
+def make_metric(
+    *,
+    penalize_ambiguous_statements: bool = False,
+    strict_mode: bool = False,
+) -> AnswerRelevancyMetric:
+    with patch(
+        "deepeval.metrics.answer_relevancy.answer_relevancy.initialize_model"
+    ) as mock_initialize_model:
+        mock_initialize_model.return_value = (DummyModel(), True)
+        return AnswerRelevancyMetric(
+            async_mode=False,
+            include_reason=False,
+            strict_mode=strict_mode,
+            penalize_ambiguous_statements=penalize_ambiguous_statements,
+        )
+
+
+def make_verdicts(*values: str) -> list[AnswerRelevancyVerdict]:
+    return [AnswerRelevancyVerdict(verdict=value) for value in values]
+
+
+def test_default_behavior_counts_idk_as_relevant():
+    metric = make_metric()
+    metric.verdicts = make_verdicts("yes", "no", "idk")
+
+    assert metric.penalize_ambiguous_statements is False
+    assert metric._calculate_score() == pytest.approx(2 / 3)
+
+
+def test_penalize_ambiguous_statements_counts_idk_as_irrelevant():
+    metric = make_metric(penalize_ambiguous_statements=True)
+    metric.verdicts = make_verdicts("yes", "no", "idk")
+
+    assert metric._calculate_score() == pytest.approx(1 / 3)
+
+
+@pytest.mark.parametrize(
+    ("penalize_ambiguous_statements", "expected_score"),
+    [
+        (False, 1.0),
+        (True, 0.0),
+    ],
+)
+def test_only_idk_verdict(
+    penalize_ambiguous_statements: bool,
+    expected_score: float,
+):
+    metric = make_metric(
+        penalize_ambiguous_statements=penalize_ambiguous_statements
+    )
+    metric.verdicts = make_verdicts("idk")
+
+    assert metric._calculate_score() == expected_score
+
+
+def test_penalized_idk_respects_strict_mode():
+    metric = make_metric(
+        penalize_ambiguous_statements=True,
+        strict_mode=True,
+    )
+    metric.verdicts = make_verdicts("yes", "idk")
+
+    assert metric._calculate_score() == 0


### PR DESCRIPTION
## Summary

* Adds a `penalize_ambiguous_statements` option to `AnswerRelevancyMetric`.
* When enabled, `idk` verdicts are treated as irrelevant when calculating the answer relevancy score.
* Preserves the existing behavior by default with `penalize_ambiguous_statements=False`.
* Includes ambiguous verdicts in the generated reason when penalization is enabled.

## Motivation

Currently, `AnswerRelevancyMetric` counts every verdict other than `no` as relevant, which means an `idk` verdict contributes positively to the score.

This change provides an opt-in stricter scoring mode for users who want ambiguous statements to be penalized while remaining backward compatible with the existing behavior.

Addresses #1137.

## Testing

Added focused tests covering:

* Existing/default `idk` scoring behavior
* Penalized `idk` scoring
* Ambiguous-only verdicts
* Strict mode behavior
* Existing empty-output regression behavior

Validation performed locally:

* 8 targeted tests passed
* `black --check` passed
* Python compilation passed
* `git diff --check` passed