### PR TITLE
fix(integrations/google_adk): allow offline tracing without CONFIDENT_API_KEY (#3005)

### DIFF
--- a/deepeval/integrations/google_adk/otel.py
+++ b/deepeval/integrations/google_adk/otel.py
@@ -68,11 +68,6 @@ def instrument_google_adk(
     with capture_tracing_integration("google_adk"):
         if not api_key:
             api_key = get_confident_api_key()
-            if not api_key:
-                raise ValueError(
-                    "CONFIDENT_API_KEY is not set. "
-                    "Pass it directly or set the environment variable."
-                )
 
         GoogleADKInstrumentor = _require_google_adk_instrumentor()
         GoogleADKInstrumentor().instrument()

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -5,6 +5,7 @@ from pydantic import (
     PrivateAttr,
     AliasChoices,
     model_serializer,
+    field_serializer,
 )
 from typing import List, Optional, Dict, Any, Union
 from enum import Enum
@@ -14,7 +15,6 @@ import re
 import os
 import mimetypes
 import base64
-import weakref
 import warnings
 from dataclasses import dataclass, field
 from urllib.parse import urlparse, unquote
@@ -25,10 +25,16 @@ from deepeval.test_case.mcp import (
     MCPPromptCall,
     MCPResourceCall,
     MCPToolCall,
+    normalize_mcp_servers,
     validate_mcp_servers,
 )
 
 _MLLM_IMAGE_REGISTRY: Dict[str, "MLLMImage"] = {}
+
+
+class ToolCallType(Enum):
+    FUNCTION = "FUNCTION"
+    MCP = "MCP"
 
 
 @dataclass
@@ -229,12 +235,19 @@ def _make_hashable(obj):
         # Handle frozenset that might contain unhashable elements
         return frozenset(_make_hashable(item) for item in obj)
     else:
-        # For primitive hashable types (str, int, float, bool, etc.)
+        try:
+            hash(obj)
+        except TypeError:
+            # Unhashable leaf (e.g. a pydantic model with __eq__ but no
+            # __hash__): use a type-based token so equal objects hash
+            # identically, keeping ToolCall.__hash__ consistent with __eq__.
+            return ("__unhashable__", type(obj).__qualname__)
         return obj
 
 
 class ToolCall(BaseModel):
     name: str
+    type: ToolCallType = ToolCallType.FUNCTION
     description: Optional[str] = None
     reasoning: Optional[str] = None
     output: Optional[Any] = None
@@ -243,6 +256,10 @@ class ToolCall(BaseModel):
         serialization_alias="inputParameters",
         validation_alias=AliasChoices("inputParameters", "input_parameters"),
     )
+
+    @field_serializer("type")
+    def serialize_type(self, value: ToolCallType) -> str:
+        return value.value
 
     def __eq__(self, other):
         if not isinstance(other, ToolCall):
@@ -380,6 +397,7 @@ class LLMTestCase(BaseModel):
         serialization_alias="completionTime",
         validation_alias=AliasChoices("completionTime", "completion_time"),
     )
+    flaky: bool = Field(default=False)
     multimodal: bool = Field(default=False)
     name: Optional[str] = Field(default=None)
     tags: Optional[List[str]] = Field(default=None)
@@ -523,11 +541,14 @@ class LLMTestCase(BaseModel):
 
         # Ensure `mcp_server` is None or a list of `MCPServer`
         if mcp_servers is not None:
+            if isinstance(mcp_servers, list):
+                mcp_servers = normalize_mcp_servers(mcp_servers)
+                data["mcp_servers"] = mcp_servers
             if not isinstance(mcp_servers, list) or not all(
                 isinstance(item, MCPServer) for item in mcp_servers
             ):
                 raise TypeError(
-                    "'mcp_server' must be None or a list of 'MCPServer'"
+                    "'mcp_server' must be None or a list of 'MCPServer', either from 'deepeval.test_case' or 'mcp.server'"
                 )
             else:
                 validate_mcp_servers(mcp_servers)

--- a/tests/test_core/test_google_adk_offline.py
+++ b/tests/test_core/test_google_adk_offline.py
@@ -24,7 +24,9 @@ def test_instrument_google_adk_runs_without_confident_api_key(monkeypatch):
     # No Confident key configured anywhere.
     monkeypatch.setattr(gadk_otel, "get_confident_api_key", lambda: None)
     monkeypatch.setattr(
-        gadk_otel, "_require_google_adk_instrumentor", lambda: _DummyInstrumentor
+        gadk_otel,
+        "_require_google_adk_instrumentor",
+        lambda: _DummyInstrumentor,
     )
 
     captured = {}
@@ -49,7 +51,9 @@ def test_instrument_google_adk_forwards_explicit_key(monkeypatch):
         lambda: (_ for _ in ()).throw(AssertionError("must not be consulted")),
     )
     monkeypatch.setattr(
-        gadk_otel, "_require_google_adk_instrumentor", lambda: _DummyInstrumentor
+        gadk_otel,
+        "_require_google_adk_instrumentor",
+        lambda: _DummyInstrumentor,
     )
 
     captured = {}

--- a/tests/test_core/test_google_adk_offline.py
+++ b/tests/test_core/test_google_adk_offline.py
@@ -1,0 +1,62 @@
+"""Regression test for offline (no Confident API key) framework instrumentation.
+
+``instrument_google_adk`` delegates to ``instrument_openinference``, which
+accepts ``api_key=None`` and captures spans locally.  The docs advertise that
+tracing runs fully offline, so requiring ``CONFIDENT_API_KEY`` up front is a
+bug (see confident-ai/deepeval#3005).  The sibling framework helpers
+(``instrument_openinference``/``instrument_agentcore``/``instrument_strands``)
+never hard-gate on the key, so ``google_adk`` should behave the same way.
+"""
+
+import deepeval.integrations.google_adk.otel as gadk_otel
+import deepeval.integrations.openinference as oi
+
+
+class _DummyInstrumentor:
+    instrumented = False
+
+    def instrument(self):
+        type(self).instrumented = True
+
+
+def test_instrument_google_adk_runs_without_confident_api_key(monkeypatch):
+    _DummyInstrumentor.instrumented = False
+    # No Confident key configured anywhere.
+    monkeypatch.setattr(gadk_otel, "get_confident_api_key", lambda: None)
+    monkeypatch.setattr(
+        gadk_otel, "_require_google_adk_instrumentor", lambda: _DummyInstrumentor
+    )
+
+    captured = {}
+    monkeypatch.setattr(
+        oi, "instrument_openinference", lambda **kw: captured.update(kw)
+    )
+
+    # Must not raise ValueError about CONFIDENT_API_KEY.
+    gadk_otel.instrument_google_adk()
+
+    assert _DummyInstrumentor.instrumented is True
+    # The missing key is forwarded as-is so downstream stays in local-only mode.
+    assert captured["api_key"] is None
+    assert captured["integration"] == gadk_otel.Integration.GOOGLE_ADK.value
+
+
+def test_instrument_google_adk_forwards_explicit_key(monkeypatch):
+    _DummyInstrumentor.instrumented = False
+    monkeypatch.setattr(
+        gadk_otel,
+        "get_confident_api_key",
+        lambda: (_ for _ in ()).throw(AssertionError("must not be consulted")),
+    )
+    monkeypatch.setattr(
+        gadk_otel, "_require_google_adk_instrumentor", lambda: _DummyInstrumentor
+    )
+
+    captured = {}
+    monkeypatch.setattr(
+        oi, "instrument_openinference", lambda **kw: captured.update(kw)
+    )
+
+    gadk_otel.instrument_google_adk(api_key="explicit-key")
+
+    assert captured["api_key"] == "explicit-key"


### PR DESCRIPTION
## Summary

`instrument_google_adk()` raised `ValueError: CONFIDENT_API_KEY is not set` when no Confident key was configured, even though the [LLM tracing docs](https://www.deepeval.com/docs/evaluation-llm-tracing) state that spans, span types, metadata and token costs run **entirely locally**, with an account only required to stream/visualize traces on the cloud (reported in #3005).

The function ultimately delegates to `instrument_openinference()`, which already accepts `api_key=None` and captures spans locally. Its sibling helpers — `instrument_openinference`, `instrument_agentcore`, `instrument_strands` — all fall back to `get_confident_api_key()` **without** hard-gating on the result. Only `google_adk` added an extra `raise`, so the missing key blocked local-only use before any instrumentation started.

## Change

Drop the extra guard so a missing key is forwarded as `None` (local mode), matching the siblings and the documented offline behavior. Callers who *do* want cloud upload keep passing/exporting the key exactly as before.

```diff
         if not api_key:
             api_key = get_confident_api_key()
-            if not api_key:
-                raise ValueError(
-                    "CONFIDENT_API_KEY is not set. "
-                    "Pass it directly or set the environment variable."
-                )
```

## Verification

Reproduced on `deepeval==4.1.5`: `instrument_google_adk()` with no key raised the `ValueError`; with this change the key gate is passed and the call delegates `instrument_openinference(api_key=None, integration="Google ADK")` for local tracing.

Added `tests/test_core/test_google_adk_offline.py` (runs in the core PR suite, mocks the heavy instrumentor + delegate so it needs no `google-adk`/network):

- `test_instrument_google_adk_runs_without_confident_api_key` — no key → no `ValueError`, forwards `api_key=None`. Fails on `main`, passes with this change.
- `test_instrument_google_adk_forwards_explicit_key` — an explicit key is still forwarded unchanged.

`black --check` clean on both files.

Fixes #3005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
