### PR TITLE
fix(prompt): render Jinja templates in a sandbox to prevent SSTI

### DIFF
--- a/deepeval/prompt/utils.py
+++ b/deepeval/prompt/utils.py
@@ -1,6 +1,6 @@
 import re
 import uuid
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 from typing import (
     Any,
     Dict,
@@ -78,8 +78,18 @@ def interpolate_dollar_brackets(text: str, **kwargs: Any) -> str:
     return re.sub(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}", replace_match, text)
 
 
+# A prompt template can originate from an untrusted source (a prompt pulled from
+# the Confident AI cloud, a shared/team prompt, or a file). Rendering it with a
+# plain ``jinja2.Template`` evaluates the whole template body, which allows
+# Server-Side Template Injection (e.g. ``{{ ''.__class__.__mro__[1].__subclasses__() }}``)
+# and can lead to remote code execution. A ``SandboxedEnvironment`` blocks access
+# to unsafe attributes/methods (raising ``jinja2.exceptions.SecurityError``) while
+# still supporting normal variable substitution, filters and control structures.
+_JINJA_SANDBOX = SandboxedEnvironment()
+
+
 def interpolate_jinja(text: str, **kwargs: Any) -> str:
-    template = Template(text)
+    template = _JINJA_SANDBOX.from_string(text)
     return template.render(**kwargs)
 
 

--- a/tests/test_core/test_prompts/test_interpolation.py
+++ b/tests/test_core/test_prompts/test_interpolation.py
@@ -452,7 +452,7 @@ class TestInterpolateDollarBrackets:
 
 
 class TestInterpolateJinja:
-    """Tests for Jinja2 format - uses Jinja2 library directly"""
+    """Tests for Jinja2 format - uses a sandboxed Jinja2 environment"""
 
     def test_simple_variable(self):
         text = "Hello {{ name }}"
@@ -492,6 +492,48 @@ class TestInterpolateJinja:
         text = '{{ name }} data: {"key": "value"}'
         result = interpolate_jinja(text, name="User")
         assert result == 'User data: {"key": "value"}'
+
+
+class TestInterpolateJinjaSandbox:
+    """Jinja templates can come from untrusted sources (cloud/shared/file prompts),
+    so interpolate_jinja must run in a sandbox that blocks Server-Side Template
+    Injection while still supporting normal templating."""
+
+    # Payloads that reach Python internals -> would be RCE without a sandbox.
+    SSTI_PAYLOADS = [
+        "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+        "{{ ''.__class__.__mro__ }}",
+        "{{ cycler.__init__.__globals__ }}",
+        "{{ self.__init__.__globals__ }}",
+        "{{ ''.__class__.__base__.__subclasses__() }}",
+    ]
+
+    def test_ssti_payloads_are_blocked(self):
+        from jinja2.exceptions import SecurityError
+
+        for payload in self.SSTI_PAYLOADS:
+            with pytest.raises(SecurityError):
+                interpolate_jinja(payload)
+
+    def test_sandbox_does_not_leak_class_internals(self):
+        # Even if rendering were to succeed, it must not expose subclass gadgets.
+        from jinja2.exceptions import SecurityError
+
+        with pytest.raises(SecurityError):
+            interpolate_jinja("{{ ().__class__.__bases__[0].__subclasses__() }}")
+
+    def test_legitimate_templating_still_works(self):
+        # The sandbox must not break normal, benign templating.
+        assert interpolate_jinja("Hello {{ name }}", name="Alice") == "Hello Alice"
+        assert interpolate_jinja("{{ n|upper }}", n="bob") == "BOB"
+        assert (
+            interpolate_jinja(
+                "{% for x in items %}{{ x }}{% if not loop.last %},{% endif %}{% endfor %}",
+                items=["a", "b", "c"],
+            )
+            == "a,b,c"
+        )
+        assert interpolate_jinja("{{ val }}", val=42) == "42"
 
 
 class TestEdgeCasesAcrossAllFormats:


### PR DESCRIPTION
# PR: Render Jinja prompt templates in a sandbox to prevent SSTI

**Branch:** `fix/prompt-jinja-ssti-sandbox` → `confident-ai/deepeval:main`
**Type:** Security fix (hardening)
**Files:** `deepeval/prompt/utils.py`, `tests/test_core/test_prompts/test_interpolation.py`

---

## Summary

`interpolate_jinja()` renders prompt templates with a plain `jinja2.Template`,
which evaluates the **entire template body**, not just variable substitutions.
Because a prompt template can originate from an untrusted source, a malicious
template body can use Server-Side Template Injection (SSTI) to reach Python
internals and execute arbitrary code.

This PR renders through a `jinja2.sandbox.SandboxedEnvironment`, which blocks
access to unsafe attributes/methods while leaving normal templating untouched.

## Why this matters

The template string passed to `interpolate_jinja` is not always author-controlled.
It can come from:

- a prompt pulled from the Confident AI cloud (`Prompt.pull()` sets both the
  template body and the interpolation type from the server response),
- a shared/team prompt, or
- a prompt loaded from a file (`Prompt.load()`).

With a raw `jinja2.Template`, a template body such as:

```jinja
{{ ''.__class__.__mro__[1].__subclasses__() }}
{{ cycler.__init__.__globals__ }}
```

is evaluated and can be escalated to arbitrary code execution on the machine
that pulls/interpolates the prompt. This is the classic Jinja2 SSTI class
(CWE-1336 → CWE-94).

## The change

```diff
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 ...
+_JINJA_SANDBOX = SandboxedEnvironment()
+
 def interpolate_jinja(text: str, **kwargs: Any) -> str:
-    template = Template(text)
+    template = _JINJA_SANDBOX.from_string(text)
     return template.render(**kwargs)
```

`SandboxedEnvironment` raises `jinja2.exceptions.SecurityError` on attempts to
access unsafe attributes (`__class__`, `__mro__`, `__globals__`, `__subclasses__`,
etc.) but continues to support variable substitution, filters, conditionals, and
loops — so legitimate prompts are unaffected.

## Compatibility / blast radius

- **No behavior change for legitimate templates.** Autoescape stays off (this is
  prompt text, not HTML), so output for normal variables/filters/control
  structures is byte-for-byte identical.
- Only the JINJA interpolation path is affected; the mustache / f-string /
  dollar-bracket interpolators are unchanged.

## Tests

Adds `TestInterpolateJinjaSandbox`:

- asserts a set of SSTI payloads now raise `SecurityError`;
- asserts legitimate templating (variables, `|upper`, `for` loops, int coercion)
  still renders correctly.

All existing prompt tests continue to pass:

```
tests/test_core/test_prompts/  →  100 passed
```

## Notes

- Considered `ImmutableSandboxedEnvironment` (also forbids mutating calls on
  built-in containers). `SandboxedEnvironment` is sufficient to stop the SSTI/RCE
  vector here; happy to switch to the immutable variant if maintainers prefer the
  stricter default.
