### PR TITLE
fix(benchmarks): gate HumanEval code execution behind explicit opt-in

### DIFF
--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -9,16 +9,53 @@ from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.human_eval.task import HumanEvalTask
 from deepeval.benchmarks.human_eval.template import HumanEvalTemplate
 from deepeval.telemetry import capture_benchmark_run
+from deepeval.config.utils import get_env_bool
 
 
-def secure_exec(code_str, global_vars=None, local_vars=None):
-    """Securely execute code with restricted globals and locals."""
+# Opt-in flag required before any model-generated code is executed.
+ALLOW_CODE_EXECUTION_ENV_VAR = "DEEPEVAL_ALLOW_CODE_EXECUTION"
+
+
+def _require_code_execution_enabled() -> None:
+    """Raise unless the operator has explicitly opted in to code execution.
+
+    Scoring HumanEval functional correctness runs untrusted, model-generated
+    code on this machine, which is a remote-code-execution risk.
+    """
+    if not get_env_bool(ALLOW_CODE_EXECUTION_ENV_VAR, default=False):
+        raise RuntimeError(
+            "The HumanEval benchmark executes untrusted, model-generated code on "
+            "this machine, which is a remote-code-execution risk. It is disabled "
+            "by default. To enable it, set the environment variable "
+            f"{ALLOW_CODE_EXECUTION_ENV_VAR}=1, and only do so inside an isolated "
+            "sandbox (a disposable container/VM with no network access, no "
+            "credentials, and least privilege)."
+        )
+
+
+def _execute_untrusted_code(code_str, global_vars=None, local_vars=None):
+    """Execute model-generated code for functional-correctness scoring.
+
+    WARNING: this runs UNTRUSTED code produced by the model under evaluation.
+    The restricted ``__builtins__`` mapping below is NOT a security sandbox — it
+    can be trivially bypassed (e.g. ``().__class__.__bases__[0].__subclasses__()``),
+    so this function can execute arbitrary code, including OS commands and file
+    access, with the privileges of the current process.
+
+    Execution is therefore disabled unless the caller explicitly opts in by
+    setting ``DEEPEVAL_ALLOW_CODE_EXECUTION=1``, and it should only ever be run
+    inside a disposable, isolated sandbox (a container/VM with no network, no
+    credentials, and least privilege).
+    """
+    _require_code_execution_enabled()
     if global_vars is None:
         global_vars = {}
     if local_vars is None:
         local_vars = {}
 
-    # Create a restricted globals dictionary with only safe built-ins
+    # NOTE: this restricted builtins mapping narrows the default namespace but is
+    # NOT a security boundary (attribute traversal can reach arbitrary objects).
+    # It does not make executing untrusted code safe — see the docstring above.
     safe_globals = {
         "__builtins__": {
             "abs": abs,
@@ -191,6 +228,10 @@ class HumanEval(DeepEvalBaseBenchmark):
         c = self.c.get(task.value, None)
         functions = self.functions.get(task.value, None)
         if c is None:
+            # Fail fast (and before spending model calls) if code execution has
+            # not been explicitly enabled. The per-sample try/except below would
+            # otherwise swallow this and silently report an accuracy of 0.
+            _require_code_execution_enabled()
             # Define prompt template
             prompt: dict = HumanEvalTemplate.generate_output(
                 input=golden.input,
@@ -203,7 +244,7 @@ class HumanEval(DeepEvalBaseBenchmark):
             for function in functions:
                 try:
                     full_code = function + "\n" + golden.expected_output
-                    secure_exec(full_code)
+                    _execute_untrusted_code(full_code)
                     c += 1
                 except AssertionError:
                     pass

--- a/tests/test_benchmarks/test_human_eval_code_execution_gate.py
+++ b/tests/test_benchmarks/test_human_eval_code_execution_gate.py
@@ -1,0 +1,40 @@
+"""
+Security regression tests for the HumanEval code-execution opt-in gate.
+
+Scoring HumanEval functional correctness executes untrusted, model-generated
+code on the host. The restricted-builtins mapping is not a security boundary, so
+execution must be disabled unless the operator explicitly opts in via
+``DEEPEVAL_ALLOW_CODE_EXECUTION`` (and sandboxes the run).
+"""
+
+import pytest
+
+from deepeval.benchmarks.human_eval.human_eval import (
+    _execute_untrusted_code,
+    ALLOW_CODE_EXECUTION_ENV_VAR,
+)
+
+
+class TestCodeExecutionGate:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv(ALLOW_CODE_EXECUTION_ENV_VAR, raising=False)
+        with pytest.raises(RuntimeError, match="disabled by default"):
+            _execute_untrusted_code("x = 1")
+
+    def test_explicit_falsy_value_still_blocks(self, monkeypatch):
+        monkeypatch.setenv(ALLOW_CODE_EXECUTION_ENV_VAR, "0")
+        with pytest.raises(RuntimeError):
+            _execute_untrusted_code("x = 1")
+
+    def test_opt_in_allows_execution(self, monkeypatch):
+        monkeypatch.setenv(ALLOW_CODE_EXECUTION_ENV_VAR, "1")
+        result = _execute_untrusted_code("result = 6 * 7", local_vars={})
+        assert result["result"] == 42
+
+    def test_no_execution_side_effect_when_blocked(self, monkeypatch):
+        """The blocked path must raise before running any of the code."""
+        monkeypatch.delenv(ALLOW_CODE_EXECUTION_ENV_VAR, raising=False)
+        local_vars = {}
+        with pytest.raises(RuntimeError):
+            _execute_untrusted_code("result = 123", local_vars=local_vars)
+        assert "result" not in local_vars


### PR DESCRIPTION
# PR: Gate HumanEval code execution behind an explicit opt-in

**Branch:** `fix/human-eval-code-execution` → `confident-ai/deepeval:main`
**Type:** Security fix
**File:** `deepeval/benchmarks/human_eval/human_eval.py` (+ tests)

---

## Summary

Scoring HumanEval functional correctness executes code produced by the **model
under evaluation** via `exec()` (`secure_exec(function + "\n" + golden.expected_output)`).
`secure_exec` only swaps in a restricted `__builtins__` mapping, which is **not a
security boundary** — it is trivially bypassed:

```python
().__class__.__bases__[0].__subclasses__()   # reaches subprocess.Popen, etc.
```

So a model whose output an attacker can influence (a malicious/poisoned model, a
compromised or MITM'd inference endpoint, or prompt injection) can achieve
arbitrary code execution on the machine running the benchmark. The function name
and docstring ("Securely execute code…") also imply a safety guarantee that
doesn't exist.

Executing untrusted code can't be made safe in-process, so this PR makes the risk
**explicit and opt-in** instead of implied-safe.

## Changes

- Rename `secure_exec` → `_execute_untrusted_code` and remove the "securely
  execute" wording. The docstring now states plainly that the restricted builtins
  are **not** a sandbox and that the function can run arbitrary code.
- **Refuse to execute unless `DEEPEVAL_ALLOW_CODE_EXECUTION=1`** is set, via a
  small `_require_code_execution_enabled()` helper. The error tells the operator
  to run inside a disposable, isolated sandbox (container/VM, no network, no
  credentials, least privilege).
- Check the flag **up front in `HumanEval.predict`** (before any model calls),
  because the existing per-sample `try/except Exception: pass` would otherwise
  swallow the guard and silently report an accuracy of 0.

This is intentionally a **minimal, fail-safe** change. It does not attempt to
build a real sandbox (subprocess isolation / reliability guard / resource limits)
— happy to follow up with that if you'd prefer execution to be hardened rather
than gated.

## Behavior change

`HumanEval().evaluate(model)` now raises unless `DEEPEVAL_ALLOW_CODE_EXECUTION=1`
is set. This is a deliberate fail-closed default for a code-execution feature.
Existing import/usage is otherwise unchanged (the public `HumanEval` class is
untouched); only the internal helper was renamed.

## Tests

`tests/test_benchmarks/test_human_eval_code_execution_gate.py`:

- execution is blocked by default;
- blocked when the flag is explicitly falsy (`=0`);
- runs when opted in (`=1`);
- no code side effects occur on the blocked path.

Existing import smoke test (`tests/test_core/test_imports.py`) still passes.

## Note

This issue has been raised previously in the community; this PR is a concrete,
minimal remediation. I'm happy to iterate on the approach (e.g. a sandboxed
subprocess executor) based on your preference.
