### PR TITLE
fix(models): fetch remote multimodal images safely (SSRF + DNS rebinding)

### DIFF
--- a/deepeval/models/llms/gemini_model.py
+++ b/deepeval/models/llms/gemini_model.py
@@ -205,21 +205,18 @@ class GeminiModel(DeepEvalBaseLLM):
                 # Gemini doesn't support direct external URLs
                 # Must convert all images to bytes
                 if element.url and not element.local:
-                    import requests
+                    from deepeval.models.media_fetch import fetch_remote_media
 
                     settings = get_settings()
-
-                    response = requests.get(
+                    # SSRF-safe fetch (blocks internal/link-local targets and
+                    # pins the connection to the validated IP; see media_fetch).
+                    image_data, content_type = fetch_remote_media(
                         element.url,
-                        timeout=(
-                            settings.MEDIA_IMAGE_CONNECT_TIMEOUT_SECONDS,
-                            settings.MEDIA_IMAGE_READ_TIMEOUT_SECONDS,
-                        ),
+                        connect_timeout=settings.MEDIA_IMAGE_CONNECT_TIMEOUT_SECONDS,
+                        read_timeout=settings.MEDIA_IMAGE_READ_TIMEOUT_SECONDS,
                     )
-                    response.raise_for_status()
-                    image_data = response.content
-                    mime_type = response.headers.get(
-                        "content-type", element.mimeType or "image/jpeg"
+                    mime_type = (
+                        content_type or element.mimeType or "image/jpeg"
                     )
                 else:
                     element.ensure_images_loaded()

--- a/deepeval/models/llms/local_model.py
+++ b/deepeval/models/llms/local_model.py
@@ -151,35 +151,22 @@ class LocalModel(DeepEvalBaseLLM):
                 # For local servers, use data URIs for both remote and local images
                 # Most local servers don't support fetching external URLs
                 if element.url and not element.local:
-                    import requests
                     import base64
+                    from deepeval.models.media_fetch import fetch_remote_media
 
                     settings = get_settings()
-                    try:
-                        response = requests.get(
-                            element.url,
-                            timeout=(
-                                settings.MEDIA_IMAGE_CONNECT_TIMEOUT_SECONDS,
-                                settings.MEDIA_IMAGE_READ_TIMEOUT_SECONDS,
-                            ),
-                        )
-                        response.raise_for_status()
-
-                        # Get mime type from response
-                        mime_type = response.headers.get(
-                            "content-type", element.mimeType or "image/jpeg"
-                        )
-
-                        # Encode to base64
-                        b64_data = base64.b64encode(response.content).decode(
-                            "utf-8"
-                        )
-                        data_uri = f"data:{mime_type};base64,{b64_data}"
-
-                    except Exception as e:
-                        raise ValueError(
-                            f"Failed to fetch remote image {element.url}: {e}"
-                        )
+                    # SSRF-safe fetch (blocks internal/link-local targets and
+                    # pins the connection to the validated IP; see media_fetch).
+                    content, content_type = fetch_remote_media(
+                        element.url,
+                        connect_timeout=settings.MEDIA_IMAGE_CONNECT_TIMEOUT_SECONDS,
+                        read_timeout=settings.MEDIA_IMAGE_READ_TIMEOUT_SECONDS,
+                    )
+                    mime_type = (
+                        content_type or element.mimeType or "image/jpeg"
+                    )
+                    b64_data = base64.b64encode(content).decode("utf-8")
+                    data_uri = f"data:{mime_type};base64,{b64_data}"
                 else:
                     element.ensure_images_loaded()
                     mime_type = element.mimeType or "image/jpeg"

--- a/deepeval/models/llms/ollama_model.py
+++ b/deepeval/models/llms/ollama_model.py
@@ -146,24 +146,22 @@ class OllamaModel(DeepEvalBaseLLM):
                 )
             elif isinstance(element, MLLMImage):
                 if element.url and not element.local:
-                    import requests
                     from PIL import Image
                     import io
+                    from deepeval.models.media_fetch import fetch_remote_media
 
                     settings = get_settings()
                     try:
-                        response = requests.get(
+                        # SSRF-safe fetch (blocks internal/link-local targets and
+                        # pins the connection to the validated IP; see media_fetch).
+                        content, _ = fetch_remote_media(
                             element.url,
-                            stream=True,
-                            timeout=(
-                                settings.MEDIA_IMAGE_CONNECT_TIMEOUT_SECONDS,
-                                settings.MEDIA_IMAGE_READ_TIMEOUT_SECONDS,
-                            ),
+                            connect_timeout=settings.MEDIA_IMAGE_CONNECT_TIMEOUT_SECONDS,
+                            read_timeout=settings.MEDIA_IMAGE_READ_TIMEOUT_SECONDS,
                         )
-                        response.raise_for_status()
 
                         # Convert to JPEG and encode
-                        image = Image.open(io.BytesIO(response.content))
+                        image = Image.open(io.BytesIO(content))
                         buffered = io.BytesIO()
 
                         # Convert RGBA/LA/P to RGB for JPEG
@@ -173,7 +171,7 @@ class OllamaModel(DeepEvalBaseLLM):
                         image.save(buffered, format="JPEG")
                         img_b64 = base64.b64encode(buffered.getvalue()).decode()
 
-                    except (requests.exceptions.RequestException, OSError) as e:
+                    except OSError as e:
                         print(f"Image fetch/encode failed: {e}")
                         raise
                 else:

--- a/deepeval/models/media_fetch.py
+++ b/deepeval/models/media_fetch.py
@@ -1,0 +1,175 @@
+"""
+SSRF-safe fetching of remote media (images) referenced by multimodal test cases.
+
+A multimodal ``MLLMImage`` can carry an ``http(s)://`` URL that originates from
+untrusted data (a dataset, a traced message, a retrieved document). Fetching it
+naively with ``requests.get(url)`` is a Server-Side Request Forgery vector: the
+URL can point at internal/link-local services or the cloud metadata endpoint
+(``169.254.169.254``) and the response is folded back into the model payload.
+
+This module fetches such URLs safely:
+
+* only ``http``/``https`` schemes are allowed;
+* the host is resolved and **every** resolved address must be publicly routable
+  (private, loopback, link-local, CGNAT, reserved, multicast and unspecified
+  ranges are refused);
+* the connection is **pinned to the validated IP** rather than re-resolved by
+  the HTTP client. This is what prevents DNS-rebinding: without pinning an
+  attacker's DNS can return a public IP for the validation lookup and a private
+  IP for the actual request. TLS SNI / certificate validation still use the
+  original hostname;
+* redirects are followed manually and each hop is re-validated and re-pinned.
+"""
+
+import ipaddress
+import socket
+from typing import List, Optional, Tuple
+from urllib.parse import urljoin, urlparse
+
+import certifi
+import urllib3
+
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_DEFAULT_MAX_REDIRECTS = 3
+
+
+class MediaFetchError(ValueError):
+    """Raised when a remote media URL is unsafe to fetch or cannot be fetched."""
+
+
+def _is_disallowed_ip(ip_str: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True
+    # Normalise IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) to its IPv4 form.
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+    return (
+        not addr.is_global
+        or addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def _resolve_public_ips(host: str, port: int) -> List[str]:
+    try:
+        infos = socket.getaddrinfo(
+            host, port, proto=socket.IPPROTO_TCP
+        )
+    except socket.gaierror as e:
+        raise MediaFetchError(f"could not resolve host {host!r}: {e}")
+
+    ips: List[str] = []
+    for info in infos:
+        ip = info[4][0].split("%")[0]  # drop any IPv6 scope id
+        if ip not in ips:
+            ips.append(ip)
+
+    if not ips:
+        raise MediaFetchError(f"host {host!r} did not resolve to any address")
+
+    # Every resolved address must be public: an attacker must not be able to
+    # slip in a single internal address alongside public ones.
+    for ip in ips:
+        if _is_disallowed_ip(ip):
+            raise MediaFetchError(
+                f"refusing to fetch {host!r}: resolves to non-public address {ip}"
+            )
+    return ips
+
+
+def _host_header(host: str, port: int, scheme: str) -> str:
+    bracketed = f"[{host}]" if ":" in host else host
+    default_port = 443 if scheme == "https" else 80
+    return bracketed if port == default_port else f"{bracketed}:{port}"
+
+
+def fetch_remote_media(
+    url: str,
+    *,
+    connect_timeout: Optional[float] = None,
+    read_timeout: Optional[float] = None,
+    max_redirects: int = _DEFAULT_MAX_REDIRECTS,
+) -> Tuple[bytes, Optional[str]]:
+    """Fetch a remote media URL with SSRF (and DNS-rebinding) protection.
+
+    Returns ``(content_bytes, content_type)``. Raises ``MediaFetchError`` if the
+    URL is unsafe, cannot be resolved to a public address, or fails to fetch.
+    """
+    current = url
+    for _ in range(max_redirects + 1):
+        parsed = urlparse(current)
+        scheme = parsed.scheme.lower()
+        if scheme not in ("http", "https"):
+            raise MediaFetchError(
+                f"unsupported URL scheme {scheme!r}; only http/https are allowed"
+            )
+        host = parsed.hostname
+        if not host:
+            raise MediaFetchError(f"URL has no host: {current!r}")
+        port = parsed.port or (443 if scheme == "https" else 80)
+
+        # Resolve + validate, then pin the connection to a validated IP so the
+        # HTTP client cannot re-resolve to a different (internal) address.
+        pinned_ip = _resolve_public_ips(host, port)[0]
+        timeout = urllib3.Timeout(connect=connect_timeout, read=read_timeout)
+
+        if scheme == "https":
+            pool = urllib3.HTTPSConnectionPool(
+                host=pinned_ip,
+                port=port,
+                cert_reqs="CERT_REQUIRED",
+                ca_certs=certifi.where(),
+                server_hostname=host,  # SNI + certificate hostname
+                assert_hostname=host,
+                timeout=timeout,
+                retries=False,
+                maxsize=1,
+            )
+        else:
+            pool = urllib3.HTTPConnectionPool(
+                host=pinned_ip,
+                port=port,
+                timeout=timeout,
+                retries=False,
+                maxsize=1,
+            )
+
+        target = parsed.path or "/"
+        if parsed.query:
+            target += f"?{parsed.query}"
+
+        try:
+            resp = pool.urlopen(
+                "GET",
+                target,
+                headers={"Host": _host_header(host, port, scheme)},
+                redirect=False,
+                preload_content=True,
+                decode_content=False,
+            )
+            status = resp.status
+            if status in _REDIRECT_STATUSES:
+                location = resp.headers.get("Location")
+                if not location:
+                    raise MediaFetchError(
+                        f"redirect with no Location while fetching {url!r}"
+                    )
+                current = urljoin(current, location)
+                continue  # re-validate + re-pin the next hop
+            if status >= 400:
+                raise MediaFetchError(
+                    f"failed to fetch {url!r}: HTTP status {status}"
+                )
+            return resp.data, resp.headers.get("Content-Type")
+        except urllib3.exceptions.HTTPError as e:
+            raise MediaFetchError(f"failed to fetch {url!r}: {e}")
+        finally:
+            pool.close()
+
+    raise MediaFetchError(f"too many redirects while fetching {url!r}")

--- a/tests/test_core/test_models/test_media_fetch_ssrf.py
+++ b/tests/test_core/test_models/test_media_fetch_ssrf.py
@@ -1,0 +1,114 @@
+"""
+Security regression tests for SSRF-safe remote media fetching.
+
+`fetch_remote_media` is used by the multimodal model integrations to download an
+image referenced by an (untrusted) `MLLMImage.url`. It must refuse internal /
+link-local / metadata targets and must be resistant to DNS rebinding (validate
+and then pin the connection to the validated IP rather than re-resolving).
+"""
+
+import socket
+
+import pytest
+
+from deepeval.models.media_fetch import (
+    fetch_remote_media,
+    MediaFetchError,
+    _is_disallowed_ip,
+)
+
+
+class TestIpClassification:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "169.254.169.254",  # cloud metadata / link-local
+            "127.0.0.1",  # loopback
+            "10.0.0.5",  # private
+            "192.168.1.1",  # private
+            "172.16.0.1",  # private
+            "0.0.0.0",  # unspecified
+            "::1",  # ipv6 loopback
+            "fe80::1",  # ipv6 link-local
+            "fc00::1",  # ipv6 unique-local
+            "::ffff:169.254.169.254",  # ipv4-mapped metadata
+            "100.64.0.1",  # CGNAT / shared address space
+            "not-an-ip",
+        ],
+    )
+    def test_disallowed(self, ip):
+        assert _is_disallowed_ip(ip) is True
+
+    @pytest.mark.parametrize("ip", ["8.8.8.8", "1.1.1.1", "93.184.216.34"])
+    def test_allowed(self, ip):
+        assert _is_disallowed_ip(ip) is False
+
+
+class TestFetchBlocks:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://127.0.0.1:8080/admin",
+            "http://localhost/x",
+            "http://10.0.0.5/",
+            "http://[::1]/",
+            "file:///etc/passwd",
+            "ftp://example.com/x",
+            "gopher://127.0.0.1:6379/_INFO",
+        ],
+    )
+    def test_unsafe_urls_are_refused(self, url):
+        with pytest.raises(MediaFetchError):
+            fetch_remote_media(url, connect_timeout=2, read_timeout=2)
+
+    def test_dns_rebinding_is_blocked(self, monkeypatch):
+        """A hostname that resolves to an internal IP must be refused, even if
+        it looks like an ordinary public hostname."""
+        real_getaddrinfo = socket.getaddrinfo
+
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            if host == "rebind.example":
+                return [
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("169.254.169.254", port),
+                    )
+                ]
+            return real_getaddrinfo(host, port, *args, **kwargs)
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        with pytest.raises(MediaFetchError, match="non-public address"):
+            fetch_remote_media(
+                "http://rebind.example/latest/meta-data/",
+                connect_timeout=2,
+                read_timeout=2,
+            )
+
+    def test_mixed_public_and_private_resolution_is_refused(self, monkeypatch):
+        """If a host resolves to several addresses and any one is internal, the
+        fetch must be refused (an attacker must not slip in one bad IP)."""
+        real_getaddrinfo = socket.getaddrinfo
+
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            if host == "mixed.example":
+                return [
+                    (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port)),
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("127.0.0.1", port),
+                    ),
+                ]
+            return real_getaddrinfo(host, port, *args, **kwargs)
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        with pytest.raises(MediaFetchError):
+            fetch_remote_media(
+                "http://mixed.example/x", connect_timeout=2, read_timeout=2
+            )


### PR DESCRIPTION
# PR: Fetch remote multimodal images safely (SSRF + DNS rebinding)

**Branch:** `fix/ssrf-media-fetch` → `confident-ai/deepeval:main`
**Type:** Security fix
**Files:** `deepeval/models/media_fetch.py` (new), `deepeval/models/llms/{local,gemini,ollama}_model.py` (+ tests)

---

## Summary

The `local`, `gemini`, and `ollama` multimodal integrations download an image
referenced by `MLLMImage.url` with a bare `requests.get(url)` and **no host
validation** (only the URL scheme is loosely constrained upstream):

```python
response = requests.get(element.url, timeout=(...))   # local_model.py, gemini_model.py, ollama_model.py
```

That `url` can originate from untrusted data — an evaluation dataset, a traced
message, or a retrieved (RAG) document. So it is a Server-Side Request Forgery
vector: an attacker-controlled image URL such as

```
http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>
```

makes the eval host issue that request from inside its network and folds the
response back into the model payload — allowing theft of cloud instance
credentials and access to internal-only services (CWE-918).

## Fix

Add a shared, SSRF-safe fetcher `deepeval/models/media_fetch.py::fetch_remote_media`
and route all three integrations through it. It:

- allows only `http` / `https` schemes;
- resolves the host and refuses the fetch if **any** resolved address is not
  publicly routable — private, loopback, link-local, CGNAT (100.64.0.0/10),
  reserved, multicast, unspecified, and IPv4-mapped IPv6 equivalents;
- **pins the connection to the validated IP** instead of letting the HTTP client
  re-resolve the hostname. This is the key defense against **DNS rebinding**:
  without pinning, an attacker's DNS can return a public IP for the validation
  lookup and an internal IP (e.g. `169.254.169.254`) for the actual request
  (TOCTOU). TLS SNI and certificate verification still use the original hostname;
- follows redirects manually, **re-validating and re-pinning every hop** (so a
  public URL can't 302 to an internal one).

Returns `(content_bytes, content_type)`; unsafe or failed fetches raise
`MediaFetchError` (a `ValueError` subclass).

## Behavior / compatibility

- Legitimate public image URLs continue to work (verified end-to-end against a
  real HTTPS host — IP-pinned connection with correct SNI/cert validation).
- Requests to internal / link-local / metadata addresses now raise instead of
  being fetched.
- `data:` URIs and local images are unaffected (they don't go through this path).

## Tests

`tests/test_core/test_models/test_media_fetch_ssrf.py`:

- IP classification (metadata, loopback, private, CGNAT, IPv6 loopback/ULA,
  IPv4-mapped) — allowed vs. disallowed;
- unsafe URLs are refused (metadata, loopback, private, `[::1]`, `file://`,
  `ftp://`, `gopher://`);
- **DNS rebinding**: a hostname resolving to an internal IP is refused;
- mixed public/private resolution is refused (one bad IP fails the whole fetch).

Existing model tests still pass (e.g. `tests/test_core/test_models/test_gemini_model.py`).

## Notes / possible follow-ups

- A response size cap and an optional explicit allow-list of image hosts would be
  reasonable further hardening; happy to add if you'd like.
- The same safe fetcher can be reused if other integrations start fetching remote
  media.
