### PR TITLE
feat: preserve cache token usage in model costs

### DIFF
--- a/deepeval/evaluate/utils.py
+++ b/deepeval/evaluate/utils.py
@@ -67,6 +67,8 @@ def create_metric_data(metric: BaseMetric) -> MetricData:
             evaluationCost=metric.evaluation_cost,
             inputTokenCount=metric.input_tokens,
             outputTokenCount=metric.output_tokens,
+            cacheReadInputTokenCount=metric.cache_read_input_tokens,
+            cacheCreationInputTokenCount=metric.cache_creation_input_tokens,
             verboseLogs=metric.verbose_logs,
         )
     else:
@@ -83,6 +85,8 @@ def create_metric_data(metric: BaseMetric) -> MetricData:
             evaluationCost=metric.evaluation_cost,
             inputTokenCount=metric.input_tokens,
             outputTokenCount=metric.output_tokens,
+            cacheReadInputTokenCount=metric.cache_read_input_tokens,
+            cacheCreationInputTokenCount=metric.cache_creation_input_tokens,
             verboseLogs=metric.verbose_logs,
         )
 
@@ -101,6 +105,8 @@ def create_arena_metric_data(metric: ArenaGEval, contestant: str) -> MetricData:
             evaluationCost=metric.evaluation_cost,
             inputTokenCount=metric.input_tokens,
             outputTokenCount=metric.output_tokens,
+            cacheReadInputTokenCount=metric.cache_read_input_tokens,
+            cacheCreationInputTokenCount=metric.cache_creation_input_tokens,
             verboseLogs=metric.verbose_logs,
         )
     else:
@@ -116,6 +122,8 @@ def create_arena_metric_data(metric: ArenaGEval, contestant: str) -> MetricData:
             evaluationCost=metric.evaluation_cost,
             inputTokenCount=metric.input_tokens,
             outputTokenCount=metric.output_tokens,
+            cacheReadInputTokenCount=metric.cache_read_input_tokens,
+            cacheCreationInputTokenCount=metric.cache_creation_input_tokens,
             verboseLogs=metric.verbose_logs,
         )
 

--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -57,6 +57,8 @@ class BaseMetric(PromptMixin):
     evaluation_cost: Optional[float] = None
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
+    cache_read_input_tokens: Optional[int] = None
+    cache_creation_input_tokens: Optional[int] = None
     verbose_logs: Optional[str] = None
     skipped = False
     flaky: bool = False
@@ -107,11 +109,21 @@ class BaseMetric(PromptMixin):
         self,
         input_tokens: Optional[int],
         output_tokens: Optional[int],
+        cache_read_input_tokens: Optional[int] = None,
+        cache_creation_input_tokens: Optional[int] = None,
     ) -> None:
         if input_tokens is not None:
             self.input_tokens = (self.input_tokens or 0) + input_tokens
         if output_tokens is not None:
             self.output_tokens = (self.output_tokens or 0) + output_tokens
+        if cache_read_input_tokens is not None:
+            self.cache_read_input_tokens = (
+                self.cache_read_input_tokens or 0
+            ) + cache_read_input_tokens
+        if cache_creation_input_tokens is not None:
+            self.cache_creation_input_tokens = (
+                self.cache_creation_input_tokens or 0
+            ) + cache_creation_input_tokens
 
 
 class BaseConversationalMetric(PromptMixin):
@@ -129,6 +141,8 @@ class BaseConversationalMetric(PromptMixin):
     evaluation_cost: Optional[float] = None
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
+    cache_read_input_tokens: Optional[int] = None
+    cache_creation_input_tokens: Optional[int] = None
     verbose_logs: Optional[str] = None
     skipped = False
     flaky: bool = False
@@ -182,11 +196,21 @@ class BaseConversationalMetric(PromptMixin):
         self,
         input_tokens: Optional[int],
         output_tokens: Optional[int],
+        cache_read_input_tokens: Optional[int] = None,
+        cache_creation_input_tokens: Optional[int] = None,
     ) -> None:
         if input_tokens is not None:
             self.input_tokens = (self.input_tokens or 0) + input_tokens
         if output_tokens is not None:
             self.output_tokens = (self.output_tokens or 0) + output_tokens
+        if cache_read_input_tokens is not None:
+            self.cache_read_input_tokens = (
+                self.cache_read_input_tokens or 0
+            ) + cache_read_input_tokens
+        if cache_creation_input_tokens is not None:
+            self.cache_creation_input_tokens = (
+                self.cache_creation_input_tokens or 0
+            ) + cache_creation_input_tokens
 
 
 class BaseArenaMetric(PromptMixin):
@@ -199,6 +223,8 @@ class BaseArenaMetric(PromptMixin):
     evaluation_cost: Optional[float] = None
     input_tokens: Optional[int] = None
     output_tokens: Optional[int] = None
+    cache_read_input_tokens: Optional[int] = None
+    cache_creation_input_tokens: Optional[int] = None
     verbose_logs: Optional[str] = None
     model: Optional[DeepEvalBaseLLM] = None
     using_native_model: Optional[bool] = None
@@ -238,8 +264,18 @@ class BaseArenaMetric(PromptMixin):
         self,
         input_tokens: Optional[int],
         output_tokens: Optional[int],
+        cache_read_input_tokens: Optional[int] = None,
+        cache_creation_input_tokens: Optional[int] = None,
     ) -> None:
         if input_tokens is not None:
             self.input_tokens = (self.input_tokens or 0) + input_tokens
         if output_tokens is not None:
             self.output_tokens = (self.output_tokens or 0) + output_tokens
+        if cache_read_input_tokens is not None:
+            self.cache_read_input_tokens = (
+                self.cache_read_input_tokens or 0
+            ) + cache_read_input_tokens
+        if cache_creation_input_tokens is not None:
+            self.cache_creation_input_tokens = (
+                self.cache_creation_input_tokens or 0
+            ) + cache_creation_input_tokens

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -476,14 +476,19 @@ def accrue_token_usage(
     metric.
 
     Native models return their cost as an ``EvaluationCost`` (a ``float``
-    subclass carrying ``input_tokens``/``output_tokens``). Costs from providers
-    that aren't wrapped yet — or ``None`` when pricing is unknown — are plain
-    floats with no token data, so tokens are only accrued when ``cost`` actually
-    carries them. Call this right after ``metric._accrue_cost(cost)`` so token
-    usage tracks cost exactly.
+    subclass carrying input, output, and cache input token counts). Costs from
+    providers that aren't wrapped yet — or ``None`` when pricing is unknown —
+    are plain floats with no token data, so tokens are only accrued when
+    ``cost`` actually carries them. Call this right after
+    ``metric._accrue_cost(cost)`` so token usage tracks cost exactly.
     """
     if isinstance(cost, EvaluationCost):
-        metric._accrue_tokens(cost.input_tokens, cost.output_tokens)
+        metric._accrue_tokens(
+            cost.input_tokens,
+            cost.output_tokens,
+            cost.cache_read_input_tokens,
+            cost.cache_creation_input_tokens,
+        )
 
 
 def verdict_from_json(

--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -13,6 +13,7 @@ from deepeval.models.utils import (
     require_secret_api_key,
     normalize_kwargs_and_extract_aliases,
     EvaluationCost,
+    get_cache_token_counts,
 )
 from deepeval.test_case import MLLMImage
 from deepeval.utils import check_if_multimodal, convert_to_multi_modal_array
@@ -157,9 +158,7 @@ class AnthropicModel(DeepEvalBaseLLM):
         ):
             create_kwargs["temperature"] = self.temperature
         message = chat_model.messages.create(**create_kwargs)
-        cost = self.calculate_cost(
-            message.usage.input_tokens, message.usage.output_tokens
-        )
+        cost = self._calculate_message_cost(message)
         if schema is None:
             return message.content[0].text, cost
         else:
@@ -197,9 +196,7 @@ class AnthropicModel(DeepEvalBaseLLM):
         ):
             create_kwargs["temperature"] = self.temperature
         message = await chat_model.messages.create(**create_kwargs)
-        cost = self.calculate_cost(
-            message.usage.input_tokens, message.usage.output_tokens
-        )
+        cost = self._calculate_message_cost(message)
         if schema is None:
             return message.content[0].text, cost
         else:
@@ -239,13 +236,33 @@ class AnthropicModel(DeepEvalBaseLLM):
     # Utilities
     ###############################################
 
-    def calculate_cost(self, input_tokens: int, output_tokens: int) -> float:
+    def calculate_cost(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_input_tokens: Optional[int] = None,
+        cache_creation_input_tokens: Optional[int] = None,
+    ) -> float:
         if self.model_data.input_price and self.model_data.output_price:
             input_cost = input_tokens * self.model_data.input_price
             output_cost = output_tokens * self.model_data.output_price
             return EvaluationCost(
-                input_cost + output_cost, input_tokens, output_tokens
+                input_cost + output_cost,
+                input_tokens,
+                output_tokens,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
             )
+
+    def _calculate_message_cost(self, message) -> float:
+        usage = message.usage
+        cache_read, cache_creation = get_cache_token_counts(usage)
+        return self.calculate_cost(
+            usage.input_tokens,
+            usage.output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        )
 
     #########################
     # Capabilities          #

--- a/deepeval/models/llms/openai_model.py
+++ b/deepeval/models/llms/openai_model.py
@@ -20,6 +20,7 @@ from deepeval.models.utils import (
     require_secret_api_key,
     normalize_kwargs_and_extract_aliases,
     EvaluationCost,
+    get_cache_token_counts,
 )
 from deepeval.models.retry_policy import (
     create_retry_decorator,
@@ -171,10 +172,7 @@ class GPTModel(DeepEvalBaseLLM):
                 structured_output: BaseModel = completion.choices[
                     0
                 ].message.parsed
-                cost = self.calculate_cost(
-                    completion.usage.prompt_tokens,
-                    completion.usage.completion_tokens,
-                )
+                cost = self._calculate_completion_cost(completion)
                 self._update_llm_span_from_completion(completion, messages)
                 return structured_output, cost
             if self.supports_json_mode() is True:
@@ -188,10 +186,7 @@ class GPTModel(DeepEvalBaseLLM):
                 json_output = trim_and_load_json(
                     completion.choices[0].message.content
                 )
-                cost = self.calculate_cost(
-                    completion.usage.prompt_tokens,
-                    completion.usage.completion_tokens,
-                )
+                cost = self._calculate_completion_cost(completion)
                 self._update_llm_span_from_completion(completion, messages)
                 return schema.model_validate(json_output), cost
 
@@ -202,9 +197,7 @@ class GPTModel(DeepEvalBaseLLM):
             **self.generation_kwargs,
         )
         output = completion.choices[0].message.content
-        cost = self.calculate_cost(
-            completion.usage.prompt_tokens, completion.usage.completion_tokens
-        )
+        cost = self._calculate_completion_cost(completion)
         self._update_llm_span_from_completion(completion, messages)
         if schema:
             json_output = trim_and_load_json(output)
@@ -238,10 +231,7 @@ class GPTModel(DeepEvalBaseLLM):
                 structured_output: BaseModel = completion.choices[
                     0
                 ].message.parsed
-                cost = self.calculate_cost(
-                    completion.usage.prompt_tokens,
-                    completion.usage.completion_tokens,
-                )
+                cost = self._calculate_completion_cost(completion)
                 self._update_llm_span_from_completion(completion, messages)
                 return structured_output, cost
             if self.supports_json_mode() is True:
@@ -255,10 +245,7 @@ class GPTModel(DeepEvalBaseLLM):
                 json_output = trim_and_load_json(
                     completion.choices[0].message.content
                 )
-                cost = self.calculate_cost(
-                    completion.usage.prompt_tokens,
-                    completion.usage.completion_tokens,
-                )
+                cost = self._calculate_completion_cost(completion)
                 self._update_llm_span_from_completion(completion, messages)
                 return schema.model_validate(json_output), cost
 
@@ -269,9 +256,7 @@ class GPTModel(DeepEvalBaseLLM):
             **self.generation_kwargs,
         )
         output = completion.choices[0].message.content
-        cost = self.calculate_cost(
-            completion.usage.prompt_tokens, completion.usage.completion_tokens
-        )
+        cost = self._calculate_completion_cost(completion)
         self._update_llm_span_from_completion(completion, messages)
         if schema:
             json_output = trim_and_load_json(output)
@@ -322,9 +307,7 @@ class GPTModel(DeepEvalBaseLLM):
             top_logprobs=top_logprobs,
             **self.generation_kwargs,
         )
-        input_tokens = completion.usage.prompt_tokens
-        output_tokens = completion.usage.completion_tokens
-        cost = self.calculate_cost(input_tokens, output_tokens)
+        cost = self._calculate_completion_cost(completion)
         self._update_llm_span_from_completion(completion, messages)
 
         return completion, cost
@@ -361,9 +344,7 @@ class GPTModel(DeepEvalBaseLLM):
             top_logprobs=top_logprobs,
             **self.generation_kwargs,
         )
-        input_tokens = completion.usage.prompt_tokens
-        output_tokens = completion.usage.completion_tokens
-        cost = self.calculate_cost(input_tokens, output_tokens)
+        cost = self._calculate_completion_cost(completion)
         self._update_llm_span_from_completion(completion, messages)
 
         return completion, cost
@@ -395,17 +376,37 @@ class GPTModel(DeepEvalBaseLLM):
     #############
 
     def calculate_cost(
-        self, input_tokens: int, output_tokens: int
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        cache_read_input_tokens: Optional[int] = None,
+        cache_creation_input_tokens: Optional[int] = None,
     ) -> Optional[float]:
         if self.model_data.input_price and self.model_data.output_price:
             input_cost = input_tokens * self.model_data.input_price
             output_cost = output_tokens * self.model_data.output_price
             # Carry token counts alongside the cost so metric runs can surface
-            # input/output token usage (EvaluationCost subclasses float, so every
-            # existing `output, cost = generate(...)` caller is unaffected).
+            # token usage (EvaluationCost subclasses float, so every existing
+            # `output, cost = generate(...)` caller is unaffected).
             return EvaluationCost(
-                input_cost + output_cost, input_tokens, output_tokens
+                input_cost + output_cost,
+                input_tokens,
+                output_tokens,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
             )
+
+    def _calculate_completion_cost(
+        self, completion: ChatCompletion
+    ) -> Optional[float]:
+        usage = completion.usage
+        cache_read, cache_creation = get_cache_token_counts(usage)
+        return self.calculate_cost(
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        )
 
     #########################
     # Capabilities          #

--- a/deepeval/models/utils.py
+++ b/deepeval/models/utils.py
@@ -8,8 +8,8 @@ logger = logging.getLogger(__name__)
 
 
 class EvaluationCost(float):
-    """A generation cost (USD) that also carries the input/output token counts
-    that produced it.
+    """A generation cost (USD) that also carries the token counts that
+    produced it.
 
     It subclasses ``float``, so it behaves exactly like the plain cost float for
     every existing call site (``output, cost = model.generate(...)``,
@@ -17,7 +17,10 @@ class EvaluationCost(float):
     ``cost.input_tokens`` / ``cost.output_tokens`` to surface token usage
     e.g. for metric-run token visibility, without changing any return
     signatures. Token data rides along the returned value, so it stays correct
-    under concurrent async fan-out (no shared model-instance state).
+    under concurrent async fan-out (no shared model-instance state). Cache token
+    counts are carried separately when providers expose them because cached
+    input, cache writes, uncached input, and output can all have different
+    billing rates.
 
     Providers that have not yet been updated simply return a plain ``float``;
     readers fall back to ``None`` tokens via ``getattr(cost, "input_tokens",
@@ -26,18 +29,88 @@ class EvaluationCost(float):
 
     input_tokens: Optional[int]
     output_tokens: Optional[int]
+    cache_read_input_tokens: Optional[int]
+    cache_creation_input_tokens: Optional[int]
 
     def __new__(
         cls,
         value: Optional[float],
         input_tokens: Optional[int] = None,
         output_tokens: Optional[int] = None,
+        cache_read_input_tokens: Optional[int] = None,
+        cache_creation_input_tokens: Optional[int] = None,
     ) -> "EvaluationCost":
         obj = super().__new__(cls, value if value is not None else 0.0)
         obj.value = value
         obj.input_tokens = input_tokens
         obj.output_tokens = output_tokens
+        obj.cache_read_input_tokens = cache_read_input_tokens
+        obj.cache_creation_input_tokens = cache_creation_input_tokens
         return obj
+
+
+def _get_usage_field(usage: Any, field_name: str) -> Any:
+    if usage is None:
+        return None
+    if isinstance(usage, dict):
+        return usage.get(field_name)
+    return getattr(usage, field_name, None)
+
+
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _first_usage_field(usage: Any, *field_names: str) -> Any:
+    for field_name in field_names:
+        value = _get_usage_field(usage, field_name)
+        if value is not None:
+            return value
+    return None
+
+
+def get_cache_token_counts(
+    usage: Any,
+) -> Tuple[Optional[int], Optional[int]]:
+    """Extract cache read/write input token counts from provider usage data."""
+
+    input_details = _first_usage_field(
+        usage,
+        "prompt_tokens_details",
+        "input_tokens_details",
+        "input_token_details",
+    )
+    cache_read = (
+        _get_usage_field(input_details, "cached_tokens")
+        if input_details is not None
+        else None
+    )
+    if cache_read is None:
+        cache_read = _first_usage_field(
+            usage,
+            "cache_read_input_tokens",
+            "cached_input_tokens",
+            "cached_tokens",
+        )
+
+    cache_creation = _get_usage_field(usage, "cache_creation_input_tokens")
+    if cache_creation is None and input_details is not None:
+        cache_creation = _first_usage_field(
+            input_details,
+            "cache_creation_input_tokens",
+            "cache_write_tokens",
+        )
+
+    return (
+        _coerce_optional_int(cache_read),
+        _coerce_optional_int(cache_creation),
+    )
 
 
 def parse_model_name(model_name: Optional[str] = None) -> Optional[str]:

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -15,7 +15,6 @@ import re
 import os
 import mimetypes
 import base64
-import weakref
 import warnings
 from dataclasses import dataclass, field
 from urllib.parse import urlparse, unquote
@@ -257,7 +256,7 @@ class ToolCall(BaseModel):
         validation_alias=AliasChoices("inputParameters", "input_parameters"),
     )
 
-    @field_serializer('type')
+    @field_serializer("type")
     def serialize_type(self, value: ToolCallType) -> str:
         return value.value
 

--- a/deepeval/tracing/api.py
+++ b/deepeval/tracing/api.py
@@ -51,6 +51,12 @@ class MetricData(BaseModel):
     evaluation_cost: Union[float, None] = Field(None, alias="evaluationCost")
     input_tokens: Optional[int] = Field(None, alias="inputTokenCount")
     output_tokens: Optional[int] = Field(None, alias="outputTokenCount")
+    cache_read_input_tokens: Optional[int] = Field(
+        None, alias="cacheReadInputTokenCount"
+    )
+    cache_creation_input_tokens: Optional[int] = Field(
+        None, alias="cacheCreationInputTokenCount"
+    )
     verbose_logs: Optional[str] = Field(None, alias="verboseLogs")
 
 

--- a/tests/test_core/test_evaluation/test_metric_data.py
+++ b/tests/test_core/test_evaluation/test_metric_data.py
@@ -8,9 +8,11 @@ from deepeval.metrics import (
     ExactMatchMetric,
 )
 from deepeval.metrics.utils import (
+    accrue_token_usage,
     check_at_least_one_metric_has_threshold,
     copy_metrics,
 )
+from deepeval.models.utils import EvaluationCost
 from deepeval.test_case import LLMTestCase
 from deepeval.tracing.api import MetricData
 
@@ -103,6 +105,28 @@ def test_flaky_is_reflected_in_metric_data(metric_class, error):
 
     assert metric_data.flaky is True
     assert metric_data.model_dump(by_alias=True)["flaky"] is True
+
+
+def test_metric_data_preserves_cache_token_counts():
+    metric = StubMetric()
+    cost = EvaluationCost(
+        0.01,
+        input_tokens=100,
+        output_tokens=20,
+        cache_read_input_tokens=40,
+        cache_creation_input_tokens=10,
+    )
+
+    accrue_token_usage(metric, cost)
+    metric_data = create_metric_data(metric)
+    serialized = metric_data.model_dump(by_alias=True)
+
+    assert metric_data.input_tokens == 100
+    assert metric_data.output_tokens == 20
+    assert metric_data.cache_read_input_tokens == 40
+    assert metric_data.cache_creation_input_tokens == 10
+    assert serialized["cacheReadInputTokenCount"] == 40
+    assert serialized["cacheCreationInputTokenCount"] == 10
 
 
 def test_check_at_least_one_metric_has_threshold():

--- a/tests/test_core/test_models/test_anthropic_model.py
+++ b/tests/test_core/test_models/test_anthropic_model.py
@@ -273,6 +273,41 @@ def test_anthropic_calculate_cost_returns_correct_value(
 
 
 @patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_message_cost_preserves_cache_token_usage(
+    mock_require_dep, settings
+):
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 0.003
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 0.012
+
+    fake_anthropic_module = SimpleNamespace(
+        Anthropic=_RecordingClient,
+        AsyncAnthropic=_RecordingClient,
+    )
+    mock_require_dep.return_value = fake_anthropic_module
+
+    model = AnthropicModel(model="claude-3-7-sonnet-latest")
+    model.model_data.input_price = 0.003
+    model.model_data.output_price = 0.012
+    message = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=500,
+            output_tokens=200,
+            cache_read_input_tokens=80,
+            cache_creation_input_tokens=30,
+        )
+    )
+
+    cost = model._calculate_message_cost(message)
+
+    expected = 500 * 0.003 + 200 * 0.012
+    assert cost == expected
+    assert cost.cache_read_input_tokens == 80
+    assert cost.cache_creation_input_tokens == 30
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
 def test_anthropic_calculate_cost_returns_none_when_prices_missing(
     mock_require_dep, settings
 ):

--- a/tests/test_core/test_models/test_models_utils.py
+++ b/tests/test_core/test_models/test_models_utils.py
@@ -1,10 +1,13 @@
 import pytest
 import logging
+from types import SimpleNamespace
 from pydantic import SecretStr
 
 from deepeval.errors import DeepEvalError
 from deepeval.models.base_model import DeepEvalModelData
 from deepeval.models.utils import (
+    EvaluationCost,
+    get_cache_token_counts,
     require_secret_api_key,
     require_costs,
     normalize_kwargs_and_extract_aliases,
@@ -99,6 +102,33 @@ def test_normalize_kwargs_and_extract_aliases_no_alias_usage_no_logs(caplog):
 
     # no warnings logged
     assert caplog.records == []
+
+
+def test_evaluation_cost_carries_cache_token_counts():
+    cost = EvaluationCost(
+        0.25,
+        input_tokens=100,
+        output_tokens=20,
+        cache_read_input_tokens=40,
+        cache_creation_input_tokens=10,
+    )
+
+    assert cost == 0.25
+    assert cost.input_tokens == 100
+    assert cost.output_tokens == 20
+    assert cost.cache_read_input_tokens == 40
+    assert cost.cache_creation_input_tokens == 10
+
+
+def test_get_cache_token_counts_preserves_explicit_zero_values():
+    usage = SimpleNamespace(
+        prompt_tokens_details=SimpleNamespace(
+            cached_tokens=0,
+            cache_write_tokens=0,
+        ),
+    )
+
+    assert get_cache_token_counts(usage) == (0, 0)
 
 
 ##############################

--- a/tests/test_core/test_models/test_openai_model.py
+++ b/tests/test_core/test_models/test_openai_model.py
@@ -872,6 +872,39 @@ def test_openai_calculate_cost_returns_correct_value(settings):
     assert cost == expected
 
 
+@patch("deepeval.models.llms.openai_model.OpenAI")
+def test_openai_generate_preserves_cache_token_usage(
+    mock_openai_class, settings
+):
+    mock_client = Mock()
+    mock_openai_class.return_value = mock_client
+    mock_completion = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="cached"))],
+        usage=SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=40,
+                cache_write_tokens=12,
+            ),
+        ),
+    )
+    mock_client.chat.completions.create.return_value = mock_completion
+
+    with settings.edit(persist=False):
+        settings.OPENAI_API_KEY = "test-key"
+        settings.OPENAI_COST_PER_INPUT_TOKEN = 0.005
+        settings.OPENAI_COST_PER_OUTPUT_TOKEN = 0.015
+
+    model = GPTModel(model="model-not-in-registry")
+
+    output, cost = model.generate("test prompt")
+
+    assert output == "cached"
+    assert cost.cache_read_input_tokens == 40
+    assert cost.cache_creation_input_tokens == 12
+
+
 def test_openai_calculate_cost_returns_none_when_prices_missing(settings):
     with settings.edit(persist=False):
         settings.OPENAI_API_KEY = "test-key"


### PR DESCRIPTION
## Summary
- carry cache read/write input token counts on EvaluationCost without changing its float behavior
- extract OpenAI prompt cache counters and Anthropic cache read/write counters from provider usage
- accrue and serialize cache token counts in metric data for downstream reporting

## Why
DeepEval already preserves input/output token counts alongside native model costs. Providers now expose cache-specific input token classes too, and flattening those away makes cache-aware cost analysis difficult. This keeps the existing cost return contract intact while making the cache counters available to callers and reports.

## Validation
- .venv312/bin/python -m pytest tests/test_core/test_models/test_models_utils.py tests/test_core/test_models/test_openai_model.py tests/test_core/test_models/test_anthropic_model.py tests/test_core/test_evaluation/test_metric_data.py -q
- python3 -m compileall -q touched source and test files
- .venv312/bin/ruff check --select F touched source and test files
- git diff --check