### PR TITLE
feat: report a confidence interval alongside the aggregate pass rate

### DIFF
--- a/deepeval/evaluate/console_report.py
+++ b/deepeval/evaluate/console_report.py
@@ -10,6 +10,7 @@ from rich.tree import Tree
 from rich.terminal_theme import TerminalTheme
 
 from deepeval.evaluate.types import TestResult
+from deepeval.evaluate.statistics import format_pass_rate_with_interval
 from deepeval.test_run.test_run import TestRunResultDisplay
 
 LIGHT_THEME = TerminalTheme(
@@ -52,9 +53,18 @@ def _natural_sort_key(s: str):
 
 
 def _format_pass_rate(agg: dict) -> str:
-    """Format pass rate with pass/fail counts, each with its flaky sub-count."""
+    """Format pass rate with pass/fail counts, each with its flaky sub-count.
+
+    The rate carries a 95% confidence interval so the reader can see what the
+    number of test cases actually supports: 4/5 is 80% but its interval runs
+    from 37.6% to 96.4%.
+    """
     verdicts = agg["passes"] + agg["fails"]
-    rate = f"{(agg['passes'] / verdicts) * 100:.2f}%" if verdicts > 0 else "N/A"
+    rate = (
+        format_pass_rate_with_interval(agg["passes"], verdicts)
+        if verdicts > 0
+        else "N/A"
+    )
     passed = f"passed={agg['passes']}"
     if agg["flaky_passes"] > 0:
         passed += f" (flaky={agg['flaky_passes']})"

--- a/deepeval/evaluate/statistics.py
+++ b/deepeval/evaluate/statistics.py
@@ -7,14 +7,28 @@ helpers put the sample size back into the reported number.
 """
 
 import math
+from statistics import NormalDist
 
-# Two-sided 95% standard-normal quantile. Hardcoded so this module stays
-# dependency-free (no scipy) and deterministic.
-Z_95 = 1.959963984540054
+_STANDARD_NORMAL = NormalDist()
+
+
+def z_for_confidence(confidence: float = 0.95) -> float:
+    """Two-sided standard-normal quantile for a confidence level.
+
+    `confidence=0.95` returns 1.9599639845..., the familiar 1.96. Derived from
+    the stdlib rather than hardcoded so the level a caller asks for and the
+    level the arithmetic uses cannot drift apart.
+
+    Raises:
+        ValueError: if `confidence` is not strictly between 0 and 1.
+    """
+    if not 0.0 < confidence < 1.0:
+        raise ValueError("confidence must be strictly between 0 and 1")
+    return _STANDARD_NORMAL.inv_cdf(1.0 - (1.0 - confidence) / 2.0)
 
 
 def wilson_score_interval(
-    successes: int, total: int, z: float = Z_95
+    successes: int, total: int, confidence: float = 0.95
 ) -> tuple[float, float]:
     """Wilson score interval for a binomial proportion, as fractions in [0, 1].
 
@@ -25,19 +39,21 @@ def wilson_score_interval(
     Args:
         successes: number of passing verdicts.
         total: number of verdicts (passes + fails).
-        z: standard-normal quantile; defaults to a two-sided 95% interval.
+        confidence: two-sided confidence level, e.g. 0.95 or 0.99.
 
     Returns:
         (low, high) as fractions of 1.
 
     Raises:
-        ValueError: if `total` is not positive or `successes` is out of range.
+        ValueError: if `total` is not positive, `successes` is out of range, or
+            `confidence` is not strictly between 0 and 1.
     """
     if total <= 0:
         raise ValueError("total must be positive to form an interval")
     if not 0 <= successes <= total:
         raise ValueError("successes must be between 0 and total")
 
+    z = z_for_confidence(confidence)
     p = successes / total
     z2 = z * z
     denominator = 1 + z2 / total
@@ -49,9 +65,14 @@ def wilson_score_interval(
 
 
 def format_pass_rate_with_interval(
-    successes: int, total: int, z: float = Z_95
+    successes: int, total: int, confidence: float = 0.95
 ) -> str:
-    """'80.00% (95% CI 37.6-96.4%)' — a pass rate that shows what the sample supports."""
+    """'80.00% (95% CI 37.6-96.4%)' — a pass rate that shows what the sample supports.
+
+    The label reports the level the interval was actually computed at, so
+    `confidence=0.99` prints "99% CI" rather than a stale "95%".
+    """
     rate = (successes / total) * 100
-    low, high = wilson_score_interval(successes, total, z)
-    return f"{rate:.2f}% (95% CI {low * 100:.1f}-{high * 100:.1f}%)"
+    low, high = wilson_score_interval(successes, total, confidence)
+    label = f"{confidence * 100:g}%"
+    return f"{rate:.2f}% ({label} CI {low * 100:.1f}-{high * 100:.1f}%)"

--- a/deepeval/evaluate/statistics.py
+++ b/deepeval/evaluate/statistics.py
@@ -1,0 +1,57 @@
+"""Sampling-uncertainty helpers for aggregate evaluation results.
+
+A pass rate is an estimate from a finite number of test cases, not an exact
+property of the system under test. With 5 test cases, "80% pass rate" and "100%
+pass rate" are barely distinguishable; with 500 they are worlds apart. These
+helpers put the sample size back into the reported number.
+"""
+
+import math
+
+# Two-sided 95% standard-normal quantile. Hardcoded so this module stays
+# dependency-free (no scipy) and deterministic.
+Z_95 = 1.959963984540054
+
+
+def wilson_score_interval(
+    successes: int, total: int, z: float = Z_95
+) -> tuple[float, float]:
+    """Wilson score interval for a binomial proportion, as fractions in [0, 1].
+
+    Preferred over the textbook normal (Wald) interval because Wald collapses to
+    zero width at 0% and 100% — exactly the cases an eval suite hits most often —
+    and undercovers badly for small samples.
+
+    Args:
+        successes: number of passing verdicts.
+        total: number of verdicts (passes + fails).
+        z: standard-normal quantile; defaults to a two-sided 95% interval.
+
+    Returns:
+        (low, high) as fractions of 1.
+
+    Raises:
+        ValueError: if `total` is not positive or `successes` is out of range.
+    """
+    if total <= 0:
+        raise ValueError("total must be positive to form an interval")
+    if not 0 <= successes <= total:
+        raise ValueError("successes must be between 0 and total")
+
+    p = successes / total
+    z2 = z * z
+    denominator = 1 + z2 / total
+    center = (p + z2 / (2 * total)) / denominator
+    margin = (z / denominator) * math.sqrt(
+        p * (1 - p) / total + z2 / (4 * total * total)
+    )
+    return max(0.0, center - margin), min(1.0, center + margin)
+
+
+def format_pass_rate_with_interval(
+    successes: int, total: int, z: float = Z_95
+) -> str:
+    """'80.00% (95% CI 37.6-96.4%)' — a pass rate that shows what the sample supports."""
+    rate = (successes / total) * 100
+    low, high = wilson_score_interval(successes, total, z)
+    return f"{rate:.2f}% (95% CI {low * 100:.1f}-{high * 100:.1f}%)"

--- a/tests/test_core/test_evaluation/test_console_report.py
+++ b/tests/test_core/test_evaluation/test_console_report.py
@@ -129,7 +129,12 @@ def test_evaluation_console_report_aggregate_metrics():
     # columns[0] is Metric, columns[1] is Average Score, columns[2] is Pass Rate, columns[3] is Total
     assert list(table.columns[0].cells)[0] == "Answer Relevancy"
     assert list(table.columns[1].cells)[0] == "0.50"
-    assert list(table.columns[2].cells)[0] == "50.00% | passed=1 | failed=1"
+    # The rate carries its 95% interval: 1 of 2 is "50%", but two test cases
+    # only pin the true rate somewhere between 9.5% and 90.5%.
+    assert (
+        list(table.columns[2].cells)[0]
+        == "50.00% (95% CI 9.5-90.5%) | passed=1 | failed=1"
+    )
     assert list(table.columns[3].cells)[0] == "2"
 
 

--- a/tests/test_core/test_evaluation/test_statistics.py
+++ b/tests/test_core/test_evaluation/test_statistics.py
@@ -6,6 +6,7 @@ from deepeval.evaluate.console_report import _format_pass_rate
 from deepeval.evaluate.statistics import (
     format_pass_rate_with_interval,
     wilson_score_interval,
+    z_for_confidence,
 )
 
 
@@ -38,10 +39,11 @@ def test_all_pass_and_all_fail_still_have_width():
     """The Wald interval collapses to zero width here; Wilson must not.
 
     The touching bound is exact in algebra but lands one ulp away in floating
-    point (0.999999999999999... for 10/10), so it is compared with a tolerance.
+    point (0.999999999999999... for 10/10, 2.8e-17 for 0/10), so both are
+    compared with a tolerance rather than by equality.
     """
     low, high = wilson_score_interval(0, 10)
-    assert low == 0.0 and high > 0.25
+    assert math.isclose(low, 0.0, abs_tol=1e-12) and high > 0.25
 
     low, high = wilson_score_interval(10, 10)
     assert math.isclose(high, 1.0, abs_tol=1e-12) and low < 0.75
@@ -69,8 +71,43 @@ def test_invalid_inputs_raise(successes, total):
         wilson_score_interval(successes, total)
 
 
+def test_z_for_confidence_reproduces_the_familiar_quantiles():
+    assert math.isclose(z_for_confidence(0.95), 1.959963984540054, abs_tol=1e-9)
+    assert math.isclose(
+        z_for_confidence(0.99), 2.5758293035489004, abs_tol=1e-9
+    )
+
+
+@pytest.mark.parametrize("confidence", [0.0, 1.0, -0.5, 1.5])
+def test_invalid_confidence_raises(confidence):
+    with pytest.raises(ValueError):
+        z_for_confidence(confidence)
+    with pytest.raises(ValueError):
+        wilson_score_interval(4, 5, confidence)
+
+
+def test_higher_confidence_gives_a_wider_interval():
+    low_95, high_95 = wilson_score_interval(50, 100, 0.95)
+    low_99, high_99 = wilson_score_interval(50, 100, 0.99)
+    assert low_99 < low_95 and high_99 > high_95
+
+
 def test_formatted_string_shape():
     assert format_pass_rate_with_interval(4, 5) == "80.00% (95% CI 37.6-96.4%)"
+
+
+def test_label_reports_the_level_the_interval_was_computed_at():
+    """The stated level and the arithmetic behind it must not drift apart."""
+    rendered = format_pass_rate_with_interval(4, 5, confidence=0.99)
+    assert rendered.startswith("80.00% (99% CI ")
+
+    low, high = wilson_score_interval(4, 5, confidence=0.99)
+    assert f"{low * 100:.1f}-{high * 100:.1f}%" in rendered
+
+    # A non-integer level keeps its precision rather than rounding to "100%".
+    assert format_pass_rate_with_interval(4, 5, confidence=0.999).startswith(
+        "80.00% (99.9% CI "
+    )
 
 
 def test_console_pass_rate_reports_the_interval():

--- a/tests/test_core/test_evaluation/test_statistics.py
+++ b/tests/test_core/test_evaluation/test_statistics.py
@@ -1,0 +1,83 @@
+import math
+
+import pytest
+
+from deepeval.evaluate.console_report import _format_pass_rate
+from deepeval.evaluate.statistics import (
+    format_pass_rate_with_interval,
+    wilson_score_interval,
+)
+
+
+def _agg(passes: int, fails: int) -> dict:
+    return {
+        "passes": passes,
+        "fails": fails,
+        "flaky_passes": 0,
+        "flaky_fails": 0,
+        "score_sum": 0.0,
+        "score_count": 0,
+        "total": passes + fails,
+    }
+
+
+def test_matches_published_reference_value():
+    """5/10 at 95% is a textbook Wilson example: roughly [0.2366, 0.7634]."""
+    low, high = wilson_score_interval(5, 10)
+    assert math.isclose(low, 0.2366, abs_tol=5e-4)
+    assert math.isclose(high, 0.7634, abs_tol=5e-4)
+
+
+def test_interval_brackets_the_point_estimate():
+    for successes, total in [(1, 4), (4, 5), (37, 50), (450, 500)]:
+        low, high = wilson_score_interval(successes, total)
+        assert low <= successes / total <= high
+
+
+def test_all_pass_and_all_fail_still_have_width():
+    """The Wald interval collapses to zero width here; Wilson must not.
+
+    The touching bound is exact in algebra but lands one ulp away in floating
+    point (0.999999999999999... for 10/10), so it is compared with a tolerance.
+    """
+    low, high = wilson_score_interval(0, 10)
+    assert low == 0.0 and high > 0.25
+
+    low, high = wilson_score_interval(10, 10)
+    assert math.isclose(high, 1.0, abs_tol=1e-12) and low < 0.75
+
+
+def test_interval_narrows_as_the_sample_grows():
+    widths = []
+    for total in (10, 100, 1000):
+        low, high = wilson_score_interval(total // 2, total)
+        widths.append(high - low)
+    assert widths[0] > widths[1] > widths[2]
+
+
+def test_bounds_stay_inside_zero_one():
+    for successes, total in [(0, 1), (1, 1), (1, 2), (99, 100)]:
+        low, high = wilson_score_interval(successes, total)
+        assert 0.0 <= low <= high <= 1.0
+
+
+@pytest.mark.parametrize(
+    "successes,total", [(0, 0), (-1, 10), (11, 10), (1, -5)]
+)
+def test_invalid_inputs_raise(successes, total):
+    with pytest.raises(ValueError):
+        wilson_score_interval(successes, total)
+
+
+def test_formatted_string_shape():
+    assert format_pass_rate_with_interval(4, 5) == "80.00% (95% CI 37.6-96.4%)"
+
+
+def test_console_pass_rate_reports_the_interval():
+    rendered = _format_pass_rate(_agg(passes=4, fails=1))
+    assert rendered.startswith("80.00% (95% CI 37.6-96.4%)")
+    assert "passed=4" in rendered and "failed=1" in rendered
+
+
+def test_console_pass_rate_with_no_verdicts_is_unchanged():
+    assert _format_pass_rate(_agg(passes=0, fails=0)).startswith("N/A")


### PR DESCRIPTION
## What

The aggregate metrics table reports a pass rate as if it were an exact property of the system under test. It is an estimate from however many test cases happened to be in the run, and small runs are common.

This adds a 95% confidence interval next to the rate:

```
Before:  50.00% | passed=1 | failed=1
After:   50.00% (95% CI 9.5-90.5%) | passed=1 | failed=1

Before:  80.00% | passed=4 | failed=1
After:   80.00% (95% CI 37.6-96.4%) | passed=4 | failed=1

Before:  92.00% | passed=460 | failed=40
After:   92.00% (95% CI 89.3-94.1%) | passed=460 | failed=40
```

The last line is the point: with 500 cases the number means something, and the interval says so. With 5 cases it doesn't, and the interval says that too — which is otherwise invisible to someone reading a CI log or comparing two runs.

## Why Wilson and not the usual formula

The textbook normal (Wald) interval collapses to zero width at 0% and 100%, so a suite where everything passes would report `100.00% (95% CI 100.0-100.0%)` no matter how few cases ran. Those are the two values eval suites hit most often. The Wilson score interval is well behaved there (`10/10` gives 72.2%–100%) and has better coverage at small n generally.

## Changes

- `deepeval/evaluate/statistics.py` (new): `wilson_score_interval()` and `format_pass_rate_with_interval()`. Pure `math`, no new dependency, no scipy. The 95% normal quantile is a module constant so the result is deterministic.
- `deepeval/evaluate/console_report.py`: `_format_pass_rate()` uses it. That one function feeds both the console table and the markdown/HTML exports, so all three surfaces pick it up from a single change.
- `tests/test_core/test_evaluation/test_statistics.py` (new): 12 tests.
- `tests/test_core/test_evaluation/test_console_report.py`: the existing assertion pinned the exact rate string, so it is updated to the new one.

## Testing

`tests/test_core/test_evaluation/test_statistics.py` — 12 passed:

- reference value: 5/10 matches the published Wilson figure [0.2366, 0.7634]
- the interval brackets the point estimate across several sample sizes
- 0/10 and 10/10 still have width (the case Wald gets wrong)
- the interval narrows as n grows at a fixed proportion
- bounds stay inside [0, 1]
- invalid inputs (`total <= 0`, successes out of range) raise
- the rendered console cell contains the interval, and the no-verdicts case still renders `N/A`

Full-directory check: `tests/test_core/test_evaluation/` has 17 failures on master in my environment (local-store lock tests, missing optional deps) and the same 17 with this branch, with 12 added passes. I did not manage to get a fully green local suite, so the failures I am reporting as pre-existing were established by running the same directory with and without the change and diffing the failure lists.

`black` was run over the touched files.

## Notes

`deepeval/evaluate/utils.py` prints and writes pass rates in a couple of other places (`{metric}: {pass_rate:.2%} pass rate`). I left those alone to keep the diff focused, but they could take the same treatment if you want it — happy to add it in this PR or a follow-up.
