### PR TITLE
chore: format llm_test_case.py with black

### DIFF
--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -257,7 +257,7 @@ class ToolCall(BaseModel):
         validation_alias=AliasChoices("inputParameters", "input_parameters"),
     )
 
-    @field_serializer('type')
+    @field_serializer("type")
     def serialize_type(self, value: ToolCallType) -> str:
         return value.value
 


### PR DESCRIPTION
The `lint` job runs `black --check` over the tree and is currently failing on `main`:

```
would reformat /home/runner/work/deepeval/deepeval/deepeval/test_case/llm_test_case.py
1 file would be reformatted, 930 files would be left unchanged.
```

The cause is one single-quoted string in a decorator (`@field_serializer('type')` in `ToolCall.serialize_type`), introduced in #3003. Because the check runs over the whole tree, it fails the lint job on every open PR rather than only the one that introduced it — I noticed it because it turned my own PR red.

This is the one-character fix black wants. `black --check` is clean on the file afterwards; no behaviour change.