### PR TITLE
fix(dag): reject a root node that is reachable from another root

### DIFF
--- a/deepeval/metrics/dag/graph.py
+++ b/deepeval/metrics/dag/graph.py
@@ -61,6 +61,13 @@ class DeepAcyclicGraph:
         self.root_nodes = root_nodes
         self.indegree, self.parents = self._build_graph()
 
+        for root in self.root_nodes:
+            if self.indegree[root] > 0:
+                raise ValueError(
+                    "You cannot declare a node as a root node when it is "
+                    "also reachable from another root node."
+                )
+
     def _build_graph(self) -> Tuple[Dict[Node, int], Dict[Node, List[Node]]]:
         indegree: Dict[Node, int] = {}
         parents: Dict[Node, List[Node]] = {}

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -292,6 +292,22 @@ class TestDeepAcyclicGraph:
         dag = DeepAcyclicGraph(root_nodes=[node1, node2])
         assert is_valid_dag(dag, multiturn=False) is True
 
+    def test_disallow_root_that_is_a_child_of_another_root(self):
+        """A root with incoming edges is reached twice and runs twice."""
+        extract = TaskNode(
+            instructions="Extract",
+            output_label="X",
+            evaluation_params=[SingleTurnParams.INPUT],
+        )
+        summarise = TaskNode(
+            instructions="Summarise",
+            output_label="Y",
+            evaluation_params=[SingleTurnParams.INPUT],
+        )
+        extract.add_node(summarise)
+        with pytest.raises(ValueError):
+            DeepAcyclicGraph(root_nodes=[extract, summarise])
+
     def test_copy_graph_isolated_and_deep(self):
         INSTRUCTIONS = "Instruction 1:"
         OUTPUT_LABEL = "Output label"


### PR DESCRIPTION
Fixes #3026.

Declaring a node as a root when it's also a child of another root gives it two ways in, so the runner visits it once per path. In sync mode the whole subtree runs again, which means the same LLM calls are made and the cost is counted twice over. In async mode it doesn't get that far — it raises `KeyError` while looking up the node's parent.

A root with incoming edges is a contradiction, and declaring it doesn't add anything since it's already reached through its parent. So this now raises when the graph is built, next to the existing check on multiple judgement roots:

```python
for root in self.root_nodes:
    if self.indegree[root] > 0:
        raise ValueError(
            "You cannot declare a node as a root node when it is "
            "also reachable from another root node."
        )
```

Multiple independent roots are unaffected, since those have no incoming edges — `test_allow_multiple_tasknode_roots` still passes.

The test builds the shape from #3026 and checks it raises. The DAG suites are at 92 passed, 6 skipped, and the test fails if the check is removed.

One note on ordering: this touches `graph.py` and so does #3024, in a different place. Whichever goes in second may want a trivial rebase, and they're independent otherwise.
