### PR TITLE
fix(metrics): enforce strict_mode in RoleViolationMetric

### DIFF
--- a/deepeval/metrics/role_violation/role_violation.py
+++ b/deepeval/metrics/role_violation/role_violation.py
@@ -45,7 +45,9 @@ class RoleViolationMetric(BaseMetric):
                 "Role parameter is required. Please specify the expected role (e.g., 'helpful assistant', 'customer service agent', etc.)"
             )
 
-        self.threshold = 0 if strict_mode else threshold
+        # In strict mode, any detected role violation (score 0.0) must fail.
+        # A threshold of 0 would let 0.0 >= 0 pass, so require a perfect 1.0.
+        self.threshold = 1 if strict_mode else threshold
         self.role = role
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()

--- a/tests/test_metrics/test_role_violation_strict_mode.py
+++ b/tests/test_metrics/test_role_violation_strict_mode.py
@@ -1,0 +1,71 @@
+"""Regression tests for RoleViolationMetric's strict-mode threshold.
+
+In strict mode the metric must fail whenever a role violation is detected.
+The bug was initializing ``threshold = 0`` in strict mode: the scoring is
+binary (0.0 = violation, 1.0 = adherence), so a violating score of 0.0 still
+satisfied ``0.0 >= 0`` and the metric always "succeeded". Strict mode now uses
+a threshold of 1, so only a perfect adherence score passes.
+
+These tests exercise the threshold and ``is_successful`` logic directly with a
+stub model, so they run without an LLM provider API key.
+"""
+
+from deepeval.metrics import RoleViolationMetric
+from deepeval.models.base_model import DeepEvalBaseLLM
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM that never calls out to a provider."""
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        raise AssertionError("generate should not be called in this test")
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        raise AssertionError("a_generate should not be called in this test")
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+def _metric(strict_mode: bool) -> RoleViolationMetric:
+    return RoleViolationMetric(
+        role="helpful assistant",
+        model=_StubLLM(),
+        strict_mode=strict_mode,
+    )
+
+
+def test_strict_mode_threshold_is_one():
+    assert _metric(strict_mode=True).threshold == 1
+
+
+def test_strict_mode_fails_on_violation():
+    metric = _metric(strict_mode=True)
+    # A detected role violation scores 0.0 (see ``_calculate_score``).
+    metric.score = 0.0
+    assert metric.is_successful() is False
+
+
+def test_strict_mode_passes_on_full_adherence():
+    metric = _metric(strict_mode=True)
+    metric.score = 1.0
+    assert metric.is_successful() is True
+
+
+def test_non_strict_mode_uses_provided_threshold():
+    metric = RoleViolationMetric(
+        role="helpful assistant",
+        model=_StubLLM(),
+        threshold=0.5,
+        strict_mode=False,
+    )
+    assert metric.threshold == 0.5
+    # A violating score of 0.0 fails a 0.5 threshold either way, but a
+    # partial/perfect score should still pass as before.
+    metric.score = 0.0
+    assert metric.is_successful() is False
+    metric.score = 1.0
+    assert metric.is_successful() is True


### PR DESCRIPTION
## Summary

`RoleViolationMetric` did not enforce `strict_mode` correctly — it always succeeded even when a role violation was detected.

In strict mode the threshold was initialized to `0`:

```python
self.threshold = 0 if strict_mode else threshold
```

Scoring is binary (`0.0` = violation, `1.0` = adherence) and success is evaluated as `score >= threshold`, so a violating score of `0.0` still satisfied `0.0 >= 0` and the metric reported success. Strict mode was effectively a no-op.

## Fix

```python
self.threshold = 1 if strict_mode else threshold
```

Only a perfect adherence score (`1.0`) passes in strict mode. This matches the convention already used by the sibling `RoleAdherenceMetric` and every other non-inverted metric in the library (`answer_relevancy`, `faithfulness`, `g_eval`, etc.).

## Tests

Adds `tests/test_metrics/test_role_violation_strict_mode.py`, which exercises the threshold and `is_successful` logic directly with a stub model (no LLM/API key required):

- strict mode sets `threshold == 1`
- strict mode fails on a violating score (`0.0`)
- strict mode passes on full adherence (`1.0`)
- non-strict mode keeps the caller-provided threshold and behaves as before

All four tests pass locally, and the changed files are clean under `black` (line-length 80) and `ruff`.

Closes #2901
