### PR TITLE
fix: restore nested trace span contexts

### DIFF
--- a/deepeval/tracing/trace_context.py
+++ b/deepeval/tracing/trace_context.py
@@ -98,10 +98,16 @@ def trace(
         expected_tools=expected_tools,
     )
 
-    if llm_span_context:
+    llm_context_token = (
         current_llm_context.set(llm_span_context)
-    if agent_span_context:
+        if llm_span_context is not None
+        else None
+    )
+    agent_context_token = (
         current_agent_context.set(agent_span_context)
+        if agent_span_context is not None
+        else None
+    )
     try:
         yield current_trace
     finally:
@@ -110,5 +116,7 @@ def trace(
 
         current_trace_context.reset(trace_ctx_token)
 
-        current_llm_context.set(LlmSpanContext())
-        current_agent_context.set(AgentSpanContext())
+        if llm_context_token is not None:
+            current_llm_context.reset(llm_context_token)
+        if agent_context_token is not None:
+            current_agent_context.reset(agent_context_token)

--- a/tests/test_core/test_tracing/test_nested_spans/test_trace_context.py
+++ b/tests/test_core/test_tracing/test_nested_spans/test_trace_context.py
@@ -1,0 +1,53 @@
+import pytest
+
+from deepeval.tracing.trace_context import (
+    AgentSpanContext,
+    LlmSpanContext,
+    current_agent_context,
+    current_llm_context,
+    trace,
+)
+
+
+def test_nested_trace_restores_outer_span_contexts():
+    initial_llm_context = current_llm_context.get()
+    initial_agent_context = current_agent_context.get()
+    outer_llm_context = LlmSpanContext(metric_collection="outer-llm")
+    outer_agent_context = AgentSpanContext(metric_collection="outer-agent")
+    inner_llm_context = LlmSpanContext(metric_collection="inner-llm")
+    inner_agent_context = AgentSpanContext(metric_collection="inner-agent")
+
+    with trace(
+        llm_span_context=outer_llm_context,
+        agent_span_context=outer_agent_context,
+    ):
+        with pytest.raises(RuntimeError):
+            with trace(
+                llm_span_context=inner_llm_context,
+                agent_span_context=inner_agent_context,
+            ):
+                assert current_llm_context.get() is inner_llm_context
+                assert current_agent_context.get() is inner_agent_context
+                raise RuntimeError
+
+        assert current_llm_context.get() is outer_llm_context
+        assert current_agent_context.get() is outer_agent_context
+
+    assert current_llm_context.get() is initial_llm_context
+    assert current_agent_context.get() is initial_agent_context
+
+
+def test_nested_trace_without_override_preserves_outer_span_contexts():
+    outer_llm_context = LlmSpanContext(metric_collection="outer-llm")
+    outer_agent_context = AgentSpanContext(metric_collection="outer-agent")
+
+    with trace(
+        llm_span_context=outer_llm_context,
+        agent_span_context=outer_agent_context,
+    ):
+        with trace():
+            assert current_llm_context.get() is outer_llm_context
+            assert current_agent_context.get() is outer_agent_context
+
+        assert current_llm_context.get() is outer_llm_context
+        assert current_agent_context.get() is outer_agent_context


### PR DESCRIPTION
## Summary

- restore the previous LLM and agent `ContextVar` values when a nested `trace()` exits
- preserve inherited span contexts when a nested trace does not provide an override
- add regression coverage for explicit overrides, exception unwinding, and no-override nesting

## Problem

`trace()` sets `current_llm_context` and `current_agent_context` when span contexts are provided, but its `finally` block always replaces both values with fresh empty contexts. As a result, exiting an inner trace discards the outer trace's prompt, metrics, metric collection, expected output/tools, and retrieval context for later instrumented model calls.

## Root cause and fix

The span context variables were set without retaining their `ContextVar` tokens. The fix stores each token when an override is supplied and resets it during cleanup, matching the existing token-based handling of `current_trace_context`. Nested traces without overrides now leave inherited contexts untouched.

## Validation

- `pytest -q tests/test_core/test_tracing` — 188 passed, 1 skipped (requires `OPENAI_API_KEY`)
- `black --check` on the changed files
- Ruff `E4,E7,E9,F` checks on the changed files
- `compileall` on the changed files
- all core and integration test workflows pass on the PR

## CI note

The repository-wide Black check currently fails on the unchanged `.scripts/release.py`; the same failure reproduces on `origin/main`, and #3018 already includes the format-only correction. The Vercel check requires Confident AI team authorization for fork deployments. Neither failure is caused by this diff.
