### PR TITLE
fix(models): support SummaC batch inputs

### DIFF
--- a/deepeval/models/summac_model.py
+++ b/deepeval/models/summac_model.py
@@ -1,8 +1,9 @@
+from typing import List, Optional, Union
+
 import torch
-from typing import Union, List, Optional
-from typing import List, Union, get_origin
-from deepeval.models.base_model import DeepEvalBaseModel
+
 from deepeval.models._summac_model import _SummaCZS
+from deepeval.models.base_model import DeepEvalBaseModel
 
 
 class SummaCModels(DeepEvalBaseModel):
@@ -47,12 +48,7 @@ class SummaCModels(DeepEvalBaseModel):
     def _call(
         self, predictions: Union[str, List[str]], targets: Union[str, List[str]]
     ) -> Union[float, dict]:
-        list_type = List[str]
-
-        if (
-            get_origin(predictions) is list_type
-            and get_origin(targets) is list_type
-        ):
+        if isinstance(predictions, list) and isinstance(targets, list):
             return self.model.score(targets, predictions)
         elif isinstance(predictions, str) and isinstance(targets, str):
             return self.model.score_one(targets, predictions)

--- a/tests/test_core/test_models/test_summac_model.py
+++ b/tests/test_core/test_models/test_summac_model.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+def _load_summac_model(monkeypatch):
+    fake_torch = ModuleType("torch")
+    fake_torch.nn = SimpleNamespace(Module=object)
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "nltk", ModuleType("nltk"))
+    monkeypatch.delitem(
+        sys.modules, "deepeval.models._summac_model", raising=False
+    )
+    monkeypatch.delitem(
+        sys.modules, "deepeval.models.summac_model", raising=False
+    )
+    return importlib.import_module("deepeval.models.summac_model")
+
+
+class _RecordingBackend:
+    def __init__(self):
+        self.calls = []
+
+    def score(self, targets, predictions):
+        self.calls.append(("score", targets, predictions))
+        return {"scores": [0.75]}
+
+    def score_one(self, target, prediction):
+        self.calls.append(("score_one", target, prediction))
+        return {"score": 0.5}
+
+
+def test_summac_dispatches_list_inputs_to_batch_score(monkeypatch):
+    summac_model = _load_summac_model(monkeypatch)
+    model = object.__new__(summac_model.SummaCModels)
+    model.model = _RecordingBackend()
+
+    result = model._call(["prediction"], ["target"])
+
+    assert result == {"scores": [0.75]}
+    assert model.model.calls == [
+        ("score", ["target"], ["prediction"]),
+    ]
+
+
+def test_summac_dispatches_string_inputs_to_single_score(monkeypatch):
+    summac_model = _load_summac_model(monkeypatch)
+    model = object.__new__(summac_model.SummaCModels)
+    model.model = _RecordingBackend()
+
+    result = model._call("prediction", "target")
+
+    assert result == {"score": 0.5}
+    assert model.model.calls == [
+        ("score_one", "target", "prediction"),
+    ]


### PR DESCRIPTION
## Summary

- dispatch `list[str]` inputs to SummaC's batch `score()` method
- preserve the existing string-to-`score_one()` path
- add isolated regression tests without requiring the optional Torch/NLTK packages

## Problem

`SummaCModels._call()` declares support for both strings and lists, but it uses `typing.get_origin()` on runtime values:

```python
get_origin(["prediction"])  # None
```

As a result, two valid lists always fall through to `TypeError` and the backend's batch scoring method is unreachable.

## Fix

Use runtime `isinstance(..., list)` checks for the list branch. The argument order and backend return values remain unchanged.

## Verification

- Before the fix: `1 failed, 1 passed`; the list case raised `TypeError`.
- After the fix: `pytest tests/test_core/test_models/test_summac_model.py -q` (`2 passed`).
- Black passes for both changed files.
- Ruff `F`/`I` checks pass with the project's Python 3.9 target.
- `py_compile` and `git diff --check` pass.

## Scope

This only changes SummaC input dispatch. It does not load models, alter scoring behavior, or add runtime dependencies.
