### PR TITLE
fix: clone custom metrics without constructors

### DIFF
--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -1,22 +1,51 @@
 from __future__ import annotations
 
+import copy
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Optional, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from deepeval.test_case import (
-    LLMTestCase,
-    ConversationalTestCase,
-    SingleTurnParams,
-    ArenaTestCase,
-)
 from deepeval.templates.resolver import (
     MetricTemplateMethod,
     resolve_template,
 )
 from deepeval.templates.template_class import filter_template_kwargs
+from deepeval.test_case import (
+    ArenaTestCase,
+    ConversationalTestCase,
+    LLMTestCase,
+    SingleTurnParams,
+)
 
 if TYPE_CHECKING:
     from deepeval.models import DeepEvalBaseLLM
+
+
+_RUN_STATE = {
+    "score",
+    "reason",
+    "success",
+    "error",
+    "verdicts",
+    "skipped",
+    "evaluation_cost",
+    "input_tokens",
+    "output_tokens",
+    "verbose_logs",
+}
+
+
+def _clone_metric(metric):
+    copied = copy.copy(metric)
+
+    for key, value in vars(copied).items():
+        if key not in _RUN_STATE and isinstance(value, (list, dict, set)):
+            setattr(copied, key, copy.copy(value))
+
+    for key in _RUN_STATE:
+        if hasattr(copied, key):
+            setattr(copied, key, None)
+
+    return copied
 
 
 class PromptMixin:
@@ -73,6 +102,10 @@ class BaseMetric(PromptMixin):
     requires_trace: bool = False
     model: Optional[DeepEvalBaseLLM] = None
     using_native_model: Optional[bool] = None
+
+    def clone(self) -> "BaseMetric":
+        """Return a per-test-case copy without duplicating the model client."""
+        return _clone_metric(self)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -144,6 +177,10 @@ class BaseConversationalMetric(PromptMixin):
     flaky: bool = False
     model: Optional[DeepEvalBaseLLM] = None
     using_native_model: Optional[bool] = None
+
+    def clone(self) -> "BaseConversationalMetric":
+        """Return a per-test-case copy without duplicating the model client."""
+        return _clone_metric(self)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 import re
 import sys
@@ -101,24 +100,7 @@ def check_at_least_one_metric_has_threshold(
 def copy_metrics(
     metrics: List[Union[BaseMetric, BaseConversationalMetric]],
 ) -> List[Union[BaseMetric, BaseConversationalMetric]]:
-    copied_metrics = []
-    for metric in metrics:
-        metric_class = type(metric)
-        args = vars(metric)
-
-        superclasses = metric_class.__mro__
-
-        valid_params = []
-
-        for superclass in superclasses:
-            signature = inspect.signature(superclass.__init__)
-            superclass_params = signature.parameters.keys()
-            valid_params.extend(superclass_params)
-        valid_params = set(valid_params)
-        valid_args = {key: args[key] for key in valid_params if key in args}
-
-        copied_metrics.append(metric_class(**valid_args))
-    return copied_metrics
+    return [metric.clone() for metric in metrics]
 
 
 def format_turns(

--- a/tests/test_core/test_evaluation/test_metric_data.py
+++ b/tests/test_core/test_evaluation/test_metric_data.py
@@ -6,6 +6,7 @@ from deepeval.metrics import (
     BaseConversationalMetric,
     BaseMetric,
     ExactMatchMetric,
+    ToolPermissionMetric,
 )
 from deepeval.metrics.utils import (
     check_at_least_one_metric_has_threshold,
@@ -27,6 +28,28 @@ class StubMetric(BaseMetric):
 
 class StubConversationalMetric(BaseConversationalMetric):
     threshold = 0.5
+
+    def measure(self, test_case, *args, **kwargs):
+        return 1
+
+    async def a_measure(self, test_case, *args, **kwargs):
+        return 1
+
+
+class NarrowToolPermissionMetric(ToolPermissionMetric):
+    def __init__(self, threshold=1.0):
+        super().__init__(denied_tools=["shell"], threshold=threshold)
+
+
+class KwargsExactMatchMetric(ExactMatchMetric):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class NarrowConversationalMetric(BaseConversationalMetric):
+    def __init__(self, threshold=0.5):
+        self.threshold = threshold
+        self.custom_config = {"labels": ["conversation"]}
 
     def measure(self, test_case, *args, **kwargs):
         return 1
@@ -69,6 +92,52 @@ def test_copy_metrics_preserves_flaky():
     copied_metric = copy_metrics([metric])[0]
 
     assert copied_metric.flaky is True
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        NarrowToolPermissionMetric(),
+        KwargsExactMatchMetric(threshold=0.8),
+        NarrowConversationalMetric(),
+    ],
+)
+def test_copy_metrics_clones_custom_metrics_without_reconstructing(
+    metric,
+):
+    metric.custom_config = ["custom"]
+    metric.model = object()
+    metric.score = 0.25
+    metric.reason = "old reason"
+    metric.success = False
+    metric.error = "old error"
+    metric.verdicts = ["old verdict"]
+    metric.skipped = True
+    metric.evaluation_cost = 3.0
+    metric.input_tokens = 4
+    metric.output_tokens = 5
+    metric.verbose_logs = "old logs"
+
+    copied_metric = copy_metrics([metric])[0]
+
+    assert type(copied_metric) is type(metric)
+    assert copied_metric is not metric
+    assert copied_metric.custom_config == metric.custom_config
+    assert copied_metric.custom_config is not metric.custom_config
+    assert copied_metric.model is metric.model
+    for field in (
+        "score",
+        "reason",
+        "success",
+        "error",
+        "verdicts",
+        "skipped",
+        "evaluation_cost",
+        "input_tokens",
+        "output_tokens",
+        "verbose_logs",
+    ):
+        assert getattr(copied_metric, field) is None
 
 
 @pytest.mark.parametrize("metric_class", [StubMetric, StubConversationalMetric])

--- a/tests/test_core/test_evaluation/test_metric_data.py
+++ b/tests/test_core/test_evaluation/test_metric_data.py
@@ -58,6 +58,17 @@ class NarrowConversationalMetric(BaseConversationalMetric):
         return 1
 
 
+class FixedThresholdMetric(BaseMetric):
+    def __init__(self):
+        self.threshold = 0.8
+
+    def measure(self, test_case, *args, **kwargs):
+        return 1
+
+    async def a_measure(self, test_case, *args, **kwargs):
+        return 1
+
+
 def test_metric_data_threshold_defaults_to_none():
     metric_data = MetricData(name="Metric")
 
@@ -100,6 +111,7 @@ def test_copy_metrics_preserves_flaky():
         NarrowToolPermissionMetric(),
         KwargsExactMatchMetric(threshold=0.8),
         NarrowConversationalMetric(),
+        FixedThresholdMetric(),
     ],
 )
 def test_copy_metrics_clones_custom_metrics_without_reconstructing(
@@ -125,6 +137,7 @@ def test_copy_metrics_clones_custom_metrics_without_reconstructing(
     assert copied_metric.custom_config == metric.custom_config
     assert copied_metric.custom_config is not metric.custom_config
     assert copied_metric.model is metric.model
+    assert copied_metric.threshold == metric.threshold
     for field in (
         "score",
         "reason",


### PR DESCRIPTION
## Summary
- Replace constructor reconstruction with base metric clone semantics.
- Preserve metric configuration and shared model clients while resetting per-run state.
- Cover narrowed, **kwargs, and conversational metric subclasses.

Fixes #3037

## Testing
- `pytest -q tests/test_core/test_evaluation/test_metric_data.py --disable-warnings`
- `pytest -q tests/test_core/test_evaluation --disable-warnings`
- `black --check deepeval/metrics/base_metric.py deepeval/metrics/utils.py tests/test_core/test_evaluation/test_metric_data.py`