### PR TITLE
fix: preserve zero-valued GenAI token usage

### DIFF
--- a/deepeval/integrations/agentcore/instrumentator.py
+++ b/deepeval/integrations/agentcore/instrumentator.py
@@ -883,12 +883,12 @@ class AgentCoreSpanInterceptor(SpanProcessor):
                     span, "confident.trace.output", output_text
                 )
 
-        input_tokens = attrs.get("gen_ai.usage.input_tokens") or attrs.get(
-            "gen_ai.usage.prompt_tokens"
-        )
-        output_tokens = attrs.get("gen_ai.usage.output_tokens") or attrs.get(
-            "gen_ai.usage.completion_tokens"
-        )
+        input_tokens = attrs.get("gen_ai.usage.input_tokens")
+        if input_tokens is None:
+            input_tokens = attrs.get("gen_ai.usage.prompt_tokens")
+        output_tokens = attrs.get("gen_ai.usage.output_tokens")
+        if output_tokens is None:
+            output_tokens = attrs.get("gen_ai.usage.completion_tokens")
         if input_tokens is not None:
             self._set_attr_post_end(
                 span, "confident.llm.input_token_count", int(input_tokens)

--- a/deepeval/integrations/strands/instrumentator.py
+++ b/deepeval/integrations/strands/instrumentator.py
@@ -895,12 +895,12 @@ class StrandsSpanInterceptor(SpanProcessor):
                     span, "confident.trace.output", output_text
                 )
 
-        input_tokens = attrs.get("gen_ai.usage.input_tokens") or attrs.get(
-            "gen_ai.usage.prompt_tokens"
-        )
-        output_tokens = attrs.get("gen_ai.usage.output_tokens") or attrs.get(
-            "gen_ai.usage.completion_tokens"
-        )
+        input_tokens = attrs.get("gen_ai.usage.input_tokens")
+        if input_tokens is None:
+            input_tokens = attrs.get("gen_ai.usage.prompt_tokens")
+        output_tokens = attrs.get("gen_ai.usage.output_tokens")
+        if output_tokens is None:
+            output_tokens = attrs.get("gen_ai.usage.completion_tokens")
         if input_tokens is not None:
             self._set_attr_post_end(
                 span, "confident.llm.input_token_count", int(input_tokens)

--- a/tests/test_integrations/test_genai_token_usage.py
+++ b/tests/test_integrations/test_genai_token_usage.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+
+import pytest
+
+from deepeval.integrations.agentcore.instrumentator import (
+    AgentCoreSpanInterceptor,
+)
+from deepeval.integrations.strands.instrumentator import StrandsSpanInterceptor
+
+
+class _Span:
+    def __init__(self, attributes):
+        self.attributes = attributes
+        self._attributes = attributes
+        self.events = []
+        self.name = "chat"
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+@pytest.mark.parametrize(
+    "interceptor_class",
+    [AgentCoreSpanInterceptor, StrandsSpanInterceptor],
+)
+@pytest.mark.parametrize(
+    ("modern_key", "legacy_key", "target_key"),
+    [
+        (
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.prompt_tokens",
+            "confident.llm.input_token_count",
+        ),
+        (
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.completion_tokens",
+            "confident.llm.output_token_count",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("usage_attributes", "expected"),
+    [
+        ({"modern": 0, "legacy": 17}, 0),
+        ({"legacy": 17}, 17),
+    ],
+)
+def test_genai_token_usage_prefers_present_modern_attribute(
+    interceptor_class,
+    modern_key,
+    legacy_key,
+    target_key,
+    usage_attributes,
+    expected,
+):
+    attributes = {"gen_ai.operation.name": "chat"}
+    if "modern" in usage_attributes:
+        attributes[modern_key] = usage_attributes["modern"]
+    if "legacy" in usage_attributes:
+        attributes[legacy_key] = usage_attributes["legacy"]
+
+    span = _Span(attributes)
+    interceptor = interceptor_class(SimpleNamespace())
+
+    interceptor._serialize_framework_attrs(span)
+
+    assert span.attributes[target_key] == expected


### PR DESCRIPTION
## Summary

- Preserve explicit zero values from modern OpenTelemetry GenAI input and output token attributes.
- Fall back to legacy prompt and completion token attributes only when the modern attribute is absent.
- Apply the same behavior to the AgentCore and Strands span interceptors.

## Validation

- `pytest tests/test_integrations/test_strands/test_span_interceptor.py tests/test_integrations/test_agentcore/test_span_interceptor.py tests/test_integrations/test_genai_token_usage.py -q` — 84 passed with a synthetic environment value and no external API calls.
- The same test set repeated three times — 252 passed.
- `black --check` on the three changed files.
- `ruff check` on the three changed files.
- `git diff --check`.