### PR TITLE
fix(telemetry): respect read-only filesystem mode

### DIFF
--- a/deepeval/telemetry/__init__.py
+++ b/deepeval/telemetry/__init__.py
@@ -10,6 +10,7 @@ Opt out with `DEEPEVAL_TELEMETRY_OPT_OUT=1`.
 
 import os
 
+from deepeval.config.settings import get_settings
 from deepeval.constants import HIDDEN_DIR, KEY_FILE
 from deepeval.telemetry.api import (
     LoginSpan,
@@ -89,7 +90,10 @@ from deepeval.telemetry.runtime import detect_runtime
 
 def _migrate_project_files() -> None:
     """Move stray project files into the hidden dir. Predates this package."""
-    if telemetry_opt_out():
+    if (
+        telemetry_opt_out()
+        or get_settings().DEEPEVAL_FILE_SYSTEM == "READ_ONLY"
+    ):
         return
     try:
         if os.path.exists(KEY_FILE) and not os.path.isdir(HIDDEN_DIR):

--- a/deepeval/telemetry/identity.py
+++ b/deepeval/telemetry/identity.py
@@ -108,8 +108,12 @@ def _load() -> Dict[str, str]:
 
 def _persist(data: Dict[str, str]) -> None:
     from deepeval.telemetry.client import telemetry_opt_out
+    from deepeval.config.settings import get_settings
 
-    if telemetry_opt_out():
+    if (
+        telemetry_opt_out()
+        or get_settings().DEEPEVAL_FILE_SYSTEM == "READ_ONLY"
+    ):
         return
     try:
         path = telemetry_path()

--- a/tests/test_core/test_telemetry.py
+++ b/tests/test_core/test_telemetry.py
@@ -59,6 +59,25 @@ class TestIdentity:
         stored = (tmp_path / "home" / telemetry.TELEMETRY_DATA_FILE).read_text()
         assert f"{TelemetryKey.ID.value}={unique_id}" in stored
 
+    def test_id_is_not_written_in_read_only_mode(
+        self, backend, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+
+        assert telemetry.get_unique_id()
+        assert not (tmp_path / "home" / telemetry.TELEMETRY_DATA_FILE).exists()
+
+    def test_project_store_is_not_created_in_read_only_mode(
+        self, backend, tmp_path, monkeypatch
+    ):
+        project_store = tmp_path / "project-store"
+        monkeypatch.setenv("DEEPEVAL_FILE_SYSTEM", "READ_ONLY")
+        monkeypatch.setattr(telemetry, "HIDDEN_DIR", str(project_store))
+
+        telemetry._migrate_project_files()
+
+        assert not project_store.exists()
+
     def test_id_survives_a_change_of_working_directory(
         self, backend, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- skip legacy project-file migration when `DEEPEVAL_FILE_SYSTEM=READ_ONLY`
- keep anonymous telemetry identity in memory without persisting it
- add regression coverage for both write paths

Refs #1200
Refs #1707

## Relationship to prior attempts

- #1713 was a broader first pass at read-only behavior. It was closed without
  merge after review feedback noted that additional write paths still needed
  coverage.
- #2977 later covered a much wider set of filesystem writes, but its author
  withdrew it.
- Both PRs are closed and unmerged. This PR is intentionally limited to the
  two telemetry-owned writes that still reproduce on current `main`: legacy
  project-file migration and anonymous identity persistence.

## Problem

The documented read-only mode promises to stop DeepEval from writing its own
files, but importing telemetry still created `.deepeval/`, and resolving the
anonymous identity still wrote `$DEEPEVAL_HOME/.deepeval_telemetry.txt`.

## Verification

- Before: the isolated reproduction reported
  `project_store_exists=True` and `telemetry_file_exists=True`.
- After: the same reproduction reports both values as `False`.
- `pytest tests/test_core/test_telemetry.py tests/test_core/test_config/test_settings.py -q`
  (`94 passed`)
- Black 25.12, Ruff 0.13.3, `py_compile`, and `git diff --check` pass.

## Scope

This only suppresses telemetry-owned disk writes in the existing read-only
mode. Telemetry remains enabled in memory and can still emit events.
