### PR TITLE
fix(plugin): render evaluation results after plain pytest runs

### DIFF
--- a/deepeval/plugins/plugin.py
+++ b/deepeval/plugins/plugin.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import sys
 import uuid
 from contextlib import AbstractContextManager
 from rich import print
@@ -14,6 +15,7 @@ from deepeval.telemetry import (
     capture_evaluation_run,
 )
 from deepeval.test_run import global_test_run_manager
+from deepeval.test_run.test_run import TestRunResultDisplay
 from deepeval.utils import get_is_running_deepeval
 
 
@@ -126,3 +128,27 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         if report.skipped:
             reason = report.longreprtext.split("\n")[-1]
             print(f"Test {report.nodeid} was skipped. Reason: {reason}")
+
+    # Under plain `pytest`, output capture swallows the stdout-rendered
+    # progress/report from evaluate(), so re-render the accumulated results
+    # table here at session end to keep evaluation results visible.
+    if not get_is_running_deepeval():
+        try:
+            test_run = global_test_run_manager.test_run
+            if test_run is not None and (
+                len(test_run.test_cases) > 0
+                or len(test_run.conversational_test_cases) > 0
+            ):
+                global_test_run_manager.display_results_table(
+                    test_run, TestRunResultDisplay.ALL
+                )
+        except Exception as e:
+            print(
+                f"Warning: could not display evaluation results: {e}",
+                file=sys.stderr,
+            )
+        finally:
+            # A plain-pytest session owns no test run: drop it so results
+            # accumulated in this session do not leak into the next one
+            # (e.g. a second `pytest.main` call in the same process).
+            global_test_run_manager.test_run = None

--- a/tests/test_core/test_plugin/test_terminal_report.py
+++ b/tests/test_core/test_plugin/test_terminal_report.py
@@ -1,0 +1,139 @@
+pytest_plugins = ["pytester"]
+
+
+def test_plain_pytest_renders_results_table(pytester):
+    pytester.makepyfile(
+        test_eval="""
+import os
+os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "1"
+os.environ["COLUMNS"] = "200"
+
+from deepeval.evaluate import evaluate
+from deepeval.evaluate.configs import DisplayConfig
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+
+
+class AlwaysPassMetric(BaseMetric):
+    threshold = 0.5
+
+    def __init__(self):
+        self.score = None
+
+    def measure(self, test_case):
+        self.score = 1.0
+        return self.score
+
+    async def a_measure(self, test_case):
+        return self.measure(test_case)
+
+    @property
+    def __name__(self):
+        return "AlwaysPassMetric"
+
+
+def test_evaluation():
+    evaluate(
+        test_cases=[LLMTestCase(input="hello", actual_output="hello")],
+        metrics=[AlwaysPassMetric()],
+        display_config=DisplayConfig(show_indicator=False, print_results=False, inspect_after_run=False),
+    )
+"""
+    )
+    result = pytester.runpytest()
+    # The table title and a metric name must be visible after the run.
+    assert "Test Results" in result.stdout.str()
+    assert "AlwaysPassMetric" in result.stdout.str()
+
+
+def test_unrelated_suite_prints_no_table(pytester):
+    pytester.makepyfile(test_plain="""def test_ok():\n    assert True\n""")
+    result = pytester.runpytest()
+    assert "Test Results" not in result.stdout.str()
+
+
+def test_assert_test_session_renders_results_table(pytester):
+    pytester.makepyfile(
+        test_assert="""
+import os
+os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "1"
+os.environ["COLUMNS"] = "200"
+
+from deepeval.evaluate import assert_test
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+
+
+class AlwaysPassMetric(BaseMetric):
+    threshold = 0.5
+
+    def __init__(self):
+        self.score = None
+
+    def measure(self, test_case):
+        self.score = 1.0
+        return self.score
+
+    async def a_measure(self, test_case):
+        return self.measure(test_case)
+
+    @property
+    def __name__(self):
+        return "AlwaysPassMetric"
+
+
+def test_evaluation():
+    assert_test(
+        test_case=LLMTestCase(input="hello", actual_output="hello"),
+        metrics=[AlwaysPassMetric()],
+    )
+"""
+    )
+    result = pytester.runpytest()
+    assert "Test Results" in result.stdout.str()
+    assert "AlwaysPassMetric" in result.stdout.str()
+
+
+def test_failing_assert_test_still_renders_results_table(pytester):
+    pytester.makepyfile(
+        test_assert="""
+import os
+os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "1"
+os.environ["COLUMNS"] = "200"
+
+from deepeval.evaluate import assert_test
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+
+
+class AlwaysFailMetric(BaseMetric):
+    threshold = 0.5
+
+    def __init__(self):
+        self.score = None
+
+    def measure(self, test_case):
+        self.score = 0.0
+        return self.score
+
+    async def a_measure(self, test_case):
+        return self.measure(test_case)
+
+    @property
+    def __name__(self):
+        return "AlwaysFailMetric"
+
+
+def test_evaluation():
+    assert_test(
+        test_case=LLMTestCase(input="hello", actual_output="hello"),
+        metrics=[AlwaysFailMetric()],
+    )
+"""
+    )
+    result = pytester.runpytest()
+    # The inner test fails (metric score 0.0 < threshold), but the results
+    # table must still be rendered after the session.
+    assert result.ret != 0
+    assert "Test Results" in result.stdout.str()
+    assert "AlwaysFailMetric" in result.stdout.str()


### PR DESCRIPTION
Fixes #2986.

## Problem
Running evaluations with plain `pytest` (without `-s`) shows no progress bar and no per-test results — only pytest's own `PASSED [100%]` line at the end. pytest's default output capture swallows the rich report `evaluate()` writes to stdout while the test runs, and the deepeval pytest plugin never re-renders the accumulated results after capture is lifted.

## Root cause
`evaluate()` renders progress and the `EvaluationConsoleReport` to stdout during the test, where pytest discards captured output on success. The CLI (`deepeval test run`) avoids this by forcing `-s` and printing the results table after pytest returns; plain pytest has no equivalent step.

## Fix
`pytest_terminal_summary` now renders the accumulated test-run results table (Test case / Metric / Score / Status) at session end, when capture is suspended, using the same `display_results_table` used by the CLI. Rendering is skipped in `deepeval test run` (the CLI already prints the table) and for sessions that recorded no evaluation, so unrelated suites stay silent.

## Tests
- 4 pytester-based regression tests under `tests/test_core/test_plugin/`: a plain pytest run of an `evaluate()` test now shows the table; an `assert_test`-only session shows the table (including when the assertion fails); a session without evaluations prints nothing.
- All three rendering cases fail on the base commit and pass with the fix.
- `pytest tests/test_core/test_run/ tests/test_core/test_evaluation/`: 168 passed, 18 skipped.
- `black --check` and `git diff --check` are clean.

## Notes
- In a session with multiple `evaluate()` calls, each call owns an independent run, so the last run's table is rendered.
- Under `pytest -n` (xdist) the terminal summary runs in the controller process, so the workers' tables are not printed.