### PR TITLE
fix(dataset): align CSV context delimiters with save_as output

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -265,9 +265,9 @@ class EvaluationDataset:
         actual_output_col_name: str,
         expected_output_col_name: Optional[str] = "expected_output",
         context_col_name: Optional[str] = "context",
-        context_col_delimiter: str = ";",
+        context_col_delimiter: str = "|",
         retrieval_context_col_name: Optional[str] = "retrieval_context",
-        retrieval_context_col_delimiter: str = ";",
+        retrieval_context_col_delimiter: str = "|",
         tools_called_col_name: Optional[str] = "tools_called",
         tools_called_col_delimiter: str = ";",
         expected_tools_col_name: Optional[str] = "expected_tools",
@@ -285,9 +285,9 @@ class EvaluationDataset:
             actual_output_col_name (str): The column name in the CSV corresponding to the actual output for the test case.
             expected_output_col_name (str, optional): The column name in the CSV corresponding to the expected output for the test case. Defaults to None.
             context_col_name (str, optional): The column name in the CSV corresponding to the context for the test case. Defaults to None.
-            context_delimiter (str, optional): The delimiter used to separate items in the context list within the CSV file. Defaults to ';'.
+            context_col_delimiter (str, optional): The delimiter used to separate items in the context list within the CSV file. Defaults to '|'.
             retrieval_context_col_name (str, optional): The column name in the CSV corresponding to the retrieval context for the test case. Defaults to None.
-            retrieval_context_delimiter (str, optional): The delimiter used to separate items in the retrieval context list within the CSV file. Defaults to ';'.
+            retrieval_context_col_delimiter (str, optional): The delimiter used to separate items in the retrieval context list within the CSV file. Defaults to '|'.
             additional_metadata_col_name (str, optional): The column name in the CSV corresponding to additional metadata for the test case. Defaults to None.
 
         Returns:

--- a/docs/content/docs/(concepts)/evaluation-datasets.mdx
+++ b/docs/content/docs/(concepts)/evaluation-datasets.mdx
@@ -1092,9 +1092,9 @@ dataset.add_test_cases_from_csv_file(
     actual_output_col_name="actual_output",
     expected_output_col_name="expected_output",
     context_col_name="context",
-    context_col_delimiter= ";",
+    context_col_delimiter="|",
     retrieval_context_col_name="retrieval_context",
-    retrieval_context_col_delimiter= ";"
+    retrieval_context_col_delimiter="|"
 )
 ```
 

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -664,3 +664,31 @@ class TestSaveAndLoad:
 
         assert len(test_cases) == 1
         assert test_cases[0].expected_outcome == "User gets flight options"
+
+    def test_save_as_csv_round_trips_context_via_test_case_loader(self):
+        """save_as writes context joined by '|', so the test case loader must
+        default to the same delimiter to read its own output back."""
+        golden = Golden(
+            input="q",
+            actual_output="out",
+            expected_output="a",
+            context=["c1", "c2"],
+            retrieval_context=["r1", "r2"],
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = EvaluationDataset([golden]).save_as(
+                "csv", tmpdir, file_name="rt"
+            )
+
+            reloaded = EvaluationDataset()
+            reloaded.add_test_cases_from_csv_file(
+                file_path=path,
+                input_col_name="input",
+                actual_output_col_name="actual_output",
+                expected_output_col_name="expected_output",
+                context_col_name="context",
+                retrieval_context_col_name="retrieval_context",
+            )
+
+            assert reloaded.test_cases[0].context == ["c1", "c2"]
+            assert reloaded.test_cases[0].retrieval_context == ["r1", "r2"]


### PR DESCRIPTION
## Summary

`save_as("csv")` writes `context` and `retrieval_context` joined by `|`, but `add_test_cases_from_csv_file` defaults both delimiters to `;`. Reloading a CSV that deepeval itself wrote silently collapses the list into a single bogus element — no exception, no warning:

```python
import tempfile
from deepeval.dataset import EvaluationDataset, Golden

golden = Golden(input="q", context=["Geography", "Mountains"])

with tempfile.TemporaryDirectory() as tmpdir:
    path = EvaluationDataset([golden]).save_as("csv", tmpdir, file_name="rt")
    # deepeval writes:  context = "Geography|Mountains"

    a = EvaluationDataset()
    a.add_test_cases_from_csv_file(path, "input", "actual_output")

    b = EvaluationDataset()
    b.add_goldens_from_csv_file(file_path=path)

    print(a.test_cases[0].context)   # ['Geography|Mountains']   <- wrong
    print(b.goldens[0].context)      # ['Geography', 'Mountains'] <- correct
```

Two loaders, one file, different results. No exception in either case.


Every RAG metric downstream then scores against one malformed chunk instead of two.

## Why `|` is the correct side to change

`add_test_cases_from_csv_file` is the only place in the codebase using `;` for these two fields:

| Location | context / retrieval_context delimiter |
|---|---|
| `save_as("csv")` writer (3 call sites) | `\|` |
| `join_retrieval_context()` — `dataset/utils.py` | `\|` |
| `add_goldens_from_csv_file` | `\|` |
| `add_goldens_from_jsonl_file` | `\|` |
| `tests/test_core/test_datasets/goldens.csv` fixture | `\|` |
| **`add_test_cases_from_csv_file`** | **`;`** |

`tools_called` and `expected_tools` use `;` consistently across every loader and are left untouched — the inconsistency is confined to exactly the two fields that break.

## Changes

- `deepeval/dataset/dataset.py`: default `context_col_delimiter` and `retrieval_context_col_delimiter` to `|` in `add_test_cases_from_csv_file`
- same file: the docstring documented two parameters that don't exist (`context_delimiter`, `retrieval_context_delimiter` — the real names are `*_col_delimiter`) and stated the old defaults; both corrected
- `docs/.../evaluation-datasets.mdx`: the example passed `;` explicitly, demonstrating a delimiter no deepeval writer emits
- regression test asserting the `save_as` → `add_test_cases_from_csv_file` round trip for both fields

## Behavior change

This changes a default. Anyone relying on the implicit `;` when loading their own `;`-delimited CSVs will need to pass `context_col_delimiter=";"` explicitly.

Flagging it rather than burying it — though the current default silently corrupts data written by deepeval's own `save_as`, fails without any error, and disagrees with every other loader in the codebase.

## Testing

```
pytest tests/test_core/test_datasets/     ->  22 passed
pytest tests/test_core/                   ->  1241 passed, 9 failed, 56 skipped
```

The 9 failures are pre-existing and unrelated (Windows path/encoding, chromadb, telemetry, ollama) — verified identical on a clean tree with these changes stashed. Two of them are what #2906 describes.

Run on Python 3.12.5 / Windows 11. black could not be run locally (it refuses on 3.12.5 due to a known AST-safety bug); line lengths were checked manually against the repo's line-length = 80 and no added code line exceeds it.

The new test fails without the source change:

```
AssertionError: assert ['c1|c2'] == ['c1', 'c2']
```
