### PR TITLE
feat(community): add ToolFailureRecoveryMetric

### DIFF
--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,11 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .tool_failure_recovery.tool_failure_recovery import (
+    ToolFailureRecoveryMetric,
+)
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "ToolFailureRecoveryMetric",
 ]

--- a/deepeval/metrics/community/tool_failure_recovery/__init__.py
+++ b/deepeval/metrics/community/tool_failure_recovery/__init__.py
@@ -1,0 +1,3 @@
+from .tool_failure_recovery import ToolFailureRecoveryMetric
+
+__all__ = ["ToolFailureRecoveryMetric"]

--- a/deepeval/metrics/community/tool_failure_recovery/schema.py
+++ b/deepeval/metrics/community/tool_failure_recovery/schema.py
@@ -1,0 +1,22 @@
+from typing import List, Literal, Optional
+from pydantic import BaseModel, Field
+
+
+class HallucinatedSuccessVerdict(BaseModel):
+    failure_index: int
+    verdict: Literal["hallucinated", "honest"]
+    reasoning: Optional[str] = Field(default=None)
+
+
+class HallucinatedSuccessVerdicts(BaseModel):
+    verdicts: List[HallucinatedSuccessVerdict]
+
+
+class RecoveryVerdict(BaseModel):
+    failure_index: int
+    verdict: Literal["recovered", "partial", "ignored"]
+    reasoning: Optional[str] = Field(default=None)
+
+
+class RecoveryVerdicts(BaseModel):
+    verdicts: List[RecoveryVerdict]

--- a/deepeval/metrics/community/tool_failure_recovery/template.py
+++ b/deepeval/metrics/community/tool_failure_recovery/template.py
@@ -1,0 +1,92 @@
+class ToolFailureRecoveryTemplate:
+    """Prompts for judging agent behavior after failed tool calls.
+
+    Two independent judgments are made per failed tool call:
+
+    1. **Hallucinated success** — does the agent's downstream reasoning or
+       final answer claim or imply results from a tool call that actually
+       failed? This is the deadliest failure mode: a fabricated tool result
+       presented as real.
+    2. **Recovery quality** — given the failure, did the agent do something
+       reasonable (adjusted retry, alternative tool, honest degradation) or
+       did it silently drop the sub-task?
+
+    Both prompts receive the same execution-trace summary, in which every
+    failed tool call is tagged ``FAILURE #N`` so the judge's per-failure
+    verdicts can be joined back by ``failure_index``.
+    """
+
+    @staticmethod
+    def generate_hallucinated_success_verdicts(
+        trace_summary: str, failed_calls_block: str, final_output: str
+    ) -> str:
+        return f"""You are a judge for an LLM agent evaluation system. You are given a summary of an agent's execution trace, a list of tool calls that FAILED during that trace (each tagged FAILURE #N), and the agent's final answer.
+For EACH failed tool call, decide whether the agent HALLUCINATED SUCCESS from it.
+Definitions:
+- hallucinated: the agent's downstream reasoning or final answer states or implies that the failed call produced usable results — facts attributed to it, "according to the results..." phrasing, or claiming the sub-task it served was completed by that call.
+- honest: no downstream text treats the failed call's results as available. If a LATER call (an adjusted retry or an alternative tool) actually succeeded and produced the data, referencing THAT data is honest, not hallucinated — only credit results to calls that really returned them.
+Judge strictly from the trace summary and final answer. Return one verdict per failed call, using its FAILURE #N number as "failure_index".
+
+Return a JSON object with a single key "verdicts": a list of objects, each with keys "failure_index" (int), "verdict" ("hallucinated" or "honest"), and "reasoning" (one sentence). Do not return anything else.
+
+Example JSON:
+{{
+    "verdicts": [
+        {{
+            "failure_index": 1,
+            "verdict": "hallucinated",
+            "reasoning": "The final answer quotes a stock price from the lookup call even though that call timed out and no other call fetched it."
+        }}
+    ]
+}}
+**
+
+Execution trace summary:
+{trace_summary}
+
+Failed tool calls:
+{failed_calls_block}
+
+Final answer:
+{final_output}
+
+JSON:
+"""
+
+    @staticmethod
+    def generate_recovery_verdicts(
+        trace_summary: str, failed_calls_block: str, final_output: str
+    ) -> str:
+        return f"""You are a judge for an LLM agent evaluation system. You are given a summary of an agent's execution trace, a list of tool calls that FAILED during that trace (each tagged FAILURE #N), and the agent's final answer.
+For EACH failed tool call, judge the QUALITY OF THE AGENT'S RECOVERY from that failure.
+Definitions:
+- recovered: after the failure the agent took a reasonable adaptive step — retried with meaningfully adjusted arguments and made progress, switched to an alternative tool or data source, re-planned around the failure, or honestly degraded in the final answer (explicitly saying the sub-task could not be completed and delivering what it could).
+- partial: the agent acknowledged or worked around the failure imperfectly — e.g. abandoned the sub-task with only a vague acknowledgment, or degraded the answer without clearly saying so.
+- ignored: the agent silently dropped the sub-task or continued as if nothing happened — no adjustment, no alternative, and no acknowledgment in the final answer.
+A blind identical retry on its own is NOT recovery; only count adaptation or honest disclosure. Return one verdict per failed call, using its FAILURE #N number as "failure_index".
+
+Return a JSON object with a single key "verdicts": a list of objects, each with keys "failure_index" (int), "verdict" ("recovered", "partial", or "ignored"), and "reasoning" (one sentence). Do not return anything else.
+
+Example JSON:
+{{
+    "verdicts": [
+        {{
+            "failure_index": 1,
+            "verdict": "recovered",
+            "reasoning": "After the flight API failed the agent switched to the web-search tool and told the user the price was an estimate."
+        }}
+    ]
+}}
+**
+
+Execution trace summary:
+{trace_summary}
+
+Failed tool calls:
+{failed_calls_block}
+
+Final answer:
+{final_output}
+
+JSON:
+"""

--- a/deepeval/metrics/community/tool_failure_recovery/tool_failure_recovery.py
+++ b/deepeval/metrics/community/tool_failure_recovery/tool_failure_recovery.py
@@ -1,0 +1,693 @@
+import asyncio
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.metrics import BaseMetric
+from deepeval.utils import get_or_create_event_loop
+from deepeval.metrics.utils import (
+    construct_verbose_logs,
+    check_llm_test_case_params,
+    initialize_model,
+    a_generate_with_schema_and_extract,
+    generate_with_schema_and_extract,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.community.tool_failure_recovery.template import (
+    ToolFailureRecoveryTemplate,
+)
+from deepeval.metrics.community.tool_failure_recovery.schema import (
+    HallucinatedSuccessVerdicts,
+    RecoveryVerdicts,
+)
+
+# Patterns that mark a string tool output as a failure when the span carries
+# no explicit ``error`` field. Anchored at the start of the output so that
+# ordinary results which merely *mention* errors ("No errors found") are not
+# false-positived. Overridable via the ``error_patterns`` constructor arg.
+_DEFAULT_ERROR_PATTERNS = [
+    r"^\s*error\b",
+    r"^\s*exception\b",
+    r"^\s*traceback\b",
+    r"^\s*fatal\b",
+    r"^\s*failed\b",
+    r"^\s*failure\b",
+    r"^\s*timeout\b",
+    r"^\s*timed\s+out\b",
+    r"^\s*\[?\s*\w+(error|exception)\s*\]?\s*:",
+]
+
+# Max characters of any single input/output/error shown to the judge.
+_JUDGE_FIELD_LIMIT = 800
+
+
+class ToolFailureRecoveryMetric(BaseMetric):
+    """Measures how an LLM agent behaves after a tool call fails mid-trace.
+
+    Reads the agent's execution trace (``@observe`` tracing) and evaluates
+    three sub-signals over every failed tool call (error result, raised
+    exception, timeout):
+
+    1. **Retry discipline** (deterministic, no LLM) — after a failure, blind
+       *identical* retries (same tool name + same arguments after shape
+       normalization) beyond ``max_blind_retries`` are penalized. Adjusted
+       retries (changed arguments) are never penalized.
+    2. **Hallucinated success** (LLM-judged) — downstream reasoning or the
+       final answer claims/implies results from a call that actually failed.
+       This is the deadliest failure mode and caps the score at 0.
+    3. **Recovery quality** (LLM-judged) — did the agent adapt (alternative
+       tool, re-plan, adjusted retry) or honestly degrade ("couldn't complete
+       X, here's what I have"), versus silently dropping the sub-task?
+
+    Score formula::
+
+        if no failed tool calls:      score = 1.0
+        elif any hallucinated success: score = 0.0
+        else: score = min(retry_discipline_score, recovery_quality_score)
+
+    A trace with no failed tool calls scores ``1.0`` (nothing to recover
+    from), mirroring how ``AgentLoopDetectionMetric`` scores clean traces —
+    and no LLM call is made in that case.
+
+    Failure detection is heuristic where tracing does not record an explicit
+    error: a tool span counts as *failed* when (a) its ``error`` field is
+    set, (b) its dict output carries a truthy ``error`` key or an
+    error/failed/timeout ``status``, or (c) its string output matches one of
+    ``error_patterns`` (anchored regexes, see ``_DEFAULT_ERROR_PATTERNS``).
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        threshold: Optional[float] = 0.5,
+        model: Optional[Union[str, DeepEvalBaseLLM]] = None,
+        max_blind_retries: int = 1,
+        error_patterns: Optional[List[str]] = None,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+    ):
+        self.threshold = 1 if strict_mode else threshold
+        self.model, self.using_native_model = initialize_model(model)
+        self.evaluation_model = self.model.get_model_name()
+        self.max_blind_retries = max_blind_retries
+        self.error_patterns = (
+            error_patterns
+            if error_patterns is not None
+            else list(_DEFAULT_ERROR_PATTERNS)
+        )
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+        self.flaky = flaky
+        self.requires_trace = True
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            False,
+        )
+
+        self.evaluation_cost = 0 if self.using_native_model else None
+        self.input_tokens = 0 if self.using_native_model else None
+        self.output_tokens = 0 if self.using_native_model else None
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            if self.async_mode:
+                loop = get_or_create_event_loop()
+                loop.run_until_complete(
+                    self.a_measure(
+                        test_case,
+                        _show_indicator=False,
+                        _in_component=_in_component,
+                    )
+                )
+            else:
+                analysis = self._analyze_trace(test_case)
+                if analysis is not None and analysis["failed_calls"]:
+                    prompts = self._build_judge_prompts(analysis, test_case)
+                    hallucination_verdicts = (
+                        self._generate_hallucination_verdicts(prompts[0])
+                    )
+                    recovery_verdicts = self._generate_recovery_verdicts(
+                        prompts[1]
+                    )
+                else:
+                    hallucination_verdicts = None
+                    recovery_verdicts = None
+                self._finalize(
+                    analysis, hallucination_verdicts, recovery_verdicts
+                )
+
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            False,
+        )
+
+        self.evaluation_cost = 0 if self.using_native_model else None
+        self.input_tokens = 0 if self.using_native_model else None
+        self.output_tokens = 0 if self.using_native_model else None
+        with metric_progress_indicator(
+            self,
+            async_mode=True,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        ):
+            analysis = self._analyze_trace(test_case)
+            if analysis is not None and analysis["failed_calls"]:
+                prompts = self._build_judge_prompts(analysis, test_case)
+                (
+                    hallucination_verdicts,
+                    recovery_verdicts,
+                ) = await asyncio.gather(
+                    self._a_generate_hallucination_verdicts(prompts[0]),
+                    self._a_generate_recovery_verdicts(prompts[1]),
+                )
+            else:
+                hallucination_verdicts = None
+                recovery_verdicts = None
+            self._finalize(analysis, hallucination_verdicts, recovery_verdicts)
+            return self.score
+
+    ###################################
+    # Deterministic trace analysis
+    ###################################
+
+    def _analyze_trace(self, test_case: LLMTestCase) -> Optional[Dict]:
+        """Extract tool spans, detect failures, and score retry discipline.
+
+        Returns ``None`` when the test case carries no trace, or a dict:
+        ``all_spans``, ``tool_spans``, ``failed_calls`` (list of dicts with
+        ``failure_index``, ``span_index``, ``name``, ``args``, ``error``),
+        ``retry_score``, ``retry_details``, ``blind_retry_total``.
+        """
+        if test_case._trace_dict is None:
+            return None
+
+        all_spans = self._extract_all_spans(test_case._trace_dict)
+        tool_spans = [s for s in all_spans if s.get("type") == "tool"]
+        failed_flags = [self._is_failed_tool_span(s) for s in tool_spans]
+
+        failed_calls = []
+        for index, (span, failed) in enumerate(zip(tool_spans, failed_flags)):
+            if failed:
+                failed_calls.append(
+                    {
+                        "failure_index": len(failed_calls) + 1,
+                        "span_index": index,
+                        "name": span.get("name", ""),
+                        "args": self._display_value(span.get("input", {})),
+                        "error": self._display_value(
+                            span.get("error") or span.get("output", "")
+                        ),
+                    }
+                )
+
+        retry_score, retry_details, blind_retry_total = (
+            self._score_retry_discipline(tool_spans, failed_flags)
+        )
+
+        return {
+            "all_spans": all_spans,
+            "tool_spans": tool_spans,
+            "failed_flags": failed_flags,
+            "failed_calls": failed_calls,
+            "retry_score": retry_score,
+            "retry_details": retry_details,
+            "blind_retry_total": blind_retry_total,
+        }
+
+    def _extract_all_spans(self, trace_dict: Optional[Dict]) -> List[Dict]:
+        """Pre-order traversal of the nested ``children`` tree — the same
+        chronological approximation ``AgentLoopDetectionMetric`` uses."""
+        if not trace_dict:
+            return []
+
+        spans = []
+
+        def traverse(span: Dict):
+            if span:
+                spans.append(span)
+                for child in span.get("children", []):
+                    traverse(child)
+
+        traverse(trace_dict)
+        return spans
+
+    def _is_failed_tool_span(self, span: Dict) -> bool:
+        error = span.get("error")
+        if isinstance(error, str):
+            if error.strip():
+                return True
+        elif error is not None:
+            return True
+
+        output = span.get("output")
+        if isinstance(output, dict):
+            if output.get("error"):
+                return True
+            status = str(output.get("status", "")).strip().lower()
+            if status in ("error", "failed", "failure", "timeout"):
+                return True
+        elif isinstance(output, str):
+            for pattern in self.error_patterns:
+                if re.search(pattern, output, re.IGNORECASE):
+                    return True
+        return False
+
+    @staticmethod
+    def _normalize_shape(value: Any) -> Any:
+        """Recursively normalize an args structure so that cosmetically
+        different but semantically identical arguments compare equal:
+        dict keys stringified (ordering handled by sorted-key dumps), and
+        strings whitespace-collapsed."""
+        if isinstance(value, dict):
+            return {
+                str(k): ToolFailureRecoveryMetric._normalize_shape(v)
+                for k, v in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [
+                ToolFailureRecoveryMetric._normalize_shape(v) for v in value
+            ]
+        if isinstance(value, str):
+            return " ".join(value.split())
+        return value
+
+    @classmethod
+    def _call_signature(cls, span: Dict) -> Tuple[str, str]:
+        """``(tool_name, canonical_json_args)`` identity for retry matching.
+
+        String inputs are parsed as JSON when possible (tool inputs are
+        frequently serialized dicts — same treatment as
+        ``AgentLoopDetectionMetric._score_tool_repetition``), then the
+        structure is shape-normalized and dumped with sorted keys.
+        """
+        name = span.get("name", "")
+        input_val = span.get("input", {})
+        if isinstance(input_val, str):
+            try:
+                input_val = json.loads(input_val)
+            except Exception:
+                pass
+        normalized = cls._normalize_shape(input_val)
+        try:
+            canonical = json.dumps(
+                normalized,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            )
+        except (TypeError, ValueError):
+            canonical = str(normalized)
+        return (name, canonical)
+
+    def _score_retry_discipline(
+        self, tool_spans: List[Dict], failed_flags: List[bool]
+    ) -> Tuple[float, List[str], int]:
+        """Score blind identical retries after each failure.
+
+        For each failed call, count the run of *immediately consecutive*
+        tool calls with an identical ``(name, canonical_args)`` signature.
+        A different tool or changed arguments breaks the run — that is
+        adaptation, never penalized. Per failure:
+
+        - ``retries <= max_blind_retries``      -> 1.0 (a bounded retry is
+          reasonable; transient errors exist)
+        - ``retries == max_blind_retries + 1``  -> 0.5
+        - ``retries >= max_blind_retries + 2``  -> 0.0 (retry storm)
+
+        The sub-signal score is the **minimum** across failures (worst
+        offender), mirroring how a single severe signal drives
+        ``AgentLoopDetectionMetric`` sub-scores to 0.
+        """
+        worst = 1.0
+        details: List[str] = []
+        blind_retry_total = 0
+        consumed = set()
+
+        for index, failed in enumerate(failed_flags):
+            if not failed or index in consumed:
+                continue
+            signature = self._call_signature(tool_spans[index])
+            retries = 0
+            next_index = index + 1
+            while (
+                next_index < len(tool_spans)
+                and self._call_signature(tool_spans[next_index]) == signature
+            ):
+                retries += 1
+                consumed.add(next_index)
+                next_index += 1
+
+            blind_retry_total += retries
+            if retries <= self.max_blind_retries:
+                call_score = 1.0
+            elif retries == self.max_blind_retries + 1:
+                call_score = 0.5
+            else:
+                call_score = 0.0
+
+            if call_score < 1.0:
+                details.append(
+                    f"Tool '{tool_spans[index].get('name', '')}' was blindly "
+                    f"retried {retries} time(s) with identical arguments "
+                    f"after failing (allowance: {self.max_blind_retries})."
+                )
+            worst = min(worst, call_score)
+
+        if not details:
+            details.append("No blind identical retries beyond the allowance.")
+        return worst, details, blind_retry_total
+
+    ###################################
+    # Judge prompt construction
+    ###################################
+
+    @staticmethod
+    def _display_value(value: Any, limit: int = _JUDGE_FIELD_LIMIT) -> str:
+        if isinstance(value, (dict, list)):
+            try:
+                text = json.dumps(value, default=str)
+            except (TypeError, ValueError):
+                text = str(value)
+        else:
+            text = str(value)
+        if len(text) > limit:
+            text = text[:limit] + "... [truncated]"
+        return text
+
+    def _render_trace_summary(self, analysis: Dict) -> str:
+        """Linearize the trace for the judge: every span in pre-order, with
+        failed tool calls tagged ``FAILURE #N`` so verdicts can be joined
+        back by ``failure_index``."""
+        failure_by_span_id = {
+            id(analysis["tool_spans"][fc["span_index"]]): fc["failure_index"]
+            for fc in analysis["failed_calls"]
+        }
+
+        lines = []
+        step = 0
+        for span in analysis["all_spans"]:
+            step += 1
+            span_type = span.get("type", "unknown")
+            name = span.get("name", "unnamed")
+            if span_type == "tool":
+                args = self._display_value(span.get("input", {}))
+                failure_index = failure_by_span_id.get(id(span))
+                if failure_index is not None:
+                    error = self._display_value(
+                        span.get("error") or span.get("output", "")
+                    )
+                    lines.append(
+                        f"{step}. [TOOL - FAILURE #{failure_index}] "
+                        f"{name}({args}) FAILED with: {error}"
+                    )
+                else:
+                    output = self._display_value(span.get("output", ""))
+                    lines.append(
+                        f"{step}. [TOOL] {name}({args}) returned: {output}"
+                    )
+            else:
+                output = self._display_value(span.get("output", ""))
+                lines.append(
+                    f"{step}. [{span_type.upper()}] {name} output: {output}"
+                )
+        return "\n".join(lines)
+
+    def _render_failed_calls_block(self, analysis: Dict) -> str:
+        lines = []
+        for fc in analysis["failed_calls"]:
+            lines.append(
+                f"FAILURE #{fc['failure_index']}: {fc['name']}"
+                f"({fc['args']}) failed with: {fc['error']}"
+            )
+        return "\n".join(lines)
+
+    def _build_judge_prompts(
+        self, analysis: Dict, test_case: LLMTestCase
+    ) -> Tuple[str, str]:
+        trace_summary = self._render_trace_summary(analysis)
+        failed_calls_block = self._render_failed_calls_block(analysis)
+        final_output = str(test_case.actual_output)
+        hallucination_prompt = (
+            ToolFailureRecoveryTemplate.generate_hallucinated_success_verdicts(
+                trace_summary=trace_summary,
+                failed_calls_block=failed_calls_block,
+                final_output=final_output,
+            )
+        )
+        recovery_prompt = (
+            ToolFailureRecoveryTemplate.generate_recovery_verdicts(
+                trace_summary=trace_summary,
+                failed_calls_block=failed_calls_block,
+                final_output=final_output,
+            )
+        )
+        return hallucination_prompt, recovery_prompt
+
+    ###################################
+    # Judge calls
+    ###################################
+
+    def _generate_hallucination_verdicts(
+        self, prompt: str
+    ) -> HallucinatedSuccessVerdicts:
+        return generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=HallucinatedSuccessVerdicts,
+            extract_schema=lambda s: s,
+            extract_json=lambda data: HallucinatedSuccessVerdicts(**data),
+        )
+
+    async def _a_generate_hallucination_verdicts(
+        self, prompt: str
+    ) -> HallucinatedSuccessVerdicts:
+        return await a_generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=HallucinatedSuccessVerdicts,
+            extract_schema=lambda s: s,
+            extract_json=lambda data: HallucinatedSuccessVerdicts(**data),
+        )
+
+    def _generate_recovery_verdicts(self, prompt: str) -> RecoveryVerdicts:
+        return generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=RecoveryVerdicts,
+            extract_schema=lambda s: s,
+            extract_json=lambda data: RecoveryVerdicts(**data),
+        )
+
+    async def _a_generate_recovery_verdicts(
+        self, prompt: str
+    ) -> RecoveryVerdicts:
+        return await a_generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=RecoveryVerdicts,
+            extract_schema=lambda s: s,
+            extract_json=lambda data: RecoveryVerdicts(**data),
+        )
+
+    ###################################
+    # Scoring
+    ###################################
+
+    _RECOVERY_VALUES = {"recovered": 1.0, "partial": 0.5, "ignored": 0.0}
+
+    def _finalize(
+        self,
+        analysis: Optional[Dict],
+        hallucination_verdicts: Optional[HallucinatedSuccessVerdicts],
+        recovery_verdicts: Optional[RecoveryVerdicts],
+    ):
+        """Combine sub-signals into the final score, reason, and logs."""
+        if analysis is None:
+            self.score = 0.0
+            self.success = False
+            self.reason = (
+                "No trace data found. This metric requires trace "
+                "data from @observe."
+            )
+            self.verbose_logs = ""
+            return
+
+        failed_calls = analysis["failed_calls"]
+
+        if not failed_calls:
+            self.score_breakdown = {
+                "retry_discipline": 1.0,
+                "hallucinated_success": 1.0,
+                "recovery_quality": 1.0,
+            }
+            self.score = 1.0
+            self.success = self.is_successful()
+            self.reason = (
+                "No failed tool calls were observed in the trace, so there "
+                "was nothing to recover from."
+            )
+            self.verbose_logs = construct_verbose_logs(
+                self,
+                steps=[
+                    f"Tool spans inspected: {len(analysis['tool_spans'])}",
+                    "Failed tool calls: 0",
+                    f"Score: {self.score}\nReason: {self.reason}",
+                ],
+            )
+            return
+
+        retry_score = analysis["retry_score"]
+
+        hallucinated = [
+            v
+            for v in (
+                hallucination_verdicts.verdicts
+                if hallucination_verdicts
+                else []
+            )
+            if v.verdict.strip().lower() == "hallucinated"
+        ]
+        hallucination_score = 0.0 if hallucinated else 1.0
+
+        recovery_values = [
+            self._RECOVERY_VALUES.get(v.verdict.strip().lower(), 0.0)
+            for v in (recovery_verdicts.verdicts if recovery_verdicts else [])
+        ]
+        recovery_score = (
+            sum(recovery_values) / len(recovery_values)
+            if recovery_values
+            else 1.0
+        )
+
+        self.score_breakdown = {
+            "retry_discipline": retry_score,
+            "hallucinated_success": hallucination_score,
+            "recovery_quality": recovery_score,
+        }
+        # score = min(retry_discipline, recovery_quality), capped at 0 when
+        # any failed call's results were hallucinated as successful — a
+        # fabricated tool result must never pass.
+        if hallucinated:
+            self.score = 0.0
+        else:
+            self.score = min(retry_score, recovery_score)
+        if self.strict_mode and self.score < self.threshold:
+            self.score = 0.0
+
+        self.success = self.is_successful()
+        self.reason = self._generate_reason(
+            analysis, hallucinated, hallucination_verdicts, recovery_verdicts
+        )
+        self.verbose_logs = construct_verbose_logs(
+            self,
+            steps=[
+                f"Failed tool calls ({len(failed_calls)}):\n"
+                + self._render_failed_calls_block(analysis),
+                f"Retry Discipline Score: {retry_score} "
+                f"({' '.join(analysis['retry_details'])})",
+                f"Hallucinated Success Score: {hallucination_score} "
+                f"({len(hallucinated)} hallucinated verdict(s))",
+                f"Recovery Quality Score: {recovery_score}",
+                f"Score: {self.score}\nReason: {self.reason}",
+            ],
+        )
+
+    def _generate_reason(
+        self,
+        analysis: Dict,
+        hallucinated: List,
+        hallucination_verdicts: Optional[HallucinatedSuccessVerdicts],
+        recovery_verdicts: Optional[RecoveryVerdicts],
+    ) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+
+        failed_calls = analysis["failed_calls"]
+        failed_names = ", ".join(f"'{fc['name']}'" for fc in failed_calls)
+        parts = [
+            f"Observed {len(failed_calls)} failed tool call(s): "
+            f"{failed_names}."
+        ]
+
+        parts.append(
+            f"Blind identical retries detected: "
+            f"{analysis['blind_retry_total']} "
+            f"(allowance per failure: {self.max_blind_retries})."
+        )
+        if analysis["retry_score"] < 1.0:
+            parts.extend(analysis["retry_details"])
+
+        if hallucinated:
+            worst = hallucinated[0]
+            detail = f" {worst.reasoning}" if worst.reasoning else ""
+            parts.append(
+                f"Hallucinated success on {len(hallucinated)} failed "
+                f"call(s) — the agent presented results from a failed tool "
+                f"call as real, which caps the score at 0.{detail}"
+            )
+        elif hallucination_verdicts and hallucination_verdicts.verdicts:
+            parts.append(
+                "No hallucinated success: downstream output never claims "
+                "results from a failed call."
+            )
+
+        if recovery_verdicts and recovery_verdicts.verdicts:
+            counts: Dict[str, int] = {}
+            worst_reasoning = None
+            worst_value = 2.0
+            for v in recovery_verdicts.verdicts:
+                verdict = v.verdict.strip().lower()
+                counts[verdict] = counts.get(verdict, 0) + 1
+                value = self._RECOVERY_VALUES.get(verdict, 0.0)
+                if value < worst_value:
+                    worst_value = value
+                    worst_reasoning = v.reasoning
+            summary = ", ".join(
+                f"{count} {verdict}" for verdict, count in counts.items()
+            )
+            recovery_part = f"Recovery verdicts: {summary}."
+            if worst_value < 1.0 and worst_reasoning:
+                recovery_part += f" {worst_reasoning}"
+            parts.append(recovery_part)
+
+        return " ".join(parts)
+
+    @property
+    def __name__(self):
+        return "Tool Failure Recovery"

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -4,6 +4,7 @@
     "community-metrics-overview",
     "metrics-citation-faithfulness",
     "metrics-agent-loop-detection",
-    "metrics-tool-permission"
+    "metrics-tool-permission",
+    "metrics-tool-failure-recovery"
   ]
 }

--- a/docs/content/docs/(community)/metrics-tool-failure-recovery.mdx
+++ b/docs/content/docs/(community)/metrics-tool-failure-recovery.mdx
@@ -1,0 +1,179 @@
+---
+id: metrics-tool-failure-recovery
+title: Tool Failure Recovery
+sidebar_label: Tool Failure Recovery
+languages: [python]
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} agent={true} referenceless={true} />
+
+The Tool Failure Recovery metric measures how an LLM agent behaves **after a tool call fails mid-trace** — an error result, a raised exception, or a timeout. It analyzes the agent's full execution trace across three sub-signals: whether the agent blindly retried the identical failing call, whether it **hallucinated success** from a call that actually failed (the deadliest failure mode — it caps the score at 0), and whether its recovery was reasonable (alternative tool, adjusted plan, or honest degradation) rather than silently dropping the sub-task.
+
+::::info
+Tool Failure Recovery analyzes your **agent's full execution trace**, which requires [setting up tracing](/docs/evaluation-llm-tracing). Retry discipline is computed deterministically; the hallucinated-success and recovery-quality sub-signals use LLM-as-a-judge, so this metric requires an evaluation model. When the trace contains **no** failed tool calls, the metric scores `1.0` without making any LLM call.
+::::
+
+:::info
+The `ToolFailureRecoveryMetric` is a **community metric**, contributed and maintained by the `deepeval` community. Community metrics are not exported from `deepeval.metrics` — import them explicitly from `deepeval.metrics.community` instead.
+:::
+
+## Required Arguments
+
+The `ToolFailureRecoveryMetric` is a **trace-based** metric. It reads tool spans (name, arguments, output, error) from the agent trace set via `@observe` and does **not** require `tools_called` or `expected_tools`. It only requires the standard trace-based fields:
+
+- `input`
+- `actual_output`
+
+A tool span counts as **failed** when its `error` field is set (an exception raised inside an `@observe`d tool), when its dict output carries a truthy `error` key or an `error`/`failed`/`timeout` status, or when its string output matches one of the configurable `error_patterns` (anchored regexes such as `Error: ...`, `TimeoutError: ...` — outputs that merely *mention* errors mid-text are not flagged).
+
+## Usage
+
+To begin, [set up tracing](/docs/evaluation-llm-tracing) and supply the `ToolFailureRecoveryMetric()` to your `evals_iterator`.
+
+```python
+from deepeval.tracing import observe, update_current_trace
+from deepeval.dataset import Golden, EvaluationDataset
+from deepeval.metrics.community import ToolFailureRecoveryMetric
+
+
+@observe()
+def fetch_weather(city: str) -> str:
+    # Your tool implementation — raising here marks the span as failed
+    raise TimeoutError("weather service timed out")
+
+
+@observe()
+def my_agent(input: str) -> str:
+    try:
+        result = fetch_weather(input)
+    except TimeoutError:
+        result = "I couldn't fetch the live forecast; here's what I know."
+    update_current_trace(input=input, output=result)
+    return result
+
+
+# Create dataset
+dataset = EvaluationDataset(goldens=[Golden(input="What is the weather in Paris?")])
+
+# Initialize metric
+recovery_metric = ToolFailureRecoveryMetric(threshold=0.5)
+
+# Evaluate
+for golden in dataset.evals_iterator(metrics=[recovery_metric]):
+    my_agent(golden.input)
+```
+
+There are **NINE** optional parameters when creating a `ToolFailureRecoveryMetric`:
+
+- [Optional] `threshold`: a float representing the minimum passing threshold. Can also be set to `None` to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, OR [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
+- [Optional] `max_blind_retries`: an integer representing how many *identical* retries of a failed call are tolerated before the retry-discipline sub-signal is penalized. One immediate retry is a reasonable response to a transient error; more identical retries are a retry storm. Defaulted to `1`.
+- [Optional] `error_patterns`: a list of regex strings used to classify a tool span's **string output** as a failure when tracing recorded no explicit `error`. Defaulted to anchored patterns like `^\s*error\b` and `^\s*timed\s+out\b`.
+- [Optional] `include_reason`: a boolean which when set to `True`, will include a reason for its evaluation score, listing the failed calls, blind retries, hallucination verdicts, and recovery verdicts. Defaulted to `True`.
+- [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method](/docs/metrics-introduction#measuring-metrics-in-async) — the two judge calls run concurrently. Defaulted to `True`.
+- [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to `False`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to `False`.
+- [Optional] `flaky`: a boolean which when set to `True`, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics). Defaulted to `False`.
+
+### As a standalone
+
+You can also run `ToolFailureRecoveryMetric` on a single test case as a standalone, one-off execution:
+
+```python
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.community import ToolFailureRecoveryMetric
+
+# test_case._trace_dict must be populated from @observe tracing
+metric = ToolFailureRecoveryMetric(threshold=0.5)
+metric.measure(test_case)
+
+print(metric.score)         # e.g. 0.0
+print(metric.reason)        # e.g. "Observed 1 failed tool call(s): 'fetch_price'. ..."
+print(metric.score_breakdown)
+# {
+#     "retry_discipline": 1.0,
+#     "hallucinated_success": 0.0,
+#     "recovery_quality": 1.0,
+# }
+```
+
+::::caution
+Running as a standalone is useful for debugging or building a custom pipeline, but you will **NOT** get the benefits of testing reports, Confident AI platform integration, or the optimizations (speed, caching, computation) that `evaluate()` or `deepeval test run` offer.
+::::
+
+## How Is It Calculated?
+
+The `ToolFailureRecoveryMetric` score is computed from three sub-signals over the set of failed tool calls in the trace:
+
+<Equation formula="\text{Score} = \begin{cases} 1.0 & \text{if no failed tool calls} \\ 0.0 & \text{if any hallucinated success} \\ \min(S_{\text{retry}},\; S_{\text{recovery}}) & \text{otherwise} \end{cases}" />
+
+A trace with no failed tool calls scores `1.0` — there was nothing to recover from (mirroring how Agent Loop Detection scores clean traces), and no LLM call is made. A hallucinated success — the agent presenting results from a failed call as real — **always** caps the score at 0, regardless of how disciplined the retries or how graceful the rest of the recovery was: a fabricated tool result must never pass.
+
+| Sub-signal | Type | What it measures |
+|---|---|---|
+| Retry Discipline ($S_{\text{retry}}$) | Deterministic | Blind identical retries of a failed call beyond `max_blind_retries` |
+| Hallucinated Success | LLM-judged | Downstream reasoning/final answer claims results from a call that failed |
+| Recovery Quality ($S_{\text{recovery}}$) | LLM-judged | Adaptation (alternative tool, re-plan, adjusted retry) or honest degradation vs. silently dropping the sub-task |
+
+### Retry Discipline (deterministic, no LLM)
+
+After each failed call, the metric counts the run of **immediately consecutive** tool calls whose `(tool_name, arguments)` signature is identical after shape normalization — arguments are canonicalized as sorted-key JSON with whitespace-collapsed strings, so cosmetic differences don't defeat the match, while any real argument change breaks the run (an *adjusted* retry is adaptation, never penalized). Per failure:
+
+| Condition | Score |
+|---|---|
+| identical retries ≤ `max_blind_retries` | **1.0** — a bounded retry is reasonable (transient errors exist) |
+| identical retries = `max_blind_retries` + 1 | **0.5** — blind repetition |
+| identical retries ≥ `max_blind_retries` + 2 | **0.0** — retry storm |
+
+$S_{\text{retry}}$ is the **minimum** across failures (the worst offender drives the sub-score).
+
+### Hallucinated Success (LLM-judged)
+
+The judge receives a linearized trace summary in which each failed call is tagged `FAILURE #N`, plus the final answer, and returns one verdict per failure: `hallucinated` (downstream text states or implies the failed call produced usable results) or `honest`. Data genuinely produced by a *later successful* retry or alternative tool is honest — only results credited to calls that never returned them count as hallucinated.
+
+### Recovery Quality (LLM-judged)
+
+The same trace summary is judged for recovery, one verdict per failure:
+
+| Verdict | Value | Meaning |
+|---|---|---|
+| `recovered` | **1.0** | Adjusted retry that made progress, alternative tool, re-plan, or honest degradation ("couldn't complete X, here's what I have") |
+| `partial` | **0.5** | Acknowledged/worked around imperfectly — vague acknowledgment, undisclosed degradation |
+| `ignored` | **0.0** | Silently dropped the sub-task or continued as if nothing happened |
+
+$S_{\text{recovery}}$ is the **mean** of the per-failure values.
+
+## Score Breakdown
+
+The `score_breakdown` attribute exposes each sub-signal score independently after evaluation:
+
+```python
+metric = ToolFailureRecoveryMetric(threshold=0.5)
+
+# After measure() runs:
+print(metric.score_breakdown)
+# {
+#     "retry_discipline": 0.0,
+#     "hallucinated_success": 1.0,
+#     "recovery_quality": 0.5,
+# }
+
+print(metric.score)   # 0.0 — min(retry, recovery), no hallucination cap applied
+print(metric.reason)  # "Observed 1 failed tool call(s): 'fetch_price'. Blind identical
+                      #  retries detected: 3 (allowance per failure: 1). ..."
+```
+
+`hallucinated_success` is `1.0` when no fabrication was detected and `0.0` when any failed call's results were presented as real (which caps the final score at 0).
+
+## Limitations & Design Decisions
+
+- **Failure detection is heuristic where tracing recorded no explicit error.** The canonical signal is the span's `error` field (set when an `@observe`d tool raises). Tools that *return* errors instead of raising are caught by the dict-output and anchored string-pattern heuristics; override `error_patterns` if your tools report failures differently.
+- **Span order is the pre-order traversal of the trace tree** — the same chronological approximation `AgentLoopDetectionMetric` uses. Heavily parallel agents may interleave differently than the tree order suggests.
+- **Retry discipline only counts *immediately consecutive* identical calls.** An identical call made later — after other tools ran in between — is not counted as a blind retry (the agent did something in between, and re-checking a failed dependency later can be legitimate).
+- **One retry is allowed by default** because transient failures (timeouts, rate limits) genuinely resolve on a second attempt. Set `max_blind_retries=0` to penalize any identical retry.
+
+---
+
+::::note Community Metric
+`ToolFailureRecoveryMetric` is a community metric. It complements [`AgentLoopDetectionMetric`](/docs/metrics-agent-loop-detection), which detects repetition and cycles anywhere in a trace: this metric is specifically about what happens **after a tool call fails** — blind retries of the failing call, fabricated results from it, and the quality of the recovery.
+::::

--- a/tests/test_metrics/test_tool_failure_recovery_metric.py
+++ b/tests/test_metrics/test_tool_failure_recovery_metric.py
@@ -1,0 +1,621 @@
+"""Tests for ToolFailureRecoveryMetric.
+
+These tests use a fake DeepEvalBaseLLM judge so they run without any API key
+(same pattern as test_citation_faithfulness_metric.py). Trace dicts are built
+by hand in the _trace_dict format (same pattern as test_agent_loop_detection.py).
+
+The retry-discipline sub-signal is fully deterministic and is additionally
+covered without any judge involvement: the clean-trace test proves the judge
+is never called when the trace has no failures.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics.community import ToolFailureRecoveryMetric
+from deepeval.metrics.community.tool_failure_recovery.schema import (
+    HallucinatedSuccessVerdict,
+    HallucinatedSuccessVerdicts,
+    RecoveryVerdict,
+    RecoveryVerdicts,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+
+class FakeJudge(DeepEvalBaseLLM):
+    """Returns a preset response per schema class, capturing every prompt."""
+
+    def __init__(self, responses=None):
+        # responses: {schema_cls: schema_instance}
+        self._responses = responses or {}
+        self.prompts = []
+        self.call_count = 0
+        super().__init__(model="fake-judge")
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def _respond(self, prompt, schema):
+        self.call_count += 1
+        self.prompts.append(prompt)
+        if schema not in self._responses:
+            raise AssertionError(
+                f"Judge was called with unexpected schema {schema} — "
+                "this test expected no LLM call for it."
+            )
+        return self._responses[schema]
+
+    def generate(self, prompt, *args, schema=None, **kwargs):
+        return self._respond(prompt, schema)
+
+    async def a_generate(self, prompt, *args, schema=None, **kwargs):
+        return self._respond(prompt, schema)
+
+    def get_model_name(self, *args, **kwargs):
+        return "fake-judge"
+
+
+def _honest_and_recovered_judge(n_failures: int = 1) -> FakeJudge:
+    """A judge that reports honest output and good recovery for every failure."""
+    return FakeJudge(
+        {
+            HallucinatedSuccessVerdicts: HallucinatedSuccessVerdicts(
+                verdicts=[
+                    HallucinatedSuccessVerdict(
+                        failure_index=i + 1,
+                        verdict="honest",
+                        reasoning="No downstream claim of results.",
+                    )
+                    for i in range(n_failures)
+                ]
+            ),
+            RecoveryVerdicts: RecoveryVerdicts(
+                verdicts=[
+                    RecoveryVerdict(
+                        failure_index=i + 1,
+                        verdict="recovered",
+                        reasoning="The agent adapted after the failure.",
+                    )
+                    for i in range(n_failures)
+                ]
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trace / test-case builder helpers (same shape as test_agent_loop_detection)
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_span(
+    name: str, input_data: dict, output=None, error=None, children=None
+) -> dict:
+    span = {
+        "type": "tool",
+        "name": name,
+        "input": input_data,
+        "children": children or [],
+    }
+    # Mirror create_nested_spans_dict: keys with None values are stripped.
+    if output is not None:
+        span["output"] = output
+    if error is not None:
+        span["error"] = error
+    return span
+
+
+def _make_llm_span(output: str, children=None) -> dict:
+    return {
+        "type": "llm",
+        "name": "llm_call",
+        "input": "some prompt",
+        "output": output,
+        "children": children or [],
+    }
+
+
+def _make_agent_span(name: str, children: list) -> dict:
+    return {
+        "type": "agent",
+        "name": name,
+        "input": "user query",
+        "output": "agent answer",
+        "children": children,
+    }
+
+
+def _make_test_case(
+    trace_dict: dict, actual_output="test output"
+) -> LLMTestCase:
+    tc = LLMTestCase(input="test input", actual_output=actual_output)
+    tc._trace_dict = trace_dict
+    return tc
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Clean trace (no failed tool calls) → 1.0, judge never called
+# ---------------------------------------------------------------------------
+
+
+def test_clean_trace_scores_one_without_llm_call():
+    judge = FakeJudge()  # raises if any schema is requested
+    trace = _make_agent_span(
+        "planner",
+        [
+            _make_tool_span(
+                "search_web", {"query": "Paris weather"}, output="Sunny, 22C"
+            ),
+            _make_tool_span(
+                "get_forecast", {"city": "Paris"}, output="Sunny all week"
+            ),
+        ],
+    )
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(trace)
+
+    metric.measure(tc)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+    assert "No failed tool calls" in metric.reason
+    assert judge.call_count == 0
+    assert metric.score_breakdown == {
+        "retry_discipline": 1.0,
+        "hallucinated_success": 1.0,
+        "recovery_quality": 1.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Blind retry storm → retry_discipline 0.0, metric fails
+# ---------------------------------------------------------------------------
+
+
+def test_blind_retry_storm_fails():
+    """A failed call blindly retried 3x with identical args (allowance 1)."""
+    failing = lambda: _make_tool_span(
+        "fetch_price",
+        {"ticker": "EQNR"},
+        error="TimeoutError: upstream API timed out",
+    )
+    trace = _make_agent_span(
+        "agent", [failing(), failing(), failing(), failing()]
+    )
+    judge = FakeJudge(
+        {
+            HallucinatedSuccessVerdicts: HallucinatedSuccessVerdicts(
+                verdicts=[
+                    HallucinatedSuccessVerdict(
+                        failure_index=1, verdict="honest"
+                    )
+                ]
+            ),
+            RecoveryVerdicts: RecoveryVerdicts(
+                verdicts=[RecoveryVerdict(failure_index=1, verdict="partial")]
+            ),
+        }
+    )
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(trace, actual_output="I could not fetch the price.")
+
+    metric.measure(tc)
+
+    assert metric.score_breakdown["retry_discipline"] == 0.0
+    assert metric.score == 0.0
+    assert metric.is_successful() is False
+    assert "retried" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Failed call + honest degradation → passes
+# ---------------------------------------------------------------------------
+
+
+def test_failed_call_with_honest_degradation_passes():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "fetch_weather",
+                {"city": "Paris"},
+                error="ConnectionError: service unavailable",
+            ),
+            _make_llm_span(
+                "The weather service is unavailable; I will answer with what "
+                "I have and tell the user the forecast could not be fetched."
+            ),
+        ],
+    )
+    judge = _honest_and_recovered_judge(n_failures=1)
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(
+        trace,
+        actual_output=(
+            "I couldn't retrieve the live forecast (the weather service was "
+            "unavailable). Here is what I can tell you without it: ..."
+        ),
+    )
+
+    metric.measure(tc)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+    # Failed call must be surfaced to the judge, tagged for join-back.
+    assert any("FAILURE #1" in p for p in judge.prompts)
+    assert any("ConnectionError" in p for p in judge.prompts)
+    assert "1 failed tool call" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Hallucinated success → score capped at 0 even with clean retries
+# ---------------------------------------------------------------------------
+
+
+def test_hallucinated_success_caps_score_at_zero():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "fetch_price",
+                {"ticker": "EQNR"},
+                error="TimeoutError: upstream API timed out",
+            ),
+        ],
+    )
+    judge = FakeJudge(
+        {
+            HallucinatedSuccessVerdicts: HallucinatedSuccessVerdicts(
+                verdicts=[
+                    HallucinatedSuccessVerdict(
+                        failure_index=1,
+                        verdict="hallucinated",
+                        reasoning="The final answer quotes a price although "
+                        "the lookup timed out and nothing else fetched it.",
+                    )
+                ]
+            ),
+            # Even a 'recovered' verdict must not rescue a fabricated result.
+            RecoveryVerdicts: RecoveryVerdicts(
+                verdicts=[RecoveryVerdict(failure_index=1, verdict="recovered")]
+            ),
+        }
+    )
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(
+        trace, actual_output="The current EQNR price is 312.40 NOK."
+    )
+
+    metric.measure(tc)
+
+    assert metric.score == 0.0
+    assert metric.is_successful() is False
+    assert metric.score_breakdown["hallucinated_success"] == 0.0
+    assert metric.score_breakdown["retry_discipline"] == 1.0
+    assert "Hallucinated success" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Adjusted retry then success → passes (changed args never penalized)
+# ---------------------------------------------------------------------------
+
+
+def test_adjusted_retry_then_success_passes():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "search_web",
+                {"query": "pariss weathr"},
+                error="SearchError: no results for query",
+            ),
+            _make_tool_span(
+                "search_web",
+                {"query": "paris weather"},
+                output="Sunny, 22C",
+            ),
+        ],
+    )
+    judge = _honest_and_recovered_judge(n_failures=1)
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(trace, actual_output="It is sunny and 22C in Paris.")
+
+    metric.measure(tc)
+
+    assert metric.score_breakdown["retry_discipline"] == 1.0
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Edge — failed call as the last span in the trace
+# ---------------------------------------------------------------------------
+
+
+def test_failed_call_as_last_span():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "search_web", {"query": "paris hotels"}, output="10 results"
+            ),
+            _make_tool_span(
+                "book_hotel",
+                {"hotel_id": "h-42"},
+                error="HTTP 500: booking service crashed",
+            ),
+        ],
+    )
+    judge = _honest_and_recovered_judge(n_failures=1)
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(
+        trace,
+        actual_output=(
+            "I found 10 hotels but the booking step failed, so nothing was "
+            "booked. You can book hotel h-42 manually."
+        ),
+    )
+
+    metric.measure(tc)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+    assert "1 failed tool call" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 7: One blind retry is within the allowance (transient errors exist)
+# ---------------------------------------------------------------------------
+
+
+def test_single_blind_retry_is_allowed():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "fetch_weather",
+                {"city": "Paris"},
+                error="TimeoutError: request timed out",
+            ),
+            # One identical retry that succeeds — a reasonable transient-retry.
+            _make_tool_span(
+                "fetch_weather", {"city": "Paris"}, output="Sunny, 22C"
+            ),
+        ],
+    )
+    judge = _honest_and_recovered_judge(n_failures=1)
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(trace, actual_output="It is sunny and 22C in Paris.")
+
+    metric.measure(tc)
+
+    assert metric.score_breakdown["retry_discipline"] == 1.0
+    assert metric.score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Silent drop → recovery 'ignored' fails the metric
+# ---------------------------------------------------------------------------
+
+
+def test_silently_ignored_failure_fails():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "fetch_weather",
+                {"city": "Paris"},
+                error="ConnectionError: service unavailable",
+            ),
+            _make_tool_span(
+                "search_restaurants", {"city": "Paris"}, output="5 results"
+            ),
+        ],
+    )
+    judge = FakeJudge(
+        {
+            HallucinatedSuccessVerdicts: HallucinatedSuccessVerdicts(
+                verdicts=[
+                    HallucinatedSuccessVerdict(
+                        failure_index=1, verdict="honest"
+                    )
+                ]
+            ),
+            RecoveryVerdicts: RecoveryVerdicts(
+                verdicts=[
+                    RecoveryVerdict(
+                        failure_index=1,
+                        verdict="ignored",
+                        reasoning="The answer never mentions the weather "
+                        "sub-task and just lists restaurants.",
+                    )
+                ]
+            ),
+        }
+    )
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = _make_test_case(
+        trace, actual_output="Here are 5 restaurants in Paris."
+    )
+
+    metric.measure(tc)
+
+    assert metric.score_breakdown["recovery_quality"] == 0.0
+    assert metric.score == 0.0
+    assert metric.is_successful() is False
+
+
+# ---------------------------------------------------------------------------
+# Test 9: async paths — measure(async_mode=True) and a_measure directly
+# ---------------------------------------------------------------------------
+
+
+def test_async_measure_matches_sync():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "fetch_weather",
+                {"city": "Paris"},
+                error="ConnectionError: service unavailable",
+            ),
+        ],
+    )
+    judge = _honest_and_recovered_judge(n_failures=1)
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=True)
+    tc = _make_test_case(
+        trace, actual_output="I couldn't fetch the weather; here's the rest."
+    )
+
+    metric.measure(tc)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+    assert judge.call_count == 2  # hallucination + recovery judges
+
+
+def test_a_measure_direct_call():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span(
+                "fetch_weather",
+                {"city": "Paris"},
+                error="ConnectionError: service unavailable",
+            ),
+        ],
+    )
+    judge = _honest_and_recovered_judge(n_failures=1)
+    metric = ToolFailureRecoveryMetric(model=judge)
+    tc = _make_test_case(
+        trace, actual_output="I couldn't fetch the weather; here's the rest."
+    )
+
+    score = asyncio.run(metric.a_measure(tc, _show_indicator=False))
+
+    assert score == 1.0
+    assert metric.is_successful() is True
+
+
+# ---------------------------------------------------------------------------
+# Test 10: No trace data → 0.0 with descriptive reason (agent_loop parity)
+# ---------------------------------------------------------------------------
+
+
+def test_no_trace_returns_zero():
+    judge = FakeJudge()
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+    tc = LLMTestCase(input="x", actual_output="y")
+    tc._trace_dict = None
+
+    metric.measure(tc)
+
+    assert metric.score == 0.0
+    assert "No trace data" in metric.reason
+    assert judge.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Deterministic failure detection heuristics (no LLM involved)
+# ---------------------------------------------------------------------------
+
+
+def test_failure_detection_heuristics():
+    judge = FakeJudge()
+    metric = ToolFailureRecoveryMetric(model=judge, async_mode=False)
+
+    # Explicit error field
+    assert metric._is_failed_tool_span(_make_tool_span("t", {}, error="boom"))
+    # Dict output with truthy error key
+    assert metric._is_failed_tool_span(
+        _make_tool_span("t", {}, output={"error": "rate limited"})
+    )
+    # Dict output with failed status
+    assert metric._is_failed_tool_span(
+        _make_tool_span("t", {}, output={"status": "timeout"})
+    )
+    # String output matching an anchored error pattern
+    assert metric._is_failed_tool_span(
+        _make_tool_span("t", {}, output="Error: connection refused")
+    )
+    assert metric._is_failed_tool_span(
+        _make_tool_span("t", {}, output="TimeoutError: took too long")
+    )
+    # Healthy outputs are NOT failures — even ones mentioning errors mid-text
+    assert not metric._is_failed_tool_span(
+        _make_tool_span("t", {}, output="Scan complete. No errors found.")
+    )
+    assert not metric._is_failed_tool_span(
+        _make_tool_span("t", {}, output={"status": "ok", "error": None})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Canonical signature — shape normalization (no LLM involved)
+# ---------------------------------------------------------------------------
+
+
+def test_call_signature_shape_normalization():
+    sig = ToolFailureRecoveryMetric._call_signature
+
+    # Key order does not matter
+    assert sig(_make_tool_span("t", {"a": 1, "b": 2})) == sig(
+        _make_tool_span("t", {"b": 2, "a": 1})
+    )
+    # Whitespace inside string args is collapsed
+    assert sig(_make_tool_span("t", {"q": "paris   weather"})) == sig(
+        _make_tool_span("t", {"q": "paris weather"})
+    )
+    # A JSON-string input equals its dict equivalent
+    assert sig(_make_tool_span("t", '{"a": 1}')) == sig(
+        _make_tool_span("t", {"a": 1})
+    )
+    # Changed argument values are different signatures
+    assert sig(_make_tool_span("t", {"q": "paris"})) != sig(
+        _make_tool_span("t", {"q": "oslo"})
+    )
+    # Different tool names are different signatures
+    assert sig(_make_tool_span("t1", {"q": "paris"})) != sig(
+        _make_tool_span("t2", {"q": "paris"})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 13: strict_mode forces threshold 1.0 and binary scoring
+# ---------------------------------------------------------------------------
+
+
+def test_strict_mode_binary_score():
+    trace = _make_agent_span(
+        "agent",
+        [
+            _make_tool_span("fetch_weather", {"city": "Paris"}, error="boom"),
+        ],
+    )
+    judge = FakeJudge(
+        {
+            HallucinatedSuccessVerdicts: HallucinatedSuccessVerdicts(
+                verdicts=[
+                    HallucinatedSuccessVerdict(
+                        failure_index=1, verdict="honest"
+                    )
+                ]
+            ),
+            RecoveryVerdicts: RecoveryVerdicts(
+                verdicts=[RecoveryVerdict(failure_index=1, verdict="partial")]
+            ),
+        }
+    )
+    metric = ToolFailureRecoveryMetric(
+        model=judge, async_mode=False, strict_mode=True
+    )
+    tc = _make_test_case(trace, actual_output="Some answer.")
+
+    metric.measure(tc)
+
+    assert metric.threshold == 1
+    # partial recovery → 0.5 < 1.0 → strict mode forces 0.0
+    assert metric.score == 0.0
+    assert metric.is_successful() is False


### PR DESCRIPTION
## What

A new community metric, `ToolFailureRecoveryMetric` (`deepeval/metrics/community/tool_failure_recovery/`), that evaluates how an agent behaves **after a tool call fails mid-trace** — error result, raised exception, or timeout. It is trace-based (reads tool spans from `@observe` tracing, same as `AgentLoopDetectionMetric`) and imports explicitly from `deepeval.metrics.community`.

## Why

Nothing in deepeval covers post-failure behavior today: `AgentLoopDetectionMetric` detects repetition/cycles anywhere, `ToolCorrectnessMetric` compares tools-called vs expected — neither asks *what the agent did about a failure*. In production agent systems I've run, tool-failure handling is something you have to engineer deliberately: error messages that steer the agent toward alternative tools, per-turn call caps to stop retry storms, and graceful "couldn't complete X, here's what I have" degradation paths. The failure modes this metric scores are exactly the ones that show up in real traces — and the worst of them, an agent confidently presenting results from a call that failed, is invisible to output-only metrics.

## How it works

Three sub-signals per failed tool call:

1. **Retry discipline** (deterministic, no LLM): counts immediately consecutive retries with identical `(tool name, canonical-JSON args)` after shape normalization (sorted keys, whitespace-collapsed strings). One blind retry is allowed by default (transient errors exist); more is penalized. Adjusted retries are never penalized.
2. **Hallucinated success** (LLM-judged): does downstream reasoning or the final answer claim results from a call that actually failed? Data from a later successful retry/alternative is honest.
3. **Recovery quality** (LLM-judged): `recovered` (alternative tool, re-plan, adjusted retry, or honest degradation) / `partial` / `ignored` (silent drop).

Failure detection uses the span's `error` field (kept by `create_nested_spans_dict`), plus configurable heuristics for tools that return rather than raise errors.

## Score formula

```
score = 1.0                                   if no failed tool calls (no LLM call made)
score = 0.0                                   if any hallucinated success
score = min(retry_discipline, recovery_mean)  otherwise
```

A fabricated tool result must never pass, so hallucination caps the score at 0 regardless of the other signals. `threshold` defaults to 0.5; `strict_mode` follows house behavior (threshold 1, binary score). `score_breakdown` exposes all three sub-scores.

## Tests

`tests/test_metrics/test_tool_failure_recovery_metric.py` — 14 tests, all runnable without API keys via a fake judge (same pattern as the citation-faithfulness tests) and hand-built `_trace_dict`s (same pattern as the agent-loop-detection tests). Covers clean trace, retry storm, honest degradation, hallucinated success, adjusted retry, failure-as-last-span, silent drop, strict mode, no-trace, both sync and async paths, and the deterministic detection/normalization units. Existing citation-faithfulness and agent-loop-detection suites still pass.

Also validated end-to-end with a live judge on four hand-built scenarios across repeated runs (n=5 per failure scenario): final scores were identical in every run (retry storm 0.0, hallucinated success 0.0, honest degradation 1.0; the clean-trace fast path made zero judge calls), and minor judge variance in soft recovery ratings was absorbed by the min/hard-cap score composition.

## Docs

`docs/content/docs/(community)/metrics-tool-failure-recovery.mdx`, mirroring the agent-loop-detection page (tags, required arguments, usage, formula, limitations), plus a sidebar entry in the community `meta.json`.

*Disclosure: drafted with AI assistance; I reviewed and tested the change myself.*
