### PR TITLE
docs(metrics): correct the actual_output guard comment (#3050)

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -353,8 +353,10 @@ def check_llm_test_case_params(
         metric.error = error_str
         raise ValueError(error_str)
 
-    # Centralized: if a metric requires actual_output, reject empty/whitespace
-    # (including empty multimodal outputs) as "missing params".
+    # Centralized: if a metric requires actual_output, reject an empty string
+    # as "missing params". Whitespace-only strings are intentionally accepted
+    # (see test_answer_relevancy_whitespace_actual_output_does_not_raise_validation),
+    # and non-string (e.g. multimodal) outputs are not checked for emptiness here.
     if SingleTurnParams.ACTUAL_OUTPUT in test_case_params:
         actual_output = getattr(test_case, SingleTurnParams.ACTUAL_OUTPUT.value)
         if isinstance(actual_output, str) and actual_output == "":


### PR DESCRIPTION
## Summary

Fixes the misleading comment above the `actual_output` guard in `check_llm_test_case_params`, reported in #3050.

The comment claims the guard rejects **empty/whitespace** outputs (and empty multimodal outputs):

```python
# Centralized: if a metric requires actual_output, reject empty/whitespace
# (including empty multimodal outputs) as "missing params".
if SingleTurnParams.ACTUAL_OUTPUT in test_case_params:
    actual_output = getattr(test_case, SingleTurnParams.ACTUAL_OUTPUT.value)
    if isinstance(actual_output, str) and actual_output == "":
        ...
```

But the guard only rejects the empty string `""`. Whitespace-only outputs (`"   "`, `"\n"`, `"\t"`) are **intentionally** accepted — that decision is pinned by `test_answer_relevancy_whitespace_actual_output_does_not_raise_validation`, whose docstring states:

> Whitespace-only strings are intentionally not validated because we can't make assumptions about the value of the actual_output beyond its existence or emptiness.

Non-string (e.g. multimodal) outputs are likewise not checked for emptiness here.

## Decision

Rather than change behavior (which would break the pinned test and the deliberate design), this aligns the **comment** with the actual, tested behavior. This is the answer to the "which is authoritative?" question raised in #3050: the committed test is authoritative, so the comment is what's wrong.

## Change

Comment-only, no functional change:

```python
# Centralized: if a metric requires actual_output, reject an empty string
# as "missing params". Whitespace-only strings are intentionally accepted
# (see test_answer_relevancy_whitespace_actual_output_does_not_raise_validation),
# and non-string (e.g. multimodal) outputs are not checked for emptiness here.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
