### PR TITLE
fix(metrics): reject whitespace-only actual_output in the shared guard

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -372,7 +372,7 @@ def check_llm_test_case_params(
     # (including empty multimodal outputs) as "missing params".
     if SingleTurnParams.ACTUAL_OUTPUT in test_case_params:
         actual_output = getattr(test_case, SingleTurnParams.ACTUAL_OUTPUT.value)
-        if isinstance(actual_output, str) and actual_output == "":
+        if isinstance(actual_output, str) and not actual_output.strip():
             error_str = f"'actual_output' cannot be empty for the '{metric.__name__}' metric"
             metric.error = error_str
             raise MissingTestCaseParamsError(error_str)

--- a/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
+++ b/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
@@ -5,8 +5,8 @@ when actual_output is missing/empty:
   - None (missing param)
   - "" (empty string)
 
-Whitespace-only strings are intentionally not validated because we can't make assumptions
-about the value of the actual_output beyond its existence or emptiness.
+Whitespace-only strings (e.g. "   ", "\n", "\t") are treated as empty and raise
+MissingTestCaseParamsError.
 
 These tests use DummyModel and do not require OPENAI_API_KEY.
 """
@@ -54,15 +54,28 @@ def test_answer_relevancy_empty_actual_output_raises_sync():
     assert "cannot be empty" in msg or "actual_output" in msg
 
 
-def test_answer_relevancy_whitespace_actual_output_does_not_raise_validation():
-    """Whitespace-only actual_output should NOT raise MissingTestCaseParamsError."""
+@pytest.mark.parametrize("whitespace", ["   ", "\n", "\t"])
+def test_answer_relevancy_whitespace_actual_output_raises_sync(whitespace: str):
+    """Whitespace-only actual_output should raise MissingTestCaseParamsError (sync)."""
     metric = make_metric(async_mode=False)
     tc = LLMTestCase(
-        input="What if these shoes don't fit?", actual_output="   "
+        input="What if these shoes don't fit?", actual_output=whitespace
     )
 
-    # Only validate inputs here. Running the full metric would require a real
-    # model that supports generate_with_schema.
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        metric.measure(tc, _show_indicator=False)
+
+    msg = str(exc_info.value).lower()
+    assert "cannot be empty" in msg or "actual_output" in msg
+
+
+def test_answer_relevancy_valid_actual_output_passes_validation():
+    """A non-whitespace actual_output passes the guard (guard does not reject all strings)."""
+    metric = make_metric(async_mode=False)
+    tc = LLMTestCase(
+        input="What if these shoes don't fit?", actual_output="a real answer"
+    )
+
     check_llm_test_case_params(
         test_case=tc,
         test_case_params=metric._required_params,


### PR DESCRIPTION
## Summary

The centralized `check_llm_test_case_params` guard only rejects the exact
empty string (`actual_output == ""`), so whitespace-only `actual_output`
values (`"   "`, `"\n"`, `"\t"`) pass validation and reach the scorer.
When an LLM judge returns no statements for blank text, this lands on the
same score-1.0 path reported in #2385 -- an empty answer silently scored
as fully relevant.

## Root cause

`deepeval/metrics/utils.py:375` checks `actual_output == ""`, not whether
the string is empty after stripping. The guard's own comment says it
rejects "empty/whitespace" output; the code only ever rejected `""`.
`LLMTestCase` does no normalization upstream, so whitespace-only strings
flow straight through to the judge prompt.

## Change

- Reject whitespace-only strings with `not actual_output.strip()` in the
  shared guard (one line, `deepeval/metrics/utils.py`).
- Flip the pinned `...whitespace_actual_output_does_not_raise_validation`
  test to a parametrized `...raises_sync` test over
  `["   ", "\n", "\t"]` and update the file docstring. The pinned
  acceptance behavior was never ratified by a maintainer: #2451 merged
  with no reviews, the author flipped to whitespace acceptance mid-PR,
  and the PR description and code comment both claimed rejection.
- Add a positive control proving the guard does not reject non-empty
  strings.
- Leave the comment above the guard untouched: after this fix the code
  finally matches it.

## Testing

`poetry run pytest tests/test_metrics/test_answer_relevancy_metric_empty_output.py`

- Before the fix: the three whitespace cases fail (`MissingTestCaseParamsError`
  is not raised and execution falls through to the model).
- After the fix: 6 passed (whitespace x3, None, "", valid-string control).

On #3052: this PR supersedes its docs-only resolution. #3052 argues the
committed test makes whitespace acceptance authoritative; the test it
relies on is corrected here because the acceptance was a unilateral,
review-less mid-PR decision that reproduces a bug-labeled symptom and was
never ratified by a maintainer. With this change #3052 has nothing left to
do -- the comment it proposes to edit now matches the code.

Fixes #3050