### PR TITLE
fix: raise AnthropicModel default max_tokens and surface truncation clearly

### DIFF
--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -27,6 +27,13 @@ from deepeval.models.llms.constants import (
 # consistent retry rules
 retry_anthropic = create_retry_decorator(PS.ANTHROPIC)
 
+# Anthropic's ``max_tokens`` caps thinking *plus* response text. The current
+# default judge (``claude-opus-5``) thinks by default when no ``thinking``
+# parameter is sent, so a budget sized for the response alone gets eaten by
+# reasoning and the verdict is cut off mid-JSON. This is a ceiling, not a spend:
+# raising it costs nothing on responses that stay small.
+DEFAULT_MAX_TOKENS = 8192
+
 _ALIAS_MAP = {
     "api_key": ["_anthropic_api_key"],
 }
@@ -118,7 +125,9 @@ class AnthropicModel(DeepEvalBaseLLM):
         self.generation_kwargs.pop(
             "temperature", None
         )  # to avoid duplicate with self.temperature
-        default_max_tokens = 1024 if max_tokens is None else max_tokens
+        default_max_tokens = (
+            DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens
+        )
         self._max_tokens = int(
             self.generation_kwargs.pop("max_tokens", default_max_tokens)
         )
@@ -160,6 +169,7 @@ class AnthropicModel(DeepEvalBaseLLM):
         ):
             create_kwargs["temperature"] = self.temperature
         message = chat_model.messages.create(**create_kwargs)
+        self._raise_if_truncated(message, max_tokens, schema)
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )
@@ -200,6 +210,7 @@ class AnthropicModel(DeepEvalBaseLLM):
         ):
             create_kwargs["temperature"] = self.temperature
         message = await chat_model.messages.create(**create_kwargs)
+        self._raise_if_truncated(message, max_tokens, schema)
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )
@@ -209,6 +220,34 @@ class AnthropicModel(DeepEvalBaseLLM):
             json_output = trim_and_load_json(message.content[0].text)
 
             return schema.model_validate(json_output), cost
+
+    @staticmethod
+    def _raise_if_truncated(
+        message, max_tokens: int, schema: Optional[BaseModel]
+    ) -> None:
+        """Fail loudly when the response was cut off by the token budget.
+
+        Anthropic's ``max_tokens`` caps thinking and response text together, so a
+        thinking-by-default model can spend the whole budget reasoning and return
+        truncated (or empty) text. Without this check the caller sees a generic
+        "invalid JSON" error from ``trim_and_load_json`` and has no way to tell a
+        model-quality problem from a budget one.
+        """
+        if getattr(message, "stop_reason", None) != "max_tokens":
+            return
+        if schema is None:
+            # Free-form text: a truncated answer is still an answer.
+            return
+        raise DeepEvalError(
+            f"Anthropic stopped generating because it hit max_tokens "
+            f"({max_tokens}), so the structured output is truncated and cannot "
+            f"be parsed. `max_tokens` caps thinking and response tokens "
+            f"together, and models such as "
+            f"{DEFAULT_ANTHROPIC_MODEL} think by default, so reasoning can "
+            f"consume the whole budget. Raise it, e.g. "
+            f"`AnthropicModel(generation_kwargs={{'max_tokens': "
+            f"{max_tokens * 2}}})`."
+        )
 
     def generate_content(self, multimodal_input: List[Union[str, MLLMImage]]):
         content = []

--- a/tests/test_core/test_models/test_anthropic_model.py
+++ b/tests/test_core/test_models/test_anthropic_model.py
@@ -3,9 +3,12 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from deepeval.errors import DeepEvalError
-from deepeval.models.llms.anthropic_model import AnthropicModel
+from deepeval.models.llms.anthropic_model import (
+    AnthropicModel,
+    DEFAULT_MAX_TOKENS,
+)
 from deepeval.config.settings import reset_settings, get_settings
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 
 from tests.test_core.stubs import _RecordingClient
 
@@ -311,3 +314,125 @@ def test_anthropic_calculate_cost_with_zero_tokens(mock_require_dep, settings):
     model = AnthropicModel(model="claude-3-7-sonnet-latest")
     cost = model.calculate_cost(input_tokens=0, output_tokens=0)
     assert cost == 0.0
+
+
+###########################################
+# max_tokens budget / truncation (#3042)  #
+###########################################
+
+
+class _FakeMessagesClient:
+    """Anthropic-shaped client that returns a canned `messages.create` result."""
+
+    def __init__(self, *args, stop_reason="end_turn", text="{}", **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.create_kwargs = None
+        self.messages = SimpleNamespace(create=self._create)
+        self._stop_reason = stop_reason
+        self._text = text
+
+    def _create(self, **kwargs):
+        self.create_kwargs = kwargs
+        return SimpleNamespace(
+            content=[SimpleNamespace(type="text", text=self._text)],
+            stop_reason=self._stop_reason,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+        )
+
+
+class _FakeAsyncMessagesClient(_FakeMessagesClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.messages = SimpleNamespace(create=self._acreate)
+
+    async def _acreate(self, **kwargs):
+        return self._create(**kwargs)
+
+
+class _Verdict(BaseModel):
+    verdict: str
+
+
+def _anthropic_model(mock_require_dep, settings, client, **model_kwargs):
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 1e-6
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 1e-6
+
+    mock_require_dep.return_value = SimpleNamespace(
+        Anthropic=lambda *a, **kw: client,
+        AsyncAnthropic=lambda *a, **kw: client,
+    )
+    return AnthropicModel(model="claude-3-7-sonnet-latest", **model_kwargs)
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_default_max_tokens_leaves_room_for_thinking(
+    mock_require_dep, settings
+):
+    """`max_tokens` caps thinking plus response text, so 1024 truncated judges
+    running on thinking-by-default models. See issue #3042."""
+    client = _FakeMessagesClient(text='{"verdict": "yes"}')
+    model = _anthropic_model(mock_require_dep, settings, client)
+
+    assert model._max_tokens == DEFAULT_MAX_TOKENS
+    assert DEFAULT_MAX_TOKENS > 1024
+
+    model.generate("prompt", schema=_Verdict)
+    assert client.create_kwargs["max_tokens"] == DEFAULT_MAX_TOKENS
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_explicit_max_tokens_still_wins(mock_require_dep, settings):
+    client = _FakeMessagesClient(text='{"verdict": "yes"}')
+    model = _anthropic_model(
+        mock_require_dep,
+        settings,
+        client,
+        generation_kwargs={"max_tokens": 256},
+    )
+
+    assert model._max_tokens == 256
+    model.generate("prompt", schema=_Verdict)
+    assert client.create_kwargs["max_tokens"] == 256
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_truncated_structured_output_names_max_tokens(
+    mock_require_dep, settings
+):
+    """A budget-exhausted structured response must not surface as invalid JSON."""
+    client = _FakeMessagesClient(
+        stop_reason="max_tokens", text='{"verdict": "ye'
+    )
+    model = _anthropic_model(mock_require_dep, settings, client)
+
+    with pytest.raises(DeepEvalError, match="max_tokens"):
+        model.generate("prompt", schema=_Verdict)
+
+
+@pytest.mark.asyncio
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+async def test_anthropic_truncated_structured_output_async(
+    mock_require_dep, settings
+):
+    client = _FakeAsyncMessagesClient(
+        stop_reason="max_tokens", text='{"verdict": "ye'
+    )
+    model = _anthropic_model(mock_require_dep, settings, client)
+
+    with pytest.raises(DeepEvalError, match="max_tokens"):
+        await model.a_generate("prompt", schema=_Verdict)
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_truncated_free_text_is_returned_as_is(
+    mock_require_dep, settings
+):
+    """Without a schema a truncated answer is still usable, so don't raise."""
+    client = _FakeMessagesClient(stop_reason="max_tokens", text="partial answ")
+    model = _anthropic_model(mock_require_dep, settings, client)
+
+    text, _ = model.generate("prompt")
+    assert text == "partial answ"


### PR DESCRIPTION
Fixes #3042.

`AnthropicModel` defaulted `max_tokens` to 1024. Anthropic's `max_tokens` caps **thinking plus response text** together, and the current default judge (`claude-opus-5`, since #2993) thinks by default when no `thinking` parameter is sent — which `AnthropicModel` never sends. Judge and verdict prompts induce reasoning often, so the thinking spend eats into the 1024 budget and the verdict comes back cut off with `stop_reason: "max_tokens"`.

The failure surfaced far from its cause: `trim_and_load_json` raised *"Evaluation LLM outputted an invalid JSON"*, which reads like a model-quality problem rather than a budget one, and the thinking tokens were billed regardless.

## Changes

**1. Default `max_tokens` 1024 → 8192** (`DEFAULT_MAX_TOKENS`).

`max_tokens` is a ceiling, not a spend — raising it costs nothing on responses that stay small. Explicit values still win, whether passed via `generation_kwargs={"max_tokens": ...}` or `max_tokens=...`.

**2. A clear error when a structured response is truncated.**

When `stop_reason == "max_tokens"` and a `schema` was requested, `generate`/`a_generate` now raise a `DeepEvalError` naming `max_tokens` and the budget that was hit, instead of handing half-written JSON to the parser. Free-form text (no schema) is deliberately left alone — a truncated answer is still an answer.

## Relationship to #2946 / #2947

Distinct issue. #2946 is about `content[0].text` assuming the first block is a `TextBlock` — a block *extraction* bug. This one is about the *budget*: even with by-type extraction in place, the text block that gets extracted is truncated or empty. This PR doesn't touch the `content[0].text` lines, so it should merge cleanly alongside #2947.

## Tests

Added to `tests/test_core/test_models/test_anthropic_model.py`, all offline against a stub client:

- default budget is applied and exceeds the old 1024
- an explicit `generation_kwargs["max_tokens"]` still wins
- a truncated structured response raises an error naming `max_tokens` — sync and async
- a truncated free-form response is returned as-is

Verified the two truncation tests fail against the unfixed code path and pass with it. The full file passes: `15 passed`. Formatted with `black --line-length 79` to match the repo.
