### PR TITLE
fix: make DAGMetric score deterministic when several verdicts can score

### DIFF
--- a/deepeval/metrics/dag/runner.py
+++ b/deepeval/metrics/dag/runner.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, Union
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from deepeval.metrics.dag.nodes import (
     BaseNode,
@@ -40,6 +41,21 @@ _JUDGEMENT = (
 )
 
 
+@dataclass
+class _ScoreCandidate:
+    """A scoring verdict that fired during a run.
+
+    ``order`` is the node's position in a pre-order walk of the graph, so it
+    reflects how the DAG was declared and never how the run happened to
+    interleave.
+    """
+
+    order: int
+    score: float
+    node: Node
+    child_metric: Optional[Metric] = None
+
+
 class _DeepAcyclicGraphRunner:
     def __init__(self, graph: DeepAcyclicGraph):
         self.graph = graph
@@ -47,9 +63,30 @@ class _DeepAcyclicGraphRunner:
         self.outputs: Dict[Node, Any] = {}
         self.verdicts: Dict[Node, Any] = {}
         self.depth: Dict[Node, int] = {}
+        self.score_candidates: List[_ScoreCandidate] = []
+        self._order = self._build_order(graph)
         self._verbose_log = (
             _mt_verbose_log if graph.multiturn else _st_verbose_log
         )
+
+    @staticmethod
+    def _build_order(graph: DeepAcyclicGraph) -> Dict[Node, int]:
+        """Number every node by a pre-order walk of the declared graph."""
+        order: Dict[Node, int] = {}
+
+        def visit(node: Node) -> None:
+            if node in order:
+                return
+            order[node] = len(order)
+            for child in getattr(node, "children", None) or ():
+                visit(child)
+            child = getattr(node, "child", None)
+            if isinstance(child, _NODE):
+                visit(child)
+
+        for root in graph.root_nodes:
+            visit(root)
+        return order
 
     def _check_remaining(self, node: Node) -> bool:
         self.remaining[node] -= 1
@@ -74,18 +111,65 @@ class _DeepAcyclicGraphRunner:
         metric._verbose_steps.append(
             self._verbose_log(node, depth, child_metric)
         )
-        metric.score = child_metric.score
-        if metric.include_reason:
-            metric.reason = child_metric.reason
+        # Cost and tokens were really spent, so accrue them for every branch
+        # that ran. Only the score and reason are deferred to `_finalize`.
         metric._accrue_cost(child_metric.evaluation_cost)
         metric._accrue_tokens(
             child_metric.input_tokens, child_metric.output_tokens
         )
+        self._record_score(node, child_metric.score, child_metric)
+
+    def _record_score(
+        self,
+        node: Node,
+        score: float,
+        child_metric: Optional[Metric] = None,
+    ) -> None:
+        self.score_candidates.append(
+            _ScoreCandidate(
+                order=self._order.get(node, len(self._order)),
+                score=score,
+                node=node,
+                child_metric=child_metric,
+            )
+        )
+
+    def _winning_candidate(self) -> Optional[_ScoreCandidate]:
+        """Pick the metric's score from every scoring verdict that fired.
+
+        A DAG can have more than one scoring verdict reachable at once. Writing
+        each one straight to ``metric.score`` made the result depend on which
+        branch happened to finish last, which differs between the depth-first
+        sync walk and the interleaved async one. Choosing here instead makes
+        both agree.
+
+        The lowest score wins: a metric that measures several things should
+        report its weakest, in the same spirit as a failing check. ``order``
+        breaks ties by declaration order so the choice is fully determined by
+        how the DAG was written.
+        """
+        if not self.score_candidates:
+            return None
+        return min(self.score_candidates, key=lambda c: (c.score, c.order))
+
+    def _finalize(self, metric: Metric) -> Optional[_ScoreCandidate]:
+        """Commit the winning score. Returns the winner so the caller can
+        produce its reason, which needs `metric.score` to already be set."""
+        winner = self._winning_candidate()
+        if winner is not None:
+            metric.score = winner.score
+        return winner
 
     # ------------------------------------------------------------------ sync
     def run(self, metric: Metric, test_case: TestCase) -> None:
         for root in self.graph.root_nodes:
             self._visit(root, metric, test_case, 0)
+        winner = self._finalize(metric)
+        if winner is not None and metric.include_reason:
+            if winner.child_metric is not None:
+                metric.reason = winner.child_metric.reason
+            else:
+                metric.reason = winner.node._generate_reason(metric=metric)
 
     def _visit(
         self, node: Node, metric: Metric, test_case: TestCase, depth: int
@@ -122,9 +206,7 @@ class _DeepAcyclicGraphRunner:
         child = node.child
         if child is None:
             metric._verbose_steps.append(self._verbose_log(node, depth))
-            metric.score = node.score / 10
-            if metric.include_reason:
-                metric.reason = node._generate_reason(metric=metric)
+            self._record_score(node, node.score / 10)
         elif isinstance(child, _NODE):
             self._visit(child, metric, test_case, depth)
         else:
@@ -138,6 +220,14 @@ class _DeepAcyclicGraphRunner:
                 for root in self.graph.root_nodes
             )
         )
+        winner = self._finalize(metric)
+        if winner is not None and metric.include_reason:
+            if winner.child_metric is not None:
+                metric.reason = winner.child_metric.reason
+            else:
+                metric.reason = await winner.node._a_generate_reason(
+                    metric=metric
+                )
 
     async def _a_visit(
         self, node: Node, metric: Metric, test_case: TestCase, depth: int
@@ -178,9 +268,7 @@ class _DeepAcyclicGraphRunner:
         child = node.child
         if child is None:
             metric._verbose_steps.append(self._verbose_log(node, depth))
-            metric.score = node.score / 10
-            if metric.include_reason:
-                metric.reason = await node._a_generate_reason(metric=metric)
+            self._record_score(node, node.score / 10)
         elif isinstance(child, _NODE):
             await self._a_visit(child, metric, test_case, depth)
         else:

--- a/docs/content/docs/(custom)/metrics-dag.mdx
+++ b/docs/content/docs/(custom)/metrics-dag.mdx
@@ -402,6 +402,14 @@ There is **ONE** mandatory and **TWO** optional arguments when registering a ver
 
 Each call must define exactly one of `score` or `then`. A `score` terminates evaluation and becomes the metric's result, and so does a `then` that points to a `GEval` or another `BaseMetric` — the child metric's score is adopted as the final score. Only a `then` that points to another task or judgement node keeps the graph going, so every path is guaranteed to end at either a fixed score or a metric.
 
+### When More Than One Verdict Scores
+
+Most DAGs are shaped so exactly one scoring verdict is reachable per run. If your graph has independent branches, though, several can fire at once — for example a root `TaskNode` feeding two judgements that each end in a score.
+
+When that happens **the lowest of the scores that fired becomes the metric's result**, with ties broken by declaration order. A metric that measures several things reports its weakest, in the same spirit as a failing check, and the generated `reason` describes the score that was kept.
+
+The rule is applied after the whole graph has run, so the result is identical whether the metric runs with <Term py="async_mode=True" ts="asyncMode: true"/> or <Term py="async_mode=False" ts="asyncMode: false"/>, and does not depend on the order in which branches happen to complete.
+
 ### Graph Validation
 
 `DeepAcyclicGraph` validates the complete graph when it is constructed. It rejects:

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -1147,3 +1147,113 @@ class TestDAGMetric:
     def test_dag_metric_via_evaluate(self):
         metric = DAGMetric(name="Refund Period", dag=self._build_dag())
         evaluate([self._test_case()], [metric])
+
+
+#############################################################
+# Multiple reachable scoring verdicts (issue #3025)         #
+#############################################################
+
+
+def build_two_scoring_branches_dag(deep_first: bool) -> DeepAcyclicGraph:
+    """Two independent scoring branches, both reachable.
+
+    ``deep`` is two judgements down and scores 10; ``shallow`` is one
+    judgement down and scores 5.
+    """
+    extract = TaskNode(
+        instructions="Extract the headings",
+        output_label="Headings",
+        evaluation_params=SHARED_NODE_PARAMS,
+    )
+    deep = BinaryJudgementNode(criteria="All three headings present?")
+    inner = BinaryJudgementNode(criteria="Headings in the right order?")
+    shallow = BinaryJudgementNode(criteria="Summary under 100 words?")
+
+    if deep_first:
+        extract.add_node(deep)
+        extract.add_node(shallow)
+    else:
+        extract.add_node(shallow)
+        extract.add_node(deep)
+
+    deep.add_verdict(True, then=inner)
+    deep.add_verdict(False, score=0)
+    inner.add_verdict(True, score=10)
+    inner.add_verdict(False, score=0)
+    shallow.add_verdict(True, score=5)
+    shallow.add_verdict(False, score=0)
+    return DeepAcyclicGraph(root_nodes=[extract])
+
+
+class ReasoningSharedNodeModel(SharedNodeModel):
+    """`SharedNodeModel` that can also produce a `MetricScoreReason`."""
+
+    def generate(self, prompt, schema=None, **kwargs):
+        assert schema is not None
+        if schema.__name__ == "MetricScoreReason":
+            self.schema_calls.append(schema.__name__)
+            return schema(reason="mocked reason")
+        return super().generate(prompt, schema=schema, **kwargs)
+
+
+class TestMultipleScoringVerdicts:
+    """When two scoring verdicts can both fire, the score used to be whichever
+    one was assigned last -- which depended on node declaration order and on
+    sync vs async, since ``asyncio.gather`` changes completion order.
+    """
+
+    @pytest.mark.parametrize("deep_first", [True, False])
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_score_is_the_same_in_every_configuration(
+        self, deep_first, async_mode
+    ):
+        metric = measure_shared_node(
+            build_two_scoring_branches_dag(deep_first),
+            SharedNodeModel(binary_verdict=True),
+            async_mode,
+        )
+        # The lower of the two reachable scores (5/10), not whichever branch
+        # happened to finish last.
+        assert metric.score == 0.5
+
+    def test_sync_and_async_agree(self):
+        scores = {
+            (deep_first, async_mode): measure_shared_node(
+                build_two_scoring_branches_dag(deep_first),
+                SharedNodeModel(binary_verdict=True),
+                async_mode,
+            ).score
+            for deep_first in (True, False)
+            for async_mode in (False, True)
+        }
+        assert len(set(scores.values())) == 1, scores
+
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_single_scoring_verdict_is_unchanged(self, async_mode):
+        """One reachable scoring verdict must still produce its own score."""
+        order = _order_node()
+        metric = measure_shared_node(
+            DeepAcyclicGraph(root_nodes=[order]),
+            SharedNodeModel(non_binary_verdict="Yes"),
+            async_mode,
+        )
+        assert metric.score == 1.0
+
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_reason_belongs_to_the_winning_verdict(self, async_mode):
+        """The reason must describe the score that was kept, and be generated
+        once rather than once per scoring branch."""
+        dag = build_two_scoring_branches_dag(deep_first=True)
+        model = ReasoningSharedNodeModel(binary_verdict=True)
+        metric = DAGMetric(
+            name="Shared Node",
+            dag=dag,
+            model=model,
+            include_reason=True,
+            async_mode=async_mode,
+        )
+        metric.measure(shared_node_test_case(), _show_indicator=False)
+
+        assert metric.score == 0.5
+        assert metric.reason is not None
+        assert model.schema_calls.count("MetricScoreReason") == 1


### PR DESCRIPTION
Fixes #3025.

When a DAG has more than one scoring verdict reachable in a single run, each one wrote straight to `metric.score`, so the result was whichever branch happened to be assigned last. That depended on node declaration order **and** on sync vs async, since the sync walk is depth-first while `asyncio.gather` interleaves:

```
deep declared first    async=False score=0.5
deep declared first    async=True  score=1.0
shallow declared first async=False score=1.0
shallow declared first async=True  score=1.0
```

Same DAG, same judgements, different scores.

## Approach

The issue names two separable problems, and this takes the position the issue suggests on both.

**Sync/async divergence** is the unambiguous bug — there's no way for a user to reason about it. `_DeepAcyclicGraphRunner` now collects every scoring verdict that fires and picks the score once, in `_finalize`, after the whole graph has run. Nothing depends on completion order any more.

**Which score wins when two branches both score** is a policy call, and the issue's own suggestion was that `min` is the conservative pick for an eval metric. That's what's implemented: lowest score wins, ties broken by a pre-order index over the declared graph so the outcome is fully determined by how the DAG was written. A metric that measures several things reports its weakest, in the same spirit as a failing check. All four rows above now give `0.5`.

This is deliberately the aggregation option rather than the reject-at-construction option — as the issue notes, a construction-time check would have to reason about *simultaneous reachability* rather than just counting scoring verdicts, which is a much larger change and would break existing graphs. Happy to swap the rule (`max`, first-declared, strict rejection) — it's the one-line `min(...)` in `_winning_candidate`.

## Two consequences of deferring

- **The reason is generated once**, for the verdict whose score was kept, instead of once per scoring branch with the last one surviving. That's one fewer LLM call per extra scoring branch, and the reason now actually describes the reported score.
- **Cost and token accrual stay inline.** Those were really spent by every branch that ran, so only score and reason are deferred.

Graphs with a single reachable scoring verdict — nearly all of them — are unaffected.

## Docs

Added a "When More Than One Verdict Scores" section to `metrics-dag.mdx`, which previously said only that a score "becomes the metric's result". The issue asked for the rule to be written down.

## Tests

Added `TestMultipleScoringVerdicts` to `tests/test_metrics/test_dag.py`, built from the issue's repro and reusing the existing `SharedNodeModel` (whose `a_generate` yields to the event loop so async runs really interleave):

- the score is identical across all four declaration-order × sync/async configurations
- sync and async agree
- a single reachable scoring verdict is unchanged
- the reason belongs to the winning verdict and is generated exactly once

6 of the 9 fail against the unfixed runner; the 3 that pass are the no-regression guards. Full suite: `tests/test_metrics/` is `172 passed, 271 skipped, 6 xfailed` (skips are `OPENAI_API_KEY`-gated), including all 128 DAG / conversational-DAG / serialization tests. Formatted with `black --line-length 79`.
