### PR TITLE
feat(metrics): add deterministic trace alignment layer

### DIFF
--- a/deepeval/metrics/community/trace_divergence/__init__.py
+++ b/deepeval/metrics/community/trace_divergence/__init__.py
@@ -1,0 +1,17 @@
+from .alignment import (
+    DIVERGENCE_KINDS,
+    TRACE_PROJECTION_VERSION,
+    AlignmentResult,
+    Event,
+    align,
+    project,
+)
+
+__all__ = [
+    "DIVERGENCE_KINDS",
+    "TRACE_PROJECTION_VERSION",
+    "AlignmentResult",
+    "Event",
+    "align",
+    "project",
+]

--- a/deepeval/metrics/community/trace_divergence/alignment.py
+++ b/deepeval/metrics/community/trace_divergence/alignment.py
@@ -1,0 +1,358 @@
+# ruff: noqa: UP006, UP035, UP045
+"""Deterministic alignment for baseline and candidate execution traces.
+
+This module deliberately contains no metric policy. It reports where two
+single-turn traces first differ, whether they recover, and which events could
+not be matched. A metric wrapper can then decide which differences are
+acceptable for its use case.
+"""
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+TRACE_PROJECTION_VERSION = "1.0.0"
+DEFAULT_LOOKAHEAD = 4
+DEFAULT_RESYNC_RUN = 2
+
+DIVERGENCE_KINDS = (
+    "arg_change",
+    "tool_change",
+    "order_change",
+    "absent",
+    "extra",
+)
+
+
+@dataclass(frozen=True)
+class Event:
+    """One versioned, comparable projection of a trace step."""
+
+    index: int
+    event_id: str
+    kind: str
+    name: str
+    arguments: Any
+    strong_identity: str
+    weak_identity: str
+
+
+@dataclass
+class AlignmentResult:
+    """Policy-neutral output consumed by a trace-divergence metric."""
+
+    aligned: bool
+    matched_prefix_len: int
+    first_divergence: Optional[int]
+    divergence_kind: Optional[str]
+    resync_at: Optional[int]
+    unmatched_baseline: List[str] = field(default_factory=list)
+    unmatched_candidate: List[str] = field(default_factory=list)
+    reordered: List[Tuple[str, str]] = field(default_factory=list)
+    baseline_len: int = 0
+    candidate_len: int = 0
+    projection_version: str = TRACE_PROJECTION_VERSION
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @property
+    def divergence_ratio(self) -> float:
+        """Return the divergent fraction without applying pass/fail policy."""
+
+        longest = max(self.baseline_len, self.candidate_len)
+        if not longest or self.aligned:
+            return 0.0
+        end = self.resync_at if self.resync_at is not None else longest
+        return max(0.0, end - self.matched_prefix_len) / longest
+
+
+def _canonical(value: Any) -> Any:
+    if isinstance(value, dict):
+        if any(not isinstance(key, str) for key in value):
+            raise ValueError("trace argument mappings must use string keys")
+        return {key: _canonical(value[key]) for key in sorted(value)}
+    if isinstance(value, (list, tuple)):
+        return [_canonical(item) for item in value]
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _digest(payload: Any) -> str:
+    try:
+        blob = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("trace arguments must be JSON serializable") from exc
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def _get(step: Any, *names: str, default: Any = None) -> Any:
+    for name in names:
+        if isinstance(step, dict):
+            value = step.get(name)
+        else:
+            value = getattr(step, name, None)
+        if value is not None:
+            return value
+    return default
+
+
+def _text(value: Any) -> str:
+    return str(value.value if isinstance(value, Enum) else value)
+
+
+def project(trace: Iterable[Any]) -> List[Event]:
+    """Project dict, ToolCall, or span-like steps into comparable events."""
+
+    events = []
+    for index, step in enumerate(trace):
+        kind = _text(_get(step, "kind", "type", "span_type", default="tool"))
+        name = _text(
+            _get(step, "name", "tool", "tool_name", "function", default="")
+        )
+        if not name:
+            raise ValueError("trace steps must have a non-empty name")
+        arguments = _canonical(
+            _get(
+                step,
+                "args",
+                "arguments",
+                "input_parameters",
+                "input",
+                "parameters",
+                default={},
+            )
+        )
+        raw_id = _get(
+            step,
+            "id",
+            "event_id",
+            "span_id",
+            "uuid",
+            default=f"idx-{index}",
+        )
+        event_id = _text(raw_id) or f"idx-{index}"
+        weak_identity = f"{kind}:{name}"
+        strong_identity = f"{weak_identity}:{_digest(arguments)}"
+        events.append(
+            Event(
+                index=index,
+                event_id=event_id,
+                kind=kind,
+                name=name,
+                arguments=arguments,
+                strong_identity=strong_identity,
+                weak_identity=weak_identity,
+            )
+        )
+    return events
+
+
+def _common_prefix(
+    baseline: Sequence[Event], candidate: Sequence[Event]
+) -> int:
+    index = 0
+    while (
+        index < len(baseline)
+        and index < len(candidate)
+        and baseline[index].strong_identity == candidate[index].strong_identity
+    ):
+        index += 1
+    return index
+
+
+def _reorder_at(
+    baseline: Sequence[Event],
+    candidate: Sequence[Event],
+    index: int,
+    lookahead: int,
+) -> Tuple[List[Tuple[str, str]], int]:
+    for width in range(2, lookahead + 1):
+        baseline_window = baseline[index : index + width]
+        candidate_window = candidate[index : index + width]
+        if len(baseline_window) < width or len(candidate_window) < width:
+            break
+        baseline_ids = [event.strong_identity for event in baseline_window]
+        candidate_ids = [event.strong_identity for event in candidate_window]
+        if (
+            Counter(baseline_ids) == Counter(candidate_ids)
+            and baseline_ids != candidate_ids
+        ):
+            pairs = [
+                (left.event_id, right.event_id)
+                for left, right in zip(baseline_window, candidate_window)
+                if left.strong_identity != right.strong_identity
+            ]
+            return pairs, width
+    return [], 0
+
+
+def _classify(
+    baseline: Sequence[Event], candidate: Sequence[Event], index: int
+) -> str:
+    left = baseline[index] if index < len(baseline) else None
+    right = candidate[index] if index < len(candidate) else None
+    if left is None:
+        return "extra"
+    if right is None:
+        return "absent"
+    if left.weak_identity == right.weak_identity:
+        return "arg_change"
+    if (
+        index + 1 < len(candidate)
+        and left.strong_identity == candidate[index + 1].strong_identity
+    ):
+        return "extra"
+    if (
+        index + 1 < len(baseline)
+        and right.strong_identity == baseline[index + 1].strong_identity
+    ):
+        return "absent"
+    return "tool_change"
+
+
+def _find_resync(
+    baseline: Sequence[Event],
+    candidate: Sequence[Event],
+    index: int,
+    lookahead: int,
+    resync_run: int,
+) -> Optional[int]:
+    """Find the nearest sustained rejoin in a bounded 2-D offset window.
+
+    A rejoin can consume divergent events on either or both sides. Searching
+    only one-sided skew misses same-length substitutions (both sides advance
+    once) and unequal local replacements where both sides advance before the
+    shared suffix resumes.
+    """
+
+    offsets = [
+        (left_offset, right_offset)
+        for left_offset in range(lookahead + 1)
+        for right_offset in range(lookahead + 1)
+        if left_offset or right_offset
+    ]
+    offsets.sort(
+        key=lambda pair: (
+            pair[0] + pair[1],
+            abs(pair[0] - pair[1]),
+            max(pair),
+            pair,
+        )
+    )
+
+    for left_offset, right_offset in offsets:
+        left = index + left_offset
+        right = index + right_offset
+        if left >= len(baseline) or right >= len(candidate):
+            continue
+
+        run = 0
+        while (
+            left + run < len(baseline)
+            and right + run < len(candidate)
+            and baseline[left + run].strong_identity
+            == candidate[right + run].strong_identity
+        ):
+            run += 1
+            if run >= resync_run:
+                return max(left, right)
+    return None
+
+
+def _unmatched(
+    baseline: Sequence[Event], candidate: Sequence[Event]
+) -> Tuple[List[str], List[str]]:
+    """Return occurrence-aware unmatched IDs, including duplicate steps."""
+
+    candidate_counts = Counter(event.strong_identity for event in candidate)
+    unmatched_baseline = []
+    for event in baseline:
+        if candidate_counts[event.strong_identity]:
+            candidate_counts[event.strong_identity] -= 1
+        else:
+            unmatched_baseline.append(event.event_id)
+
+    baseline_counts = Counter(event.strong_identity for event in baseline)
+    unmatched_candidate = []
+    for event in candidate:
+        if baseline_counts[event.strong_identity]:
+            baseline_counts[event.strong_identity] -= 1
+        else:
+            unmatched_candidate.append(event.event_id)
+    return unmatched_baseline, unmatched_candidate
+
+
+def align(
+    baseline: Iterable[Any],
+    candidate: Iterable[Any],
+    *,
+    lookahead: int = DEFAULT_LOOKAHEAD,
+    resync_run: int = DEFAULT_RESYNC_RUN,
+) -> AlignmentResult:
+    """Locate the first sustained divergence between two traces."""
+
+    if lookahead < 1 or resync_run < 1:
+        raise ValueError("lookahead and resync_run must be positive")
+    base = project(baseline)
+    cand = project(candidate)
+    prefix = _common_prefix(base, cand)
+    if prefix == len(base) == len(cand):
+        return AlignmentResult(
+            aligned=True,
+            matched_prefix_len=prefix,
+            first_divergence=None,
+            divergence_kind=None,
+            resync_at=None,
+            baseline_len=len(base),
+            candidate_len=len(cand),
+        )
+
+    unmatched_baseline, unmatched_candidate = _unmatched(
+        base[prefix:], cand[prefix:]
+    )
+    reordered, reorder_width = _reorder_at(base, cand, prefix, lookahead)
+    if reordered:
+        tail_prefix = _common_prefix(
+            base[prefix + reorder_width :],
+            cand[prefix + reorder_width :],
+        )
+        if prefix + reorder_width + tail_prefix == len(
+            base
+        ) and prefix + reorder_width + tail_prefix == len(cand):
+            return AlignmentResult(
+                aligned=False,
+                matched_prefix_len=prefix,
+                first_divergence=prefix,
+                divergence_kind="order_change",
+                resync_at=prefix + reorder_width,
+                reordered=reordered,
+                baseline_len=len(base),
+                candidate_len=len(cand),
+            )
+
+    kind = _classify(base, cand, prefix)
+    return AlignmentResult(
+        aligned=False,
+        matched_prefix_len=prefix,
+        first_divergence=prefix,
+        divergence_kind=kind,
+        resync_at=_find_resync(base, cand, prefix, lookahead, resync_run),
+        unmatched_baseline=unmatched_baseline,
+        unmatched_candidate=unmatched_candidate,
+        reordered=reordered,
+        baseline_len=len(base),
+        candidate_len=len(cand),
+    )

--- a/tests/test_metrics/test_trace_divergence_alignment.py
+++ b/tests/test_metrics/test_trace_divergence_alignment.py
@@ -1,0 +1,175 @@
+import json
+
+import pytest
+
+from deepeval.metrics.community.trace_divergence import (
+    DIVERGENCE_KINDS,
+    TRACE_PROJECTION_VERSION,
+    align,
+    project,
+)
+
+
+def step(name, event_id=None, **arguments):
+    return {
+        "kind": "tool",
+        "name": name,
+        "args": arguments,
+        "id": event_id or name,
+    }
+
+
+SEARCH = step("search", q="revenue 2024")
+OPEN = step("open_document", document_id=7)
+SUMMARIZE = step("summarize", style="brief")
+EMAIL = step("send_email", to="cfo@example.com")
+
+
+def test_identical_traces_are_aligned():
+    result = align([SEARCH, OPEN], [SEARCH, OPEN])
+    assert result.aligned
+    assert result.first_divergence is None
+    assert result.divergence_ratio == 0.0
+
+
+def test_encoding_only_differences_are_aligned():
+    baseline = [step("search", q="x", limit=10)]
+    candidate = [
+        {
+            "name": "search",
+            "args": {"limit": 10.0, "q": "x"},
+            "kind": "tool",
+        }
+    ]
+    assert align(baseline, candidate).aligned
+
+
+def test_same_tool_with_different_arguments_is_arg_change():
+    result = align([SEARCH, OPEN], [step("search", q="2025"), OPEN])
+    assert not result.aligned
+    assert result.first_divergence == 0
+    assert result.divergence_kind == "arg_change"
+
+
+def test_same_length_substitution_that_rejoins_reports_resync():
+    result = align(
+        [SEARCH, OPEN, SUMMARIZE],
+        [step("lookup", q="revenue 2024"), OPEN, SUMMARIZE],
+    )
+    assert not result.aligned
+    assert result.divergence_kind == "tool_change"
+    assert result.resync_at == 1
+    assert result.divergence_ratio == pytest.approx(1 / 3)
+
+
+def test_both_sides_can_advance_before_rejoining():
+    result = align(
+        [SEARCH, step("baseline_only"), OPEN, SUMMARIZE],
+        [step("candidate_a"), step("candidate_b"), OPEN, SUMMARIZE],
+    )
+    assert not result.aligned
+    assert result.divergence_kind == "tool_change"
+    assert result.resync_at == 2
+
+
+def test_reorder_is_localized_without_assuming_independence():
+    result = align(
+        [SEARCH, OPEN, SUMMARIZE],
+        [OPEN, SEARCH, SUMMARIZE],
+    )
+    assert not result.aligned
+    assert result.divergence_kind == "order_change"
+    assert result.resync_at == 2
+    assert result.reordered
+
+
+def test_retry_that_rejoins_reports_resync():
+    result = align(
+        [SEARCH, OPEN, SUMMARIZE, EMAIL],
+        [
+            SEARCH,
+            step("search", event_id="retry", q="revenue 2024", retry=1),
+            OPEN,
+            SUMMARIZE,
+            EMAIL,
+        ],
+    )
+    assert not result.aligned
+    assert result.divergence_kind == "extra"
+    assert result.resync_at == 2
+    assert result.unmatched_candidate == ["retry"]
+    assert result.divergence_ratio == 0.2
+
+
+def test_path_change_does_not_report_recovery():
+    candidate = [SEARCH, step("ask_human"), step("wait")]
+    result = align([SEARCH, OPEN, SUMMARIZE], candidate)
+    assert result.divergence_kind == "tool_change"
+    assert result.resync_at is None
+
+
+@pytest.mark.parametrize(
+    ("baseline", "candidate", "kind", "unmatched"),
+    [
+        ([SEARCH, OPEN], [SEARCH], "absent", ["open_document"]),
+        ([SEARCH], [SEARCH, EMAIL], "extra", ["send_email"]),
+    ],
+)
+def test_trailing_steps_are_classified(baseline, candidate, kind, unmatched):
+    result = align(baseline, candidate)
+    assert result.divergence_kind == kind
+    observed = (
+        result.unmatched_baseline
+        if kind == "absent"
+        else result.unmatched_candidate
+    )
+    assert observed == unmatched
+
+
+def test_duplicate_steps_are_counted_by_occurrence():
+    first = step("poll", event_id="poll-1")
+    duplicate = step("poll", event_id="poll-2")
+    result = align([first], [first, duplicate])
+    assert result.divergence_kind == "extra"
+    assert result.unmatched_candidate == ["poll-2"]
+
+
+def test_result_is_json_serializable_and_versioned():
+    payload = align([SEARCH], [SEARCH]).as_dict()
+    assert payload["projection_version"] == TRACE_PROJECTION_VERSION
+    assert set(DIVERGENCE_KINDS) == {
+        "arg_change",
+        "tool_change",
+        "order_change",
+        "absent",
+        "extra",
+    }
+    json.dumps(payload)
+
+
+def test_projection_supports_deepeval_shaped_objects():
+    class ToolCall:
+        def __init__(self):
+            self.name = "search"
+            self.input_parameters = {"q": "x"}
+            self.id = "call-1"
+
+    assert project([ToolCall()])[0].event_id == "call-1"
+
+
+@pytest.mark.parametrize(
+    "bad_step",
+    [
+        {"name": "", "args": {}},
+        {"name": "search", "args": {1: "not-json-object"}},
+        {"name": "search", "args": {"bad": object()}},
+    ],
+)
+def test_malformed_projection_fails_closed(bad_step):
+    with pytest.raises(ValueError):
+        project([bad_step])
+
+
+def test_invalid_alignment_options_fail_closed():
+    with pytest.raises(ValueError):
+        align([], [], lookahead=0)


### PR DESCRIPTION
Draft alignment layer for #3019, split from the metric wrapper as agreed with @lostmartian.

This contributes the policy-neutral seam only:

- versioned projection for dicts, DeepEval `ToolCall`-shaped objects, and span-like objects
- deterministic `align(baseline, candidate) -> AlignmentResult`
- separate difference kind, recovery point, and metric-policy inputs
- conservative `order_change` reporting without inferring causal independence
- occurrence-aware unmatched IDs for duplicated or aliased steps
- fail-closed malformed names, non-JSON argument maps, and invalid alignment bounds

The metric wrapper, threshold, reason text, and final `ArenaTestCase` versus community-metric placement remain deliberately outside this commit. @lostmartian can wire against `AlignmentResult`; maintainer placement guidance can change the wrapper without rewriting this layer.

The retry/recovery and reorder semantics match the source-level Amberfork comparison recorded in #3019: a recovered difference remains observable, and a reorder is not waived without dependency evidence.

Verification:

- `uvx ruff check deepeval/metrics/community/trace_divergence tests/test_metrics/test_trace_divergence_alignment.py`
- `uvx black --check deepeval/metrics/community/trace_divergence tests/test_metrics/test_trace_divergence_alignment.py`
- `uv run --no-project --with-editable . --with pytest -- python -m pytest tests/test_metrics/test_trace_divergence_alignment.py -q` — 15 passed

This is draft because the wrapper ownership and repository placement question are still open; the alignment code and fixtures are ready for review.