### PR TITLE
fix(metrics): use PEP 440 ordering for the ragas version check

### DIFF
--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -553,12 +553,19 @@ class RagasMetric(BaseMetric):
 
 def import_ragas():
     import ragas
+    from packaging.version import InvalidVersion, Version
 
     required_version = "0.2.1"
     if not hasattr(ragas, "__version__"):
         raise ImportError("Version information is not available for ragas.")
     installed_version = ragas.__version__
-    if installed_version < required_version:
+    try:
+        outdated = Version(installed_version) < Version(required_version)
+    except InvalidVersion:
+        # A version string that doesn't follow PEP 440 cannot be ordered
+        # reliably, so don't reject the installed ragas over it.
+        outdated = False
+    if outdated:
         raise ImportError(
             f"ragas version {required_version} or higher is required, but {installed_version} is installed."
         )

--- a/tests/test_metrics/test_ragas_import.py
+++ b/tests/test_metrics/test_ragas_import.py
@@ -1,0 +1,50 @@
+import sys
+import types
+
+import pytest
+
+from deepeval.metrics.ragas import import_ragas
+
+
+@pytest.fixture
+def fake_ragas(monkeypatch):
+    def _install(version):
+        module = types.ModuleType("ragas")
+        if version is not None:
+            module.__version__ = version
+        monkeypatch.setitem(sys.modules, "ragas", module)
+        return module
+
+    return _install
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["0.2.1", "0.2.10", "0.3.5", "0.10.0", "0.11.2", "1.0.0"],
+)
+def test_import_ragas_accepts_required_or_newer_versions(fake_ragas, version):
+    # Regression test for #2905: the version check compared strings
+    # lexicographically, so "0.10.0" < "0.2.1" evaluated to True and any
+    # release with a two-digit minor version was rejected as outdated.
+    fake_ragas(version)
+    import_ragas()
+
+
+@pytest.mark.parametrize("version", ["0.1.0", "0.1.22", "0.2.0"])
+def test_import_ragas_rejects_older_versions(fake_ragas, version):
+    fake_ragas(version)
+    with pytest.raises(ImportError, match="0.2.1 or higher is required"):
+        import_ragas()
+
+
+def test_import_ragas_rejects_missing_version_attribute(fake_ragas):
+    fake_ragas(None)
+    with pytest.raises(
+        ImportError, match="Version information is not available"
+    ):
+        import_ragas()
+
+
+def test_import_ragas_tolerates_non_pep_440_versions(fake_ragas):
+    fake_ragas("unknown")
+    import_ragas()


### PR DESCRIPTION
Fixes #2905

**Describe the bug**

`import_ragas()` in `deepeval/metrics/ragas.py` gates every `RagasMetric` sub-metric behind a minimum ragas version of `0.2.1`, but compared the version strings lexicographically:

```python
installed_version = ragas.__version__
if installed_version < required_version:  # string "<"
```

`"0.10.0" < "0.2.1"` is `True` for strings, so any ragas release with a two-digit minor version (0.10+) is rejected as outdated:

```
ImportError: ragas version 0.2.1 or higher is required, but 0.10.0 is installed.
```

**The fix**

Compare `packaging.version.Version` objects instead, as suggested in the issue. Two notes on the shape of the change:

- No new dependency is introduced: `packaging` is a hard requirement of `pytest` and `pytest-rerunfailures`, both mandatory deepeval dependencies, so it is present in every install. The import lives inside `import_ragas()` next to the deferred `import ragas`, keeping deepeval's module import path unchanged.
- If the installed version string is not PEP 440 parseable (`InvalidVersion`), the check is skipped rather than failing — an unorderable string is no evidence the install is too old, and the version check itself should never be the thing that crashes.

**Tests**

`tests/test_metrics/test_ragas_import.py` stubs the `ragas` module in `sys.modules`, so it needs no ragas install, no LLM calls, and no API keys. It covers versions at/above the floor (including the regressing `0.10.0`), versions below the floor, a missing `__version__` attribute, and a non-PEP 440 string. The two `0.10.x`/`0.11.x` cases fail on `main` and pass with this change. `black==25.12.0 --check` (the CI pin) is clean on both touched files.

**Prior art**

#2915 proposed the same `packaging.version` approach but was closed by its author while trimming their open-PR count; this PR re-lands the fix with regression tests and slightly different `InvalidVersion` handling (skip the check instead of falling back to the string comparison).
