### PR TITLE
fix(g-eval): use final score token for logprob weighting

### DIFF
--- a/deepeval/metrics/g_eval/utils.py
+++ b/deepeval/metrics/g_eval/utils.py
@@ -339,9 +339,10 @@ def calculate_weighted_summed_score(
 ) -> Union[int, float]:
     try:
         generated_logprobs = raw_response.choices[0].logprobs.content
-        # First, locate the token that we care for logprobs, i.e., the token matching the score
+        # First, locate the final token matching the score. The reasoning may
+        # contain the same token before the model emits its final score.
         score_logprobs = None
-        for token_logprobs in generated_logprobs:
+        for token_logprobs in reversed(generated_logprobs):
             if token_logprobs.token == str(raw_score):
                 score_logprobs = token_logprobs
                 break

--- a/tests/test_metrics/test_g_eval_utils.py
+++ b/tests/test_metrics/test_g_eval_utils.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from deepeval.errors import MissingTestCaseParamsError
@@ -7,6 +9,7 @@ from deepeval.metrics.g_eval.utils import (
     construct_geval_upload_payload,
     construct_non_turns_test_case_string,
     construct_test_case_string,
+    calculate_weighted_summed_score,
 )
 from deepeval.metrics.utils import (
     check_conversational_test_case_params,
@@ -30,6 +33,41 @@ class DummyMetric:
 class DummyConversationalMetric:
     __name__ = "DummyConversationalMetric"
     error = None
+
+
+def create_raw_response(tokens):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                logprobs=SimpleNamespace(content=tokens),
+            )
+        ]
+    )
+
+
+def create_token(token, top_token):
+    return SimpleNamespace(
+        token=token,
+        top_logprobs=[SimpleNamespace(token=top_token, logprob=0)],
+    )
+
+
+def test_calculate_weighted_summed_score_uses_final_score_token():
+    raw_response = create_raw_response(
+        [
+            create_token("9", "1"),
+            create_token("because", "because"),
+            create_token("9", "9"),
+        ]
+    )
+
+    assert calculate_weighted_summed_score(9, raw_response) == 9
+
+
+def test_calculate_weighted_summed_score_with_single_score_token():
+    raw_response = create_raw_response([create_token("6", "4")])
+
+    assert calculate_weighted_summed_score(6, raw_response) == 4
 
 
 def test_geval_accepts_metadata_and_tags():


### PR DESCRIPTION
## Summary

- select the final token matching the raw G-Eval score when reading logprobs
- add offline regression coverage for repeated and single score-token outputs

## Root cause

`calculate_weighted_summed_score()` scanned generated tokens from the beginning.
When the reasoning mentioned the same number as the final score, the function
used the reasoning token's probability distribution and could calculate an
unrelated weighted score.

Searching from the end selects the score token emitted at the end of the model
response while preserving the existing weighting behavior.

## Impact

Weighted G-Eval scores now use the probability distribution associated with the
model's final score rather than an earlier matching token in its reasoning.
There are no public API or schema changes.

## Validation

- `poetry run pytest -q tests/test_metrics/test_g_eval_utils.py` — 7 passed
- `poetry run black --check deepeval/metrics/g_eval/utils.py tests/test_metrics/test_g_eval_utils.py` — passed
- `poetry run ruff check tests/test_metrics/test_g_eval_utils.py` — passed
- `poetry run ruff check --ignore F811 deepeval/metrics/g_eval/utils.py` — passed (`F811` excludes pre-existing duplicate imports)

Fixes #3000
