### PR TITLE
fix(metrics): honor include_reason and align sync/async reason generation

### DIFF
--- a/deepeval/metrics/conversation_completeness/conversation_completeness.py
+++ b/deepeval/metrics/conversation_completeness/conversation_completeness.py
@@ -171,6 +171,9 @@ class ConversationCompletenessMetric(BaseConversationalMetric):
             return self.score
 
     async def _a_generate_reason(self, multimodal: bool) -> str:
+        if self.include_reason is False:
+            return None
+
         incompletenesses: List[str] = []
         for verdict in self.verdicts:
             if (

--- a/deepeval/metrics/topic_adherence/topic_adherence.py
+++ b/deepeval/metrics/topic_adherence/topic_adherence.py
@@ -232,6 +232,9 @@ class TopicAdherenceMetric(BaseConversationalMetric):
             return self.score
 
     def _generate_reason(self, TP, TN, FP, FN, *, multimodal: bool):
+        if self.include_reason is False:
+            return None
+
         total = TP[0] + TN[0] + FP[0] + FN[0]
         if total <= 0:
             return "There were no question-answer pairs to evaluate. Please enable verbose logs to look at the evaluation steps taken"
@@ -259,6 +262,12 @@ class TopicAdherenceMetric(BaseConversationalMetric):
         )
 
     async def _a_generate_reason(self, TP, TN, FP, FN, *, multimodal: bool):
+        if self.include_reason is False:
+            return None
+
+        total = TP[0] + TN[0] + FP[0] + FN[0]
+        if total <= 0:
+            return "There were no question-answer pairs to evaluate. Please enable verbose logs to look at the evaluation steps taken"
         tp_line = prettify_list(TP[1]) if TP[1] else "(none)"
         tn_line = prettify_list(TN[1]) if TN[1] else "(none)"
         fp_line = prettify_list(FP[1]) if FP[1] else "(none)"

--- a/tests/test_metrics/test_conversation_completeness_include_reason.py
+++ b/tests/test_metrics/test_conversation_completeness_include_reason.py
@@ -1,0 +1,90 @@
+"""Regression tests for ConversationCompletenessMetric and include_reason.
+
+`_generate_reason` returns None when `include_reason=False`, but its async
+twin `_a_generate_reason` was missing the guard, so the default
+`async_mode=True` configuration still made the reason LLM call (and attached
+a reason) that the user explicitly disabled.
+
+These tests run with a stub model, so they need no LLM provider API key.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics import ConversationCompletenessMetric
+from deepeval.metrics.conversation_completeness.schema import (
+    ConversationCompletenessVerdict,
+    UserIntentions,
+)
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.test_case import ConversationalTestCase, Turn
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM that never calls out to a provider."""
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        raise AssertionError("generate should not be called in this test")
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        raise AssertionError("a_generate should not be called in this test")
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+class _SchemaStubLLM(_StubLLM):
+    """Answers intention/verdict prompts; the reason prompt must never come."""
+
+    def generate(self, prompt, schema=None, *args, **kwargs):
+        if schema is None:
+            raise AssertionError("schema-less generate call not expected")
+        if schema.__name__ == "UserIntentions":
+            return UserIntentions(intentions=["get a refund"])
+        if schema.__name__ == "ConversationCompletenessVerdict":
+            return ConversationCompletenessVerdict(verdict="yes")
+        raise AssertionError(
+            f"unexpected schema requested: {schema.__name__} "
+            "(the reason prompt must be skipped when include_reason=False)"
+        )
+
+    async def a_generate(self, prompt, schema=None, *args, **kwargs):
+        return self.generate(prompt, schema=schema, *args, **kwargs)
+
+
+def _metric(**kwargs) -> ConversationCompletenessMetric:
+    metric = ConversationCompletenessMetric(model=_StubLLM(), **kwargs)
+    metric.user_intentions = ["get a refund"]
+    metric.verdicts = [ConversationCompletenessVerdict(verdict="yes")]
+    metric.score = 1.0
+    return metric
+
+
+def test_sync_generate_reason_respects_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert metric._generate_reason(multimodal=False) is None
+
+
+def test_async_generate_reason_respects_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert asyncio.run(metric._a_generate_reason(multimodal=False)) is None
+
+
+def test_default_async_measure_skips_reason_when_disabled():
+    metric = ConversationCompletenessMetric(
+        model=_SchemaStubLLM(), include_reason=False
+    )
+    test_case = ConversationalTestCase(
+        turns=[
+            Turn(role="user", content="These shoes don't fit."),
+            Turn(role="assistant", content="We offer a 30-day full refund."),
+        ]
+    )
+    metric.measure(test_case, _show_indicator=False)
+
+    assert metric.score is not None
+    assert metric.reason is None

--- a/tests/test_metrics/test_topic_adherence_include_reason.py
+++ b/tests/test_metrics/test_topic_adherence_include_reason.py
@@ -1,0 +1,74 @@
+"""Regression tests for TopicAdherenceMetric's reason generation.
+
+Two related defects:
+
+- `include_reason` was accepted by the constructor but never consulted, so
+  both the sync and async paths always made the reason LLM call the user
+  explicitly disabled.
+- On the empty case (no question-answer pairs), `_generate_reason` returns a
+  canned message without an LLM call, but its async twin was missing that
+  guard and still prompted the model, so sync and async produced different
+  reasons for the same conversation.
+
+These tests run with a stub model, so they need no LLM provider API key.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics import TopicAdherenceMetric
+from deepeval.models.base_model import DeepEvalBaseLLM
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM that never calls out to a provider."""
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        raise AssertionError("generate should not be called in this test")
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        raise AssertionError("a_generate should not be called in this test")
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+def _metric(**kwargs) -> TopicAdherenceMetric:
+    metric = TopicAdherenceMetric(
+        relevant_topics=["refunds"], model=_StubLLM(), **kwargs
+    )
+    metric.score = 0.5
+    metric.success = True
+    return metric
+
+
+_NON_EMPTY = ([1, ["on topic"]], [1, ["off topic"]], [0, []], [0, []])
+_EMPTY = ([0, []], [0, []], [0, []], [0, []])
+
+
+def test_sync_generate_reason_respects_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert metric._generate_reason(*_NON_EMPTY, multimodal=False) is None
+
+
+def test_async_generate_reason_respects_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert (
+        asyncio.run(metric._a_generate_reason(*_NON_EMPTY, multimodal=False))
+        is None
+    )
+
+
+def test_async_empty_case_matches_sync_without_llm_call():
+    metric = _metric()
+    sync_reason = metric._generate_reason(*_EMPTY, multimodal=False)
+    async_reason = asyncio.run(
+        metric._a_generate_reason(*_EMPTY, multimodal=False)
+    )
+
+    assert isinstance(sync_reason, str) and sync_reason
+    assert async_reason == sync_reason


### PR DESCRIPTION
**Describe the bug**

Two metrics ignore `include_reason=False`, and one of them also produces a different `reason` depending on `async_mode`:

1. `ConversationCompletenessMetric`: `_generate_reason()` returns `None` when `include_reason=False`, but its async twin `_a_generate_reason()` was missing the guard. Since `async_mode` defaults to `True` — and `measure()` delegates to the async path — the default configuration still makes the reason LLM call (and attaches a reason) that the user explicitly disabled.

2. `TopicAdherenceMetric`: `include_reason` is accepted by the constructor and stored, but never consulted anywhere, so both the sync and async paths always make the reason LLM call. Separately, when there are no question-answer pairs to evaluate (`total <= 0`), the sync `_generate_reason()` returns a canned message without prompting the model, but the async twin was missing that guard: it still made an LLM call with all-"(none)" reason lines, so the same conversation produces a different `reason` depending on `async_mode`.

**The fix**

- Add the `include_reason` early return to `ConversationCompletenessMetric._a_generate_reason`, mirroring the sync helper.
- Add the `include_reason` early return to both `TopicAdherenceMetric` reason helpers, matching the convention sibling metrics already follow (the turn-contextual and MCP metrics all guard inside the helper).
- Mirror the sync `total <= 0` canned-message guard into `TopicAdherenceMetric._a_generate_reason`.

**Tests**

Two offline regression test files driven through stub models (no LLM calls, no API keys), following the pattern of `tests/test_metrics/test_turn_faithfulness_metric_empty_verdicts.py`:

- `test_conversation_completeness_include_reason.py`: helper-level sync/async `include_reason=False` tests, plus a full default-configuration `measure()` test in which the stub answers the intention/verdict prompts but fails the test if the reason schema is ever requested.
- `test_topic_adherence_include_reason.py`: helper-level `include_reason=False` tests for both paths, and an empty-case parity test asserting the async helper returns the sync path's canned message without calling the model.

On current `main`, 5 of the 6 tests fail (the sync ConversationCompleteness control passes); all 6 pass with this change. The rest of `tests/test_metrics` is unchanged: 169 passed, 271 skipped, 6 xfailed. `black==25.12.0 --check` (the CI pin) is clean on all four touched files.

**Additional context**

A quick survey while writing this found several other metrics that store `include_reason` without consulting it (`GoalAccuracy`, `ToolUse`, `PlanAdherence`, `PlanQuality`, `TaskCompletion`, `StepEfficiency`, `ToolCorrectness`, and the DAG variants). For some of those the reason comes back in the same LLM response as the score, so skipping it is not the clear win it is for the two fixed here; happy to follow up separately if maintainers want the rest aligned too.
