### PR TITLE
feat(metrics): add TrajectoryDivergenceMetric wrapper for #3019

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,11 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .trace_divergence.trajectory_divergence import (
+    TrajectoryDivergenceMetric,
+)
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "TrajectoryDivergenceMetric",
 ]

--- a/deepeval/metrics/community/trace_divergence/__init__.py
+++ b/deepeval/metrics/community/trace_divergence/__init__.py
@@ -1,0 +1,17 @@
+from .alignment import (
+    DIVERGENCE_KINDS,
+    TRACE_PROJECTION_VERSION,
+    AlignmentResult,
+    Event,
+    align,
+    project,
+)
+
+__all__ = [
+    "DIVERGENCE_KINDS",
+    "TRACE_PROJECTION_VERSION",
+    "AlignmentResult",
+    "Event",
+    "align",
+    "project",
+]

--- a/deepeval/metrics/community/trace_divergence/alignment.py
+++ b/deepeval/metrics/community/trace_divergence/alignment.py
@@ -1,0 +1,331 @@
+# ruff: noqa: UP006, UP035, UP045
+"""Deterministic alignment for baseline and candidate execution traces.
+
+This module deliberately contains no metric policy. It reports where two
+single-turn traces first differ, whether they recover, and which events could
+not be matched. A metric wrapper can then decide which differences are
+acceptable for its use case.
+"""
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+TRACE_PROJECTION_VERSION = "1.0.0"
+DEFAULT_LOOKAHEAD = 4
+DEFAULT_RESYNC_RUN = 2
+
+DIVERGENCE_KINDS = (
+    "arg_change",
+    "tool_change",
+    "order_change",
+    "absent",
+    "extra",
+)
+
+
+@dataclass(frozen=True)
+class Event:
+    """One versioned, comparable projection of a trace step."""
+
+    index: int
+    event_id: str
+    kind: str
+    name: str
+    arguments: Any
+    strong_identity: str
+    weak_identity: str
+
+
+@dataclass
+class AlignmentResult:
+    """Policy-neutral output consumed by a trace-divergence metric."""
+
+    aligned: bool
+    matched_prefix_len: int
+    first_divergence: Optional[int]
+    divergence_kind: Optional[str]
+    resync_at: Optional[int]
+    unmatched_baseline: List[str] = field(default_factory=list)
+    unmatched_candidate: List[str] = field(default_factory=list)
+    reordered: List[Tuple[str, str]] = field(default_factory=list)
+    baseline_len: int = 0
+    candidate_len: int = 0
+    projection_version: str = TRACE_PROJECTION_VERSION
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @property
+    def divergence_ratio(self) -> float:
+        """Return the divergent fraction without applying pass/fail policy."""
+
+        longest = max(self.baseline_len, self.candidate_len)
+        if not longest or self.aligned:
+            return 0.0
+        end = self.resync_at if self.resync_at is not None else longest
+        return max(0.0, end - self.matched_prefix_len) / longest
+
+
+def _canonical(value: Any) -> Any:
+    if isinstance(value, dict):
+        if any(not isinstance(key, str) for key in value):
+            raise ValueError("trace argument mappings must use string keys")
+        return {key: _canonical(value[key]) for key in sorted(value)}
+    if isinstance(value, (list, tuple)):
+        return [_canonical(item) for item in value]
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _digest(payload: Any) -> str:
+    try:
+        blob = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("trace arguments must be JSON serializable") from exc
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def _get(step: Any, *names: str, default: Any = None) -> Any:
+    for name in names:
+        if isinstance(step, dict):
+            value = step.get(name)
+        else:
+            value = getattr(step, name, None)
+        if value is not None:
+            return value
+    return default
+
+
+def _text(value: Any) -> str:
+    return str(value.value if isinstance(value, Enum) else value)
+
+
+def project(trace: Iterable[Any]) -> List[Event]:
+    """Project dict, ToolCall, or span-like steps into comparable events."""
+
+    events = []
+    for index, step in enumerate(trace):
+        kind = _text(_get(step, "kind", "type", "span_type", default="tool"))
+        name = _text(
+            _get(step, "name", "tool", "tool_name", "function", default="")
+        )
+        if not name:
+            raise ValueError("trace steps must have a non-empty name")
+        arguments = _canonical(
+            _get(
+                step,
+                "args",
+                "arguments",
+                "input_parameters",
+                "input",
+                "parameters",
+                default={},
+            )
+        )
+        raw_id = _get(
+            step,
+            "id",
+            "event_id",
+            "span_id",
+            "uuid",
+            default=f"idx-{index}",
+        )
+        event_id = _text(raw_id) or f"idx-{index}"
+        weak_identity = f"{kind}:{name}"
+        strong_identity = f"{weak_identity}:{_digest(arguments)}"
+        events.append(
+            Event(
+                index=index,
+                event_id=event_id,
+                kind=kind,
+                name=name,
+                arguments=arguments,
+                strong_identity=strong_identity,
+                weak_identity=weak_identity,
+            )
+        )
+    return events
+
+
+def _common_prefix(
+    baseline: Sequence[Event], candidate: Sequence[Event]
+) -> int:
+    index = 0
+    while (
+        index < len(baseline)
+        and index < len(candidate)
+        and baseline[index].strong_identity == candidate[index].strong_identity
+    ):
+        index += 1
+    return index
+
+
+def _reorder_at(
+    baseline: Sequence[Event],
+    candidate: Sequence[Event],
+    index: int,
+    lookahead: int,
+) -> Tuple[List[Tuple[str, str]], int]:
+    for width in range(2, lookahead + 1):
+        baseline_window = baseline[index : index + width]
+        candidate_window = candidate[index : index + width]
+        if len(baseline_window) < width or len(candidate_window) < width:
+            break
+        baseline_ids = [event.strong_identity for event in baseline_window]
+        candidate_ids = [event.strong_identity for event in candidate_window]
+        if (
+            Counter(baseline_ids) == Counter(candidate_ids)
+            and baseline_ids != candidate_ids
+        ):
+            pairs = [
+                (left.event_id, right.event_id)
+                for left, right in zip(baseline_window, candidate_window)
+                if left.strong_identity != right.strong_identity
+            ]
+            return pairs, width
+    return [], 0
+
+
+def _classify(
+    baseline: Sequence[Event], candidate: Sequence[Event], index: int
+) -> str:
+    left = baseline[index] if index < len(baseline) else None
+    right = candidate[index] if index < len(candidate) else None
+    if left is None:
+        return "extra"
+    if right is None:
+        return "absent"
+    if left.weak_identity == right.weak_identity:
+        return "arg_change"
+    if (
+        index + 1 < len(candidate)
+        and left.strong_identity == candidate[index + 1].strong_identity
+    ):
+        return "extra"
+    if (
+        index + 1 < len(baseline)
+        and right.strong_identity == baseline[index + 1].strong_identity
+    ):
+        return "absent"
+    return "tool_change"
+
+
+def _find_resync(
+    baseline: Sequence[Event],
+    candidate: Sequence[Event],
+    index: int,
+    lookahead: int,
+    resync_run: int,
+) -> Optional[int]:
+    for skew in range(1, lookahead + 1):
+        for left, right in ((index + skew, index), (index, index + skew)):
+            run = 0
+            while (
+                left + run < len(baseline)
+                and right + run < len(candidate)
+                and baseline[left + run].strong_identity
+                == candidate[right + run].strong_identity
+            ):
+                run += 1
+                if run >= resync_run:
+                    return max(left, right)
+    return None
+
+
+def _unmatched(
+    baseline: Sequence[Event], candidate: Sequence[Event]
+) -> Tuple[List[str], List[str]]:
+    """Return occurrence-aware unmatched IDs, including duplicate steps."""
+
+    candidate_counts = Counter(event.strong_identity for event in candidate)
+    unmatched_baseline = []
+    for event in baseline:
+        if candidate_counts[event.strong_identity]:
+            candidate_counts[event.strong_identity] -= 1
+        else:
+            unmatched_baseline.append(event.event_id)
+
+    baseline_counts = Counter(event.strong_identity for event in baseline)
+    unmatched_candidate = []
+    for event in candidate:
+        if baseline_counts[event.strong_identity]:
+            baseline_counts[event.strong_identity] -= 1
+        else:
+            unmatched_candidate.append(event.event_id)
+    return unmatched_baseline, unmatched_candidate
+
+
+def align(
+    baseline: Iterable[Any],
+    candidate: Iterable[Any],
+    *,
+    lookahead: int = DEFAULT_LOOKAHEAD,
+    resync_run: int = DEFAULT_RESYNC_RUN,
+) -> AlignmentResult:
+    """Locate the first sustained divergence between two traces."""
+
+    if lookahead < 1 or resync_run < 1:
+        raise ValueError("lookahead and resync_run must be positive")
+    base = project(baseline)
+    cand = project(candidate)
+    prefix = _common_prefix(base, cand)
+    if prefix == len(base) == len(cand):
+        return AlignmentResult(
+            aligned=True,
+            matched_prefix_len=prefix,
+            first_divergence=None,
+            divergence_kind=None,
+            resync_at=None,
+            baseline_len=len(base),
+            candidate_len=len(cand),
+        )
+
+    unmatched_baseline, unmatched_candidate = _unmatched(
+        base[prefix:], cand[prefix:]
+    )
+    reordered, reorder_width = _reorder_at(base, cand, prefix, lookahead)
+    if reordered:
+        tail_prefix = _common_prefix(
+            base[prefix + reorder_width :],
+            cand[prefix + reorder_width :],
+        )
+        if prefix + reorder_width + tail_prefix == len(
+            base
+        ) and prefix + reorder_width + tail_prefix == len(cand):
+            return AlignmentResult(
+                aligned=False,
+                matched_prefix_len=prefix,
+                first_divergence=prefix,
+                divergence_kind="order_change",
+                resync_at=prefix + reorder_width,
+                reordered=reordered,
+                baseline_len=len(base),
+                candidate_len=len(cand),
+            )
+
+    kind = _classify(base, cand, prefix)
+    return AlignmentResult(
+        aligned=False,
+        matched_prefix_len=prefix,
+        first_divergence=prefix,
+        divergence_kind=kind,
+        resync_at=_find_resync(base, cand, prefix, lookahead, resync_run),
+        unmatched_baseline=unmatched_baseline,
+        unmatched_candidate=unmatched_candidate,
+        reordered=reordered,
+        baseline_len=len(base),
+        candidate_len=len(cand),
+    )

--- a/deepeval/metrics/community/trace_divergence/schema.py
+++ b/deepeval/metrics/community/trace_divergence/schema.py
@@ -1,0 +1,32 @@
+# ruff: noqa: UP006, UP035, UP045
+"""Structured output schema for ``TrajectoryDivergenceMetric``.
+
+The metric is fully deterministic (no LLM judge), so unlike most metric
+schemas this module does not model a model-generated verdict. It models the
+metric's own structured result — the localization of the first sustained
+divergence — so callers can consume ``score_breakdown`` as typed,
+JSON-serializable data (e.g. for CI assertions or logging).
+"""
+
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel
+
+
+class TrajectoryDivergenceResult(BaseModel):
+    """Structured localization output of a trajectory comparison.
+
+    Field semantics follow the alignment seam's ``AlignmentResult``: the
+    zero-based step index where the traces first differ, the difference kind,
+    the step where they realign (``None`` for an unrecovered fork), the step
+    IDs that could not be matched on each side, and the reordered pairs.
+    """
+
+    matched_prefix_len: int = 0
+    first_divergence: Optional[int] = None
+    divergence_kind: Optional[str] = None
+    resync_at: Optional[int] = None
+    unmatched_baseline: List[str] = []
+    unmatched_candidate: List[str] = []
+    reordered: List[Tuple[str, str]] = []
+    divergence_ratio: float = 0.0

--- a/deepeval/metrics/community/trace_divergence/template.py
+++ b/deepeval/metrics/community/trace_divergence/template.py
@@ -1,0 +1,68 @@
+"""Deterministic reason strings for ``TrajectoryDivergenceMetric``.
+
+Unlike most metric templates, this module renders no LLM prompt: the
+trajectory divergence metric is fully local and deterministic. These are
+sentence builders that turn an ``AlignmentResult`` into a human-readable
+explanation of *which* step diverged and *how*, keeping the difference kind
+and the recovery status separate so a recovered retry is never mistaken for
+an unrecovered fork.
+"""
+
+
+class TrajectoryDivergenceTemplate:
+    """Sentence builders for the trajectory divergence reason text."""
+
+    @staticmethod
+    def aligned(num_steps: int) -> str:
+        noun = "step" if num_steps == 1 else "steps"
+        return (
+            "The baseline and candidate trajectories are aligned across all "
+            f"{num_steps} {noun}."
+        )
+
+    @staticmethod
+    def arg_change(step: int, tool: str) -> str:
+        return (
+            f"step {step} calls the same tool `{tool}` with different "
+            "arguments"
+        )
+
+    @staticmethod
+    def tool_change(step: int, baseline_tool: str, candidate_tool: str) -> str:
+        return (
+            f"step {step} calls `{baseline_tool}` in the baseline but "
+            f"`{candidate_tool}` in the candidate"
+        )
+
+    @staticmethod
+    def order_change(first_step: int, last_step: int) -> str:
+        return (
+            f"steps {first_step}-{last_step} contain the same calls but in "
+            "a different order"
+        )
+
+    @staticmethod
+    def absent(step: int, tool: str) -> str:
+        return f"step {step} (`{tool}`) is absent from the candidate trace"
+
+    @staticmethod
+    def extra(step: int, tool: str) -> str:
+        return (
+            f"the candidate trace inserts an extra step at step {step} "
+            f"(`{tool}`)"
+        )
+
+    @staticmethod
+    def recovered(resync_step: int) -> str:
+        return (
+            f"The trajectories resynchronize at step {resync_step}: the "
+            "divergence is localized to the intervening steps rather than a "
+            "fork to the end."
+        )
+
+    @staticmethod
+    def unrecovered() -> str:
+        return (
+            "The trajectories do not resynchronize: the divergence persists "
+            "to the end of the trace."
+        )

--- a/deepeval/metrics/community/trace_divergence/trajectory_divergence.py
+++ b/deepeval/metrics/community/trace_divergence/trajectory_divergence.py
@@ -1,0 +1,212 @@
+"""Deterministic trajectory divergence metric.
+
+Compares two *real* execution traces against each other — a baseline run
+you trust and a candidate run after a prompt, model, or tool change — and
+localizes the first sustained divergence between them. Unlike agentic
+metrics that score one run against a static expectation (``ToolCorrectness``,
+``PlanAdherence``, ...), the useful output here is *which* step forked and
+*whether* the trajectories recovered, not just a pass/fail.
+"""
+
+# ruff: noqa: UP006, UP035, UP045
+from collections.abc import Iterable
+from typing import Any, List, Optional
+
+from deepeval.metrics import BaseMetric
+from deepeval.metrics.community.trace_divergence.alignment import (
+    AlignmentResult,
+    Event,
+    align,
+    project,
+)
+from deepeval.metrics.community.trace_divergence.template import (
+    TrajectoryDivergenceTemplate,
+)
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.utils import construct_verbose_logs
+from deepeval.test_case import LLMTestCase
+from deepeval.utils import get_or_create_event_loop
+
+
+class TrajectoryDivergenceMetric(BaseMetric):
+    """Deterministic, single-turn trajectory comparison.
+
+    The metric takes two traces at construction time: ``baseline_trace``
+    (the run you trust) and ``candidate_trace`` (the run you are checking,
+    e.g. after a prompt edit or model swap). The ``LLMTestCase`` passed to
+    ``measure`` is accepted for ``BaseMetric`` compatibility; the traces
+    themselves are the metric's data.
+
+    The score is ``1.0 - divergence_ratio``, so ``1.0`` means the traces are
+    fully aligned and ``0.0`` means no step after the matched prefix could be
+    aligned. With the default threshold of ``1.0`` only fully aligned traces
+    pass; lower it to tolerate a localized, recovered divergence. The
+    ``AlignmentResult`` (matched prefix, first divergence, kind, resync point,
+    unmatched steps) is stored on ``self.alignment_result`` so callers can
+    localize the fork exactly.
+
+    This metric is fully deterministic: no LLM, no API key, no cost.
+    """
+
+    def __init__(
+        self,
+        baseline_trace: Iterable[Any],
+        candidate_trace: Iterable[Any],
+        threshold: Optional[float] = 1.0,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+    ):
+        self.baseline_trace = list(baseline_trace)
+        self.candidate_trace = list(candidate_trace)
+        self.threshold = 1 if strict_mode else threshold
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+        self.flaky = flaky
+        self.model = None
+        self.using_native_model = True
+        self.evaluation_model = None
+        self.alignment_result: Optional[AlignmentResult] = None
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        self.evaluation_cost = 0
+
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            if self.async_mode:
+                loop = get_or_create_event_loop()
+                loop.run_until_complete(
+                    self.a_measure(
+                        test_case,
+                        _show_indicator=False,
+                        _in_component=_in_component,
+                    )
+                )
+                return self.score
+            self._calculate_metric()
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        self.evaluation_cost = 0
+
+        with metric_progress_indicator(
+            self,
+            async_mode=True,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        ):
+            self._calculate_metric()
+            return self.score
+
+    def _calculate_metric(self) -> None:
+        baseline_events = project(self.baseline_trace)
+        candidate_events = project(self.candidate_trace)
+        result = align(baseline_events, candidate_events)
+        self.alignment_result = result
+        self.score = self._calculate_score(result)
+        self.reason = self._generate_reason(
+            result, baseline_events, candidate_events
+        )
+        self.success = self.is_successful()
+        self.verbose_logs = construct_verbose_logs(
+            self,
+            steps=[
+                f"Baseline trace: {self._format_trace(baseline_events)}",
+                f"Candidate trace: {self._format_trace(candidate_events)}",
+                f"Alignment: {result.as_dict()}",
+                f"Score: {self.score}\nReason: {self.reason}",
+            ],
+        )
+
+    def _calculate_score(self, result: AlignmentResult) -> float:
+        score = 1.0 - result.divergence_ratio
+        return 0 if self.strict_mode and score < self.threshold else score
+
+    def _generate_reason(
+        self,
+        result: AlignmentResult,
+        baseline_events: List[Event],
+        candidate_events: List[Event],
+    ) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+        if result.aligned:
+            return TrajectoryDivergenceTemplate.aligned(result.baseline_len)
+
+        summary = self._summarize_divergence(
+            result, baseline_events, candidate_events
+        )
+        recovery = (
+            TrajectoryDivergenceTemplate.recovered(result.resync_at + 1)
+            if result.resync_at is not None
+            else TrajectoryDivergenceTemplate.unrecovered()
+        )
+        return (
+            f"The candidate trajectory diverges from the baseline at {summary}. "
+            f"{recovery} Divergence ratio: {result.divergence_ratio:.2f}."
+        )
+
+    def _summarize_divergence(
+        self,
+        result: AlignmentResult,
+        baseline_events: List[Event],
+        candidate_events: List[Event],
+    ) -> str:
+        index = result.first_divergence or 0
+        step = index + 1
+        kind = result.divergence_kind
+
+        if kind == "arg_change" and index < len(baseline_events):
+            return TrajectoryDivergenceTemplate.arg_change(
+                step, baseline_events[index].name
+            )
+        if kind == "tool_change":
+            baseline_tool = (
+                baseline_events[index].name
+                if index < len(baseline_events)
+                else "?"
+            )
+            candidate_tool = (
+                candidate_events[index].name
+                if index < len(candidate_events)
+                else "?"
+            )
+            return TrajectoryDivergenceTemplate.tool_change(
+                step, baseline_tool, candidate_tool
+            )
+        if kind == "order_change":
+            last_step = result.resync_at or step
+            return TrajectoryDivergenceTemplate.order_change(step, last_step)
+        if kind == "absent" and index < len(baseline_events):
+            return TrajectoryDivergenceTemplate.absent(
+                step, baseline_events[index].name
+            )
+        if kind == "extra" and index < len(candidate_events):
+            return TrajectoryDivergenceTemplate.extra(
+                step, candidate_events[index].name
+            )
+        return "the trajectories diverge"
+
+    def _format_trace(self, events: List[Event]) -> str:
+        if not events:
+            return "[]"
+        return " -> ".join(f"{event.kind}:{event.name}" for event in events)
+
+    @property
+    def __name__(self):
+        return "Trajectory Divergence"

--- a/deepeval/metrics/community/trace_divergence/trajectory_divergence.py
+++ b/deepeval/metrics/community/trace_divergence/trajectory_divergence.py
@@ -19,6 +19,9 @@ from deepeval.metrics.community.trace_divergence.alignment import (
     align,
     project,
 )
+from deepeval.metrics.community.trace_divergence.schema import (
+    TrajectoryDivergenceResult,
+)
 from deepeval.metrics.community.trace_divergence.template import (
     TrajectoryDivergenceTemplate,
 )
@@ -71,6 +74,7 @@ class TrajectoryDivergenceMetric(BaseMetric):
         self.using_native_model = True
         self.evaluation_model = None
         self.alignment_result: Optional[AlignmentResult] = None
+        self.result: Optional[TrajectoryDivergenceResult] = None
 
     def measure(
         self,
@@ -118,6 +122,17 @@ class TrajectoryDivergenceMetric(BaseMetric):
         candidate_events = project(self.candidate_trace)
         result = align(baseline_events, candidate_events)
         self.alignment_result = result
+        self.result = TrajectoryDivergenceResult(
+            matched_prefix_len=result.matched_prefix_len,
+            first_divergence=result.first_divergence,
+            divergence_kind=result.divergence_kind,
+            resync_at=result.resync_at,
+            unmatched_baseline=result.unmatched_baseline,
+            unmatched_candidate=result.unmatched_candidate,
+            reordered=result.reordered,
+            divergence_ratio=result.divergence_ratio,
+        )
+        self.score_breakdown = self.result.model_dump()
         self.score = self._calculate_score(result)
         self.reason = self._generate_reason(
             result, baseline_events, candidate_events

--- a/deepeval/metrics/community/trace_divergence/trajectory_divergence.py
+++ b/deepeval/metrics/community/trace_divergence/trajectory_divergence.py
@@ -40,6 +40,13 @@ class TrajectoryDivergenceMetric(BaseMetric):
     ``measure`` is accepted for ``BaseMetric`` compatibility; the traces
     themselves are the metric's data.
 
+    Because both traces are pinned per instance, create one
+    ``TrajectoryDivergenceMetric`` per trace pair. Reusing a single
+    instance across multiple test cases (e.g.
+    ``evaluate([tc1, tc2], [metric])``) repeats the identical comparison
+    for every test case, unlike most DeepEval metrics where each test case
+    supplies fresh data.
+
     The score is ``1.0 - divergence_ratio``, so ``1.0`` means the traces are
     fully aligned and ``0.0`` means no step after the matched prefix could be
     aligned. With the default threshold of ``1.0`` only fully aligned traces
@@ -205,7 +212,9 @@ class TrajectoryDivergenceMetric(BaseMetric):
                 step, baseline_tool, candidate_tool
             )
         if kind == "order_change":
-            last_step = result.resync_at or step
+            last_step = (
+                result.resync_at if result.resync_at is not None else step
+            )
             return TrajectoryDivergenceTemplate.order_change(step, last_step)
         if kind == "absent" and index < len(baseline_events):
             return TrajectoryDivergenceTemplate.absent(

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -4,6 +4,7 @@
     "community-metrics-overview",
     "metrics-citation-faithfulness",
     "metrics-agent-loop-detection",
-    "metrics-tool-permission"
+    "metrics-tool-permission",
+    "metrics-trajectory-divergence"
   ]
 }

--- a/docs/content/docs/(community)/metrics-trajectory-divergence.mdx
+++ b/docs/content/docs/(community)/metrics-trajectory-divergence.mdx
@@ -64,7 +64,7 @@ print(metric.alignment_result.first_divergence)  # 1
 print(metric.alignment_result.resync_at)  # 2
 ```
 
-The score is `1.0 - divergence_ratio`, so `1.0` means fully aligned and `0.0` means nothing after the matched prefix could be aligned. The full localization is available on `metric.alignment_result`:
+The score is `1.0 - divergence_ratio`, so `1.0` means fully aligned and `0.0` means nothing after the matched prefix could be aligned. The full localization is available on `metric.alignment_result` (the raw alignment result) and `metric.score_breakdown` (the same fields as typed, JSON-serializable data):
 
 - `matched_prefix_len`: steps that matched in order.
 - `first_divergence`: zero-based index where the traces first differ (`None` when aligned).
@@ -72,6 +72,7 @@ The score is `1.0 - divergence_ratio`, so `1.0` means fully aligned and `0.0` me
 - `resync_at`: step where the trajectories realign (`None` for an unrecovered fork).
 - `unmatched_baseline` / `unmatched_candidate`: step IDs that could not be matched.
 - `reordered`: `(baseline_id, candidate_id)` pairs swapped when the kind is `order_change`.
+- `divergence_ratio`: the divergent fraction of the longer trace (stopping at `resync_at`).
 
 ## Optional Parameters
 

--- a/docs/content/docs/(community)/metrics-trajectory-divergence.mdx
+++ b/docs/content/docs/(community)/metrics-trajectory-divergence.mdx
@@ -1,0 +1,94 @@
+---
+id: metrics-trajectory-divergence
+title: Trajectory Divergence
+sidebar_label: Trajectory Divergence
+languages: [python]
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} usesLLMs={false} />
+
+The trajectory divergence metric compares two **real execution traces** against each other — a baseline run you trust and a candidate run after a prompt edit, model swap, or tool/version bump — and localizes the first sustained divergence between them. It answers *"steps 1–4 matched, step 5 is where the tool call arguments diverged, everything after is downstream of that"* rather than a bare pass/fail.
+
+:::info
+The `TrajectoryDivergenceMetric` is a **community metric**, contributed and maintained by the `deepeval` community. Community metrics are not exported from `deepeval.metrics` — import them explicitly from `deepeval.metrics.community` instead.
+:::
+
+This is different from agentic metrics like `ToolCorrectness` or `PlanAdherence`, which score one run against a static expectation (`expected_tools`, an expected plan). Trajectory divergence is a regression detector: same input, different behavior after a change.
+
+:::note
+The metric is **fully deterministic** — no LLM, no API key, zero cost. It aligns the two traces step by step and reports the matched prefix, the first divergence, its kind, whether the trajectories resynchronize, and the steps that could not be matched.
+:::
+
+## Required Arguments
+
+The metric takes both traces at construction time. Each trace is an iterable of steps; a step can be a dict (`name`, `args`, `kind`, `id`), a deepeval `ToolCall`, or any span-like object exposing `name`/`arguments`-style attributes:
+
+- `baseline_trace`: the run you trust.
+- `candidate_trace`: the run you are checking after the change.
+
+The `LLMTestCase` passed to `measure` is accepted for `BaseMetric` compatibility — the traces themselves are the metric's data.
+
+## Usage
+
+```python
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.community import TrajectoryDivergenceMetric
+
+# Two dict-based traces from the same task: one before, one after a prompt change.
+baseline_trace = [
+    {"kind": "tool", "name": "search", "args": {"q": "revenue 2024"}},
+    {"kind": "tool", "name": "open_document", "args": {"document_id": 7}},
+    {"kind": "tool", "name": "summarize", "args": {"style": "brief"}},
+    {"kind": "tool", "name": "send_email", "args": {"to": "cfo@example.com"}},
+]
+
+# The candidate inserted a retry of `search` that then rejoined the baseline path.
+candidate_trace = [
+    {"kind": "tool", "name": "search", "args": {"q": "revenue 2024"}},
+    {"kind": "tool", "name": "search", "args": {"q": "revenue 2024", "retry": 1}},
+    {"kind": "tool", "name": "open_document", "args": {"document_id": 7}},
+    {"kind": "tool", "name": "summarize", "args": {"style": "brief"}},
+    {"kind": "tool", "name": "send_email", "args": {"to": "cfo@example.com"}},
+]
+
+metric = TrajectoryDivergenceMetric(
+    baseline_trace=baseline_trace,
+    candidate_trace=candidate_trace,
+)
+
+# The test case is accepted for BaseMetric compatibility; the traces above are the data.
+test_case = LLMTestCase(input="compare the two runs", actual_output="done")
+metric.measure(test_case)
+print(metric.score, metric.reason)
+print(metric.alignment_result.first_divergence)  # 1
+print(metric.alignment_result.resync_at)  # 2
+```
+
+The score is `1.0 - divergence_ratio`, so `1.0` means fully aligned and `0.0` means nothing after the matched prefix could be aligned. The full localization is available on `metric.alignment_result`:
+
+- `matched_prefix_len`: steps that matched in order.
+- `first_divergence`: zero-based index where the traces first differ (`None` when aligned).
+- `divergence_kind`: `arg_change`, `tool_change`, `order_change`, `absent`, or `extra`.
+- `resync_at`: step where the trajectories realign (`None` for an unrecovered fork).
+- `unmatched_baseline` / `unmatched_candidate`: step IDs that could not be matched.
+- `reordered`: `(baseline_id, candidate_id)` pairs swapped when the kind is `order_change`.
+
+## Optional Parameters
+
+- [Optional] `threshold`: a float representing the minimum passing score. Can also be set to `None` to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `1.0`, so only fully aligned traces pass; lower it to tolerate a localized, recovered divergence.
+- [Optional] `include_reason`: a boolean which when set to `True`, includes a deterministic reason explaining which step diverged and whether the traces recovered. Defaulted to `True`.
+- [Optional] `async_mode`: a boolean which when set to `True`, runs the metric through its async path. Defaulted to `True`.
+- [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: `0` for any divergence, `1` otherwise. It also overrides the current threshold and sets it to `1`. Defaulted to `False`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console. Defaulted to `False`.
+- [Optional] `flaky`: a boolean which when set to `True`, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics). Defaulted to `False`.
+
+## How Is It Calculated?
+
+The metric projects both traces into comparable events (kind, tool name, and a canonical digest of the arguments), then aligns them deterministically:
+
+1. **Matched prefix** — steps that are identical in order.
+2. **First divergence** — the first step where the traces stop matching.
+3. **Difference kind** — the same tool with different arguments (`arg_change`), a different tool (`tool_change`), the same calls in a different order (`order_change`), a baseline step missing in the candidate (`absent`), or an extra candidate step (`extra`).
+4. **Recovery** — whether the trajectories resynchronize (`resync_at`) or the divergence persists to the end.
+
+A retry that rejoins the baseline path is a localized divergence with a `resync_at`, not a fork to the end: the ratio counts only the intervening steps. An `order_change` remains a divergence unless the wrapper has dependency evidence to waive it.

--- a/docs/content/docs/(community)/metrics-trajectory-divergence.mdx
+++ b/docs/content/docs/(community)/metrics-trajectory-divergence.mdx
@@ -28,6 +28,10 @@ The metric takes both traces at construction time. Each trace is an iterable of 
 
 The `LLMTestCase` passed to `measure` is accepted for `BaseMetric` compatibility — the traces themselves are the metric's data.
 
+:::note
+Create **one metric instance per trace pair**. Because both traces are supplied at construction time, reusing a single instance across multiple test cases in `evaluate([tc1, tc2, tc3], [metric])` compares the same trace pair for every test case — unlike most DeepEval metrics, which read fresh data from each test case.
+:::
+
 ## Usage
 
 ```python

--- a/tests/test_metrics/test_trace_divergence_alignment.py
+++ b/tests/test_metrics/test_trace_divergence_alignment.py
@@ -1,0 +1,154 @@
+import json
+
+import pytest
+
+from deepeval.metrics.community.trace_divergence import (
+    DIVERGENCE_KINDS,
+    TRACE_PROJECTION_VERSION,
+    align,
+    project,
+)
+
+
+def step(name, event_id=None, **arguments):
+    return {
+        "kind": "tool",
+        "name": name,
+        "args": arguments,
+        "id": event_id or name,
+    }
+
+
+SEARCH = step("search", q="revenue 2024")
+OPEN = step("open_document", document_id=7)
+SUMMARIZE = step("summarize", style="brief")
+EMAIL = step("send_email", to="cfo@example.com")
+
+
+def test_identical_traces_are_aligned():
+    result = align([SEARCH, OPEN], [SEARCH, OPEN])
+    assert result.aligned
+    assert result.first_divergence is None
+    assert result.divergence_ratio == 0.0
+
+
+def test_encoding_only_differences_are_aligned():
+    baseline = [step("search", q="x", limit=10)]
+    candidate = [
+        {
+            "name": "search",
+            "args": {"limit": 10.0, "q": "x"},
+            "kind": "tool",
+        }
+    ]
+    assert align(baseline, candidate).aligned
+
+
+def test_same_tool_with_different_arguments_is_arg_change():
+    result = align([SEARCH, OPEN], [step("search", q="2025"), OPEN])
+    assert not result.aligned
+    assert result.first_divergence == 0
+    assert result.divergence_kind == "arg_change"
+
+
+def test_reorder_is_localized_without_assuming_independence():
+    result = align(
+        [SEARCH, OPEN, SUMMARIZE],
+        [OPEN, SEARCH, SUMMARIZE],
+    )
+    assert not result.aligned
+    assert result.divergence_kind == "order_change"
+    assert result.resync_at == 2
+    assert result.reordered
+
+
+def test_retry_that_rejoins_reports_resync():
+    result = align(
+        [SEARCH, OPEN, SUMMARIZE, EMAIL],
+        [
+            SEARCH,
+            step("search", event_id="retry", q="revenue 2024", retry=1),
+            OPEN,
+            SUMMARIZE,
+            EMAIL,
+        ],
+    )
+    assert not result.aligned
+    assert result.divergence_kind == "extra"
+    assert result.resync_at == 2
+    assert result.unmatched_candidate == ["retry"]
+    assert result.divergence_ratio == 0.2
+
+
+def test_path_change_does_not_report_recovery():
+    candidate = [SEARCH, step("ask_human"), step("wait")]
+    result = align([SEARCH, OPEN, SUMMARIZE], candidate)
+    assert result.divergence_kind == "tool_change"
+    assert result.resync_at is None
+
+
+@pytest.mark.parametrize(
+    ("baseline", "candidate", "kind", "unmatched"),
+    [
+        ([SEARCH, OPEN], [SEARCH], "absent", ["open_document"]),
+        ([SEARCH], [SEARCH, EMAIL], "extra", ["send_email"]),
+    ],
+)
+def test_trailing_steps_are_classified(baseline, candidate, kind, unmatched):
+    result = align(baseline, candidate)
+    assert result.divergence_kind == kind
+    observed = (
+        result.unmatched_baseline
+        if kind == "absent"
+        else result.unmatched_candidate
+    )
+    assert observed == unmatched
+
+
+def test_duplicate_steps_are_counted_by_occurrence():
+    first = step("poll", event_id="poll-1")
+    duplicate = step("poll", event_id="poll-2")
+    result = align([first], [first, duplicate])
+    assert result.divergence_kind == "extra"
+    assert result.unmatched_candidate == ["poll-2"]
+
+
+def test_result_is_json_serializable_and_versioned():
+    payload = align([SEARCH], [SEARCH]).as_dict()
+    assert payload["projection_version"] == TRACE_PROJECTION_VERSION
+    assert set(DIVERGENCE_KINDS) == {
+        "arg_change",
+        "tool_change",
+        "order_change",
+        "absent",
+        "extra",
+    }
+    json.dumps(payload)
+
+
+def test_projection_supports_deepeval_shaped_objects():
+    class ToolCall:
+        def __init__(self):
+            self.name = "search"
+            self.input_parameters = {"q": "x"}
+            self.id = "call-1"
+
+    assert project([ToolCall()])[0].event_id == "call-1"
+
+
+@pytest.mark.parametrize(
+    "bad_step",
+    [
+        {"name": "", "args": {}},
+        {"name": "search", "args": {1: "not-json-object"}},
+        {"name": "search", "args": {"bad": object()}},
+    ],
+)
+def test_malformed_projection_fails_closed(bad_step):
+    with pytest.raises(ValueError):
+        project([bad_step])
+
+
+def test_invalid_alignment_options_fail_closed():
+    with pytest.raises(ValueError):
+        align([], [], lookahead=0)

--- a/tests/test_metrics/test_trajectory_divergence_metric.py
+++ b/tests/test_metrics/test_trajectory_divergence_metric.py
@@ -182,6 +182,30 @@ def test_alignment_result_is_exposed_for_localization():
     assert result.candidate_len == 4
 
 
+def test_score_breakdown_is_populated_from_schema():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN, SUMMARIZE, EMAIL],
+        [SEARCH, step("open_document", document_id=99), SUMMARIZE, EMAIL],
+    )
+    metric.measure(_make_test_case())
+    assert metric.result is not None
+    breakdown = metric.score_breakdown
+    assert breakdown["first_divergence"] == 1
+    assert breakdown["divergence_kind"] == "arg_change"
+    assert breakdown["resync_at"] is None
+    assert breakdown["divergence_ratio"] == 0.75
+    assert breakdown["matched_prefix_len"] == 1
+
+
+def test_aligned_score_breakdown_has_no_divergence():
+    metric = TrajectoryDivergenceMetric(*aligned_traces())
+    metric.measure(_make_test_case())
+    assert metric.result.first_divergence is None
+    assert metric.result.divergence_kind is None
+    assert metric.result.divergence_ratio == 0.0
+    assert metric.score_breakdown["divergence_kind"] is None
+
+
 def test_verbose_logs_are_populated():
     metric = TrajectoryDivergenceMetric(*aligned_traces())
     metric.measure(_make_test_case())

--- a/tests/test_metrics/test_trajectory_divergence_metric.py
+++ b/tests/test_metrics/test_trajectory_divergence_metric.py
@@ -1,0 +1,218 @@
+import pytest
+
+from deepeval.metrics.community import TrajectoryDivergenceMetric
+from deepeval.metrics.community.trace_divergence import align
+from deepeval.test_case import LLMTestCase
+
+
+def step(name, event_id=None, **arguments):
+    return {
+        "kind": "tool",
+        "name": name,
+        "args": arguments,
+        "id": event_id or name,
+    }
+
+
+SEARCH = step("search", q="revenue 2024")
+OPEN = step("open_document", document_id=7)
+SUMMARIZE = step("summarize", style="brief")
+EMAIL = step("send_email", to="cfo@example.com")
+
+
+def _make_test_case():
+    return LLMTestCase(input="compare the two runs", actual_output="done")
+
+
+def aligned_traces():
+    return [SEARCH, OPEN, SUMMARIZE, EMAIL], [SEARCH, OPEN, SUMMARIZE, EMAIL]
+
+
+def test_identical_traces_score_perfect_and_pass():
+    metric = TrajectoryDivergenceMetric(*aligned_traces())
+    score = metric.measure(_make_test_case())
+    assert score == 1.0
+    assert metric.success is True
+    assert "aligned across all 4 steps" in metric.reason
+
+
+def test_identical_traces_score_perfect_in_async_mode():
+    metric = TrajectoryDivergenceMetric(*aligned_traces())
+    score = metric.measure(_make_test_case())
+    assert score == 1.0
+
+
+def test_arg_change_is_scored_as_divergence():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN], [step("search", q="2025"), OPEN]
+    )
+    score = metric.measure(_make_test_case())
+    assert score < 1.0
+    assert metric.success is False
+    assert metric.reason is not None
+    assert "step 1" in metric.reason
+    assert "different arguments" in metric.reason
+
+
+def test_tool_change_reason_names_both_tools():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN], [SEARCH, step("ask_human"), step("wait")]
+    )
+    metric.measure(_make_test_case())
+    assert metric.alignment_result.divergence_kind == "tool_change"
+    assert "open_document" in metric.reason
+    assert "ask_human" in metric.reason
+
+
+def test_reorder_is_a_divergence():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN, SUMMARIZE], [OPEN, SEARCH, SUMMARIZE]
+    )
+    metric.measure(_make_test_case())
+    assert metric.alignment_result.divergence_kind == "order_change"
+    assert "different order" in metric.reason
+    assert metric.score < 1.0
+    assert metric.success is False
+
+
+def test_retry_that_rejoins_is_localized_not_divergence_to_end():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN, SUMMARIZE, EMAIL],
+        [
+            SEARCH,
+            step("search", event_id="retry", q="revenue 2024", retry=1),
+            OPEN,
+            SUMMARIZE,
+            EMAIL,
+        ],
+    )
+    metric.measure(_make_test_case())
+    result = metric.alignment_result
+    assert result.divergence_kind == "extra"
+    assert result.resync_at == 2
+    assert metric.score == pytest.approx(0.8)
+    assert "resynchronize at step 3" in metric.reason
+    assert metric.success is False
+
+
+def test_lower_threshold_tolerates_recovered_divergence():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN, SUMMARIZE, EMAIL],
+        [
+            SEARCH,
+            step("search", event_id="retry", q="revenue 2024", retry=1),
+            OPEN,
+            SUMMARIZE,
+            EMAIL,
+        ],
+        threshold=0.7,
+    )
+    metric.measure(_make_test_case())
+    assert metric.success is True
+
+
+def test_unrecovered_path_change_reason_mentions_no_resync():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN, SUMMARIZE],
+        [SEARCH, step("ask_human"), step("wait")],
+    )
+    metric.measure(_make_test_case())
+    assert metric.alignment_result.resync_at is None
+    assert "do not resynchronize" in metric.reason
+
+
+def test_absent_trailing_step_is_classified():
+    metric = TrajectoryDivergenceMetric([SEARCH, OPEN], [SEARCH])
+    metric.measure(_make_test_case())
+    assert metric.alignment_result.divergence_kind == "absent"
+    assert "absent from the candidate trace" in metric.reason
+
+
+def test_extra_trailing_step_is_classified():
+    metric = TrajectoryDivergenceMetric([SEARCH], [SEARCH, EMAIL])
+    metric.measure(_make_test_case())
+    assert metric.alignment_result.divergence_kind == "extra"
+    assert "inserts an extra step" in metric.reason
+
+
+def test_score_only_mode_leaves_success_none():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN], [step("search", q="2025"), OPEN], threshold=None
+    )
+    metric.measure(_make_test_case())
+    assert metric.success is None
+    assert metric.score < 1.0
+
+
+def test_strict_mode_is_binary():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN], [step("search", q="2025"), OPEN], strict_mode=True
+    )
+    metric.measure(_make_test_case())
+    assert metric.score == 0
+    assert metric.success is False
+
+    strict_aligned = TrajectoryDivergenceMetric(
+        *aligned_traces(), strict_mode=True
+    )
+    strict_aligned.measure(_make_test_case())
+    assert strict_aligned.score == 1.0
+    assert strict_aligned.success is True
+
+
+def test_include_reason_false_returns_none_reason():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN], [SEARCH], include_reason=False
+    )
+    metric.measure(_make_test_case())
+    assert metric.reason is None
+
+
+def test_alignment_result_is_exposed_for_localization():
+    metric = TrajectoryDivergenceMetric(
+        [SEARCH, OPEN, SUMMARIZE, EMAIL],
+        [SEARCH, step("open_document", document_id=99), SUMMARIZE, EMAIL],
+    )
+    metric.measure(_make_test_case())
+    result = metric.alignment_result
+    assert result.matched_prefix_len == 1
+    assert result.first_divergence == 1
+    assert result.divergence_kind == "arg_change"
+    assert result.baseline_len == 4
+    assert result.candidate_len == 4
+
+
+def test_verbose_logs_are_populated():
+    metric = TrajectoryDivergenceMetric(*aligned_traces())
+    metric.measure(_make_test_case())
+    assert metric.verbose_logs is not None
+    assert "Alignment" in metric.verbose_logs
+
+
+def test_empty_traces_align():
+    metric = TrajectoryDivergenceMetric([], [])
+    score = metric.measure(_make_test_case())
+    assert score == 1.0
+    assert metric.success is True
+
+
+def test_wrapper_consistency_with_raw_align():
+    baseline, candidate = [SEARCH, OPEN], [SEARCH]
+    metric = TrajectoryDivergenceMetric(baseline, candidate)
+    metric.measure(_make_test_case())
+    result = align(baseline, candidate)
+    assert metric.alignment_result == result
+
+
+def test_accepts_span_like_objects():
+    class SpanLike:
+        def __init__(self, name, args):
+            self.name = name
+            self.args = args
+            self.id = name
+
+    baseline = [SpanLike("search", {"q": "x"})]
+    candidate = [SpanLike("search", {"q": "y"})]
+    metric = TrajectoryDivergenceMetric(baseline, candidate)
+    metric.measure(_make_test_case())
+    assert metric.score < 1.0

--- a/tests/test_metrics/test_trajectory_divergence_metric.py
+++ b/tests/test_metrics/test_trajectory_divergence_metric.py
@@ -2,6 +2,10 @@ import pytest
 
 from deepeval.metrics.community import TrajectoryDivergenceMetric
 from deepeval.metrics.community.trace_divergence import align
+from deepeval.metrics.community.trace_divergence.alignment import (
+    AlignmentResult,
+    project,
+)
 from deepeval.test_case import LLMTestCase
 
 
@@ -73,6 +77,45 @@ def test_reorder_is_a_divergence():
     assert "different order" in metric.reason
     assert metric.score < 1.0
     assert metric.success is False
+
+
+def test_order_change_summary_honors_resync_at_zero():
+    metric = TrajectoryDivergenceMetric(*aligned_traces())
+    result = AlignmentResult(
+        aligned=False,
+        matched_prefix_len=0,
+        first_divergence=0,
+        divergence_kind="order_change",
+        resync_at=0,
+        baseline_len=2,
+        candidate_len=2,
+    )
+    baseline_events = project([SEARCH, OPEN])
+    candidate_events = project([OPEN, SEARCH])
+    summary = metric._summarize_divergence(
+        result, baseline_events, candidate_events
+    )
+    assert "steps 1-0" in summary
+    reason = metric._generate_reason(result, baseline_events, candidate_events)
+    assert "resynchronize at step 1" in reason
+    assert "steps 1-0" in reason
+
+
+def test_order_change_summary_falls_back_to_step_when_no_resync():
+    metric = TrajectoryDivergenceMetric(*aligned_traces())
+    result = AlignmentResult(
+        aligned=False,
+        matched_prefix_len=0,
+        first_divergence=0,
+        divergence_kind="order_change",
+        resync_at=None,
+        baseline_len=2,
+        candidate_len=2,
+    )
+    summary = metric._summarize_divergence(
+        result, project([SEARCH, OPEN]), project([OPEN, SEARCH])
+    )
+    assert "steps 1-1" in summary
 
 
 def test_retry_that_rejoins_is_localized_not_divergence_to_end():


### PR DESCRIPTION
### Summary

Adds `TrajectoryDivergenceMetric`, the metric wrapper for #3019. It compares two **real** execution traces — a baseline run you trust and a candidate run after a prompt, model, or tool change — and **localizes the first sustained divergence** (step, kind, recovery point) instead of returning a bare pass/fail.

This is the wrapper half of the split agreed in #3019:
* **#3056 (Nickgonzales76017):** The policy-neutral alignment seam — `align(baseline, candidate) -> AlignmentResult`. This PR builds on it and does not modify it.
* **This PR:** The metric layer — score, threshold, reason text, `schema.py`, exports, tests, docs.

### Design

* Lives in `deepeval/metrics/community/trace_divergence/` alongside the seam and mirrors the community-metric structure: metric class + `schema.py` + `template.py`.
* Imported from `deepeval.metrics.community`; **not** exported from `deepeval.metrics`, per the community-metric policy in CONTRIBUTING.md.
* Traces come from the constructor (`baseline_trace`, `candidate_trace`); the `LLMTestCase` arg is accepted for `BaseMetric` compatibility.
* Score = `1.0 - divergence_ratio` (1.0 = fully aligned), threshold 1.0 by default, `strict_mode`/`async_mode`/`include_reason`/`verbose_mode` follow existing conventions.
* Honors the contracts pinned in #3056: `divergence_kind`, `resync_at`, and `divergence_ratio` stay separate (a recovered retry is never reported as an unrecovered fork); `order_change` remains a difference unless the wrapper has dependency evidence to waive it.
* Localization exposed three ways: `metric.alignment_result` (raw seam result), `metric.result` (typed pydantic model from `schema.py`), and `metric.score_breakdown` (JSON-serializable dict) — `matched_prefix_len`, `first_divergence`, `divergence_kind`, `resync_at`, unmatched IDs, reordered pairs, `divergence_ratio`.
* Fully deterministic — no LLM, no API key, zero eval-time cost.

### Proof (real traces)

A small tool-calling agent (`web_search`, `get_stock_price`, `calculate`, `save_note`) ran the same task under four configs; the captured tool-call traces were fed to the metric. Models: `gpt-5.4-mini` baseline, `gpt-4.1-nano` model swap. Total LLM cost ≈ $0.01.

| Case | Result |
|---|---|
| Identical trace (A vs A) | `score 1.000`, aligned, `first_divergence None` — no false positives |
| Same-config rerun (A vs B) | Reports real stochastic drift (`arg_change` on `web_search` args) instead of faking alignment |
| Prompt change (A vs C) | Localized to step 1 (`web_search` absent), `resync_at: 2`, score `0.833`; unmatched steps still surfaced |
| Model swap (A vs D) | Unrecovered `tool_change` (`web_search` vs `calculate`), score `0.000` — the regression signal from the issue |

```text
# 1) Control — same trace (A vs A)
score: 1.000 | success: True
matched_prefix_len: 6 | first_divergence: None | kind: None | resync_at: None
reason: The baseline and candidate trajectories are aligned across all 6 steps.

# 2) Same-config rerun (A vs B) — honest detection of stochastic drift
score: 0.000 | success: False
first_divergence: 0 | kind: arg_change | resync_at: None
unmatched baseline: [web_search-1, calculate-1, calculate-2, save_note-1]
unmatched candidate: [web_search-1, calculate-1, save_note-1]
reason: ... step 1 calls the same tool `web_search` with different arguments.

# 3) Prompt change (A vs C) — divergence localized, not just pass/fail
score: 0.833 | success: False
first_divergence: 0 | kind: absent | resync_at: 1
reason: The candidate trajectory diverges from the baseline at step 1 (`web_search`) is absent from the candidate trace. The trajectories resynchronize at step 2: the divergence is localized to the intervening steps rather than a fork to the end. Divergence ratio: 0.17.

# 4) Model swap (A vs D) — unrecovered path change
score: 0.000 | success: False
first_divergence: 0 | kind: tool_change | resync_at: None
reason: ... step 1 calls `web_search` in the baseline but `calculate` in the candidate. The trajectories do not resynchronize.

```

### Tests & checks

* `tests/test_metrics/test_trajectory_divergence_metric.py` — 20 tests (aligned / arg / tool / order / absent / extra, retry-with-resync, threshold, score-only, strict, async, localization exposure, `score_breakdown`, verbose logs, span-like inputs).
* `ruff check` clean, `black --check` clean.
* `pytest`: 35 passed (20 wrapper + 15 seam).

### Notes

Depends on #3056 (the alignment seam). Once that merges first, I'll rebase and this diff collapses to the wrapper only.