### PR TITLE
fix(metrics): strip whitespace before comparing verdict strings

### DIFF
--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -200,7 +200,7 @@ class ContextualRecallMetric(BaseMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in self.verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)
@@ -230,7 +230,7 @@ class ContextualRecallMetric(BaseMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in self.verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)
@@ -260,7 +260,7 @@ class ContextualRecallMetric(BaseMetric):
 
         justified_sentences = 0
         for verdict in self.verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 justified_sentences += 1
 
         score = justified_sentences / number_of_verdicts

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -204,7 +204,7 @@ class ContextualRelevancyMetric(BaseMetric):
         relevant_statements = []
         for verdicts in self.verdicts_list:
             for verdict in verdicts.verdicts:
-                if verdict.verdict.lower() == "no":
+                if verdict.verdict.strip().lower() == "no":
                     irrelevant_statements.append(verdict.reason)
                 else:
                     relevant_statements.append(verdict.statement)
@@ -234,7 +234,7 @@ class ContextualRelevancyMetric(BaseMetric):
         relevant_statements = []
         for verdicts in self.verdicts_list:
             for verdict in verdicts.verdicts:
-                if verdict.verdict.lower() == "no":
+                if verdict.verdict.strip().lower() == "no":
                     irrelevant_statements.append(verdict.reason)
                 else:
                     relevant_statements.append(verdict.statement)
@@ -262,7 +262,7 @@ class ContextualRelevancyMetric(BaseMetric):
         for verdicts in self.verdicts_list:
             for verdict in verdicts.verdicts:
                 total_verdicts += 1
-                if verdict.verdict.lower() == "yes":
+                if verdict.verdict.strip().lower() == "yes":
                     relevant_statements += 1
 
         if total_verdicts == 0:

--- a/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
+++ b/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
@@ -403,7 +403,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)
@@ -440,7 +440,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)

--- a/tests/test_metrics/test_verdict_whitespace.py
+++ b/tests/test_metrics/test_verdict_whitespace.py
@@ -1,0 +1,112 @@
+"""Verdicts must survive surrounding whitespace.
+
+Verdict strings come straight from a model's JSON and are stored on a plain
+`str` pydantic field, which does not strip. A model that emits `"yes "` instead
+of `"yes"` used to fail the comparison silently and drive the score to zero.
+
+These drive the metrics through `measure()` with a stub model rather than
+assigning to `metric.verdicts`, so the state under test is one the normal flow
+produces.
+"""
+
+import json
+from typing import Any, Optional
+
+import pytest
+
+from deepeval.metrics import ContextualRecallMetric, ContextualRelevancyMetric
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+
+class _StubModel(DeepEvalBaseLLM):
+    def __init__(self, payloads: dict[str, Any], pad: bool) -> None:
+        self.payloads = payloads
+        self.pad = pad
+        super().__init__()
+
+    def load_model(self) -> "_StubModel":
+        return self
+
+    def get_model_name(self) -> str:
+        return "stub"
+
+    def _payload_for(self, schema: Any) -> dict[str, Any]:
+        data = self.payloads[schema.__name__]
+        if self.pad:
+            # A trailing space is what a model actually emits; the point is that
+            # nothing between the response and the score removes it.
+            data = json.loads(json.dumps(data).replace('"yes"', '"yes "'))
+        return data
+
+    def generate(
+        self, prompt: str, schema: Optional[Any] = None, **kwargs: Any
+    ) -> Any:
+        if schema is None:
+            return json.dumps({"reason": "stub"})
+        return schema(**self._payload_for(schema))
+
+    async def a_generate(
+        self, prompt: str, schema: Optional[Any] = None, **kwargs: Any
+    ) -> Any:
+        return self.generate(prompt, schema=schema, **kwargs)
+
+
+_TEST_CASE = LLMTestCase(
+    input="q",
+    actual_output="a",
+    expected_output="s1. s2. s3. s4.",
+    retrieval_context=["c1", "c2"],
+)
+
+_RECALL_PAYLOADS = {
+    "Verdicts": {
+        "verdicts": [
+            {"verdict": "yes", "reason": "supported"},
+            {"verdict": "yes", "reason": "supported"},
+            {"verdict": "no", "reason": "not supported"},
+            {"verdict": "yes", "reason": "supported"},
+        ]
+    },
+    "ContextualRecallScoreReason": {"reason": "stub"},
+}
+
+_RELEVANCY_PAYLOADS = {
+    "ContextualRelevancyVerdicts": {
+        "verdicts": [
+            {"statement": "s1", "verdict": "yes", "reason": None},
+            {"statement": "s2", "verdict": "yes", "reason": None},
+            {"statement": "s3", "verdict": "no", "reason": "off topic"},
+            {"statement": "s4", "verdict": "yes", "reason": None},
+        ]
+    },
+    "ContextualRelevancyScoreReason": {"reason": "stub"},
+}
+
+
+@pytest.mark.parametrize("pad", [False, True], ids=["clean", "padded"])
+def test_contextual_recall_ignores_whitespace_around_the_verdict(
+    pad: bool,
+) -> None:
+    metric = ContextualRecallMetric(
+        model=_StubModel(_RECALL_PAYLOADS, pad=pad),
+        async_mode=False,
+        include_reason=False,
+    )
+    metric.measure(_TEST_CASE, _show_indicator=False)
+
+    assert metric.score == 0.75
+
+
+@pytest.mark.parametrize("pad", [False, True], ids=["clean", "padded"])
+def test_contextual_relevancy_ignores_whitespace_around_the_verdict(
+    pad: bool,
+) -> None:
+    metric = ContextualRelevancyMetric(
+        model=_StubModel(_RELEVANCY_PAYLOADS, pad=pad),
+        async_mode=False,
+        include_reason=False,
+    )
+    metric.measure(_TEST_CASE, _show_indicator=False)
+
+    assert metric.score == 0.75


### PR DESCRIPTION
Fixes #3057.

Three metrics compared the raw verdict string, so a model that emits `"yes "` instead of `"yes"` had its verdict counted the wrong way. Verdicts are plain `str` pydantic fields with no validator and no `str_strip_whitespace`, so nothing between the model response and the score removes the padding.

The effect is not a small drift. Driven through `measure()` with a stub model returning four verdicts, `yes, yes, no, yes`, a single trailing space takes both metrics from the correct 0.75 to 0.0, with no error raised:

```
ContextualRecallMetric      "yes" -> 0.75      "yes " -> 0.0
ContextualRelevancyMetric   "yes" -> 0.75      "yes " -> 0.0
```

## Scope

This brings a small set of outliers in line with a convention the codebase already has. Across `deepeval/`, 70 verdict comparisons call `.strip().lower()`; eight did not, in three files:

```
deepeval/metrics/contextual_recall/contextual_recall.py:203,233,263
deepeval/metrics/contextual_relevancy/contextual_relevancy.py:207,237,265
deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py:406,443
```

After this, `grep -rn "verdict\.lower()" deepeval/ --include=*.py | grep -v "strip()"` returns nothing.

Two effects were in play, depending on the comparison. `== "yes"` unstripped drops a padded relevant verdict, which is the score collapse above. In `ContextualRelevancyMetric`'s two reason generators the test is `== "no"`, so a padded irrelevant verdict fell into the `else` branch and its statement was filed as relevant; that one does not change the score, it makes the explanation name the wrong statements.

## Tests

`tests/test_metrics/test_verdict_whitespace.py` drives both metrics through `measure()` with a stub model rather than assigning to `metric.verdicts`, so the state under test is one the normal flow produces. No API key needed.

Verified red before green against current `main`:

```
source reverted to main, tests kept   2 failed, 2 passed
with the fix                          4 passed
```

The two that fail are the padded cases; the two unpadded controls pass either way, so the test is pinned to this behaviour rather than to the implementation.

`tests/test_metrics` is unchanged at 167 passed, 271 skipped, 6 xfailed. `black --line-length 80` clean on the changed files.
