### PR TITLE
fix(tracing): record zero token counts and per-token rates on LLM spans

### DIFF
--- a/deepeval/tracing/context.py
+++ b/deepeval/tracing/context.py
@@ -198,13 +198,17 @@ def update_llm_span(
         return
     if model:
         current_span.model = model
-    if input_token_count:
+    # Zero is a meaningful value for all four numbers below (a free or
+    # self-hosted model has a per-token rate of 0.0, and a call can return
+    # zero tokens), so these are guarded on `is not None` rather than on
+    # truthiness -- same as `update_agent_span` / `update_tool_span` below.
+    if input_token_count is not None:
         current_span.input_token_count = input_token_count
-    if output_token_count:
+    if output_token_count is not None:
         current_span.output_token_count = output_token_count
-    if cost_per_input_token:
+    if cost_per_input_token is not None:
         current_span.cost_per_input_token = cost_per_input_token
-    if cost_per_output_token:
+    if cost_per_output_token is not None:
         current_span.cost_per_output_token = cost_per_output_token
     if token_intervals:
         current_span.token_intervals = token_intervals

--- a/tests/test_core/test_tracing/test_update_functions/test_update_llm_span_zero_values.py
+++ b/tests/test_core/test_tracing/test_update_functions/test_update_llm_span_zero_values.py
@@ -1,0 +1,51 @@
+from deepeval.tracing.context import current_span_context, update_llm_span
+from deepeval.tracing.types import LlmSpan, TraceSpanStatus
+
+
+def _llm_span() -> LlmSpan:
+    return LlmSpan(
+        uuid="span-uuid",
+        trace_uuid="trace-uuid",
+        parent_uuid=None,
+        start_time=0.0,
+        name="llm",
+        status=TraceSpanStatus.SUCCESS,
+        model="local/llama3",
+    )
+
+
+class TestUpdateLlmSpanZeroValues:
+
+    def test_zero_rates_and_token_counts_are_recorded(self):
+        """A free model reports a per-token rate of 0.0; that is a value, not
+        an absent value, and must not be dropped."""
+        span = _llm_span()
+        token = current_span_context.set(span)
+        try:
+            update_llm_span(
+                input_token_count=0,
+                output_token_count=0,
+                cost_per_input_token=0.0,
+                cost_per_output_token=0.0,
+            )
+        finally:
+            current_span_context.reset(token)
+
+        assert span.input_token_count == 0
+        assert span.output_token_count == 0
+        assert span.cost_per_input_token == 0.0
+        assert span.cost_per_output_token == 0.0
+
+    def test_omitted_fields_are_left_untouched(self):
+        span = _llm_span()
+        span.input_token_count = 12
+        span.cost_per_input_token = 0.5
+        token = current_span_context.set(span)
+        try:
+            update_llm_span(output_token_count=7)
+        finally:
+            current_span_context.reset(token)
+
+        assert span.input_token_count == 12
+        assert span.cost_per_input_token == 0.5
+        assert span.output_token_count == 7


### PR DESCRIPTION
### Summary

`update_llm_span()` guards its four numeric fields on truthiness, so `0` is indistinguishable from "argument not passed" and is silently discarded:

```python
# deepeval/tracing/context.py
if input_token_count:
    current_span.input_token_count = input_token_count
if output_token_count:
    current_span.output_token_count = output_token_count
if cost_per_input_token:
    current_span.cost_per_input_token = cost_per_input_token
if cost_per_output_token:
    current_span.cost_per_output_token = cost_per_output_token
```

All four are `Optional[float]` on `LlmSpan` with a `None` default, and `0` is a real value for each of them: a free or self-hosted model has a per-token rate of `0.0`, and a call can legitimately report zero tokens.

### Reproduction

```python
span = LlmSpan(..., model="local/llama3")
token = current_span_context.set(span)
update_llm_span(
    input_token_count=0,
    output_token_count=0,
    cost_per_input_token=0.0,
    cost_per_output_token=0.0,
)
current_span_context.reset(token)

print(span.input_token_count)     # None  (expected 0)
print(span.output_token_count)    # None  (expected 0)
print(span.cost_per_input_token)  # None  (expected 0.0)
print(span.cost_per_output_token) # None  (expected 0.0)
```

### Why this matters downstream

The consumers already handle a rate of zero deliberately — they check `is None` and then fall back with `or 0` — so a genuine `0.0` would render correctly if it ever arrived:

```python
# deepeval/inspect/widgets/details.py
def _estimate_cost(span: BaseSpan) -> Optional[float]:
    if span.cost_per_input_token is None or span.cost_per_output_token is None:
        return None
    ...
    return (span.cost_per_input_token or 0) * (span.input_token_count or 0) + ...
```

Because the producer turns `0.0` into `None`, a free-model span takes the early return: no `rates` row and no cost, rather than `$0.00`. `TraceSpanApiSchema` gets `null` for the same fields (`tracing.py`, `api_span.cost_per_input_token = span.cost_per_input_token`), so the same loss reaches the payload sent to Confident AI.

### Why `is not None`

That is already the convention for these fields everywhere else:

- `update_agent_span()` and `update_tool_span()`, in this same module, use `is not None`.
- The CLI stores rates with `if cost_per_input_token is not None:` (`deepeval/cli/main.py`, all seven provider commands).
- `AmazonBedrockModel.__init__` resolves them with `if cost_per_input_token is not None`.
- The LangChain integration passes `observe_kwargs.get("cost_per_input_token", None)` straight into `LlmSpan(...)` without a truthiness filter — so `@observe(cost_per_input_token=0.0)` already keeps the zero, while `update_llm_span(cost_per_input_token=0.0)` drops it.

### Changes

- `deepeval/tracing/context.py`: guard the four numeric fields of `update_llm_span()` on `is not None`. `model`, `token_intervals` and `prompt` are left on truthiness — an empty string/dict there carries no meaning.
- New test `tests/test_core/test_tracing/test_update_functions/test_update_llm_span_zero_values.py`: zeros are recorded; omitted fields still leave existing values untouched.

`update_retriever_span()` has the same shape for `top_k`/`chunk_size`, but `0` is not a meaningful value for either, so it is left alone rather than widening this change.

### How it was tested

```
$ pytest tests/test_core/test_tracing/test_update_functions/test_update_llm_span_zero_values.py
2 passed

# without the fix, to confirm the test actually covers the bug
$ git stash push deepeval/tracing/context.py && pytest tests/.../test_update_llm_span_zero_values.py
1 failed, 1 passed
   assert None == 0
    +  where None = LlmSpan(...).input_token_count
```

Existing coverage for this path still passes:

```
$ pytest tests/test_core/test_tracing/test_span_types/test_llm_span.py
6 passed
```

`black==25.12.0` and `ruff==0.6.9` (the pinned `.pre-commit-config.yaml` versions) report both files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
