### PR TITLE
fix(benchmarks): correct silent answer mis-scoring in ARC (follow-up to #2916)

### DIFF
--- a/deepeval/benchmarks/arc/arc.py
+++ b/deepeval/benchmarks/arc/arc.py
@@ -9,7 +9,7 @@ from deepeval.benchmarks.base_benchmark import (
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.arc.mode import ARCMode
 from deepeval.benchmarks.arc.template import ARCTemplate
-from deepeval.benchmarks.schema import MultipleChoiceSchema
+from deepeval.benchmarks.schema import ARCMultipleChoiceSchema
 from deepeval.telemetry import capture_benchmark_run
 
 
@@ -46,7 +46,7 @@ class ARC(DeepEvalBaseBenchmark):
         self.verbose_mode = verbose_mode
         if not confinement_instructions:
             self.confinement_instructions = (
-                "Output 'A', 'B', 'C', or 'D'. Full answer not needed."
+                "Output 'A', 'B', 'C', 'D', or 'E'. Full answer not needed."
             )
         else:
             self.confinement_instructions = confinement_instructions
@@ -108,8 +108,8 @@ class ARC(DeepEvalBaseBenchmark):
 
         # Enforced model generation
         try:
-            res: MultipleChoiceSchema = model.generate(
-                prompt=prompt, schema=MultipleChoiceSchema
+            res: ARCMultipleChoiceSchema = model.generate(
+                prompt=prompt, schema=ARCMultipleChoiceSchema
             )
             prediction = res.answer
         except TypeError:

--- a/deepeval/benchmarks/arc/template.py
+++ b/deepeval/benchmarks/arc/template.py
@@ -1,4 +1,17 @@
 class ARCTemplate:
+    # ARC does not label its options consistently. Most items use "A"-"D", but a
+    # subset labels them "1"-"4", a few offer five options ("A"-"E"), and at
+    # least one offers only three. The gold `answerKey` uses whichever labelling
+    # that item happens to carry, so a numerically labelled item produced an
+    # `expected_output` of "3" — a value the answer schema cannot represent and
+    # the confinement instructions never mention. Those items scored 0 no matter
+    # what the model answered.
+    #
+    # Option labels are positionally aligned with `choices["text"]`, so both the
+    # rendered prompt and the gold answer are normalized to letters by position.
+    # This keeps the prompt and the expected answer in the same alphabet.
+    option_letters = ["A", "B", "C", "D", "E"]
+
     n_shot_examples = [
         {
             "id": "Mercury_7220990",
@@ -78,17 +91,36 @@ class ARCTemplate:
         return prompt
 
     @staticmethod
+    def normalize_label(data: dict, label: str) -> str:
+        """Map an item's own option label onto its positional letter.
+
+        Returns `label` unchanged when it is not one of the item's options, or
+        when the item has more options than there are letters, so an unexpected
+        dataset shape degrades to the previous behaviour instead of raising.
+        """
+        labels = data["choices"]["label"]
+        try:
+            index = labels.index(label)
+        except ValueError:
+            return label
+        if index >= len(ARCTemplate.option_letters):
+            return label
+        return ARCTemplate.option_letters[index]
+
+    @staticmethod
     def format_question(data: dict, include_answer: bool = True):
         prompt = data["question"]
         texts = data["choices"]["text"]
         labels = data["choices"]["label"]
         for i in range(len(labels)):
-            prompt += "\n{}. {}".format(labels[i], texts[i])
+            prompt += "\n{}. {}".format(
+                ARCTemplate.normalize_label(data, labels[i]), texts[i]
+            )
         prompt += "\nAnswer: "
         if include_answer:
-            prompt += " {}\n\n".format(data["answerKey"])
+            prompt += " {}\n\n".format(ARCTemplate.format_answer(data))
         return prompt
 
     @staticmethod
     def format_answer(data: dict):
-        return data["answerKey"]
+        return ARCTemplate.normalize_label(data, data["answerKey"])

--- a/deepeval/benchmarks/schema.py
+++ b/deepeval/benchmarks/schema.py
@@ -36,6 +36,18 @@ class TrinaryChoiceSchema(BaseModel):
     answer: Literal["A", "B", "C"]
 
 
+# ARC Models #############################
+
+
+class ARCMultipleChoiceSchema(BaseModel):
+    # A small subset of ARC items offer five options rather than four, so the
+    # gold answer can legitimately be "E". ARC cannot reuse the shared
+    # `MultipleChoiceSchema` for this: MMLU, HellaSwag and LogiQA are strictly
+    # four-option benchmarks, and widening their schema would let a model
+    # answer with an option those questions never present.
+    answer: Literal["A", "B", "C", "D", "E"]
+
+
 # MathQA Models #############################
 
 

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -9,7 +9,12 @@ download, or API key required.
 import pytest
 
 from deepeval.scorer.scorer import Scorer
-from deepeval.benchmarks.schema import MultipleChoiceSchemaLower
+from deepeval.benchmarks.schema import (
+    ARCMultipleChoiceSchema,
+    MultipleChoiceSchema,
+    MultipleChoiceSchemaLower,
+)
+from deepeval.benchmarks.arc.template import ARCTemplate
 from deepeval.benchmarks.drop.template import DROPTemplate
 from deepeval.benchmarks.drop.drop import DELIMITER
 from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
@@ -101,3 +106,166 @@ def test_bbh_batch_predict_scores_schema_answer_correctly(enable_cot):
     # schema answer, turning "(A)" into "(A)" -> "(A" and scoring it 0.
     assert result[0]["prediction"] == "(A)"
     assert result[0]["score"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# ARC: the gold answer must be expressible in the alphabet the model is given
+# --------------------------------------------------------------------------- #
+
+# A numerically labelled item, as it appears in ai2_arc. 127 of the items in the
+# train splits (23 in ARC-Challenge, 104 in ARC-Easy) label their options this
+# way or offer five of them.
+ARC_NUMERIC_ITEM = {
+    "question": "Rocks are classified as igneous, metamorphic, or sedimentary according to",
+    "choices": {
+        "text": [
+            "their color",
+            "their shape",
+            "how they formed",
+            "the minerals they contain",
+        ],
+        "label": ["1", "2", "3", "4"],
+    },
+    "answerKey": "3",
+}
+
+ARC_LETTER_ITEM = {
+    "question": "Which factor will most likely cause a person to develop a fever?",
+    "choices": {
+        "text": [
+            "a leg muscle relaxing after exercise",
+            "a bacterial population in the bloodstream",
+            "several viral particles on the skin",
+            "carbohydrates being digested in the stomach",
+        ],
+        "label": ["A", "B", "C", "D"],
+    },
+    "answerKey": "B",
+}
+
+ARC_FIVE_OPTION_ITEM = {
+    "question": "Which is a renewable resource?",
+    "choices": {
+        "text": ["coal", "oil", "natural gas", "uranium", "timber"],
+        "label": ["A", "B", "C", "D", "E"],
+    },
+    "answerKey": "E",
+}
+
+ARC_THREE_OPTION_ITEM = {
+    "question": "Which state of matter has a fixed volume but no fixed shape?",
+    "choices": {
+        "text": ["solid", "liquid", "gas"],
+        "label": ["1", "2", "3"],
+    },
+    "answerKey": "2",
+}
+
+
+@pytest.mark.parametrize("option", ["A", "B", "C", "D", "E"])
+def test_arc_schema_accepts_all_five_options(option):
+    # A subset of ARC items have five options, so "E" is a legitimate gold
+    # answer. ARC keeps its own schema rather than widening the shared
+    # MultipleChoiceSchema, which MMLU/HellaSwag/LogiQA rely on being A-D.
+    assert ARCMultipleChoiceSchema(answer=option).answer == option
+
+
+def test_shared_multiple_choice_schema_stays_four_options():
+    # Guard against "fixing" ARC by loosening the schema the strictly
+    # four-option benchmarks depend on.
+    with pytest.raises(Exception):
+        MultipleChoiceSchema(answer="E")
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (ARC_NUMERIC_ITEM, "C"),
+        (ARC_LETTER_ITEM, "B"),
+        (ARC_FIVE_OPTION_ITEM, "E"),
+        (ARC_THREE_OPTION_ITEM, "B"),
+    ],
+)
+def test_arc_gold_answer_is_normalized_to_its_positional_letter(data, expected):
+    # Previously format_answer returned data["answerKey"] verbatim, so a
+    # numerically labelled item had expected_output "3" while the model was
+    # constrained to "A"-"D" — unmatchable, and scored 0 in silence.
+    assert ARCTemplate.format_answer(data) == expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ARC_NUMERIC_ITEM,
+        ARC_LETTER_ITEM,
+        ARC_FIVE_OPTION_ITEM,
+        ARC_THREE_OPTION_ITEM,
+    ],
+)
+def test_arc_gold_answer_is_always_schema_representable(data):
+    # The invariant the bug violated: whatever ARC stores as the expected output
+    # must be something a schema-constrained model is able to emit.
+    gold = ARCTemplate.format_answer(data)
+    assert ARCMultipleChoiceSchema(answer=gold).answer == gold
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        ARC_NUMERIC_ITEM,
+        ARC_LETTER_ITEM,
+        ARC_FIVE_OPTION_ITEM,
+        ARC_THREE_OPTION_ITEM,
+    ],
+)
+def test_arc_prompt_offers_the_gold_answer_as_a_choice(data):
+    # The rendered options and the gold answer must use the same alphabet,
+    # otherwise the prompt asks for one thing and scoring expects another.
+    prompt = ARCTemplate.format_question(data, include_answer=False)
+    gold = ARCTemplate.format_answer(data)
+    offered = [
+        line.split(".", 1)[0]
+        for line in prompt.splitlines()
+        if len(line) > 1 and line[1] == "."
+    ]
+    assert offered == ARCTemplate.option_letters[: len(data["choices"]["text"])]
+    assert gold in offered
+
+
+def test_arc_letter_labelled_items_are_unchanged():
+    # The common case must render exactly as before this fix.
+    assert ARCTemplate.format_question(ARC_LETTER_ITEM, False) == (
+        "Which factor will most likely cause a person to develop a fever?"
+        "\nA. a leg muscle relaxing after exercise"
+        "\nB. a bacterial population in the bloodstream"
+        "\nC. several viral particles on the skin"
+        "\nD. carbohydrates being digested in the stomach"
+        "\nAnswer: "
+    )
+
+
+def test_arc_few_shot_prompt_does_not_teach_an_unrepresentable_answer():
+    # The fifth built-in n-shot example is numerically labelled, so with the
+    # default n_shots=5 every ARC prompt demonstrated "Answer:  3" — an answer
+    # the schema forbids the model from giving.
+    prompt = ARCTemplate.generate_output(input="", n_shots=5)
+    for shot in ARCTemplate.n_shot_examples:
+        demonstrated = ARCTemplate.format_answer(shot)
+        assert (
+            ARCMultipleChoiceSchema(answer=demonstrated).answer == demonstrated
+        )
+    assert "Answer:  3\n" not in prompt
+
+
+def test_arc_correct_prediction_on_a_numeric_item_now_scores_one():
+    # End to end: the model picks the right option, names it in the alphabet the
+    # prompt gave it, and is scored correctly. Before the fix the gold was "3",
+    # the model could only say "C", and exact_match_score returned 0.
+    gold = ARCTemplate.format_answer(ARC_NUMERIC_ITEM)
+    prediction = ARCMultipleChoiceSchema(answer="C").answer
+    assert Scorer.exact_match_score(gold, prediction) == 1
+
+
+def test_arc_normalize_label_passes_through_unknown_labels():
+    # An unexpected dataset shape degrades to the old behaviour, never raises.
+    assert ARCTemplate.normalize_label(ARC_LETTER_ITEM, "Z") == "Z"


### PR DESCRIPTION
Follow-up to #2916, which fixed three silent answer-scoring bugs. Reviewing that PR, @ebarkhordar pointed out that the same failure mode — *a correct label the answer schema cannot represent, so the item scores 0* — is present in a benchmark it did not touch: **ARC**. This fixes it.

## The bug

`ARCTemplate.format_answer` returns `data["answerKey"]` verbatim:

```python
# deepeval/benchmarks/arc/template.py
@staticmethod
def format_answer(data: dict):
    return data["answerKey"]
```

while `ARC.predict` constrains generation to `MultipleChoiceSchema` (`Literal["A","B","C","D"]`), and the confinement instructions for the free-text fallback say `"Output 'A', 'B', 'C', or 'D'. Full answer not needed."`

But `ai2_arc` does not label its options consistently. Label counts in the train splits:

| split | non-`A`–`D` gold keys | affected |
|---|---|---|
| ARC-Challenge | `1`×6, `2`×3, `3`×4, `4`×10 | **23 / 1119 (2.1%)** |
| ARC-Easy | `1`×25, `2`×22, `3`×33, `4`×22, `E`×2 | **104 / 2251 (4.6%)** |

For those 127 items `expected_output` is a string the model is structurally forbidden from producing, so `exact_match_score` returns 0 for *every* possible prediction. Nothing raises — ARC accuracy is just silently reported low.

Reproducing on current `main`:

```
Rocks are classified as igneous, metamorphic, or sedimentary according to
1. their color
2. their shape
3. how they formed
4. the minerals they contain
Answer:

expected_output  = '3'
model CANNOT emit the gold answer -> ValidationError
best achievable score by ANY schema-constrained model: 0
```

### The default few-shot prompt makes it worse

`n_shots` defaults to `5`, and the fifth built-in n-shot example (`NYSEDREGENTS_2006_8_10`) is numerically labelled with `answerKey` `"3"`. So on the default configuration **every ARC prompt demonstrates `Answer:  3`** — actively steering the model toward an answer its own schema rejects.

## The fix

Option labels are positionally aligned with `choices["text"]`, so both the rendered options and the gold answer are normalized to letters by position (`"1"`→`"A"`, `"2"`→`"B"`, …). The prompt and the expected answer stay in the same alphabet, and the bad n-shot example is corrected as a side effect.

`normalize_label` passes unknown labels through unchanged, so an unexpected dataset shape degrades to the previous behaviour instead of raising. Verified against the real dataset: numerically labelled items are always `["1","2","3","4"]` positionally aligned, one item has only three options, and the `E` items have a full `["A","B","C","D","E"]`.

**Items already labelled `A`–`D` render byte-identically to before** — there is a test pinning that.

### Why ARC gets its own schema

Five-option items need `E`, but `MultipleChoiceSchema` is shared with **MMLU, HellaSwag and LogiQA**, which are strictly four-option. Widening it would let a model answer with an option those questions never present — trading this bug for a worse one. ARC gets `ARCMultipleChoiceSchema` instead, and a test guards the shared schema against being loosened later:

```python
def test_shared_multiple_choice_schema_stays_four_options():
    with pytest.raises(Exception):
        MultipleChoiceSchema(answer="E")
```

## Tests

Extends `tests/test_benchmarks/test_benchmark_answer_scoring.py` from #2916 — offline, no model, network, dataset download, or API key required. 35 pass.

Coverage: schema accepts `A`–`E`; shared schema stays `A`–`D`; gold normalization for numeric / letter / five-option / three-option items; the invariant that the gold answer is always schema-representable; prompt and gold share an alphabet; letter-labelled rendering unchanged; no n-shot example demonstrates an unrepresentable answer; end-to-end scoring of a numeric item; unknown-label pass-through.
