### PR TITLE
feat: add optional logprob scoring to the MMLU benchmark

### DIFF
--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -1,6 +1,7 @@
-from typing import List, Optional, Dict, Union
+from typing import List, Optional, Dict, Union, Literal
 from tqdm import tqdm
 
+from deepeval.errors import DeepEvalError
 from deepeval.dataset import Golden
 from deepeval.benchmarks.base_benchmark import (
     DeepEvalBaseBenchmark,
@@ -22,6 +23,8 @@ class MMLU(DeepEvalBaseBenchmark):
         n_problems_per_task: Optional[int] = None,
         verbose_mode: bool = False,
         confinement_instructions: Optional[str] = None,
+        scoring_mode: Literal["generation", "logprobs"] = "generation",
+        top_logprobs: int = 20,
         **kwargs,
     ):
         from deepeval.scorer import Scorer
@@ -44,6 +47,14 @@ class MMLU(DeepEvalBaseBenchmark):
             )
         else:
             self.confinement_instructions = confinement_instructions
+        if scoring_mode not in ("generation", "logprobs"):
+            raise ValueError(
+                f"Invalid scoring_mode '{scoring_mode}'. Expected "
+                "'generation' (default) or 'logprobs'."
+            )
+        self.scoring_mode: str = scoring_mode
+        self.top_logprobs: int = top_logprobs
+        self.choices: List[str] = ["A", "B", "C", "D"]
 
     def evaluate(
         self,
@@ -59,7 +70,23 @@ class MMLU(DeepEvalBaseBenchmark):
             overall_total_predictions = 0
             predictions_row = []
             scores_row = []
-            use_batch = should_use_batch(model, batch_size)
+            if (
+                self.scoring_mode == "logprobs"
+                and model.supports_log_probs() is False
+            ):
+                raise DeepEvalError(
+                    "MMLU(scoring_mode='logprobs') requires a model that "
+                    "returns token log probabilities, but "
+                    f"`{model.get_model_name()}` reports it does not support "
+                    "`logprobs`. Use a logprob-capable model or the default "
+                    "scoring_mode='generation'."
+                )
+            # Log-prob scoring is per-item (it needs generate_raw_response), so
+            # the batch generation path does not apply.
+            use_batch = (
+                should_use_batch(model, batch_size)
+                and self.scoring_mode != "logprobs"
+            )
 
             for task in self.tasks:
                 goldens = self.load_benchmark_dataset(task)
@@ -166,6 +193,9 @@ class MMLU(DeepEvalBaseBenchmark):
     def predict(
         self, model: DeepEvalBaseLLM, task: MMLUTask, golden: Golden
     ) -> Dict:
+        if self.scoring_mode == "logprobs":
+            return self._predict_logprobs(model, task, golden)
+
         # Define prompt template
         assert (
             self.shots_dataset
@@ -200,6 +230,58 @@ class MMLU(DeepEvalBaseBenchmark):
             golden.expected_output, prediction
         )
         return {"prediction": prediction, "score": score}
+
+    def _predict_logprobs(
+        self, model: DeepEvalBaseLLM, task: MMLUTask, golden: Golden
+    ) -> Dict:
+        # Score by the log probability the model assigns to each answer option
+        # (the canonical MMLU setup) instead of parsing a generated answer.
+        if model.supports_log_probs() is False:
+            raise DeepEvalError(
+                "MMLU(scoring_mode='logprobs') requires a model that returns "
+                f"token log probabilities, but `{model.get_model_name()}` "
+                "reports it does not support `logprobs`."
+            )
+        assert (
+            self.shots_dataset
+        ), "Example dataset is empty. Call load_benchmark."
+        prompt = MMLUTemplate.generate_output(
+            train_set=self.shots_dataset,
+            input=golden.input,
+            task=task,
+            n_shots=self.n_shots,
+        )
+        # Nudge the answer option to be the first generated token, whose top
+        # log probs we then score over the candidate options.
+        prompt += f"\n\n{self.confinement_instructions}"
+
+        completion, _ = model.generate_raw_response(
+            prompt, top_logprobs=self.top_logprobs
+        )
+        top_logprobs = self._extract_first_token_top_logprobs(completion)
+        prediction = self.scorer.best_choice_from_logprobs(
+            top_logprobs, self.choices
+        )
+        # No candidate option appeared among the returned log probs.
+        prediction = "" if prediction is None else prediction
+
+        score = self.scorer.exact_match_score(
+            golden.expected_output, prediction
+        )
+        return {"prediction": prediction, "score": score}
+
+    @staticmethod
+    def _extract_first_token_top_logprobs(completion) -> List:
+        """Pull the first generated token's ``top_logprobs`` out of a raw
+        chat-completion response, tolerating providers that omit them."""
+        choices = getattr(completion, "choices", None)
+        if not choices:
+            return []
+        logprobs = getattr(choices[0], "logprobs", None)
+        content = getattr(logprobs, "content", None) if logprobs else None
+        if not content:
+            return []
+        return getattr(content[0], "top_logprobs", None) or []
 
     def batch_predict(
         self, model: DeepEvalBaseLLM, task: MMLUTask, goldens: List[Golden]

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Optional, Any
+from typing import Union, List, Optional, Any, Iterable
 import textwrap
 
 from deepeval.metrics.utils import trimAndLoadJson
@@ -122,6 +122,57 @@ class Scorer:
         if not prediction:
             return 0
         return 1 if normalize_text(prediction) in normalized_targets else 0
+
+    @classmethod
+    def best_choice_from_logprobs(
+        cls,
+        top_logprobs: Iterable[Any],
+        choices: List[str],
+    ) -> Optional[str]:
+        """Return the candidate in ``choices`` with the highest log probability.
+
+        This is the canonical way multiple-choice benchmarks (MMLU, HellaSwag,
+        TruthfulQA, ...) are scored: rather than parsing a generated answer, the
+        option the model assigned the most probability mass is selected.
+
+        ``top_logprobs`` is the set of alternative tokens for a single generated
+        position (e.g. OpenAI's ``top_logprobs``). Each item may be a
+        ``(token, logprob)`` pair, a ``{"token", "logprob"}`` mapping, or any
+        object exposing ``token``/``logprob`` attributes. Matching is
+        case-insensitive and ignores surrounding whitespace, so a token like
+        ``" B"`` matches choice ``"B"``. Returns ``None`` when none of the
+        candidates appear among the provided log probs.
+        """
+
+        def _token_logprob(item):
+            if isinstance(item, dict):
+                return item.get("token"), item.get("logprob")
+            if isinstance(item, (tuple, list)):
+                return (item[0], item[1]) if len(item) >= 2 else (None, None)
+            return getattr(item, "token", None), getattr(item, "logprob", None)
+
+        # Highest logprob seen per normalized token.
+        best_by_token = {}
+        for item in top_logprobs or []:
+            token, logprob = _token_logprob(item)
+            if token is None or logprob is None:
+                continue
+            key = str(token).strip().upper()
+            if key and (
+                key not in best_by_token or logprob > best_by_token[key]
+            ):
+                best_by_token[key] = logprob
+
+        best_choice = None
+        best_logprob = None
+        for choice in choices:
+            logprob = best_by_token.get(str(choice).strip().upper())
+            if logprob is not None and (
+                best_logprob is None or logprob > best_logprob
+            ):
+                best_choice = choice
+                best_logprob = logprob
+        return best_choice
 
     # Todo: More mode based metrics to be added
 

--- a/tests/test_benchmarks/test_benchmark_logprob_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_logprob_scoring.py
@@ -1,0 +1,145 @@
+"""
+Offline tests for optional log-probability scoring in the benchmarks
+(deepeval issue #2311). No model, network, dataset download, or API key
+required.
+"""
+
+import pytest
+
+from deepeval.scorer.scorer import Scorer
+from deepeval.benchmarks.mmlu.mmlu import MMLU
+from deepeval.benchmarks.mmlu.task import MMLUTask
+from deepeval.dataset import Golden
+from deepeval.errors import DeepEvalError
+
+
+# --------------------------------------------------------------------------- #
+# Fakes: mimic the shape of an OpenAI ChatCompletion carrying top_logprobs
+# --------------------------------------------------------------------------- #
+
+
+class _TopLogprob:
+    def __init__(self, token, logprob):
+        self.token = token
+        self.logprob = logprob
+
+
+class _Content:
+    def __init__(self, top_logprobs):
+        self.top_logprobs = top_logprobs
+
+
+class _Logprobs:
+    def __init__(self, content):
+        self.content = content
+
+
+class _Choice:
+    def __init__(self, logprobs):
+        self.logprobs = logprobs
+
+
+class _Completion:
+    def __init__(self, first_token_top_logprobs):
+        self.choices = [
+            _Choice(_Logprobs([_Content(first_token_top_logprobs)]))
+        ]
+
+
+class _FakeLogprobModel:
+    def __init__(self, top_logprobs, supports=True):
+        self._top_logprobs = top_logprobs
+        self._supports = supports
+
+    def get_model_name(self):
+        return "fake-logprob-model"
+
+    def supports_log_probs(self):
+        return self._supports
+
+    def generate_raw_response(self, prompt, top_logprobs=5):
+        return _Completion(self._top_logprobs), 0.0
+
+
+def _mmlu(scoring_mode="logprobs"):
+    # Bypass __init__ (it imports the optional `datasets`/`pandas` deps); set
+    # only the attributes the log-prob predict path touches.
+    bench = MMLU.__new__(MMLU)
+    bench.scorer = Scorer()
+    bench.scoring_mode = scoring_mode
+    bench.top_logprobs = 20
+    bench.choices = ["A", "B", "C", "D"]
+    bench.n_shots = 0  # template never indexes the shots set
+    bench.shots_dataset = [{}]  # non-empty (passes the assert)
+    bench.confinement_instructions = "Output 'A', 'B', 'C', or 'D'."
+    return bench
+
+
+# --------------------------------------------------------------------------- #
+# Scorer.best_choice_from_logprobs
+# --------------------------------------------------------------------------- #
+
+
+def test_best_choice_picks_highest_logprob():
+    top = [
+        _TopLogprob("A", -2.1),
+        _TopLogprob("B", -0.05),
+        _TopLogprob("C", -3.0),
+    ]
+    assert Scorer.best_choice_from_logprobs(top, ["A", "B", "C", "D"]) == "B"
+
+
+def test_best_choice_matches_token_ignoring_whitespace_and_case():
+    # Providers often emit the option with a leading space / different case.
+    top = [{"token": " b", "logprob": -0.1}, {"token": "A", "logprob": -0.9}]
+    assert Scorer.best_choice_from_logprobs(top, ["A", "B", "C", "D"]) == "B"
+
+
+def test_best_choice_accepts_tuple_pairs():
+    top = [("A", -0.3), ("B", -1.2)]
+    assert Scorer.best_choice_from_logprobs(top, ["A", "B", "C", "D"]) == "A"
+
+
+def test_best_choice_returns_none_when_no_candidate_present():
+    top = [_TopLogprob("hello", -0.1), _TopLogprob("world", -0.2)]
+    assert Scorer.best_choice_from_logprobs(top, ["A", "B", "C", "D"]) is None
+
+
+# --------------------------------------------------------------------------- #
+# MMLU log-prob predict path
+# --------------------------------------------------------------------------- #
+
+
+def test_mmlu_logprob_predict_scores_correct_answer():
+    # Most probability mass on "C"; golden is "C" -> score 1.
+    model = _FakeLogprobModel(
+        [
+            _TopLogprob("A", -3.0),
+            _TopLogprob("C", -0.02),
+            _TopLogprob("B", -2.0),
+        ]
+    )
+    bench = _mmlu()
+    golden = Golden(
+        input="Q\nA. w\nB. x\nC. y\nD. z\nAnswer:", expected_output="C"
+    )
+    out = bench.predict(model, list(MMLUTask)[0], golden)
+    assert out["prediction"] == "C"
+    assert out["score"] == 1
+
+
+def test_mmlu_logprob_predict_marks_wrong_answer():
+    model = _FakeLogprobModel([_TopLogprob("A", -0.02), _TopLogprob("C", -3.0)])
+    bench = _mmlu()
+    golden = Golden(input="Q\nAnswer:", expected_output="C")
+    out = bench.predict(model, list(MMLUTask)[0], golden)
+    assert out["prediction"] == "A"
+    assert out["score"] == 0
+
+
+def test_mmlu_logprob_guard_raises_for_unsupported_model():
+    model = _FakeLogprobModel([], supports=False)
+    bench = _mmlu()
+    golden = Golden(input="Q\nAnswer:", expected_output="A")
+    with pytest.raises(DeepEvalError):
+        bench.predict(model, list(MMLUTask)[0], golden)


### PR DESCRIPTION
## Description

Adds an opt-in log-probability scoring path to the MMLU benchmark. Benchmarks like MMLU are canonically scored by the probability the model assigns to each answer option, rather than by parsing a generated answer. This wires that in, reusing the existing `generate_raw_response` / `supports_log_probs()` on `DeepEvalBaseLLM`. It is fully backward-compatible — the default is unchanged.

```python
MMLU().evaluate(model)                            # unchanged default (generation scoring)
MMLU(scoring_mode="logprobs").evaluate(lp_model)  # opt in to logprob scoring
```

### What changed
- `deepeval/scorer/scorer.py`: new reusable `Scorer.best_choice_from_logprobs(top_logprobs, choices)` — picks the option with the highest logprob; tolerant of provider token shapes (leading space / case) and of an option not appearing. Reusable for HellaSwag/TruthfulQA in follow-ups.
- `deepeval/benchmarks/mmlu/mmlu.py`: `scoring_mode` (`"generation"` default | `"logprobs"`) and `top_logprobs` args; a `_predict_logprobs` path scoring via `generate_raw_response`; a clear `DeepEvalError` when the model reports `supports_log_probs() is False`; the batch path is skipped in logprob mode (it needs `generate_raw_response`).
- Tests: `tests/test_benchmarks/test_benchmark_logprob_scoring.py` — offline (no model/network/keys), covering the scorer helper, correct/incorrect scoring, and the unsupported-model guard.

### Notes / open to feedback
- `scoring_mode` is on the constructor (consistent with `n_shots`, `verbose_mode`); happy to move it onto `evaluate(...)` if you'd prefer.
- For the letter-based schema I score the option-letter logprobs at the answer position (via `top_logprobs`). Can switch to full-continuation logprob scoring if you'd rather.
- MMLU first, as discussed; the scorer helper is shared so HellaSwag/TruthfulQA can follow.

### Testing
`pytest tests/test_benchmarks/test_benchmark_logprob_scoring.py` (7 passing); existing benchmark tests still green; `black` clean.

Addresses #2311 (MMLU first).
