### PR TITLE
docs: fix typos in Bedrock integration and RAG QA tutorial

### DIFF
--- a/docs/content/integrations/models/amazon-bedrock.mdx
+++ b/docs/content/integrations/models/amazon-bedrock.mdx
@@ -89,8 +89,8 @@ There are **ZERO** mandatory and **SEVEN** optional parameters when creating an 
 
 - [Optional] `model`: A string specifying the bedrock model identifier to call (e.g. `anthropic.claude-3-opus-20240229-v1:0`). Defaults to `AWS_BEDROCK_MODEL_NAME` if not passed; raises an error at runtime if unset.
 - [Optional] `region`: A string specifying the AWS region hosting your Bedrock endpoint (e.g. `us-east-1`). Defaults to `AWS_BEDROCK_REGION` if not passed; raises an error at runtime if unset.
-- [Optional] `aws_access_key_id`: A string specifiying your AWS Access Key ID. Defaults to `AWS_ACCESS_KEY_ID` if not passed; if still omitted, falls back to the AWS default credentials chain.
-- [Optional] `aws_secret_access_key`: A string specifiying your AWS Secret Access Key. Defaults to `AWS_SECRET_ACCESS_KEY` if not passed; if still omitted, falls back to the AWS default credentials chain.
+- [Optional] `aws_access_key_id`: A string specifying your AWS Access Key ID. Defaults to `AWS_ACCESS_KEY_ID` if not passed; if still omitted, falls back to the AWS default credentials chain.
+- [Optional] `aws_secret_access_key`: A string specifying your AWS Secret Access Key. Defaults to `AWS_SECRET_ACCESS_KEY` if not passed; if still omitted, falls back to the AWS default credentials chain.
 - [Optional] `cost_per_input_token`: A float specifying the per-input-token cost in USD. Defaults to `AWS_BEDROCK_COST_PER_INPUT_TOKEN` if available in `deepeval`'s model cost registry, else `None`.
 - [Optional] `cost_per_output_token`: A float specifying the per-output-token cost in USD. Defaults to `AWS_BEDROCK_COST_PER_OUTPUT_TOKEN` if available in `deepeval`'s model cost registry, else `None`.
 - [Optional] `generation_kwargs`: A dictionary of generation parameters that will be sent to Bedrock as `inferenceConfig`. Available keys may vary by the Bedrock model you choose. See the [AWS Bedrock inference parameters docs](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-parameters.html).

--- a/docs/content/tutorials/rag-qa-agent/evaluation.mdx
+++ b/docs/content/tutorials/rag-qa-agent/evaluation.mdx
@@ -30,7 +30,7 @@ test_case = LLMTestCase(
 
 When evaluating RAG based applications, **you don't want to evaluate it on a random set of queries.** You will have to create questions and queries that test the RAG application's abilities on edge cases that are in and outside your knowledge base.
 
-## Setup Testing Enviroment
+## Setup Testing Environment
 
 There are 2 primary approaches to evaluating RAG based applications. They are:
 
@@ -62,7 +62,7 @@ for query in queries:
 print(test_cases)
 ```
 
-This method is the quickest because the data already exists, however it might not be feasible becuase you may or may not store the retrieval context in your database. It also provides insights from the pevious knowledge base and does not represent your current RAG agent's capabilities. Hence, this is not recommended.
+This method is the quickest because the data already exists, however it might not be feasible because you may or may not store the retrieval context in your database. It also provides insights from the previous knowledge base and does not represent your current RAG agent's capabilities. Hence, this is not recommended.
 
 ### Generate QA Pairs
 


### PR DESCRIPTION
## What

Fixes four spelling errors in the docs:

- `docs/content/integrations/models/amazon-bedrock.mdx` — `specifiying` → `specifying` (two occurrences, in the `aws_access_key_id` and `aws_secret_access_key` descriptions)
- `docs/content/tutorials/rag-qa-agent/evaluation.mdx` — `Enviroment` → `Environment` in a section heading, and `becuase` → `because` plus `pevious` → `previous` in the paragraph on reusing existing retrieval context

## Why

These are user-facing docs pages. The Bedrock page is the reference for optional parameters, so a misspelling next to the parameter names is easy to mistake for part of the API surface.

## How it was checked

- Text-only changes: no parameter names, code samples, or links were touched.
- Grepped the repo for `#setup-testing-enviroment` before renaming the heading — there are no inbound anchor links to it, so the rename does not create a dead link.
- `git diff --check` reports no whitespace issues; code fences in both files remain balanced.

No functional change.
