### PR TITLE
feat: add optional Wilson score intervals to pass rate reporting

### DIFF
--- a/deepeval/evaluate/configs.py
+++ b/deepeval/evaluate/configs.py
@@ -27,6 +27,9 @@ class DisplayConfig:
     results_folder: Optional[str] = None
     results_subfolder: Optional[str] = None
     truncate_passing_cases: bool = True
+    # Append a 95% Wilson score interval to per-metric pass rates. Helpful
+    # for small suites, where a bare percentage hides sampling noise.
+    show_confidence_intervals: bool = False
     # Offer `deepeval inspect` after the run. Honors `DEEPEVAL_NO_INSPECT_PROMPT=1`.
     inspect_after_run: bool = True
     # Deprecated: writes one .log per TestResult. Prefer `results_folder`, which

--- a/deepeval/evaluate/console_report.py
+++ b/deepeval/evaluate/console_report.py
@@ -11,6 +11,7 @@ from rich.terminal_theme import TerminalTheme
 
 from deepeval.evaluate.types import TestResult
 from deepeval.test_run.test_run import TestRunResultDisplay
+from deepeval.evaluate.statistics import wilson_interval
 
 LIGHT_THEME = TerminalTheme(
     background=(0, 0, 0),
@@ -51,10 +52,16 @@ def _natural_sort_key(s: str):
     ]
 
 
-def _format_pass_rate(agg: dict) -> str:
+def _format_pass_rate(agg: dict, show_interval: bool = False) -> str:
     """Format pass rate with pass/fail counts, each with its flaky sub-count."""
     verdicts = agg["passes"] + agg["fails"]
     rate = f"{(agg['passes'] / verdicts) * 100:.2f}%" if verdicts > 0 else "N/A"
+
+    if show_interval and verdicts > 0:
+        ci = wilson_interval(agg["passes"], verdicts)
+        if ci is not None:
+            rate += f" [{ci[0] * 100:.1f}–{ci[1] * 100:.1f}]"
+
     passed = f"passed={agg['passes']}"
     if agg["flaky_passes"] > 0:
         passed += f" (flaky={agg['flaky_passes']})"
@@ -90,6 +97,7 @@ class EvaluationConsoleReport:
         self,
         truncate: bool = True,
         display_option: TestRunResultDisplay = TestRunResultDisplay.ALL,
+        show_confidence_intervals: bool = False,
     ) -> Group:
 
         renderables = [
@@ -259,7 +267,7 @@ class EvaluationConsoleReport:
                     if agg["score_count"] > 0
                     else "N/A"
                 )
-                pass_rate = _format_pass_rate(agg)
+                pass_rate = _format_pass_rate(agg, show_confidence_intervals)
                 agg_table.add_row(
                     metric_name, avg_score, pass_rate, str(agg["total"])
                 )
@@ -274,12 +282,14 @@ class EvaluationConsoleReport:
         self,
         truncate_passing_cases: bool = True,
         display_option: TestRunResultDisplay = TestRunResultDisplay.ALL,
+        show_confidence_intervals: bool = False,
     ):
         self.console.print()
         self.console.print(
             self._build_display_elements(
                 truncate=truncate_passing_cases,
                 display_option=display_option,
+                show_confidence_intervals=show_confidence_intervals,
             )
         )
         self.console.print()

--- a/deepeval/evaluate/evaluate.py
+++ b/deepeval/evaluate/evaluate.py
@@ -258,6 +258,7 @@ def evaluate(
             console_report = EvaluationConsoleReport(test_results)
             console_report.render_to_terminal(
                 truncate_passing_cases=display_config.truncate_passing_cases,
+                show_confidence_intervals=display_config.show_confidence_intervals,
                 display_option=display_config.display_option,
             )
 

--- a/deepeval/evaluate/statistics.py
+++ b/deepeval/evaluate/statistics.py
@@ -1,0 +1,64 @@
+"""Statistical helpers for aggregate evaluation reporting."""
+
+import math
+from typing import Optional, Tuple
+
+# Two-sided standard normal critical values.
+_Z_SCORES = {
+    0.80: 1.2816,
+    0.90: 1.6449,
+    0.95: 1.9600,
+    0.99: 2.5758,
+}
+
+
+def wilson_interval(
+    successes: int,
+    n: int,
+    confidence: float = 0.95,
+) -> Optional[Tuple[float, float]]:
+    """Wilson score interval for a binomial proportion.
+
+    Preferred over the normal approximation (Wald) interval, which can
+    produce bounds outside [0, 1] and collapses to a single point when
+    all observations succeed or all fail. Both cases are common in
+    evaluation suites, which are typically small and tuned so that most
+    test cases pass.
+
+    Note this describes sampling uncertainty only: it reflects that the
+    suite is a sample of possible inputs, not the run-to-run variance of
+    a nondeterministic judge model.
+
+    Args:
+        successes: Number of passing observations.
+        n: Total number of observations with a verdict.
+        confidence: Confidence level. One of 0.80, 0.90, 0.95, 0.99.
+
+    Returns:
+        (lower, upper) as proportions in [0, 1], or None if n <= 0.
+
+    Raises:
+        ValueError: If confidence is unsupported or successes is invalid.
+    """
+    if n <= 0:
+        return None
+    if successes < 0 or successes > n:
+        raise ValueError(
+            f"'successes' must be between 0 and {n}, got {successes}"
+        )
+
+    z = _Z_SCORES.get(confidence)
+    if z is None:
+        raise ValueError(
+            f"Unsupported confidence level: {confidence}. "
+            f"Expected one of {sorted(_Z_SCORES)}."
+        )
+
+    p = successes / n
+    z_sq = z * z
+
+    denominator = 1 + z_sq / n
+    center = (p + z_sq / (2 * n)) / denominator
+    margin = (z * math.sqrt(p * (1 - p) / n + z_sq / (4 * n * n))) / denominator
+
+    return (max(0.0, center - margin), min(1.0, center + margin))

--- a/tests/test_core/test_statistics.py
+++ b/tests/test_core/test_statistics.py
@@ -1,0 +1,51 @@
+import math
+import pytest
+
+from deepeval.evaluate.statistics import wilson_interval
+
+
+def test_returns_none_for_zero_observations():
+    assert wilson_interval(0, 0) is None
+
+
+def test_all_failures_does_not_collapse_to_zero():
+    # Wald would return (0.0, 0.0), claiming certainty from 10 samples.
+    lower, upper = wilson_interval(0, 10)
+    assert lower == 0.0
+    assert upper == pytest.approx(0.2775, abs=1e-3)
+
+
+def test_all_passes_does_not_collapse_to_one():
+    # Wald would return (1.0, 1.0).
+    lower, upper = wilson_interval(40, 40)
+    assert lower == pytest.approx(0.9124, abs=1e-3)
+    assert upper == 1.0
+
+
+def test_known_value():
+    lower, upper = wilson_interval(34, 40)
+    assert lower == pytest.approx(0.7093, abs=1e-3)
+    assert upper == pytest.approx(0.9294, abs=1e-3)
+
+
+def test_bounds_always_within_unit_interval():
+    for n in range(1, 60):
+        for k in range(n + 1):
+            lower, upper = wilson_interval(k, n)
+            assert 0.0 <= lower <= upper <= 1.0
+
+
+def test_interval_narrows_as_sample_grows():
+    small = wilson_interval(17, 20)
+    large = wilson_interval(170, 200)
+    assert (large[1] - large[0]) < (small[1] - small[0])
+
+
+def test_rejects_successes_greater_than_n():
+    with pytest.raises(ValueError):
+        wilson_interval(11, 10)
+
+
+def test_rejects_unsupported_confidence():
+    with pytest.raises(ValueError):
+        wilson_interval(5, 10, confidence=0.975)


### PR DESCRIPTION
## Problem

Pass rates are reported as bare percentages with no indication of sampling
uncertainty. Running a single passing test case currently prints:

Answer Relevancy | 100.00% | passed=1 | failed=0

One observation cannot establish a 100% pass rate, but nothing in the output
says so.

## Why Wilson

The normal approximation (Wald) produces bounds outside [0, 1] and collapses
to a single point when all cases pass or all fail — both common in tuned eval
suites. For 0/10 it reports [0%, 0%], claiming certainty from ten
observations; for 19/20 it reports an upper bound above 100%.

## Change

Adds `DisplayConfig.show_confidence_intervals` (default `False`). When
enabled, per-metric pass rates in the terminal report gain a 95% Wilson
score interval:

Answer Relevancy | 100.00% [20.7–100.0] | passed=1 | failed=0
Answer Relevancy | 85.00% [70.9–92.9] | passed=34 | failed=6