### PR TITLE
fix: return async tool correctness score

### DIFF
--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -89,7 +89,7 @@ class ToolCorrectnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/tests/test_metrics/test_tool_correctness_metric.py
+++ b/tests/test_metrics/test_tool_correctness_metric.py
@@ -55,16 +55,15 @@ class TestToolCorrectnessMetricType:
 
         assert metric.score == 1.0
         assert metric.success is True
-    
+
     def test_measure_returns_score_in_async_mode(self):
         metric = ToolCorrectnessMetric()
-        test_case = build_test_case(
-            ToolCallType.MCP, ToolCallType.MCP
-        )
+        test_case = build_test_case(ToolCallType.MCP, ToolCallType.MCP)
 
         result = metric.measure(test_case, _show_indicator=False)
 
         assert result == 1.0
+
     def test_type_mismatch_fails_exact_match(self):
         metric = ToolCorrectnessMetric(
             async_mode=False, should_exact_match=True

--- a/tests/test_metrics/test_tool_correctness_metric.py
+++ b/tests/test_metrics/test_tool_correctness_metric.py
@@ -55,7 +55,16 @@ class TestToolCorrectnessMetricType:
 
         assert metric.score == 1.0
         assert metric.success is True
+    
+    def test_measure_returns_score_in_async_mode(self):
+        metric = ToolCorrectnessMetric()
+        test_case = build_test_case(
+            ToolCallType.MCP, ToolCallType.MCP
+        )
 
+        result = metric.measure(test_case, _show_indicator=False)
+
+        assert result == 1.0
     def test_type_mismatch_fails_exact_match(self):
         metric = ToolCorrectnessMetric(
             async_mode=False, should_exact_match=True


### PR DESCRIPTION
Fixes #3088.

### What changed

`ToolCorrectnessMetric.measure()` did not return the result of `a_measure()` when `async_mode=True`, causing it to return `None` even though `metric.score` was correctly set.

This change returns the result of `a_measure()` from the async path.

### Test

Added a regression test verifying that `measure()` returns the expected score with the default async mode.

Verified:

- 8 tests passed in `tests/test_metrics/test_tool_correctness_metric.py`
- Regression test failed before the fix and passed after the fix