### PR TITLE
fix(metrics): measure() returns the score under async_mode=True across all metrics

### DIFF
--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -81,7 +81,7 @@ class AnswerRelevancyMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/arena_g_eval/arena_g_eval.py
+++ b/deepeval/metrics/arena_g_eval/arena_g_eval.py
@@ -86,7 +86,7 @@ class ArenaGEval(BaseArenaMetric):
         with metric_progress_indicator(self, _show_indicator=_show_indicator):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/argument_correctness/argument_correctness.py
+++ b/deepeval/metrics/argument_correctness/argument_correctness.py
@@ -81,7 +81,7 @@ class ArgumentCorrectnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -79,7 +79,7 @@ class BiasMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/community/citation_faithfulness/citation_faithfulness.py
+++ b/deepeval/metrics/community/citation_faithfulness/citation_faithfulness.py
@@ -90,7 +90,7 @@ class CitationFaithfulnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -103,7 +103,7 @@ class ContextualPrecisionMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -115,7 +115,7 @@ class ContextualRecallMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -116,7 +116,7 @@ class ContextualRelevancyMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/conversation_completeness/conversation_completeness.py
+++ b/deepeval/metrics/conversation_completeness/conversation_completeness.py
@@ -82,7 +82,7 @@ class ConversationCompletenessMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/conversational_dag/conversational_dag.py
+++ b/deepeval/metrics/conversational_dag/conversational_dag.py
@@ -77,7 +77,7 @@ class ConversationalDAGMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
+++ b/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
@@ -123,7 +123,7 @@ class ConversationalGEval(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/dag/dag.py
+++ b/deepeval/metrics/dag/dag.py
@@ -82,7 +82,7 @@ class DAGMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -113,7 +113,7 @@ class FaithfulnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -131,7 +131,7 @@ class GEval(BaseMetric):
                     _additional_context=_additional_context,
                 )
                 settings = get_settings()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     asyncio.wait_for(
                         coro,
                         timeout=(

--- a/deepeval/metrics/goal_accuracy/goal_accuracy.py
+++ b/deepeval/metrics/goal_accuracy/goal_accuracy.py
@@ -78,7 +78,7 @@ class GoalAccuracyMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -82,7 +82,7 @@ class HallucinationMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/json_correctness/json_correctness.py
+++ b/deepeval/metrics/json_correctness/json_correctness.py
@@ -82,7 +82,7 @@ class JsonCorrectnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -73,7 +73,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/mcp/mcp_task_completion.py
+++ b/deepeval/metrics/mcp/mcp_task_completion.py
@@ -78,7 +78,7 @@ class MCPTaskCompletionMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
+++ b/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
@@ -73,7 +73,7 @@ class MultiTurnMCPUseMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/mcp_use_metric/mcp_use_metric.py
+++ b/deepeval/metrics/mcp_use_metric/mcp_use_metric.py
@@ -80,7 +80,7 @@ class MCPUseMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/misuse/misuse.py
+++ b/deepeval/metrics/misuse/misuse.py
@@ -85,7 +85,7 @@ class MisuseMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_coherence/image_coherence.py
+++ b/deepeval/metrics/multimodal_metrics/image_coherence/image_coherence.py
@@ -77,7 +77,7 @@ class ImageCoherenceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_editing/image_editing.py
+++ b/deepeval/metrics/multimodal_metrics/image_editing/image_editing.py
@@ -75,7 +75,7 @@ class ImageEditingMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_helpfulness/image_helpfulness.py
+++ b/deepeval/metrics/multimodal_metrics/image_helpfulness/image_helpfulness.py
@@ -78,7 +78,7 @@ class ImageHelpfulnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_reference/image_reference.py
+++ b/deepeval/metrics/multimodal_metrics/image_reference/image_reference.py
@@ -78,7 +78,7 @@ class ImageReferenceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/text_to_image/text_to_image.py
+++ b/deepeval/metrics/multimodal_metrics/text_to_image/text_to_image.py
@@ -74,7 +74,7 @@ class TextToImageMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/non_advice/non_advice.py
+++ b/deepeval/metrics/non_advice/non_advice.py
@@ -91,7 +91,7 @@ class NonAdviceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/pii_leakage/pii_leakage.py
+++ b/deepeval/metrics/pii_leakage/pii_leakage.py
@@ -79,7 +79,7 @@ class PIILeakageMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/plan_adherence/plan_adherence.py
+++ b/deepeval/metrics/plan_adherence/plan_adherence.py
@@ -82,7 +82,7 @@ class PlanAdherenceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/plan_quality/plan_quality.py
+++ b/deepeval/metrics/plan_quality/plan_quality.py
@@ -80,7 +80,7 @@ class PlanQualityMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/prompt_alignment/prompt_alignment.py
+++ b/deepeval/metrics/prompt_alignment/prompt_alignment.py
@@ -93,7 +93,7 @@ class PromptAlignmentMetric(BaseMetric):
                     _show_indicator=False,
                     _in_component=_in_component,
                 )
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     asyncio.wait_for(
                         coro,
                         timeout=get_per_task_timeout(),

--- a/deepeval/metrics/role_adherence/role_adherence.py
+++ b/deepeval/metrics/role_adherence/role_adherence.py
@@ -72,7 +72,7 @@ class RoleAdherenceMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/role_violation/role_violation.py
+++ b/deepeval/metrics/role_violation/role_violation.py
@@ -88,7 +88,7 @@ class RoleViolationMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/step_efficiency/step_efficiency.py
+++ b/deepeval/metrics/step_efficiency/step_efficiency.py
@@ -74,7 +74,7 @@ class StepEfficiencyMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -106,7 +106,7 @@ class SummarizationMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/task_completion/task_completion.py
+++ b/deepeval/metrics/task_completion/task_completion.py
@@ -88,7 +88,7 @@ class TaskCompletionMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -89,7 +89,7 @@ class ToolCorrectnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/tool_use/tool_use.py
+++ b/deepeval/metrics/tool_use/tool_use.py
@@ -83,7 +83,7 @@ class ToolUseMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/topic_adherence/topic_adherence.py
+++ b/deepeval/metrics/topic_adherence/topic_adherence.py
@@ -79,7 +79,7 @@ class TopicAdherenceMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -80,7 +80,7 @@ class ToxicityMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_contextual_precision/turn_contextual_precision.py
+++ b/deepeval/metrics/turn_contextual_precision/turn_contextual_precision.py
@@ -109,7 +109,7 @@ class TurnContextualPrecisionMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
+++ b/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
@@ -116,7 +116,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_contextual_relevancy/turn_contextual_relevancy.py
+++ b/deepeval/metrics/turn_contextual_relevancy/turn_contextual_relevancy.py
@@ -120,7 +120,7 @@ class TurnContextualRelevancyMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_faithfulness/turn_faithfulness.py
+++ b/deepeval/metrics/turn_faithfulness/turn_faithfulness.py
@@ -106,7 +106,7 @@ class TurnFaithfulnessMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_relevancy/turn_relevancy.py
+++ b/deepeval/metrics/turn_relevancy/turn_relevancy.py
@@ -81,7 +81,7 @@ class TurnRelevancyMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/tests/test_metrics/test_measure_returns_score.py
+++ b/tests/test_metrics/test_measure_returns_score.py
@@ -51,7 +51,9 @@ def test_every_metric_measure_returns_under_async_mode():
         for node in ast.walk(tree):
             if isinstance(node, ast.FunctionDef) and node.name == "measure":
                 if _async_branch_discards(node):
-                    offenders.append(str(path.relative_to(METRICS_DIR.parent.parent)))
+                    offenders.append(
+                        str(path.relative_to(METRICS_DIR.parent.parent))
+                    )
     assert not offenders, (
         "measure() discards the a_measure result in the async_mode branch, so "
         "it returns None under the default async_mode=True, in: "

--- a/tests/test_metrics/test_measure_returns_score.py
+++ b/tests/test_metrics/test_measure_returns_score.py
@@ -1,0 +1,59 @@
+"""Every metric's measure() must return its score under async_mode=True.
+
+Regression net for https://github.com/confident-ai/deepeval/issues/3088.
+46 of 47 metrics ran ``loop.run_until_complete(self.a_measure(...))`` in the
+async branch of ``measure()`` and discarded the result, so ``measure()``
+returned ``None`` under the default mode while the sync branch returned the
+score. Callers that rely on the return value (including
+``deepeval/optimizer/scorer/scorer.py``, which wraps it in ``float()``) broke
+only on the default path.
+
+The check is structural, so it needs no model or API key and covers every
+metric, including ones added after this test: any ``measure()`` whose
+``async_mode`` branch fails to return a value fails here by name.
+"""
+
+import ast
+from pathlib import Path
+
+METRICS_DIR = Path(__file__).resolve().parents[2] / "deepeval" / "metrics"
+
+
+def _async_branch_discards(measure_fn: ast.FunctionDef) -> bool:
+    """True when the async_mode branch contains run_until_complete but no
+    return-with-value, i.e. the a_measure result is computed and dropped."""
+    for node in ast.walk(measure_fn):
+        if not isinstance(node, ast.If):
+            continue
+        if "async_mode" not in ast.unparse(node.test):
+            continue
+        branch = ast.Module(body=node.body, type_ignores=[])
+        runs_coro = any(
+            isinstance(n, ast.Attribute) and n.attr == "run_until_complete"
+            for n in ast.walk(branch)
+        )
+        returns_value = any(
+            isinstance(n, ast.Return) and n.value is not None
+            for n in ast.walk(branch)
+        )
+        if runs_coro and not returns_value:
+            return True
+    return False
+
+
+def test_every_metric_measure_returns_under_async_mode():
+    offenders = []
+    for path in sorted(METRICS_DIR.rglob("*.py")):
+        source = path.read_text(encoding="utf-8", errors="replace")
+        if "run_until_complete" not in source:
+            continue
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "measure":
+                if _async_branch_discards(node):
+                    offenders.append(str(path.relative_to(METRICS_DIR.parent.parent)))
+    assert not offenders, (
+        "measure() discards the a_measure result in the async_mode branch, so "
+        "it returns None under the default async_mode=True, in: "
+        + ", ".join(offenders)
+    )


### PR DESCRIPTION
Closes #3088 for the whole metrics tree, not just `ToolCorrectnessMetric`.

An AST sweep over `deepeval/metrics` found 46 of 47 metrics whose `measure()` runs `loop.run_until_complete(self.a_measure(...))` in the `async_mode` branch and discards the result, so `measure()` returns `None` under the default mode while the sync branch returns the score. `agent_loop_detection` already returns it and shows the intended convention. The internal caller in `deepeval/optimizer/scorer/scorer.py` wraps `measure()` in `float()`, which raises `TypeError` on this path.

**Change:** one line per metric, `return loop.run_until_complete(...)`, 46 files, no other edits.

**Regression net:** `tests/test_metrics/test_measure_returns_score.py` walks every metric's `measure()` structurally (no model, no API key) and fails by name if an `async_mode` branch drops its return, so the next metric added with the old copy-paste shape fails CI immediately. Verified failing on unpatched main (names all 46) and passing on this branch.

**Runtime confirmation** with the issue's repro on this branch: `ToolCorrectnessMetric().measure(tc)` returns `1.0` under default `async_mode`.

Overlaps #3089 on the single `tool_correctness` line; if that lands first this rebases cleanly, and the conformance test here still protects the other 45 plus every future metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)