### PR TITLE
fix(metrics): return the score from measure() on the default async path

### DIFF
--- a/deepeval/metrics/agent_loop_detection/agent_loop_detection.py
+++ b/deepeval/metrics/agent_loop_detection/agent_loop_detection.py
@@ -169,7 +169,7 @@ class AgentLoopDetectionMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/answer_relevancy/answer_relevancy.py
+++ b/deepeval/metrics/answer_relevancy/answer_relevancy.py
@@ -81,7 +81,7 @@ class AnswerRelevancyMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/arena_g_eval/arena_g_eval.py
+++ b/deepeval/metrics/arena_g_eval/arena_g_eval.py
@@ -86,7 +86,7 @@ class ArenaGEval(BaseArenaMetric):
         with metric_progress_indicator(self, _show_indicator=_show_indicator):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/argument_correctness/argument_correctness.py
+++ b/deepeval/metrics/argument_correctness/argument_correctness.py
@@ -81,7 +81,7 @@ class ArgumentCorrectnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/bias/bias.py
+++ b/deepeval/metrics/bias/bias.py
@@ -79,7 +79,7 @@ class BiasMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/community/citation_faithfulness/citation_faithfulness.py
+++ b/deepeval/metrics/community/citation_faithfulness/citation_faithfulness.py
@@ -90,7 +90,7 @@ class CitationFaithfulnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -103,7 +103,7 @@ class ContextualPrecisionMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -115,7 +115,7 @@ class ContextualRecallMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -116,7 +116,7 @@ class ContextualRelevancyMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/conversation_completeness/conversation_completeness.py
+++ b/deepeval/metrics/conversation_completeness/conversation_completeness.py
@@ -82,7 +82,7 @@ class ConversationCompletenessMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/conversational_dag/conversational_dag.py
+++ b/deepeval/metrics/conversational_dag/conversational_dag.py
@@ -77,7 +77,7 @@ class ConversationalDAGMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
+++ b/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
@@ -123,7 +123,7 @@ class ConversationalGEval(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/dag/dag.py
+++ b/deepeval/metrics/dag/dag.py
@@ -82,7 +82,7 @@ class DAGMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/faithfulness/faithfulness.py
+++ b/deepeval/metrics/faithfulness/faithfulness.py
@@ -113,7 +113,7 @@ class FaithfulnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/g_eval/g_eval.py
+++ b/deepeval/metrics/g_eval/g_eval.py
@@ -131,7 +131,7 @@ class GEval(BaseMetric):
                     _additional_context=_additional_context,
                 )
                 settings = get_settings()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     asyncio.wait_for(
                         coro,
                         timeout=(

--- a/deepeval/metrics/goal_accuracy/goal_accuracy.py
+++ b/deepeval/metrics/goal_accuracy/goal_accuracy.py
@@ -78,7 +78,7 @@ class GoalAccuracyMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -82,7 +82,7 @@ class HallucinationMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/json_correctness/json_correctness.py
+++ b/deepeval/metrics/json_correctness/json_correctness.py
@@ -82,7 +82,7 @@ class JsonCorrectnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -73,7 +73,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/mcp/mcp_task_completion.py
+++ b/deepeval/metrics/mcp/mcp_task_completion.py
@@ -78,7 +78,7 @@ class MCPTaskCompletionMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
+++ b/deepeval/metrics/mcp/multi_turn_mcp_use_metric.py
@@ -73,7 +73,7 @@ class MultiTurnMCPUseMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/mcp_use_metric/mcp_use_metric.py
+++ b/deepeval/metrics/mcp_use_metric/mcp_use_metric.py
@@ -80,7 +80,7 @@ class MCPUseMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/misuse/misuse.py
+++ b/deepeval/metrics/misuse/misuse.py
@@ -85,7 +85,7 @@ class MisuseMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_coherence/image_coherence.py
+++ b/deepeval/metrics/multimodal_metrics/image_coherence/image_coherence.py
@@ -77,7 +77,7 @@ class ImageCoherenceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_editing/image_editing.py
+++ b/deepeval/metrics/multimodal_metrics/image_editing/image_editing.py
@@ -75,7 +75,7 @@ class ImageEditingMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_helpfulness/image_helpfulness.py
+++ b/deepeval/metrics/multimodal_metrics/image_helpfulness/image_helpfulness.py
@@ -78,7 +78,7 @@ class ImageHelpfulnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/image_reference/image_reference.py
+++ b/deepeval/metrics/multimodal_metrics/image_reference/image_reference.py
@@ -78,7 +78,7 @@ class ImageReferenceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/multimodal_metrics/text_to_image/text_to_image.py
+++ b/deepeval/metrics/multimodal_metrics/text_to_image/text_to_image.py
@@ -74,7 +74,7 @@ class TextToImageMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/non_advice/non_advice.py
+++ b/deepeval/metrics/non_advice/non_advice.py
@@ -91,7 +91,7 @@ class NonAdviceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/pii_leakage/pii_leakage.py
+++ b/deepeval/metrics/pii_leakage/pii_leakage.py
@@ -79,7 +79,7 @@ class PIILeakageMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/plan_adherence/plan_adherence.py
+++ b/deepeval/metrics/plan_adherence/plan_adherence.py
@@ -82,7 +82,7 @@ class PlanAdherenceMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/plan_quality/plan_quality.py
+++ b/deepeval/metrics/plan_quality/plan_quality.py
@@ -80,7 +80,7 @@ class PlanQualityMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/prompt_alignment/prompt_alignment.py
+++ b/deepeval/metrics/prompt_alignment/prompt_alignment.py
@@ -93,7 +93,7 @@ class PromptAlignmentMetric(BaseMetric):
                     _show_indicator=False,
                     _in_component=_in_component,
                 )
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     asyncio.wait_for(
                         coro,
                         timeout=get_per_task_timeout(),

--- a/deepeval/metrics/role_adherence/role_adherence.py
+++ b/deepeval/metrics/role_adherence/role_adherence.py
@@ -72,7 +72,7 @@ class RoleAdherenceMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/role_violation/role_violation.py
+++ b/deepeval/metrics/role_violation/role_violation.py
@@ -88,7 +88,7 @@ class RoleViolationMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/step_efficiency/step_efficiency.py
+++ b/deepeval/metrics/step_efficiency/step_efficiency.py
@@ -74,7 +74,7 @@ class StepEfficiencyMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -106,7 +106,7 @@ class SummarizationMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/task_completion/task_completion.py
+++ b/deepeval/metrics/task_completion/task_completion.py
@@ -88,7 +88,7 @@ class TaskCompletionMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -89,7 +89,7 @@ class ToolCorrectnessMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/tool_use/tool_use.py
+++ b/deepeval/metrics/tool_use/tool_use.py
@@ -83,7 +83,7 @@ class ToolUseMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/topic_adherence/topic_adherence.py
+++ b/deepeval/metrics/topic_adherence/topic_adherence.py
@@ -79,7 +79,7 @@ class TopicAdherenceMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/toxicity/toxicity.py
+++ b/deepeval/metrics/toxicity/toxicity.py
@@ -80,7 +80,7 @@ class ToxicityMetric(BaseMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_contextual_precision/turn_contextual_precision.py
+++ b/deepeval/metrics/turn_contextual_precision/turn_contextual_precision.py
@@ -109,7 +109,7 @@ class TurnContextualPrecisionMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
+++ b/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
@@ -116,7 +116,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_contextual_relevancy/turn_contextual_relevancy.py
+++ b/deepeval/metrics/turn_contextual_relevancy/turn_contextual_relevancy.py
@@ -120,7 +120,7 @@ class TurnContextualRelevancyMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_faithfulness/turn_faithfulness.py
+++ b/deepeval/metrics/turn_faithfulness/turn_faithfulness.py
@@ -106,7 +106,7 @@ class TurnFaithfulnessMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/deepeval/metrics/turn_relevancy/turn_relevancy.py
+++ b/deepeval/metrics/turn_relevancy/turn_relevancy.py
@@ -81,7 +81,7 @@ class TurnRelevancyMetric(BaseConversationalMetric):
         ):
             if self.async_mode:
                 loop = get_or_create_event_loop()
-                loop.run_until_complete(
+                return loop.run_until_complete(
                     self.a_measure(
                         test_case,
                         _show_indicator=False,

--- a/tests/test_metrics/test_measure_return_value.py
+++ b/tests/test_metrics/test_measure_return_value.py
@@ -1,6 +1,9 @@
 import os
 
-os.environ.setdefault("OPENAI_API_KEY", "dummy-key-for-regression-test")
+# Force-set (not setdefault): CI exports an EMPTY OPENAI_API_KEY, and
+# ToolCorrectnessMetric never calls the API — it only needs a non-empty
+# value so model-client construction passes validation.
+os.environ["OPENAI_API_KEY"] = "dummy-key-for-regression-test"
 
 from deepeval.metrics import ToolCorrectnessMetric
 from deepeval.test_case import LLMTestCase, ToolCall

--- a/tests/test_metrics/test_measure_return_value.py
+++ b/tests/test_metrics/test_measure_return_value.py
@@ -1,9 +1,4 @@
-import os
-
-# Force-set (not setdefault): CI exports an EMPTY OPENAI_API_KEY, and
-# ToolCorrectnessMetric never calls the API — it only needs a non-empty
-# value so model-client construction passes validation.
-os.environ["OPENAI_API_KEY"] = "dummy-key-for-regression-test"
+import pytest
 
 from deepeval.metrics import ToolCorrectnessMetric
 from deepeval.test_case import LLMTestCase, ToolCall
@@ -16,6 +11,16 @@ def build_test_case():
         tools_called=[ToolCall(name="ask_question")],
         expected_tools=[ToolCall(name="ask_question")],
     )
+
+
+@pytest.fixture(autouse=True)
+def _dummy_openai_key(monkeypatch):
+    """ToolCorrectnessMetric never calls the API; it only needs a non-empty
+    key so model-client construction passes validation. Scoped via
+    monkeypatch so key-gated tests elsewhere keep skipping (#3092 CI:
+    setdefault kept CI's empty-string key, while os.environ[] leaked the
+    dummy into tests that really do call OpenAI)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-key-for-regression-test")
 
 
 class TestMeasureReturnValue:

--- a/tests/test_metrics/test_measure_return_value.py
+++ b/tests/test_metrics/test_measure_return_value.py
@@ -1,0 +1,47 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "dummy-key-for-regression-test")
+
+from deepeval.metrics import ToolCorrectnessMetric
+from deepeval.test_case import LLMTestCase, ToolCall
+
+
+def build_test_case():
+    return LLMTestCase(
+        input="q",
+        actual_output="ask_question({})",
+        tools_called=[ToolCall(name="ask_question")],
+        expected_tools=[ToolCall(name="ask_question")],
+    )
+
+
+class TestMeasureReturnValue:
+    """measure() must return the score on the default async path (#3088).
+
+    The async_mode branch ran a_measure() without returning it, so the
+    default path handed back None while metric.score was still set — and
+    callers like the prompt optimizer's _measure_no_indicator (float(score))
+    raised TypeError.
+    """
+
+    def test_measure_returns_score_with_default_async_mode(self):
+        metric = ToolCorrectnessMetric()
+        assert metric.async_mode is True  # the default is the broken path
+        score = metric.measure(build_test_case(), _show_indicator=False)
+        assert isinstance(score, float)
+        assert score == metric.score == 1.0
+
+    def test_optimizer_scorer_helper_receives_float(self):
+        from deepeval.optimizer.scorer.utils import _measure_no_indicator
+
+        score = _measure_no_indicator(
+            ToolCorrectnessMetric(), build_test_case()
+        )
+        assert isinstance(score, float)
+
+    def test_sync_mode_still_matches_async_result(self):
+        sync_metric = ToolCorrectnessMetric(async_mode=False)
+        async_metric = ToolCorrectnessMetric()
+        assert sync_metric.measure(
+            build_test_case(), _show_indicator=False
+        ) == async_metric.measure(build_test_case(), _show_indicator=False)


### PR DESCRIPTION
## Description

`measure()` returns `None` on the **default** configuration (`async_mode=True`): the async branch ran `loop.run_until_complete(self.a_measure(...))` without returning it, while the sync branch ends with `return self.score`. This contradicts the `-> float` annotation, `a_measure()`, the custom-metric guide ("return self.score"), and breaks internal callers — the prompt optimizer's scorer does `float(_measure_no_indicator(...))` and raises `TypeError` (#3088).

## Fix

Add `return` at the call site in all **47 affected metric files** under `deepeval/metrics/**` (one-word change each), mirroring the existing correct pattern already used in `deepeval/optimizer/prompt_optimizer.py`. A full sweep found 0 other occurrences of the un-returned pattern; no mixed files.

## Test

- New `tests/test_metrics/test_measure_return_value.py` (no API key needed — ToolCorrectnessMetric scores without a model):
  - default-path `measure()` returns a float equal to `metric.score`
  - `_measure_no_indicator` (the optimizer helper from the issue) now receives a float
  - sync and async modes return identical values
- All 47 edited files pass `ast.parse`; black (25.1.0) clean.

Fixes #3088
