### PR TITLE
fix(benchmarks): restrict WinoGrande fallback answers to A/B

### DIFF
--- a/deepeval/benchmarks/winogrande/winogrande.py
+++ b/deepeval/benchmarks/winogrande/winogrande.py
@@ -35,7 +35,7 @@ class Winogrande(DeepEvalBaseBenchmark):
         self.verbose_mode = verbose_mode
         if not confinement_instructions:
             self.confinement_instructions = (
-                "Output 'A', 'B', 'C', or 'D'. Full answer not needed."
+                "Output 'A' or 'B'. Full answer not needed."
             )
         else:
             self.confinement_instructions = confinement_instructions

--- a/tests/test_benchmarks/test_winogrande.py
+++ b/tests/test_benchmarks/test_winogrande.py
@@ -1,0 +1,41 @@
+import sys
+from types import ModuleType
+
+from deepeval.benchmarks.schema import BinaryChoiceSchema
+from deepeval.benchmarks.winogrande.winogrande import Winogrande
+from deepeval.dataset import Golden
+
+
+class _SchemaUnsupportedModel:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, prompt, schema=None):
+        self.calls.append((prompt, schema))
+        if schema is not None:
+            raise TypeError("schema generation is not supported")
+        return "A"
+
+
+def test_fallback_prompt_only_allows_winogrande_answers(monkeypatch):
+    datasets = ModuleType("datasets")
+    datasets.Dataset = object
+    pandas = ModuleType("pandas")
+    pandas.DataFrame = object
+    monkeypatch.setitem(sys.modules, "datasets", datasets)
+    monkeypatch.setitem(sys.modules, "pandas", pandas)
+
+    benchmark = Winogrande(n_shots=0, n_problems=1)
+    model = _SchemaUnsupportedModel()
+    golden = Golden(
+        input="Sentence: A _ ran.\nA. dog\nB. cat\nAnswer:", expected_output="A"
+    )
+
+    result = benchmark.predict(model, golden)
+
+    assert model.calls[0][1] is BinaryChoiceSchema
+    assert model.calls[1][1] is None
+    assert model.calls[1][0].endswith(
+        "\n\nOutput 'A' or 'B'. Full answer not needed."
+    )
+    assert result == {"prediction": "A", "score": 1}


### PR DESCRIPTION
## Summary

- restrict WinoGrande's default fallback instruction to its two valid labels, A and B
- add an offline regression test covering schema-unsupported models, the fallback prompt, and final scoring

## Context

WinoGrande renders only two answer choices and uses `BinaryChoiceSchema`, but its free-text fallback currently tells models that A, B, C, and D are valid.

Models without schema support can therefore emit nonexistent C or D labels and receive incorrect accuracy results. This change keeps the fallback instruction consistent with the benchmark's actual answer domain.

## Testing

- `python -m pytest -q tests/test_benchmarks` — 14 passed
- `black --check deepeval/benchmarks/winogrande/winogrande.py tests/test_benchmarks/test_winogrande.py`
- `ruff check deepeval/benchmarks/winogrande/winogrande.py tests/test_benchmarks/test_winogrande.py`
- `python -m compileall -q deepeval/benchmarks/winogrande tests/test_benchmarks/test_winogrande.py`
