### PR TITLE
fix(anthropic): raise default max_tokens to 8192 and surface truncation errors

### DIFF
--- a/deepeval/models/llms/anthropic_model.py
+++ b/deepeval/models/llms/anthropic_model.py
@@ -29,9 +29,12 @@ retry_anthropic = create_retry_decorator(PS.ANTHROPIC)
 
 # Anthropic's `max_tokens` caps thinking *plus* response text, and its minimum
 # thinking budget is 1024, so a thinking request needs headroom for both.
+# 8192 is a ceiling, not a spend — small verdicts cost the same as before.
+# Models that always think (e.g. claude-fable-5) need this headroom even when
+# DEEPEVAL_MODEL_THINKING is unset.
 MIN_THINKING_BUDGET_TOKENS = 1024
-DEFAULT_MAX_TOKENS = 1024
-DEFAULT_THINKING_MAX_TOKENS = 8192
+DEFAULT_MAX_TOKENS = 8192
+DEFAULT_THINKING_MAX_TOKENS = 16384
 
 _ALIAS_MAP = {
     "api_key": ["_anthropic_api_key"],
@@ -195,6 +198,13 @@ class AnthropicModel(DeepEvalBaseLLM):
         ):
             create_kwargs["temperature"] = self.temperature
         message = chat_model.messages.create(**create_kwargs)
+        if message.stop_reason == "max_tokens" and schema is not None:
+            raise DeepEvalError(
+                f"Anthropic returned stop_reason='max_tokens' — the verdict "
+                f"JSON was cut off after {max_tokens} tokens and cannot be "
+                "parsed. Raise the budget by passing "
+                "generation_kwargs={'max_tokens': <value>} to AnthropicModel."
+            )
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )
@@ -241,6 +251,13 @@ class AnthropicModel(DeepEvalBaseLLM):
         ):
             create_kwargs["temperature"] = self.temperature
         message = await chat_model.messages.create(**create_kwargs)
+        if message.stop_reason == "max_tokens" and schema is not None:
+            raise DeepEvalError(
+                f"Anthropic returned stop_reason='max_tokens' — the verdict "
+                f"JSON was cut off after {max_tokens} tokens and cannot be "
+                "parsed. Raise the budget by passing "
+                "generation_kwargs={'max_tokens': <value>} to AnthropicModel."
+            )
         cost = self.calculate_cost(
             message.usage.input_tokens, message.usage.output_tokens
         )

--- a/tests/test_core/test_models/test_anthropic_model.py
+++ b/tests/test_core/test_models/test_anthropic_model.py
@@ -443,7 +443,7 @@ def test_anthropic_explicit_thinking_kwarg_wins(mock_require_dep, settings):
 def test_anthropic_thinking_enabled_raises_max_tokens_default(
     mock_require_dep, settings
 ):
-    """Thinking needs headroom the 1024 default does not have."""
+    """Thinking needs a larger token ceiling than the plain default."""
     thinking_model, _ = _anthropic_model(
         mock_require_dep, settings, "claude-opus-5", thinking=True
     )
@@ -499,3 +499,69 @@ async def test_anthropic_thinking_applies_to_a_generate(
 
     await model.a_generate("prompt", schema=_Verdict)
     assert client.create_kwargs["thinking"]["type"] == "enabled"
+
+
+##############################################
+# stop_reason == "max_tokens" guard tests    #
+##############################################
+
+
+class _TruncatedMessagesClient(_MessagesClient):
+    """Replays a response whose stop_reason is 'max_tokens'."""
+
+    def _create(self, **create_kwargs):
+        self.create_kwargs = create_kwargs
+        return SimpleNamespace(
+            content=self.blocks,
+            stop_reason="max_tokens",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+        )
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_raises_on_max_tokens_truncation_with_schema(
+    mock_require_dep, settings
+):
+    """stop_reason='max_tokens' + schema → DeepEvalError pointing at max_tokens."""
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 1e-6
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 1e-6
+
+    client = _TruncatedMessagesClient()
+    mock_require_dep.return_value = SimpleNamespace(
+        Anthropic=lambda *a, **kw: client,
+        AsyncAnthropic=lambda *a, **kw: client,
+    )
+    model = AnthropicModel(model="claude-opus-5")
+
+    with pytest.raises(DeepEvalError, match="max_tokens"):
+        model.generate("prompt", schema=_Verdict)
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_returns_text_on_max_tokens_truncation_without_schema(
+    mock_require_dep, settings
+):
+    """stop_reason='max_tokens' without schema → truncated text is returned, not an error."""
+    with settings.edit(persist=False):
+        settings.ANTHROPIC_API_KEY = "test-key"
+        settings.ANTHROPIC_COST_PER_INPUT_TOKEN = 1e-6
+        settings.ANTHROPIC_COST_PER_OUTPUT_TOKEN = 1e-6
+
+    client = _TruncatedMessagesClient()
+    client.blocks = [SimpleNamespace(type="text", text="truncated output")]
+    mock_require_dep.return_value = SimpleNamespace(
+        Anthropic=lambda *a, **kw: client,
+        AsyncAnthropic=lambda *a, **kw: client,
+    )
+    model = AnthropicModel(model="claude-opus-5")
+
+    text, _ = model.generate("prompt")
+    assert text == "truncated output"
+
+
+@patch("deepeval.models.llms.anthropic_model.require_dependency")
+def test_anthropic_default_max_tokens_is_at_least_8192(mock_require_dep, settings):
+    """DEFAULT_MAX_TOKENS must accommodate models that think by default."""
+    assert DEFAULT_MAX_TOKENS >= 8192


### PR DESCRIPTION
## Summary

Fixes #3042.

`DEFAULT_MAX_TOKENS` was `1024` — a budget sized for pre-thinking-era models. Since `claude-opus-5` became the default `AnthropicModel` judge, extended-thinking models can spend the entire 1024-token ceiling on reasoning, leaving an empty or truncated text block. The resulting `"Evaluation LLM outputted an invalid JSON"` error gave no hint that the root cause was the token budget.

### Changes

**1. Raise `DEFAULT_MAX_TOKENS` from 1024 → 8192**

`max_tokens` is a ceiling, not a spend — verdicts shorter than 8192 tokens cost exactly the same as before. The higher ceiling gives thinking models headroom to complete their verdict JSON.

Models that always think (`claude-fable-5`) also benefit here because the code sends no `thinking:{type:disabled}` parameter for them (they don't appear in the `supports_thinking` registry field), so they hit `DEFAULT_MAX_TOKENS` directly.

`DEFAULT_THINKING_MAX_TOKENS` is raised from 8192 → 16384 to maintain meaningful headroom above the new default when `DEEPEVAL_MODEL_THINKING` is explicitly set.

**2. Add `stop_reason == "max_tokens"` guard in `generate()` and `a_generate()`**

When Anthropic truncates a response mid-JSON, parsing raises a cryptic error. The guard intercepts this case early and raises a `DeepEvalError` that:
- names `max_tokens` as the cause
- reports the current token budget
- tells the user exactly what to change (`generation_kwargs={'max_tokens': <value>}`)

The guard fires only when a `schema` is passed (i.e. JSON is expected). Plain-text generation with `stop_reason="max_tokens"` returns the truncated text unchanged, which is the existing behaviour.

## Test Plan

Three new unit tests in `tests/test_core/test_models/test_anthropic_model.py`:

| Test | What it checks |
|---|---|
| `test_anthropic_raises_on_max_tokens_truncation_with_schema` | `stop_reason='max_tokens'` + schema → `DeepEvalError` mentioning `max_tokens` |
| `test_anthropic_returns_text_on_max_tokens_truncation_without_schema` | `stop_reason='max_tokens'` without schema → truncated text returned (no error) |
| `test_anthropic_default_max_tokens_is_at_least_8192` | `DEFAULT_MAX_TOKENS >= 8192` holds |

All 22 existing + 3 new tests pass:
```
pytest tests/test_core/test_models/test_anthropic_model.py -v
# 25 passed in <1s
```