### PR TITLE
fix: benchmark batch prediction length comparisons

### DIFF
--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -257,7 +257,7 @@ class BigBenchHard(DeepEvalBaseBenchmark):
             predictions = [str(pred) for pred in predictions]
             used_schema = False
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -233,7 +233,7 @@ class HellaSwag(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/logi_qa/logi_qa.py
+++ b/deepeval/benchmarks/logi_qa/logi_qa.py
@@ -217,7 +217,7 @@ class LogiQA(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -220,7 +220,7 @@ class MathQA(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -238,7 +238,7 @@ class MMLU(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/truthful_qa/truthful_qa.py
+++ b/deepeval/benchmarks/truthful_qa/truthful_qa.py
@@ -258,7 +258,7 @@ class TruthfulQA(DeepEvalBaseBenchmark):
             predictions = model.batch_generate(prompts)
             predictions = [str(pred) for pred in predictions]
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )


### PR DESCRIPTION
Fixes #2982

SUMMARY: 
Fixes incorrect identity comparisons used when validating prediction and golden-set lengths across benchmark implementations.

The affected benchmarks used is not to compare integer values returned by len(). Identity comparison is not appropriate for comparing integer values and can produce incorrect behavior depending on Python's object identity semantics.

This PR replaces:

len(predictions) is not len(goldens)

with:

len(predictions) != len(goldens)

CHANGES:
Updated length validation across affected benchmark implementations.
Replaced integer identity comparisons with value comparisons.
No changes to benchmark behavior beyond correcting the comparison semantics.

VALIDATION:
Verified no affected is not length comparisons remain.
Ran git diff --check / staged diff checks successfully.
Confirmed the modified benchmark modules compile successfully.