### PR TITLE
fix: distinguish unscorable TruthfulQA results

### DIFF
--- a/deepeval/benchmarks/truthful_qa/truthful_qa.py
+++ b/deepeval/benchmarks/truthful_qa/truthful_qa.py
@@ -78,9 +78,9 @@ class TruthfulQA(DeepEvalBaseBenchmark):
                     and self.n_problems_per_task < len(goldens)
                 ):
                     goldens = goldens[: self.n_problems_per_task]
+
                 task_correct_predictions = 0
-                task_total_predictions = len(goldens)
-                overall_total_predictions += len(goldens)
+                task_total_predictions = 0
 
                 # Calculate task accuracy
                 if use_batch:
@@ -92,14 +92,21 @@ class TruthfulQA(DeepEvalBaseBenchmark):
                         batch_predictions = self.batch_predict(
                             model, goldens_batch, self.mode
                         )
+
                         for golden, prediction_dict in zip(
                             goldens_batch, batch_predictions
                         ):
                             prediction = prediction_dict["prediction"]
                             score = prediction_dict["score"]
-                            if score:
-                                task_correct_predictions += 1
-                                overall_correct_predictions += 1
+
+                            if score is not None:
+                                task_total_predictions += 1
+                                overall_total_predictions += 1
+
+                                if score:
+                                    task_correct_predictions += 1
+                                    overall_correct_predictions += 1
+
                             predictions_row.append(
                                 (
                                     task.value,
@@ -116,9 +123,13 @@ class TruthfulQA(DeepEvalBaseBenchmark):
                         prediction, score = self.predict(
                             model, golden, self.mode
                         ).values()
-                        if score:
+
+                        if score is not None:
+                            task_total_predictions += 1
+                            overall_total_predictions += 1
                             task_correct_predictions += score
                             overall_correct_predictions += score
+
                         predictions_row.append(
                             (
                                 task.value,
@@ -128,6 +139,7 @@ class TruthfulQA(DeepEvalBaseBenchmark):
                                 score,
                             )
                         )
+
                         if self.verbose_mode:
                             self.print_verbose_logs(
                                 idx,

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -378,7 +378,9 @@ class Scorer:
         return scorer(text)
 
     @classmethod
-    def truth_identification_score(cls, target: str, prediction: str) -> Optional[int]:
+    def truth_identification_score(
+        cls, target: str, prediction: str
+    ) -> Optional[int]:
         """
         Metrics that calculates the number of correct true answers identified in the prediction.
 

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -378,7 +378,7 @@ class Scorer:
         return scorer(text)
 
     @classmethod
-    def truth_identification_score(cls, target: str, prediction: str) -> int:
+    def truth_identification_score(cls, target: str, prediction: str) -> Optional[int]:
         """
         Metrics that calculates the number of correct true answers identified in the prediction.
 
@@ -391,7 +391,8 @@ class Scorer:
             prediction (str): The predicted string from the LLM, representing the guessed answers.
 
         Returns:
-            int: The number of correct answers identified.
+            Optional[int]: The percentage of correct answers identified, or None if the
+            input cannot be meaningfully scored.
         """
         try:
             if not prediction or not target:
@@ -410,7 +411,7 @@ class Scorer:
             )
 
             if not target_list:
-                return 0  # Return 0 if target list is empty to avoid division by zero
+                return None
 
             # Count the number of correct matches
             correct_matches = sum(
@@ -421,8 +422,8 @@ class Scorer:
             score_percentage = (correct_matches / len(target_list)) * 100
 
             return round(score_percentage)  # Return rounded percentage
-        except Exception as e:
-            return 0  # Return score as 0 in case of any exception
+        except Exception:
+            return None
 
     def pass_at_k(self, n, c, k):
         import numpy as np

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -15,6 +15,9 @@ from deepeval.benchmarks.drop.drop import DELIMITER
 from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
 from deepeval.benchmarks.tasks import BigBenchHardTask
 from deepeval.dataset import Golden
+from deepeval.benchmarks.truthful_qa.truthful_qa import TruthfulQA
+from deepeval.benchmarks.truthful_qa.mode import TruthfulQAMode
+from deepeval.benchmarks.truthful_qa.task import TruthfulQATask
 
 # --------------------------------------------------------------------------- #
 # MathQA: the answer schema must be able to represent option "e"
@@ -101,3 +104,47 @@ def test_bbh_batch_predict_scores_schema_answer_correctly(enable_cot):
     # schema answer, turning "(A)" into "(A)" -> "(A" and scoring it 0.
     assert result[0]["prediction"] == "(A)"
     assert result[0]["score"] == 1
+
+
+# TruthfulQA: unscorable inputs must not be reported as a genuine zero score
+
+
+def test_truth_identification_score_returns_zero_for_no_prediction():
+    assert Scorer.truth_identification_score("[1,2]", "") == 0
+
+
+def test_truth_identification_score_returns_zero_for_no_matching_answers():
+    assert Scorer.truth_identification_score("[1,2]", "[3]") == 0
+
+
+def test_truth_identification_score_returns_none_for_empty_target():
+    assert Scorer.truth_identification_score("[]", "[1]") is None
+
+
+def test_truth_identification_score_returns_none_for_malformed_input():
+    assert Scorer.truth_identification_score("[1,2]", "[invalid]") is None
+
+
+def test_truthfulqa_evaluate_excludes_unscorable_predictions_from_accuracy():
+    bench = TruthfulQA.__new__(TruthfulQA)
+
+    bench.tasks = [TruthfulQATask.MISCONCEPTIONS]
+    bench.mode = TruthfulQAMode.MC2
+    bench.n_problems_per_task = None
+    bench.verbose_mode = False
+
+    goldens = [
+        Golden(input="question 1", expected_output="[1]"),
+        Golden(input="question 2", expected_output="[1]"),
+    ]
+
+    bench.load_benchmark_dataset = lambda task, mode: goldens
+    bench.predict = lambda model, golden, mode: {
+        "prediction": "1",
+        "score": 100 if golden.input == "question 1" else None,
+    }
+
+    result = bench.evaluate(object())
+
+    assert result.overall_accuracy == 100
+    assert bench.task_scores.iloc[0]["Score"] == 100


### PR DESCRIPTION
Summary
Fix  "truth_identification_score" so unscorable TruthfulQA inputs are not reported as genuine zero scores.

Changes

- Return "None" when the target list is empty.
- Return "None" when parsing the target/prediction fails.
- Preserve "0" for valid predictions that identify none of the correct answers.
- Exclude unscorable ("None") results from TruthfulQA accuracy denominators.
- Add regression tests covering the scorer and benchmark accuracy behavior.

Testing

- "uvx poetry run pytest tests/test_benchmarks/test_benchmark_answer_scoring.py -q"
- 18 passed, 2 warnings
- "git diff --check"

Closes #3097