### PR TITLE
feat(dag): add deterministic custom nodes

### DIFF
--- a/deepeval/metrics/dag/__init__.py
+++ b/deepeval/metrics/dag/__init__.py
@@ -1,5 +1,6 @@
 from .nodes import (
     BaseNode,
+    CustomNode,
     VerdictNode,
     TaskNode,
     BinaryJudgementNode,

--- a/deepeval/metrics/dag/nodes.py
+++ b/deepeval/metrics/dag/nodes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional, Union
+import inspect
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass, field
 from pydantic import create_model
 
@@ -35,7 +36,7 @@ class BaseNode(PromptMixin):
         text = ""
         if parents is not None:
             for parent in parents:
-                if isinstance(parent, TaskNode):
+                if hasattr(parent, "output_label"):
                     text += f"{parent.output_label}:\n{outputs[parent]}{sep}"
         if self.evaluation_params is not None:
             for param in self.evaluation_params:
@@ -217,6 +218,64 @@ class TaskNode(BaseNode):
             extract_schema=lambda s: s.output,
             extract_json=lambda data: data["output"],
         )
+
+
+class CustomNode(BaseNode):
+    """Run deterministic user code inside a single-turn DAG.
+
+    Custom callables are intentionally not serializable because arbitrary
+    Python code cannot be safely or portably restored.
+    """
+
+    def __init__(
+        self,
+        function: Callable[[LLMTestCase, Dict[BaseNode, Any]], Any],
+        output_label: str = "Output",
+        children: Optional[List[BaseNode]] = None,
+        label: Optional[str] = None,
+    ):
+        self.function = function
+        self.output_label = output_label
+        self.children = children or []
+        self.label = label
+        self._validate()
+
+    def __hash__(self):
+        return id(self)
+
+    def _validate(self) -> None:
+        if not callable(self.function):
+            raise TypeError("CustomNode.function must be callable.")
+        if not all(isinstance(child, BaseNode) for child in self.children):
+            raise TypeError("CustomNode children must be BaseNode instances.")
+
+    def _parent_outputs(
+        self, parents: Optional[List[BaseNode]], outputs: Dict[BaseNode, Any]
+    ) -> Dict[BaseNode, Any]:
+        return {
+            parent: outputs[parent]
+            for parent in parents or []
+            if parent in outputs
+        }
+
+    def _execute(
+        self,
+        metric: BaseMetric,
+        test_case: LLMTestCase,
+        parents: Optional[List[BaseNode]],
+        outputs: Dict[BaseNode, Any],
+    ) -> Any:
+        return self.function(test_case, self._parent_outputs(parents, outputs))
+
+    async def _a_execute(
+        self,
+        metric: BaseMetric,
+        test_case: LLMTestCase,
+        parents: Optional[List[BaseNode]],
+        outputs: Dict[BaseNode, Any],
+    ) -> Any:
+        result = self._execute(metric, test_case, parents, outputs)
+        return await result if inspect.isawaitable(result) else result
 
 
 @dataclass
@@ -416,7 +475,8 @@ def construct_node_verbose_log(
     verdict: Optional[Any] = None,
 ) -> str:
     if isinstance(
-        node, (BinaryJudgementNode, NonBinaryJudgementNode, TaskNode)
+        node,
+        (BinaryJudgementNode, NonBinaryJudgementNode, TaskNode, CustomNode),
     ):
         label = node.label if node.label else "None"
 
@@ -447,6 +507,14 @@ def construct_node_verbose_log(
             f"Label: {label}\n\n"
             "Instructions:\n"
             f"{node.instructions}\n\n"
+            f"{node.output_label}:\n{output}\n"
+        )
+    elif isinstance(node, CustomNode):
+        return (
+            "____________________\n"
+            f"| CustomNode | Level == {depth} |\n"
+            "*****************************\n"
+            f"Label: {label}\n\n"
             f"{node.output_label}:\n{output}\n"
         )
     elif isinstance(node, VerdictNode):

--- a/deepeval/metrics/dag/runner.py
+++ b/deepeval/metrics/dag/runner.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Union
 
 from deepeval.metrics.dag.nodes import (
     BaseNode,
+    CustomNode,
     VerdictNode,
     TaskNode,
     BinaryJudgementNode,
@@ -63,7 +64,7 @@ class _DeepAcyclicGraphRunner:
         return True
 
     def _store_result(self, node: Node, result: Any) -> None:
-        if isinstance(node, _TASK):
+        if isinstance(node, (_TASK, CustomNode)):
             self.outputs[node] = result
         else:
             self.verdicts[node] = result

--- a/deepeval/metrics/dag/utils.py
+++ b/deepeval/metrics/dag/utils.py
@@ -6,6 +6,7 @@ import inspect
 
 from deepeval.metrics.dag import (
     BaseNode,
+    CustomNode,
     BinaryJudgementNode,
     NonBinaryJudgementNode,
     VerdictNode,
@@ -80,7 +81,7 @@ def is_valid_dag(
     stack.add(node)
     if not multiturn:
         if (
-            isinstance(node, TaskNode)
+            isinstance(node, (TaskNode, CustomNode))
             or isinstance(node, BinaryJudgementNode)
             or isinstance(node, NonBinaryJudgementNode)
         ):
@@ -114,11 +115,11 @@ def extract_required_params(
     for node in nodes:
         if not multiturn:
             if (
-                isinstance(node, TaskNode)
+                isinstance(node, (TaskNode, CustomNode))
                 or isinstance(node, BinaryJudgementNode)
                 or isinstance(node, NonBinaryJudgementNode)
             ):
-                if node.evaluation_params is not None:
+                if getattr(node, "evaluation_params", None) is not None:
                     required_params.update(node.evaluation_params)
                 extract_required_params(
                     node.children, multiturn, required_params
@@ -177,7 +178,7 @@ def copy_graph(original_dag: DeepAcyclicGraph) -> DeepAcyclicGraph:
         }
         if not original_dag.multiturn:
             if (
-                isinstance(node, TaskNode)
+                isinstance(node, (TaskNode, CustomNode))
                 or isinstance(node, BinaryJudgementNode)
                 or isinstance(node, NonBinaryJudgementNode)
             ):

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -6,6 +6,7 @@ import pytest
 from deepeval import evaluate
 from deepeval.metrics import DAGMetric
 from deepeval.metrics.dag import (
+    CustomNode,
     TaskNode,
     BinaryJudgementNode,
     NonBinaryJudgementNode,
@@ -133,6 +134,67 @@ class TestLegacyDAG:
         assert model.schema_calls.count("TaskNodeOutput") == 1
         assert model.schema_calls.count("BinaryJudgementVerdict") == 1
         assert model.schema_calls.count("NonBinaryJudgementVerdict") == 1
+
+
+class TestCustomNode:
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_custom_nodes_execute_and_pass_outputs_to_children(
+        self, async_mode
+    ):
+        verdict = VerdictNode(verdict=True, score=10)
+        child = CustomNode(
+            lambda test_case, parents: next(iter(parents.values()))
+            == len(test_case.actual_output),
+            children=[verdict],
+        )
+        root = CustomNode(
+            lambda test_case, _: len(test_case.actual_output),
+            output_label="length",
+            children=[child],
+        )
+        metric = DAGMetric(
+            name="Custom node",
+            dag=DeepAcyclicGraph(root_nodes=[root]),
+            model=LegacyDAGModel(),
+            include_reason=False,
+            async_mode=async_mode,
+        )
+
+        assert (
+            metric.measure(
+                LLMTestCase(input="input", actual_output="hello"),
+                _show_indicator=False,
+            )
+            == 1
+        )
+
+    def test_custom_node_requires_callable(self):
+        with pytest.raises(TypeError, match="must be callable"):
+            CustomNode(function="not callable")
+
+    def test_custom_node_supports_async_callable(self):
+        async def compute(test_case, _):
+            return len(test_case.actual_output)
+
+        root = CustomNode(
+            compute,
+            children=[VerdictNode(verdict=True, score=10)],
+        )
+        metric = DAGMetric(
+            name="Async custom node",
+            dag=DeepAcyclicGraph(root_nodes=[root]),
+            model=LegacyDAGModel(),
+            include_reason=False,
+            async_mode=True,
+        )
+
+        assert (
+            metric.measure(
+                LLMTestCase(input="input", actual_output="hello"),
+                _show_indicator=False,
+            )
+            == 1
+        )
 
 
 class TestDeepAcyclicGraph:


### PR DESCRIPTION
## Summary

Implements the core of #1472 by adding a deterministic `CustomNode` for single-turn DAGs.

- Supports sync and async callables.
- Callables receive the `LLMTestCase` and direct parent outputs.
- Custom node outputs flow through the DAG and can be consumed by downstream nodes.
- Supports DAG validation, copying, and verbose logging.
- Adds regression coverage for sync, async, output propagation, and invalid callables.

## Scope

This intentionally does not serialize or upload arbitrary Python callables. DAG serialization raises the existing unsupported-node error for `CustomNode` graphs.

## Verification

- `python3 -m compileall -q deepeval/metrics/dag tests/test_metrics/test_dag.py`
- `git diff --check`

The local environment does not have Poetry, pytest, or pydantic installed, so the full test suite could not be run locally.

Refs #1472
