### PR TITLE
feat(metrics): add JudgeSelfConsistencyMetric community metric

### DIFF
--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,11 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .judge_self_consistency.judge_self_consistency import (
+    JudgeSelfConsistencyMetric,
+)
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "JudgeSelfConsistencyMetric",
 ]

--- a/deepeval/metrics/community/judge_self_consistency/__init__.py
+++ b/deepeval/metrics/community/judge_self_consistency/__init__.py
@@ -1,0 +1,5 @@
+from .judge_self_consistency import JudgeSelfConsistencyMetric
+
+__all__ = [
+    "JudgeSelfConsistencyMetric",
+]

--- a/deepeval/metrics/community/judge_self_consistency/judge_self_consistency.py
+++ b/deepeval/metrics/community/judge_self_consistency/judge_self_consistency.py
@@ -1,0 +1,496 @@
+import asyncio
+import inspect
+from typing import Any, Dict, List, Optional, Tuple
+
+from deepeval.errors import MissingTestCaseParamsError
+from deepeval.metrics import BaseMetric
+from deepeval.metrics.community.judge_self_consistency.schema import (
+    JudgeSelfConsistencyResult,
+    Replicate,
+)
+from deepeval.metrics.community.judge_self_consistency.stats import (
+    bootstrap_mean_interval,
+    decision_flip_rate,
+    stability,
+)
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.utils import construct_verbose_logs, copy_metrics
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.utils import get_or_create_event_loop
+
+
+class JudgeSelfConsistencyMetric(BaseMetric):
+    """How much a judge agrees with itself.
+
+    Wraps another metric and runs it ``replicates`` times against the same
+    ``LLMTestCase``, then reports how far apart the repeats landed. Every
+    other metric in ``deepeval`` measures the application under test; this one
+    measures the judge you are measuring it with.
+
+    Two numbers come out of a run:
+
+    - **Stability** (the metric's ``score``) — ``1 - normalized spread`` of the
+      replicate scores. ``1.0`` when every repeat produced the same score,
+      falling towards ``0.0`` as they spread across the range.
+    - **Decision flip rate** (``self.decision_flip_rate``) — the fraction of
+      replicate *pairs* that landed on opposite sides of the wrapped judge's
+      threshold. This is usually the more alarming of the two: scores that vary
+      only slightly still flip a verdict when they vary across the threshold,
+      and a verdict flip is what actually changes a test result.
+
+    Because a judge that disagrees with itself is a fact about the eval harness
+    rather than about the application under test, a low reading here should not
+    by itself fail a test suite. With the default ``auto_flaky=True``, the
+    metric therefore sets its own ``flaky`` attribute when the replicates
+    disagree, which keeps the reading in the report — in ``deepeval``'s flaky
+    pass/fail sub-counts — without letting it gate.
+
+    The wrapped judge needs some source of variation for this to be
+    informative; a judge pinned to ``temperature=0`` may well return the same
+    score every time, which the metric will faithfully report as perfect
+    stability.
+    """
+
+    def __init__(
+        self,
+        metric: BaseMetric,
+        replicates: int = 5,
+        threshold: Optional[float] = 0.9,
+        auto_flaky: bool = True,
+        score_range: Tuple[float, float] = (0.0, 1.0),
+        max_concurrent: Optional[int] = None,
+        bootstrap_resamples: int = 2000,
+        confidence: float = 0.95,
+        random_seed: Optional[int] = 42,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+        _declared_flaky: Optional[bool] = None,
+    ):
+        if not isinstance(metric, BaseMetric):
+            raise TypeError(
+                f"'metric' must be a BaseMetric, got "
+                f"{type(metric).__name__}. Conversational and arena metrics "
+                "are not supported: this metric evaluates LLMTestCases."
+            )
+        if replicates < 2:
+            raise ValueError(
+                "'replicates' must be at least 2: a single run of the judge "
+                "says nothing about whether it agrees with itself."
+            )
+        if bootstrap_resamples < 1:
+            raise ValueError(
+                f"'bootstrap_resamples' must be at least 1, got "
+                f"{bootstrap_resamples}."
+            )
+        if not 0.0 < confidence < 1.0:
+            raise ValueError(
+                f"'confidence' must be strictly between 0 and 1, got "
+                f"{confidence}. Pass 0.95, not 95."
+            )
+        if score_range[0] >= score_range[1]:
+            raise ValueError(
+                f"'score_range' must be (low, high) with low < high, got "
+                f"{score_range}."
+            )
+        if max_concurrent is not None and max_concurrent < 1:
+            raise ValueError(
+                f"'max_concurrent' must be at least 1, got {max_concurrent}."
+            )
+
+        self.metric = metric
+        self.replicates = replicates
+        self.threshold = 1 if strict_mode else threshold
+        self.auto_flaky = auto_flaky
+        self.score_range = score_range
+        self.max_concurrent = max_concurrent
+        self.bootstrap_resamples = bootstrap_resamples
+        self.confidence = confidence
+        self.random_seed = random_seed
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+
+        # `auto_flaky` raises `flaky` during a run, so the value sitting on the
+        # instance afterwards is not necessarily what the caller asked for.
+        # `copy_metrics` rebuilds a metric from its current attributes, so the
+        # caller's own choice travels separately — otherwise one flaky run
+        # would latch into every copy made from that instance thereafter.
+        self._declared_flaky = (
+            flaky if _declared_flaky is None else _declared_flaky
+        )
+        self.flaky = self._declared_flaky
+
+        # The wrapped judge decides which test case fields are required, and
+        # does its own validation on every replicate. `BaseMetric` leaves
+        # `_required_params` as a bare type annotation, so only a real list
+        # from the judge itself is worth adopting.
+        judge_params = getattr(metric, "_required_params", None)
+        self._required_params: List[SingleTurnParams] = (
+            judge_params if isinstance(judge_params, list) else []
+        )
+        self.evaluation_model = getattr(metric, "evaluation_model", None)
+        self.using_native_model = getattr(metric, "using_native_model", None)
+
+        self.result: Optional[JudgeSelfConsistencyResult] = None
+        self.decision_flip_rate: Optional[float] = None
+        self.replicate_scores: List[float] = []
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        self._reset()
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            if self.async_mode:
+                loop = get_or_create_event_loop()
+                loop.run_until_complete(
+                    self.a_measure(
+                        test_case,
+                        _show_indicator=False,
+                        _in_component=_in_component,
+                    )
+                )
+            else:
+                judges = self._build_judges()
+                replicates = [
+                    self._run_replicate(judge, test_case, _in_component)
+                    for judge in judges
+                ]
+                self._finalize(judges, replicates)
+
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        self._reset()
+        with metric_progress_indicator(
+            self,
+            async_mode=True,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        ):
+            judges = self._build_judges()
+            semaphore = (
+                asyncio.Semaphore(self.max_concurrent)
+                if self.max_concurrent
+                else None
+            )
+
+            async def run(judge: BaseMetric) -> Replicate:
+                if semaphore is None:
+                    return await self._a_run_replicate(
+                        judge, test_case, _in_component
+                    )
+                async with semaphore:
+                    return await self._a_run_replicate(
+                        judge, test_case, _in_component
+                    )
+
+            settled = await asyncio.gather(
+                *(run(j) for j in judges), return_exceptions=True
+            )
+            # Everything is gathered before anything is re-raised, so a
+            # failing replicate never leaves its siblings dangling.
+            for outcome in settled:
+                if isinstance(outcome, MissingTestCaseParamsError):
+                    # The harness handles this one: it is how a test case gets
+                    # skipped rather than failed.
+                    raise outcome
+                if isinstance(outcome, BaseException) and not isinstance(
+                    outcome, Exception
+                ):
+                    # Cancellation and the like are not the judge's doing.
+                    raise outcome
+            replicates = [
+                (
+                    outcome
+                    if isinstance(outcome, Replicate)
+                    else Replicate(error=str(outcome))
+                )
+                for outcome in settled
+            ]
+            self._finalize(judges, replicates)
+            return self.score
+
+    def _reset(self) -> None:
+        """Clear the previous run so a reused metric instance starts clean."""
+        self.error = None
+        self.score = None
+        self.reason = None
+        self.success = None
+        self.skipped = False
+        self.flaky = self._declared_flaky
+        self.score_breakdown = None
+        self.verbose_logs = None
+        self.result = None
+        self.decision_flip_rate = None
+        self.replicate_scores = []
+        self.evaluation_cost = 0 if self.using_native_model else None
+        self.input_tokens = 0 if self.using_native_model else None
+        self.output_tokens = 0 if self.using_native_model else None
+
+    def _build_judges(self) -> List[BaseMetric]:
+        """One copy of the wrapped judge per replicate.
+
+        Metrics carry their per-run results as instance state, so the
+        replicates cannot share an instance. ``copy_metrics`` is the same
+        helper ``evaluate()`` uses to isolate metrics across test cases: it
+        rebuilds each copy from the constructor arguments it can recover, so
+        the copies get their own result state while sharing the judge's
+        configuration (and its model client) by reference.
+        """
+        try:
+            judges = copy_metrics([self.metric] * self.replicates)
+        except TypeError as error:
+            raise TypeError(
+                f"Could not make replicate copies of "
+                f"{getattr(self.metric, '__name__', type(self.metric).__name__)}: "
+                f"{error}. This metric copies the judge with deepeval's "
+                "'copy_metrics', which rebuilds a metric by passing its "
+                "attributes back into its constructor, so every required "
+                "constructor argument must be stored on the instance under "
+                "that same name."
+            ) from error
+
+        for judge in judges:
+            # The wrapper owns the console output for the whole run.
+            judge.verbose_mode = False
+        return judges
+
+    @staticmethod
+    def _supported_kwargs(func, **kwargs) -> Dict[str, Any]:
+        """Drop private kwargs a custom metric's signature does not accept."""
+        try:
+            parameters = inspect.signature(func).parameters
+        except (TypeError, ValueError):
+            return {}
+        if any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        ):
+            return kwargs
+        return {
+            name: value for name, value in kwargs.items() if name in parameters
+        }
+
+    def _run_replicate(
+        self, judge: BaseMetric, test_case: LLMTestCase, _in_component: bool
+    ) -> Replicate:
+        kwargs = self._supported_kwargs(
+            judge.measure, _show_indicator=False, _in_component=_in_component
+        )
+        try:
+            judge.measure(test_case, **kwargs)
+        except MissingTestCaseParamsError:
+            # The harness handles this one: it is how a test case gets skipped
+            # rather than failed, so it must not be folded into a replicate.
+            raise
+        except Exception as error:
+            return Replicate(error=str(error))
+        return self._read_replicate(judge)
+
+    async def _a_run_replicate(
+        self, judge: BaseMetric, test_case: LLMTestCase, _in_component: bool
+    ) -> Replicate:
+        if type(judge).a_measure is BaseMetric.a_measure:
+            # The judge never implemented async; go straight to the sync path
+            # rather than paying for a partial async run before it raises.
+            return await asyncio.to_thread(
+                self._run_replicate, judge, test_case, _in_component
+            )
+
+        kwargs = self._supported_kwargs(
+            judge.a_measure, _show_indicator=False, _in_component=_in_component
+        )
+        try:
+            await judge.a_measure(test_case, **kwargs)
+        except MissingTestCaseParamsError:
+            raise
+        except Exception as error:
+            return Replicate(error=str(error))
+        return self._read_replicate(judge)
+
+    @staticmethod
+    def _read_replicate(judge: BaseMetric) -> Replicate:
+        if judge.error is not None:
+            return Replicate(error=judge.error)
+        return Replicate(
+            score=judge.score,
+            success=judge.is_successful(),
+            reason=judge.reason,
+        )
+
+    def _fail(self, message: str, replicates: List[Replicate]) -> None:
+        self.error = message
+        self.result = JudgeSelfConsistencyResult(
+            stability=0.0,
+            replicates=replicates,
+            errored_replicates=sum(
+                1 for r in replicates if r.error is not None
+            ),
+        )
+        self.score = None
+        self.reason = message
+        self.success = self.is_successful()
+
+    def _finalize(
+        self, judges: List[BaseMetric], replicates: List[Replicate]
+    ) -> None:
+        scored = [
+            r for r in replicates if r.error is None and r.score is not None
+        ]
+        # Only replicates that actually ran carry cost; reading an errored
+        # judge's unset cost would null the whole accumulator.
+        for judge, replicate in zip(judges, replicates):
+            if replicate.error is None:
+                self._accrue_cost(judge.evaluation_cost)
+                self._accrue_tokens(judge.input_tokens, judge.output_tokens)
+
+        if len(scored) < 2:
+            first_error = next(
+                (r.error for r in replicates if r.error is not None),
+                "the judge returned no score.",
+            )
+            self._fail(
+                f"Only {len(scored)} of {self.replicates} replicates produced "
+                f"a score, which is too few to measure self-consistency. The "
+                f"first error was: {first_error}",
+                replicates,
+            )
+            return
+
+        scores = [r.score for r in scored]
+        low, high = self.score_range
+        out_of_range = [s for s in scores if s < low or s > high]
+        if out_of_range:
+            self._fail(
+                f"The judge returned scores outside 'score_range' "
+                f"{self.score_range}: {out_of_range}. Stability is measured "
+                f"relative to that range, so set 'score_range' to the range "
+                f"the judge actually scores on.",
+                replicates,
+            )
+            return
+
+        # A judge with no threshold runs in score-only mode and reaches no
+        # verdict, so there is nothing to flip.
+        successes = [r.success for r in scored if r.success is not None]
+        flip_rate = (
+            decision_flip_rate(successes)
+            if len(successes) == len(scored)
+            else None
+        )
+
+        self.replicate_scores = scores
+        self.decision_flip_rate = flip_rate
+        self.result = JudgeSelfConsistencyResult(
+            stability=stability(scores, self.score_range),
+            decision_flip_rate=flip_rate,
+            mean_score=sum(scores) / len(scores),
+            min_score=min(scores),
+            max_score=max(scores),
+            score_interval=bootstrap_mean_interval(
+                scores,
+                resamples=self.bootstrap_resamples,
+                confidence=self.confidence,
+                seed=self.random_seed,
+            ),
+            replicates=replicates,
+            errored_replicates=len(replicates) - len(scored),
+        )
+
+        self.score = self._calculate_score()
+        self.score_breakdown = self.result.model_dump()
+        self.reason = self._generate_reason()
+        if self.auto_flaky and self._replicates_disagree():
+            # `flaky` has always been hand-declared by whoever built the
+            # metric. Here it is populated by measurement instead.
+            self.flaky = True
+        self.success = self.is_successful()
+        self.verbose_logs = construct_verbose_logs(
+            self,
+            steps=[
+                "Replicate scores:\n"
+                + ", ".join(f"{score:.4f}" for score in scores),
+                f"Decision flip rate: {self._format_flip_rate()}",
+                f"Score: {self.score}\nReason: {self.reason}",
+            ],
+        )
+
+    def _replicates_disagree(self) -> bool:
+        """Whether this run saw disagreement worth flagging.
+
+        A verdict flip always counts, however small the score movement that
+        caused it. Otherwise the reading has to actually fail its own
+        threshold — floating-point jitter between two near-identical scores is
+        not disagreement.
+        """
+        if self.result is None:
+            return False
+        if self.result.decision_flip_rate:
+            return True
+        if self.threshold is None:
+            return False
+        return self.score < self.threshold
+
+    def _calculate_score(self) -> float:
+        score = self.result.stability
+        if self.strict_mode and score < self.threshold:
+            return 0
+        return score
+
+    def _format_flip_rate(self) -> str:
+        if self.decision_flip_rate is None:
+            return "n/a (the judge has no threshold, so it reaches no verdict)"
+        return f"{self.decision_flip_rate:.2f}"
+
+    def _generate_reason(self) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+
+        result = self.result
+        judge_name = getattr(self.metric, "__name__", "the judge")
+        parts = [
+            f"{len(result.replicates) - result.errored_replicates} repeats of "
+            f"{judge_name} scored {result.min_score:.2f}-{result.max_score:.2f} "
+            f"(mean {result.mean_score:.2f})"
+        ]
+        if result.score_interval is not None:
+            low, high = result.score_interval
+            parts.append(
+                f"{int(self.confidence * 100)}% CI [{low:.2f}, {high:.2f}]"
+            )
+        if result.decision_flip_rate is None:
+            parts.append(
+                "the judge has no threshold, so no pass/fail verdict was "
+                "reached"
+            )
+        elif result.decision_flip_rate == 0:
+            parts.append("every repeat reached the same pass/fail verdict")
+        else:
+            parts.append(
+                f"{result.decision_flip_rate:.0%} of repeat pairs disagreed on "
+                "pass/fail"
+            )
+        if result.errored_replicates:
+            parts.append(f"{result.errored_replicates} repeats errored")
+        return "; ".join(parts) + "."
+
+    @property
+    def __name__(self):
+        judge_name = getattr(self.metric, "__name__", None)
+        if not judge_name:
+            return "Judge Self-Consistency"
+        return f"Judge Self-Consistency ({judge_name})"

--- a/deepeval/metrics/community/judge_self_consistency/schema.py
+++ b/deepeval/metrics/community/judge_self_consistency/schema.py
@@ -1,0 +1,36 @@
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+
+class Replicate(BaseModel):
+    """One repeat of the wrapped judge on the same test case."""
+
+    score: Optional[float] = None
+    success: Optional[bool] = None
+    reason: Optional[str] = None
+    error: Optional[str] = None
+
+
+class JudgeSelfConsistencyResult(BaseModel):
+    """The full reliability reading across all replicates."""
+
+    stability: float = Field(
+        description="1 - normalized variance of the replicate scores, in [0, 1]."
+    )
+    decision_flip_rate: Optional[float] = Field(
+        default=None,
+        description=(
+            "Fraction of replicate pairs that landed on opposite sides of the "
+            "wrapped judge's threshold. None when the judge has no threshold."
+        ),
+    )
+    mean_score: Optional[float] = None
+    min_score: Optional[float] = None
+    max_score: Optional[float] = None
+    score_interval: Optional[Tuple[float, float]] = Field(
+        default=None,
+        description="Percentile bootstrap confidence interval for the mean score.",
+    )
+    replicates: List[Replicate] = Field(default_factory=list)
+    errored_replicates: int = 0

--- a/deepeval/metrics/community/judge_self_consistency/stats.py
+++ b/deepeval/metrics/community/judge_self_consistency/stats.py
@@ -1,0 +1,148 @@
+"""Reliability statistics for repeated measurements of a single rater.
+
+These are the standard intra-rater (test-retest) quantities, implemented on
+the Python standard library so the metric adds no dependency: `deepeval` does
+not depend on `numpy`, and every `numpy` use in the package is a deferred
+import inside an optional code path.
+
+Replicates are treated throughout as a sample drawn from the judge's own
+sampling distribution — that distribution is exactly what is being estimated —
+so the spread uses the sample standard deviation, and the interval on the mean
+uses the nonparametric bootstrap.
+
+References for the methods used here:
+
+- Nonparametric bootstrap and the percentile interval: Efron, B. and
+  Tibshirani, R. (1993), *An Introduction to the Bootstrap*, Chapman & Hall,
+  chapters 6 and 13.
+- Test-retest reliability and pairwise agreement: Shrout, P. E. and Fleiss,
+  J. L. (1979), "Intraclass correlations: uses in assessing rater
+  reliability", *Psychological Bulletin* 86(2), 420-428.
+"""
+
+from __future__ import annotations
+
+import random
+import statistics
+from typing import List, Optional, Sequence, Tuple
+
+
+def stability(
+    scores: Sequence[float], score_range: Tuple[float, float] = (0.0, 1.0)
+) -> float:
+    """Return ``1 - normalized spread`` of ``scores``, clamped to [0, 1].
+
+    Spread is the sample standard deviation divided by half the width of
+    ``score_range``. Half the width is the largest standard deviation a
+    *population* on that range can have, attained when half the mass sits at
+    each end, so the ratio puts the spread on a 0-1 scale.
+
+    ``1.0`` means every repeat produced the same score. ``0.0`` means the
+    repeats are at least as far apart as a population on that range can be.
+    The sample standard deviation of a small sample can exceed the population
+    bound — two repeats at opposite ends give ``0.707`` on a unit range — so
+    the result is clamped rather than allowed to go negative.
+
+    Standard deviation rather than variance because it shares the units of the
+    scores: halving the spread of the repeats halves the distance from a
+    perfect reading. Fewer than two scores carries no information about
+    spread, so that reports ``1.0``.
+    """
+    if len(scores) < 2:
+        return 1.0
+
+    low, high = score_range
+    half_width = (high - low) / 2
+    if half_width <= 0:
+        raise ValueError(f"'score_range' must be non-empty, got {score_range}")
+
+    normalized = 1.0 - statistics.stdev(scores) / half_width
+    return min(1.0, max(0.0, normalized))
+
+
+def decision_flip_rate(successes: Sequence[bool]) -> Optional[float]:
+    """Fraction of replicate *pairs* that landed on opposite sides of the
+    threshold.
+
+    With ``k`` replicates of which ``p`` passed, the disagreeing pairs number
+    ``p * (k - p)`` out of ``k * (k - 1) / 2`` total pairs. ``0.0`` means every
+    repeat reached the same verdict, and the value rises as the split
+    approaches even.
+
+    This is the unbiased estimator of ``2q(1-q)``, the probability that two
+    independent repeats disagree when the judge passes with probability ``q``.
+    That probability is bounded by ``0.5``, but the unbiased estimator is not:
+    an even split at small ``k`` reports above it (``1.0`` at ``k=2``, ``0.667``
+    at ``k=4``). Read the number as "how many of my pairs disagreed", and only
+    read it as a probability estimate once ``k`` is reasonably large.
+
+    Returns ``None`` when there are fewer than two replicates, or when the
+    judge has no threshold and therefore produces no pass/fail decision.
+    """
+    k = len(successes)
+    if k < 2:
+        return None
+
+    passed = sum(1 for success in successes if success)
+    disagreeing_pairs = passed * (k - passed)
+    total_pairs = k * (k - 1) / 2
+    return disagreeing_pairs / total_pairs
+
+
+def _percentile(sorted_values: List[float], fraction: float) -> float:
+    """Linear-interpolated percentile of an already-sorted list."""
+    if not sorted_values:
+        raise ValueError("cannot take a percentile of an empty sequence")
+    if not 0.0 <= fraction <= 1.0:
+        raise ValueError(f"'fraction' must be in [0, 1], got {fraction}")
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+
+    position = fraction * (len(sorted_values) - 1)
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(sorted_values) - 1)
+    weight = position - lower_index
+    lower = sorted_values[lower_index]
+    return lower + weight * (sorted_values[upper_index] - lower)
+
+
+def bootstrap_mean_interval(
+    scores: Sequence[float],
+    resamples: int = 2000,
+    confidence: float = 0.95,
+    seed: Optional[int] = None,
+) -> Optional[Tuple[float, float]]:
+    """Percentile bootstrap confidence interval for the mean of ``scores``.
+
+    Resamples ``scores`` with replacement ``resamples`` times, takes the mean
+    of each resample, and reads the interval off the percentiles of that
+    distribution. This says how precisely the repeats pin down the judge's
+    central score — a wide interval on a handful of replicates is a signal to
+    raise the replicate count, not a finding about the judge.
+
+    ``seed`` makes the interval reproducible; pass ``None`` for a fresh draw
+    each call. Returns ``None`` for an empty input.
+    """
+    if resamples < 1:
+        raise ValueError(f"'resamples' must be at least 1, got {resamples}")
+    if not 0.0 < confidence < 1.0:
+        raise ValueError(
+            f"'confidence' must be strictly between 0 and 1, got {confidence}"
+        )
+    if not scores:
+        return None
+    if len(scores) == 1:
+        return (scores[0], scores[0])
+
+    rng = random.Random(seed)
+    n = len(scores)
+    means = []
+    for _ in range(resamples):
+        total = 0.0
+        for _ in range(n):
+            total += scores[rng.randrange(n)]
+        means.append(total / n)
+    means.sort()
+
+    tail = (1.0 - confidence) / 2.0
+    return (_percentile(means, tail), _percentile(means, 1.0 - tail))

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "community-metrics-overview",
     "metrics-citation-faithfulness",
+    "metrics-judge-self-consistency",
     "metrics-agent-loop-detection",
     "metrics-tool-permission"
   ]

--- a/docs/content/docs/(community)/metrics-judge-self-consistency.mdx
+++ b/docs/content/docs/(community)/metrics-judge-self-consistency.mdx
@@ -1,0 +1,132 @@
+---
+id: metrics-judge-self-consistency
+title: Judge Self-Consistency
+sidebar_label: Judge Self-Consistency
+languages: [python]
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} referenceless={true} />
+
+The judge self-consistency metric measures **how much a judge agrees with itself**. It wraps another metric, runs it several times against the same [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case), and reports how far apart the repeats landed. Every other metric in `deepeval` measures your LLM application; this one measures the judge you are measuring it with.
+
+:::info
+The `JudgeSelfConsistencyMetric` is a **community metric**, contributed and maintained by the `deepeval` community. Community metrics are not exported from `deepeval.metrics` — import them explicitly from `deepeval.metrics.community` instead.
+:::
+
+:::note
+This metric adds no dependencies. The reliability statistics are implemented on the Python standard library.
+:::
+
+## Required Arguments
+
+The `JudgeSelfConsistencyMetric` requires whatever the metric it wraps requires — each replicate runs that judge's own validation. Wrapping an [`AnswerRelevancyMetric`](/docs/metrics-answer-relevancy) needs `input` and `actual_output`, wrapping a [`FaithfulnessMetric`](/docs/metrics-faithfulness) also needs `retrieval_context`, and so on.
+
+Only single-turn metrics are supported. Passing a conversational or arena metric raises a `TypeError`.
+
+## Usage
+
+```python
+from deepeval import evaluate
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics import AnswerRelevancyMetric
+from deepeval.metrics.community import JudgeSelfConsistencyMetric
+
+judge = AnswerRelevancyMetric(threshold=0.7)
+metric = JudgeSelfConsistencyMetric(metric=judge, replicates=5)
+
+test_case = LLMTestCase(
+    input="How tall is the Eiffel Tower?",
+    actual_output="The Eiffel Tower is about 330 metres tall.",
+)
+
+# To run metric as a standalone
+# metric.measure(test_case)
+# print(metric.score, metric.decision_flip_rate, metric.reason)
+
+evaluate(test_cases=[test_case], metrics=[judge, metric])
+```
+
+There are thirteen optional parameters when creating a `JudgeSelfConsistencyMetric`:
+
+- [Optional] `replicates`: an integer, the number of times to run the wrapped judge on each test case. Must be at least `2`. Defaulted to `5`.
+- [Optional] `threshold`: a float representing the minimum passing **stability**. Can also be set to `None` to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.9`.
+- [Optional] `auto_flaky`: a boolean which when set to `True`, [marks this metric as flaky](/docs/metrics-introduction#flaky-metrics) during a run whose replicates disagreed. Defaulted to `True`. See [Flaky, measured rather than declared](#flaky-measured-rather-than-declared).
+- [Optional] `score_range`: a `(low, high)` tuple giving the range the wrapped judge scores on. Stability is measured relative to this range, and scores outside it are reported as an error. Defaulted to `(0.0, 1.0)`.
+- [Optional] `max_concurrent`: an integer capping how many replicates run at once in async mode, or `None` for no cap. The replicates multiply your in-flight LLM calls, so set this if you are near a rate limit. Defaulted to `None`.
+- [Optional] `bootstrap_resamples`: an integer, the number of bootstrap resamples used for the confidence interval on the mean score. Defaulted to `2000`.
+- [Optional] `confidence`: a float strictly between `0` and `1`, the confidence level for that interval. Defaulted to `0.95`.
+- [Optional] `random_seed`: an integer seed making the bootstrap interval reproducible, or `None` for a fresh draw each call. Defaulted to `42`.
+- [Optional] `include_reason`: a boolean which when set to `True`, will include a reason for its evaluation score. Defaulted to `True`.
+- [Optional] `strict_mode`: a boolean which when set to `True`, requires perfect stability. It overrides the current threshold and sets it to `1`. Defaulted to `False`.
+- [Optional] `async_mode`: a boolean which when set to `True`, runs the replicates [concurrently within the `measure()` method](/docs/metrics-introduction#measuring-metrics-in-async). Defaulted to `True`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console. Defaulted to `False`.
+- [Optional] `flaky`: a boolean which when set to `True`, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics) for every run. Defaulted to `False`.
+
+## What It Reports
+
+After `measure()`, these are available on the metric:
+
+| Attribute            | Meaning                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| `score`              | **Stability**, in `[0, 1]`. `1.0` when every repeat produced the same score.          |
+| `decision_flip_rate` | Fraction of repeat **pairs** that landed on opposite sides of the judge's threshold.  |
+| `replicate_scores`   | The raw score from every replicate that ran.                                         |
+| `result`             | A `JudgeSelfConsistencyResult` with every replicate, the spread, and the interval.    |
+
+:::note
+`evaluate()` copies metrics internally, so the object you constructed is not the one that ran — read the run's results from the test run, not from your instance. A test run carries the `score`, `success`, `flaky` flag, `reason`, and verbose logs, so the flip rate reaches it as prose inside `reason`. The structured `result` and `replicate_scores` exist only on the instance, which means standalone `measure()` is the way to get at them programmatically.
+:::
+
+### Why the flip rate matters more than the score
+
+Stability answers "did the scores move?". The flip rate answers "did the **verdict** move?", and a verdict is what actually changes a test result.
+
+These come apart, which is the point of reporting both. A judge that scores `0.49, 0.51, 0.49, 0.51` against a threshold of `0.5` has barely moved — stability is `0.98`, comfortably above the default threshold — yet two thirds of its repeat pairs disagree on pass/fail. Scores clustered tightly *around* a threshold are the worst case, and a spread-only reading calls them healthy.
+
+## Flaky, Measured Rather Than Declared
+
+`deepeval` already has a [`flaky`](/docs/metrics-introduction#flaky-metrics) property on every metric: a flaky metric's score, reason, and verdict are all computed and reported, but its failure never decides its test case's pass/fail status, and its passes and fails are counted separately in the test run report.
+
+Until now that property has been something you declare from what you already know about a metric. `JudgeSelfConsistencyMetric` sets it from what it measured: when the replicates disagree, the metric marks itself flaky for that run. The reading stays in the report, in the flaky sub-count, without gating the suite:
+
+```
+ Metric                                          ┃ Average Score ┃ Pass Rate
+ Judge Self-Consistency (Answer Relevancy)       │ 0.36          │ 0.00% | passed=0 |
+                                                 │               │ failed=1 (flaky=1)
+```
+
+A run counts as disagreeing when any pair of repeats reached opposite verdicts, or when stability fell below the metric's own threshold. A verdict flip always counts, however small the score movement behind it; float-level jitter between otherwise identical scores does not.
+
+This is deliberate. A judge that disagrees with itself is a fact about your eval harness, not about the application under test, so it should be visible without failing your build. Set `auto_flaky=False` if you would rather the instability gate.
+
+## How Is It Calculated?
+
+Each replicate runs on its own copy of the wrapped judge, made with `deepeval`'s `copy_metrics` — the same helper `evaluate()` uses to isolate metrics across test cases. Each copy gets its own result state; the judge's configuration and model client are shared by reference.
+
+**Stability** is one minus the normalized spread of the replicate scores:
+
+```
+stability = 1 - stdev(scores) / (range width / 2)
+```
+
+Half the width of `score_range` is the largest standard deviation a population on that range can have, attained when half the mass sits at each end, so the ratio puts the spread on a `0-1` scale. Standard deviation rather than variance because it shares the units of the scores: halving the spread of the repeats halves the distance from a perfect reading. The sample standard deviation of a small sample can exceed the population bound, so the result is clamped at `0.0` rather than allowed to go negative.
+
+**Decision flip rate** is the fraction of replicate pairs whose verdicts disagree. With `k` replicates of which `p` passed the judge's threshold:
+
+```
+flip rate = p * (k - p) / (k * (k - 1) / 2)
+```
+
+This is the unbiased estimator of the probability that two independent repeats reach opposite verdicts. That probability is bounded by `0.5`, but the unbiased estimator is not: an even split reports `1.0` at `k=2` and `0.67` at `k=4`. Read it as "how many of my pairs disagreed", and only read it as a probability once `k` is reasonably large. It is `None` when the wrapped judge has no threshold and therefore reaches no verdict.
+
+**The confidence interval** on the mean score is a percentile bootstrap: resample the replicate scores with replacement, take the mean of each resample, and read the interval off the percentiles of that distribution. A wide interval on a handful of replicates is a signal to raise `replicates`, not a finding about the judge.
+
+:::note
+The wrapped judge needs some source of variation for this to be informative. A judge pinned to `temperature=0` may return the same score every time, which the metric will faithfully report as perfect stability.
+:::
+
+:::warning
+When wrapping a [`GEval`](/docs/metrics-llm-evals) metric built from `criteria` rather than `evaluation_steps`, each replicate generates its own evaluation steps before scoring. The reading then mixes rubric-generation variance into judge-scoring variance, and doubles the calls per replicate. Pass `evaluation_steps` explicitly to isolate the scoring variance.
+:::
+
+Methods used: the nonparametric bootstrap and percentile interval follow Efron and Tibshirani, _An Introduction to the Bootstrap_ (Chapman & Hall, 1993), chapters 6 and 13. Pairwise agreement as a test-retest reliability measure follows Shrout and Fleiss, "Intraclass correlations: uses in assessing rater reliability", _Psychological Bulletin_ 86(2), 1979.

--- a/tests/test_metrics/test_judge_self_consistency_metric.py
+++ b/tests/test_metrics/test_judge_self_consistency_metric.py
@@ -1,0 +1,550 @@
+"""Tests for JudgeSelfConsistencyMetric.
+
+The judge is scripted rather than real, so these run without an API key and
+without any nondeterminism of their own. Each test hands the wrapped judge a
+fixed sequence of scores and checks what the metric reports about them.
+"""
+
+import math
+from typing import List, Optional, Union
+
+import pytest
+
+from deepeval.errors import MissingTestCaseParamsError
+from deepeval.metrics import BaseConversationalMetric, BaseMetric
+from deepeval.metrics.community import JudgeSelfConsistencyMetric
+from deepeval.metrics.community.judge_self_consistency.stats import (
+    bootstrap_mean_interval,
+    decision_flip_rate,
+    stability,
+)
+from deepeval.metrics.utils import copy_metrics
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+TEST_CASE = LLMTestCase(
+    input="How tall is the Eiffel Tower?",
+    actual_output="It is 330 metres tall.",
+)
+
+
+class ScriptedJudge(BaseMetric):
+    """A judge that returns preset scores, one per call.
+
+    The score list is shared by reference across the copies the metric makes
+    for its replicates, so successive replicates consume successive scores
+    regardless of the order they run in. An `Exception` in the list is raised
+    instead of scored, which is how the error paths get exercised.
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        scores: List[Union[float, Exception]],
+        threshold: Optional[float] = 0.5,
+        async_mode: bool = False,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+    ):
+        self.scores = scores
+        self.threshold = threshold
+        self.async_mode = async_mode
+        self.verbose_mode = verbose_mode
+        self.flaky = flaky
+        self.evaluation_model = "scripted-judge"
+        self.using_native_model = False
+
+    def measure(self, test_case, *args, **kwargs) -> float:
+        self.error = None
+        next_score = self.scores.pop(0)
+        if isinstance(next_score, Exception):
+            raise next_score
+        self.score = next_score
+        self.reason = f"scripted {next_score}"
+        self.success = self.is_successful()
+        return self.score
+
+    async def a_measure(self, test_case, *args, **kwargs) -> float:
+        return self.measure(test_case, *args, **kwargs)
+
+    @property
+    def __name__(self):
+        return "Scripted Judge"
+
+
+class UndeclaredParamsJudge(BaseMetric):
+    """A judge that never declares `_required_params` of its own."""
+
+    def __init__(self, threshold: Optional[float] = 0.5):
+        self.threshold = threshold
+        self.async_mode = False
+        self.verbose_mode = False
+        self.evaluation_model = "scripted-judge"
+        self.using_native_model = False
+
+    def measure(self, test_case, *args, **kwargs) -> float:
+        self.error = None
+        self.score = 0.5
+        self.success = self.is_successful()
+        return self.score
+
+    async def a_measure(self, test_case, *args, **kwargs) -> float:
+        return self.measure(test_case)
+
+    @property
+    def __name__(self):
+        return "Undeclared Judge"
+
+
+# --- statistics -------------------------------------------------------------
+
+
+def test_stability_is_one_when_every_repeat_agrees():
+    assert stability([0.7, 0.7, 0.7, 0.7]) == 1.0
+
+
+def test_stability_is_zero_at_maximum_spread():
+    # Half at 0 and half at 1 is the widest a set of scores on [0, 1] can be.
+    assert stability([0.0, 1.0, 0.0, 1.0]) == 0.0
+    # An odd split reaches the floor too, unlike a population-variance reading.
+    assert stability([0.0, 0.0, 1.0, 1.0, 1.0]) == 0.0
+
+
+def test_stability_falls_as_scores_spread():
+    tight = stability([0.50, 0.52, 0.48])
+    loose = stability([0.20, 0.80, 0.50])
+    assert 0.0 < loose < tight < 1.0
+
+
+def test_stability_scales_with_the_declared_score_range():
+    # The same repeats read as stable on a wide range and unstable on a
+    # narrow one: spread only means something relative to the scale.
+    assert stability([7.0, 8.0, 7.0, 8.0], (0.0, 20.0)) > 0.9
+    assert stability([7.0, 8.0, 7.0, 8.0], (0.0, 10.0)) == pytest.approx(
+        0.8845, abs=1e-4
+    )
+    assert stability([7.0, 8.0, 7.0, 8.0], (7.0, 8.0)) == 0.0
+
+
+def test_stability_needs_two_scores():
+    assert stability([0.4]) == 1.0
+    assert stability([]) == 1.0
+
+
+def test_flip_rate_is_zero_when_every_repeat_agrees():
+    assert decision_flip_rate([True, True, True]) == 0.0
+    assert decision_flip_rate([False, False, False]) == 0.0
+
+
+def test_flip_rate_counts_disagreeing_pairs():
+    # 2 passes and 2 fails => 4 disagreeing pairs out of 6 total pairs.
+    assert decision_flip_rate([True, True, False, False]) == pytest.approx(
+        4 / 6
+    )
+    # 1 pass and 4 fails => 4 disagreeing pairs out of 10.
+    assert decision_flip_rate(
+        [True, False, False, False, False]
+    ) == pytest.approx(0.4)
+
+
+def test_flip_rate_needs_two_decisions():
+    assert decision_flip_rate([True]) is None
+    assert decision_flip_rate([]) is None
+
+
+def test_bootstrap_interval_brackets_the_mean_and_is_reproducible():
+    scores = [0.2, 0.4, 0.6, 0.8, 0.5]
+    mean = sum(scores) / len(scores)
+
+    low, high = bootstrap_mean_interval(scores, resamples=500, seed=7)
+    assert low <= mean <= high
+    # Same seed, same interval.
+    assert bootstrap_mean_interval(scores, resamples=500, seed=7) == (low, high)
+
+
+def test_bootstrap_interval_collapses_when_every_score_is_equal():
+    assert bootstrap_mean_interval([0.6, 0.6, 0.6], resamples=200, seed=1) == (
+        pytest.approx(0.6),
+        pytest.approx(0.6),
+    )
+
+
+def test_bootstrap_interval_rejects_nonsense_arguments():
+    with pytest.raises(ValueError):
+        bootstrap_mean_interval([0.1, 0.2], resamples=0)
+    with pytest.raises(ValueError):
+        bootstrap_mean_interval([0.1, 0.2], confidence=95)
+
+
+# --- metric behaviour -------------------------------------------------------
+
+
+def test_reports_perfect_stability_for_a_judge_that_agrees_with_itself():
+    judge = ScriptedJudge(scores=[0.8] * 4)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=4, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.score == 1.0
+    assert metric.decision_flip_rate == 0.0
+    assert metric.is_successful() is True
+    assert metric.flaky is False
+
+
+def test_detects_a_judge_that_flips_its_own_verdict():
+    # Four repeats hugging the judge's 0.5 threshold: two pass, two fail.
+    judge = ScriptedJudge(scores=[0.49, 0.51, 0.49, 0.51], threshold=0.5)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=4, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    # The scores barely move, so stability alone looks reassuring: it clears
+    # the metric's own default threshold comfortably...
+    assert metric.score > 0.95
+    assert metric.is_successful() is True
+    # ...while two thirds of repeat pairs reach the opposite verdict, because
+    # the scores move across the judge's threshold rather than far.
+    assert metric.decision_flip_rate == pytest.approx(4 / 6)
+    assert "disagreed on pass/fail" in metric.reason
+    # A verdict flip counts as disagreement however small the score movement.
+    assert metric.flaky is True
+
+
+def test_scores_low_when_repeats_spread_across_the_range():
+    judge = ScriptedJudge(scores=[0.0, 1.0, 0.0, 1.0])
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=4, threshold=0.9, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.score == 0.0
+    assert metric.is_successful() is False
+
+
+def test_float_jitter_alone_is_not_disagreement():
+    judge = ScriptedJudge(scores=[0.8, 0.8 + 1e-9], threshold=0.5)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=2, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.is_successful() is True
+    assert metric.flaky is False
+
+
+def test_auto_flaky_can_be_turned_off():
+    judge = ScriptedJudge(scores=[0.49, 0.51, 0.49, 0.51], threshold=0.5)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=4, auto_flaky=False, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.flaky is False
+
+
+def test_flaky_resets_between_runs():
+    judge = ScriptedJudge(scores=[0.0, 1.0, 0.9, 0.9], threshold=0.5)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=2, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+    assert metric.flaky is True
+
+    # A second, consistent run must not inherit the first run's verdict.
+    metric.measure(TEST_CASE)
+    assert metric.flaky is False
+
+
+def test_measured_flaky_does_not_latch_into_copies():
+    # `evaluate()` rebuilds metrics with `copy_metrics` for every test case, so
+    # a flaky reading must not be mistaken for a caller-declared one.
+    judge = ScriptedJudge(scores=[0.0, 1.0], threshold=0.5)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=2, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+    assert metric.flaky is True
+
+    judge.scores.extend([0.7, 0.7])
+    copied = copy_metrics([metric])[0]
+    copied.measure(TEST_CASE)
+
+    assert copied.flaky is False
+
+
+def test_declared_flaky_survives_copying():
+    judge = ScriptedJudge(scores=[0.7, 0.7], threshold=0.5)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=2, async_mode=False, flaky=True
+    )
+
+    copied = copy_metrics([metric])[0]
+    copied.measure(TEST_CASE)
+
+    assert copied.flaky is True
+
+
+def test_reports_no_flip_rate_for_a_judge_without_a_threshold():
+    judge = ScriptedJudge(scores=[0.3, 0.7, 0.5], threshold=None)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=3, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.decision_flip_rate is None
+    assert "no threshold" in metric.reason
+
+
+def test_records_the_spread_and_interval():
+    judge = ScriptedJudge(scores=[0.2, 0.6, 0.4, 0.8])
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=4, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    result = metric.result
+    assert result.min_score == 0.2
+    assert result.max_score == 0.8
+    assert result.mean_score == pytest.approx(0.5)
+    low, high = result.score_interval
+    assert low <= result.mean_score <= high
+    assert sorted(metric.replicate_scores) == [0.2, 0.4, 0.6, 0.8]
+
+
+def test_honours_a_custom_score_range():
+    judge = ScriptedJudge(scores=[7.0, 8.0, 7.0, 8.0], threshold=5.0)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge,
+        replicates=4,
+        score_range=(0.0, 10.0),
+        async_mode=False,
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.error is None
+    assert metric.score > 0.85
+
+
+def test_errors_on_scores_outside_the_declared_range():
+    judge = ScriptedJudge(scores=[7.0, 8.0], threshold=5.0)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=2, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.error is not None
+    assert "score_range" in metric.error
+    assert metric.is_successful() is False
+
+
+def test_tolerates_a_single_errored_replicate():
+    judge = ScriptedJudge(scores=[0.5, RuntimeError("judge exploded"), 0.5])
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=3, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.error is None
+    assert metric.score == 1.0
+    assert metric.result.errored_replicates == 1
+    assert "1 repeats errored" in metric.reason
+
+
+def test_errors_when_too_few_replicates_survive():
+    judge = ScriptedJudge(
+        scores=[0.5, RuntimeError("judge exploded"), RuntimeError("again")]
+    )
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=3, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.error is not None
+    assert "judge exploded" in metric.error
+    assert metric.is_successful() is False
+
+
+def test_a_failed_run_does_not_report_the_previous_run_s_numbers():
+    judge = ScriptedJudge(
+        scores=[0.5, 0.5, RuntimeError("gone"), RuntimeError("gone")]
+    )
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=2, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+    assert metric.score_breakdown is not None
+    assert metric.verbose_logs is not None
+
+    metric.measure(TEST_CASE)
+
+    assert metric.error is not None
+    assert metric.score is None
+    assert metric.score_breakdown is None
+    assert metric.verbose_logs is None
+
+
+def test_missing_params_error_is_left_for_the_harness():
+    # `MissingTestCaseParamsError` is how a test case gets skipped rather than
+    # failed, so the wrapper must not swallow it into a replicate result.
+    judge = ScriptedJudge(
+        scores=[MissingTestCaseParamsError("no retrieval_context")] * 3
+    )
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=3, async_mode=False
+    )
+
+    with pytest.raises(MissingTestCaseParamsError):
+        metric.measure(TEST_CASE)
+
+
+def test_rejects_fewer_than_two_replicates():
+    with pytest.raises(ValueError, match="at least 2"):
+        JudgeSelfConsistencyMetric(
+            metric=ScriptedJudge(scores=[0.5]), replicates=1
+        )
+
+
+def test_rejects_nonsense_constructor_arguments():
+    judge = ScriptedJudge(scores=[0.5, 0.5])
+    with pytest.raises(ValueError, match="confidence"):
+        JudgeSelfConsistencyMetric(metric=judge, confidence=95)
+    with pytest.raises(ValueError, match="bootstrap_resamples"):
+        JudgeSelfConsistencyMetric(metric=judge, bootstrap_resamples=0)
+    with pytest.raises(ValueError, match="score_range"):
+        JudgeSelfConsistencyMetric(metric=judge, score_range=(1.0, 0.0))
+    with pytest.raises(ValueError, match="max_concurrent"):
+        JudgeSelfConsistencyMetric(metric=judge, max_concurrent=0)
+
+
+def test_rejects_a_conversational_metric():
+    class ConversationalJudge(BaseConversationalMetric):
+        def measure(self, test_case, *args, **kwargs):
+            return 1.0
+
+        async def a_measure(self, test_case, *args, **kwargs):
+            return 1.0
+
+    with pytest.raises(TypeError, match="BaseMetric"):
+        JudgeSelfConsistencyMetric(metric=ConversationalJudge())
+
+
+def test_strict_mode_demands_perfect_stability():
+    judge = ScriptedJudge(scores=[0.4, 0.6, 0.4, 0.6])
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=4, strict_mode=True, async_mode=False
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.threshold == 1
+    assert metric.score == 0
+    assert metric.is_successful() is False
+
+
+def test_inherits_the_required_params_of_the_wrapped_judge():
+    judge = ScriptedJudge(scores=[0.5, 0.5])
+    metric = JudgeSelfConsistencyMetric(metric=judge, replicates=2)
+
+    assert metric._required_params == ScriptedJudge._required_params
+
+
+def test_required_params_is_empty_when_the_judge_declares_none():
+    # `BaseMetric` leaves `_required_params` as a bare type annotation, which
+    # must not be mistaken for a real list of parameters.
+    metric = JudgeSelfConsistencyMetric(
+        metric=UndeclaredParamsJudge(), replicates=2
+    )
+
+    assert metric._required_params == []
+
+
+def test_name_identifies_the_wrapped_judge():
+    # Two wrappers in one run must not collapse into a single report row.
+    relevancy = JudgeSelfConsistencyMetric(
+        metric=ScriptedJudge(scores=[0.5, 0.5]), replicates=2
+    )
+    undeclared = JudgeSelfConsistencyMetric(
+        metric=UndeclaredParamsJudge(), replicates=2
+    )
+
+    assert relevancy.__name__ == "Judge Self-Consistency (Scripted Judge)"
+    assert undeclared.__name__ != relevancy.__name__
+
+
+def test_async_measure_matches_sync():
+    scores = [0.49, 0.51, 0.49, 0.51]
+    sync_metric = JudgeSelfConsistencyMetric(
+        metric=ScriptedJudge(scores=list(scores), threshold=0.5),
+        replicates=4,
+        async_mode=False,
+    )
+    async_metric = JudgeSelfConsistencyMetric(
+        metric=ScriptedJudge(scores=list(scores), threshold=0.5),
+        replicates=4,
+        async_mode=True,
+    )
+
+    sync_metric.measure(TEST_CASE)
+    async_metric.measure(TEST_CASE)
+
+    assert math.isclose(sync_metric.score, async_metric.score)
+    assert sync_metric.decision_flip_rate == async_metric.decision_flip_rate
+    assert sync_metric.flaky == async_metric.flaky
+
+
+def test_async_measure_respects_a_concurrency_bound():
+    judge = ScriptedJudge(scores=[0.5] * 6, async_mode=True)
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=6, max_concurrent=2, async_mode=True
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.score == 1.0
+    assert len(metric.replicate_scores) == 6
+
+
+def test_missing_params_error_propagates_from_the_async_path():
+    judge = ScriptedJudge(
+        scores=[MissingTestCaseParamsError("no retrieval_context")] * 3,
+        async_mode=True,
+    )
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=3, async_mode=True
+    )
+
+    with pytest.raises(MissingTestCaseParamsError):
+        metric.measure(TEST_CASE)
+
+
+def test_async_path_folds_ordinary_replicate_errors_into_the_result():
+    judge = ScriptedJudge(
+        scores=[0.5, RuntimeError("judge exploded"), 0.5], async_mode=True
+    )
+    metric = JudgeSelfConsistencyMetric(
+        metric=judge, replicates=3, async_mode=True
+    )
+
+    metric.measure(TEST_CASE)
+
+    assert metric.error is None
+    assert metric.result.errored_replicates == 1


### PR DESCRIPTION
# Add `JudgeSelfConsistencyMetric` community metric

Adds a community metric that measures **how much a judge agrees with itself**. It wraps another metric, runs it `k` times against the same `LLMTestCase`, and reports how far apart the repeats landed.

Every other metric in `deepeval` measures the application under test. This one measures the judge you are measuring it with.

## Why

`metrics-introduction.mdx` already describes the failure mode this catches, under **Flaky Metrics**:

> This is useful for metrics you know are noisy — for example ones with borderline scores that flip between passing and failing across runs — that you still want to keep measuring and tracking without letting them gate deployments.

The words there are "metrics you know are noisy". Right now that knowledge has to come from somewhere outside `deepeval`: `BaseMetric.flaky` is declared, never measured. Every assignment in the package is `self.flaky = flaky` from a constructor argument, across all ~43 metrics that take one. The only reads are `evaluate/utils.py` packing it into `MetricData`, `console_report.py` counting `flaky_passes` / `flaky_fails`, and `metrics/utils.py` excluding flaky metrics from deciding pass/fail. The reporting scaffolding is built and wired; nothing populates it from evidence.

This metric does. When the replicates disagree, it sets `self.flaky = True` for that run, so the reading lands in the flaky sub-count without gating the suite:

```
 Metric                                    ┃ Average Score ┃ Pass Rate
 Gate                                      │ 1.00          │ 100.00% | passed=1 | failed=0
 Judge Self-Consistency (Relevancy)        │ 0.07          │ 0.00%   | passed=0 | failed=1 (flaky=1)
 Judge Self-Consistency (Faithfulness)     │ 0.98          │ 100.00% | passed=1 (flaky=1) | failed=0
```

That third row is the case worth having. Its stability score is `0.98` — the repeats barely moved — and it passes. But those repeats were `0.49, 0.51, 0.49, 0.51` against a judge threshold of `0.5`, so two thirds of repeat pairs reached the opposite verdict. Scores clustered tightly *around* a threshold are the worst case for an eval suite, and any spread-only reading calls them healthy. That is why the metric reports the flip rate separately rather than folding it into one number.

Marking the metric flaky rather than failing the build is deliberate: a judge that disagrees with itself is a fact about the eval harness, not about the application under test. `auto_flaky=False` turns it off for anyone who would rather it gate.

## What it reports

- **Stability** (the metric's `score`) — `1 - stdev(scores) / (range width / 2)`, clamped to `[0, 1]`.
- **Decision flip rate** — `p * (k - p) / (k * (k - 1) / 2)`, the fraction of replicate pairs whose verdicts disagree.
- **A percentile bootstrap interval** on the mean score, so a wide interval tells you to raise `replicates` rather than distrust the judge.

## Notes on the implementation

**No new dependency.** The statistics are on the standard library. `deepeval` does not depend on `numpy` — it is absent from `pyproject.toml`, and all 11 `numpy` uses in the package are deferred imports inside optional code paths (`scorer.py`, `_summac_model.py`, `utils.py`) — so pulling it in for one community metric seemed like the wrong trade. `k` is small enough that it buys nothing here anyway.

**No prompt templates.** The metric drives an existing judge rather than prompting an LLM itself, so there is nothing to add to `templates.json` and no `MetricTemplateMethod` literal to extend.

**Replicate isolation** uses `copy_metrics`, the same helper `evaluate()` uses to isolate metrics across test cases. Each replicate gets its own result state; configuration and the model client stay shared by reference. The docs page flags the one case where that matters: a `GEval` built from `criteria` alone has `evaluation_steps` regenerated per replicate, which mixes rubric-generation variance into the reading, so it recommends passing `evaluation_steps` explicitly.

**Structure** follows `CONTRIBUTING.md`: a folder under `deepeval/metrics/community/` holding the metric class, `schema.py`, and an export from `community/__init__.py`, plus a docs page under the Community section and tests. There is one extra module, `stats.py`, holding the three pure statistical functions so they can be unit-tested and checked independently of the metric.

## Tests

38 tests in `tests/test_metrics/test_judge_self_consistency_metric.py`, all offline against a scripted judge — no API key needed. They cover the statistics directly (including the `k=2` and odd-`k` edges), the flip-rate-without-spread case above, `auto_flaky` on and off, flaky state not latching across runs or through `copy_metrics`, partial and total replicate failure, `MissingTestCaseParamsError` being left for the harness so `skip_on_missing_params` still works, custom score ranges, constructor validation, and async/sync agreement.

`black` was run over the new files with the repo's `line-length = 80`.

## Open questions for maintainers

1. **Default `threshold=0.9`.** With the normalized-spread formula that means a standard deviation of `0.05` on a unit-range judge. Reasonable, or too strict for real judges out of the box?
2. **`self.flaky` on the wrapper vs. the wrapped judge.** The wrapper flags itself. Flagging the wrapped judge instead would arguably be more useful, but `evaluate()` copies metrics per test case, so mutating another metric in the list is not reliable. Happy to change the semantics if you see it differently.
3. **`decision_flip_rate` does not survive into `MetricData`**, which has no field for it, so it reaches a test run only as prose inside `reason` and `verboseLogs`. If you would take a patch adding a structured field, say the word — otherwise this is fine as is.
4. **Promotion path.** Happy to keep it in `community/` indefinitely; flagging only that this one has an unusual relationship to core, since it is the thing that populates an existing core reporting feature.

cc @trevor-cai @A-Vamshi @jeffreyip @kritinv
