### PR TITLE
fix(conversational-g-eval): deduplicate weighted logprob scoring

### DIFF
--- a/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
+++ b/deepeval/metrics/conversational_g_eval/conversational_g_eval.py
@@ -1,13 +1,13 @@
 """A slightly modified tailored version of the LLM evaluated metric based on the GEval framework: https://arxiv.org/pdf/2303.16634.pdf"""
 
 from openai.types.chat.chat_completion import ChatCompletion
-from typing import Optional, List, Tuple, Union, Dict, Type
+from typing import Optional, List, Tuple, Union, Type
 from rich.console import Console
-import math
 from deepeval.metrics import BaseConversationalMetric
 from deepeval.metrics.g_eval.utils import (
     MetricPullResponse,
     Rubric,
+    calculate_weighted_summed_score,
     construct_conversational_g_eval_turn_params_string,
     construct_non_turns_test_case_string,
     format_rubrics,
@@ -360,44 +360,7 @@ class ConversationalGEval(BaseConversationalMetric):
     def generate_weighted_summed_score(
         self, raw_score: int, raw_response: ChatCompletion
     ) -> Union[int, float]:
-        generated_logprobs = raw_response.choices[0].logprobs.content
-        # First, locate the token that we care for logprobs, i.e., the token matching the score
-        score_logprobs = None
-        for token_logprobs in generated_logprobs:
-            if token_logprobs.token == str(raw_score):
-                score_logprobs = token_logprobs
-                break
-        # Then, calculate the score based on the logprobs
-        token_linear_probability: Dict[int, float] = {}
-        sum_linear_probability = 0
-        # Filter out tokens with <1% linear probability, i.e., logprobs < math.log(0.01)
-        min_logprob = math.log(0.01)
-        for token_logprob in score_logprobs.top_logprobs:
-            logprob = token_logprob.logprob
-
-            # Filter out low probability tokens
-            if logprob < min_logprob:
-                continue
-            # Filter out non-decimal token to prevent errors in later int(token) conversion
-            if not token_logprob.token.isdecimal():
-                continue
-
-            # Calculate the linear probability
-            linear_prob = math.exp(logprob)
-            token_score = int(token_logprob.token)
-            if token_linear_probability.get(token_score):
-                token_linear_probability[token_score] += linear_prob
-            else:
-                token_linear_probability[token_score] = linear_prob
-            sum_linear_probability += linear_prob
-
-        sum_of_weighted_scores = 0.0
-        for score, prob in token_linear_probability.items():
-            sum_of_weighted_scores += score * prob
-
-        # Scale the sum of linear probability to 1
-        weighted_summed_score = sum_of_weighted_scores / sum_linear_probability
-        return weighted_summed_score
+        return calculate_weighted_summed_score(raw_score, raw_response)
 
     def number_evaluation_steps(self):
         evaluation_steps = """"""

--- a/tests/test_metrics/test_g_eval_utils.py
+++ b/tests/test_metrics/test_g_eval_utils.py
@@ -16,6 +16,7 @@ from deepeval.metrics.utils import (
     check_llm_test_case_params,
     convert_turn_to_dict,
 )
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import (
     ConversationalTestCase,
     LLMTestCase,
@@ -68,6 +69,56 @@ def test_calculate_weighted_summed_score_with_single_score_token():
     raw_response = create_raw_response([create_token("6", "4")])
 
     assert calculate_weighted_summed_score(6, raw_response) == 4
+
+
+def test_calculate_weighted_summed_score_zero_sum_probability():
+    raw_response = create_raw_response(
+        [
+            SimpleNamespace(
+                token="5",
+                top_logprobs=[SimpleNamespace(token="non_decimal", logprob=0)],
+            )
+        ]
+    )
+
+    assert calculate_weighted_summed_score(5, raw_response) == 5
+
+
+class FakeModel(DeepEvalBaseLLM):
+    def __init__(self):
+        pass
+
+    def load_model(self):
+        return None
+
+    def generate(self, prompt: str) -> str:
+        return ""
+
+    async def a_generate(self, prompt: str) -> str:
+        return ""
+
+    def get_model_name(self) -> str:
+        return "fake"
+
+
+def test_conversational_geval_delegates_weighted_summed_score():
+    from deepeval.metrics import ConversationalGEval
+
+    metric = ConversationalGEval(
+        name="test_convo",
+        evaluation_params=[MultiTurnParams.CONTENT],
+        criteria="criteria",
+        model=FakeModel(),
+    )
+    raw_response = create_raw_response(
+        [
+            create_token("10", "2"),
+            create_token("reasoning_text", "reasoning_text"),
+            create_token("10", "10"),
+        ]
+    )
+
+    assert metric.generate_weighted_summed_score(10, raw_response) == 10
 
 
 def test_geval_accepts_metadata_and_tags():


### PR DESCRIPTION
## Summary
- deduplicate `ConversationalGEval.generate_weighted_summed_score()` by delegating to the shared `calculate_weighted_summed_score()` in `g_eval/utils.py`
- add offline regression test verifying the delegation
## Root cause
`ConversationalGEval.generate_weighted_summed_score()` contained an inlined copy of the weighted logprob scoring logic. PR #3060 fixed the shared `calculate_weighted_summed_score()` to search tokens in `reversed()` order, but `ConversationalGEval`'s private copy was not updated and still searches forward — picking up reasoning tokens instead of the final score token.
```python
# Before (conversational_g_eval.py, line 366) — forward search, stale
for token_logprobs in generated_logprobs:
# After — delegates to g_eval/utils.py which uses reversed()
return calculate_weighted_summed_score(raw_score, raw_response)
```
## Impact
`ConversationalGEval` weighted scores now use the probability distribution associated with the model's final score rather than an earlier matching token in its reasoning, matching `GEval`'s corrected behaviour. There are no public API or schema changes.
## Changes
- **`deepeval/metrics/conversational_g_eval/conversational_g_eval.py`**: replace the 37-line inlined body of `generate_weighted_summed_score()` with a one-line delegation to `calculate_weighted_summed_score()`; remove the now-unused `import math` and `Dict` typing import.
- **`tests/test_metrics/test_g_eval_utils.py`**: add `test_calculate_weighted_summed_score_zero_sum_probability` (edge-case coverage for the existing zero-sum guard) and `test_conversational_geval_delegates_weighted_summed_score` (regression test proving the delegation uses the shared utility's `reversed()` search). Both tests are offline — no API keys required.
## Validation
- `poetry run pytest tests/test_metrics/test_g_eval_utils.py` — 9 passed
- `poetry run black --check deepeval/metrics/conversational_g_eval/conversational_g_eval.py tests/test_metrics/test_g_eval_utils.py` — passed