### PR TITLE
docs(metrics): fix constructor parameter docs that do not match the code

### DIFF
--- a/docs/content/docs/(images)/multimodal-metrics-image-coherence.mdx
+++ b/docs/content/docs/(images)/multimodal-metrics-image-coherence.mdx
@@ -14,7 +14,7 @@ Image Coherence evaluates MLLM responses containing text accompanied by retrieve
 
 ## Required Arguments
 
-To use the `ImageCoherence`, you'll have to provide the following arguments when creating a [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
+To use the `ImageCoherenceMetric`, you'll have to provide the following arguments when creating a [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
 
 - `input`
 - <Term py="actual_output" ts="actualOutput"/>
@@ -34,7 +34,6 @@ from deepeval import evaluate
 
 metric = ImageCoherenceMetric(
     threshold=0.7,
-    include_reason=True,
 )
 m_test_case = LLMTestCase(
     input=f"Provide step-by-step instructions on how to fold a paper airplane.",
@@ -86,19 +85,20 @@ await evaluate([mTestCase], [metric]);
 
 <Case id="python">
 
-There are **SIX** optional parameters when creating a `ImageCoherence`:
+There are **SEVEN** optional parameters when creating an `ImageCoherenceMetric`:
 
 </Case>
 
 <Case id="typescript">
 
-There are **FIVE** optional parameters when creating a `ImageCoherence`:
+There are **SIX** optional parameters when creating an `ImageCoherenceMetric`:
 
 </Case>
 
 </Switch>
 
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to <Term py="False" ts="false"/>.
 - <Only id="python">
     [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.

--- a/docs/content/docs/(images)/multimodal-metrics-image-editing.mdx
+++ b/docs/content/docs/(images)/multimodal-metrics-image-editing.mdx
@@ -34,7 +34,6 @@ from deepeval import evaluate
 
 metric = ImageEditingMetric(
     threshold=0.7,
-    include_reason=True,
 )
 m_test_case = LLMTestCase(
     input=f"Change the color of the shoes to blue. {MLLMImage(url='./shoes.png', local=True)}",
@@ -76,20 +75,20 @@ await evaluate([mTestCase], [metric]);
 
 <Case id="python">
 
-There are **SIX** optional parameters when creating a `ImageEditingMetric`:
+There are **SIX** optional parameters when creating an `ImageEditingMetric`:
 
 </Case>
 
 <Case id="typescript">
 
-There are **FIVE** optional parameters when creating a `ImageEditingMetric`:
+There are **FIVE** optional parameters when creating an `ImageEditingMetric`:
 
 </Case>
 
 </Switch>
 
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
-- [Optional] <Term py="include_reason" ts="includeReason"/>: a boolean which when set to <Term py="True" ts="true"/>, will include a reason for its evaluation score. Defaulted to <Term py="True" ts="true"/>.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to <Term py="False" ts="false"/>.
 - <Only id="python">
     [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.

--- a/docs/content/docs/(images)/multimodal-metrics-image-helpfulness.mdx
+++ b/docs/content/docs/(images)/multimodal-metrics-image-helpfulness.mdx
@@ -38,7 +38,6 @@ from deepeval import evaluate
 
 metric = ImageHelpfulnessMetric(
     threshold=0.7,
-    include_reason=True,
 )
 m_test_case = LLMTestCase(
     input=f"Provide step-by-step instructions on how to fold a paper airplane.",
@@ -92,19 +91,20 @@ await evaluate([mTestCase], [metric]);
 
 <Case id="python">
 
-There are **SIX** optional parameters when creating a `ImageHelpfulnessMetric`:
+There are **SEVEN** optional parameters when creating an `ImageHelpfulnessMetric`:
 
 </Case>
 
 <Case id="typescript">
 
-There are **FIVE** optional parameters when creating a `ImageHelpfulnessMetric`:
+There are **SIX** optional parameters when creating an `ImageHelpfulnessMetric`:
 
 </Case>
 
 </Switch>
 
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to <Term py="False" ts="false"/>.
 - <Only id="python">
     [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.

--- a/docs/content/docs/(images)/multimodal-metrics-image-reference.mdx
+++ b/docs/content/docs/(images)/multimodal-metrics-image-reference.mdx
@@ -38,7 +38,6 @@ from deepeval import evaluate
 
 metric = ImageReferenceMetric(
     threshold=0.7,
-    include_reason=True,
 )
 m_test_case = LLMTestCase(
     input=f"Provide step-by-step instructions on how to fold a paper airplane.",
@@ -92,19 +91,20 @@ await evaluate([mTestCase], [metric]);
 
 <Case id="python">
 
-There are **SIX** optional parameters when creating a `ImageReferenceMetric`:
+There are **SEVEN** optional parameters when creating an `ImageReferenceMetric`:
 
 </Case>
 
 <Case id="typescript">
 
-There are **FIVE** optional parameters when creating a `ImageReferenceMetric`:
+There are **SIX** optional parameters when creating an `ImageReferenceMetric`:
 
 </Case>
 
 </Switch>
 
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to <Term py="False" ts="false"/>.
 - <Only id="python">
     [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.

--- a/docs/content/docs/(images)/multimodal-metrics-text-to-image.mdx
+++ b/docs/content/docs/(images)/multimodal-metrics-text-to-image.mdx
@@ -38,7 +38,6 @@ from deepeval import evaluate
 
 metric = TextToImageMetric(
     threshold=0.7,
-    include_reason=True,
 )
 m_test_case = LLMTestCase(
     input=f"Generate an image of a blue pair of shoes.",
@@ -93,7 +92,7 @@ There are **FIVE** optional parameters when creating a `TextToImageMetric`:
 </Switch>
 
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
-- [Optional] <Term py="include_reason" ts="includeReason"/>: a boolean which when set to <Term py="True" ts="true"/>, will include a reason for its evaluation score. Defaulted to <Term py="True" ts="true"/>.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to <Term py="False" ts="false"/>.
 - <Only id="python">
     [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.

--- a/docs/content/docs/(multi-turn)/metrics-knowledge-retention.mdx
+++ b/docs/content/docs/(multi-turn)/metrics-knowledge-retention.mdx
@@ -70,12 +70,29 @@ await evaluate([convoTestCase], [metric]);
 
 </Switch>
 
+<Switch>
+
+<Case id="python">
+
+There are **SEVEN** optional parameters when creating a `KnowledgeRetentionMetric`:
+
+</Case>
+
+<Case id="typescript">
+
 There are **SIX** optional parameters when creating a `KnowledgeRetentionMetric`:
+
+</Case>
+
+</Switch>
 
 - [Optional] `threshold`: a number representing the maximum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
 - [Optional] `model`: a string specifying which of OpenAI's GPT models to use, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] <Term py="include_reason" ts="includeReason"/>: a boolean which when set to <Term py="True" ts="true"/>, will include a reason for its evaluation score. Defaulted to <Term py="True" ts="true"/>.
 - [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 0. Defaulted to <Term py="False" ts="false"/>.
+- <Only id="python">
+    [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-metrics-in-async) Defaulted to `True`.
+  </Only>
 - [Optional] <Term py="verbose_mode" ts="verboseMode"/>: a boolean which when set to <Term py="True" ts="true"/>, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to <Term py="False" ts="false"/>.
 - [Optional] `flaky`: a boolean which when set to <Term py="True" ts="true"/>, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics). Defaulted to <Term py="False" ts="false"/>.
 

--- a/docs/content/docs/(non-llm)/metrics-json-correctness.mdx
+++ b/docs/content/docs/(non-llm)/metrics-json-correctness.mdx
@@ -152,13 +152,13 @@ await evaluate([testCase], [metric]);
 
 <Case id="python">
 
-There are **ONE** mandatory and **SEVEN** optional parameters when creating an `PromptAlignmentMetric`:
+There are **ONE** mandatory and **SEVEN** optional parameters when creating a `JsonCorrectnessMetric`:
 
 </Case>
 
 <Case id="typescript">
 
-There are **ONE** mandatory and **SIX** optional parameters when creating an `PromptAlignmentMetric`:
+There are **ONE** mandatory and **SIX** optional parameters when creating a `JsonCorrectnessMetric`:
 
 </Case>
 
@@ -168,7 +168,7 @@ There are **ONE** mandatory and **SIX** optional parameters when creating an `Pr
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
 - [Optional] `model`: a string specifying which of OpenAI's GPT models to use to generate reasons, **OR** [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
 - [Optional] <Term py="include_reason" ts="includeReason"/>: a boolean which when set to <Term py="True" ts="true"/>, will include a reason for its evaluation score. Defaulted to <Term py="True" ts="true"/>.
-- [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to <Term py="False" ts="false"/>.
+- [Optional] <Term py="strict_mode" ts="strictMode"/>: a boolean which when set to <Term py="True" ts="true"/>, enforces a binary metric score: 1 for perfection, 0 otherwise. It also overrides the current threshold and sets it to 1. Defaulted to <Term py="True" ts="true"/>.
 - <Only id="python">
     [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method.](/docs/metrics-introduction#measuring-a-metric-in-async) Defaulted to `True`.
   </Only>

--- a/docs/content/docs/(non-llm)/metrics-pattern-match.mdx
+++ b/docs/content/docs/(non-llm)/metrics-pattern-match.mdx
@@ -88,7 +88,7 @@ await evaluate([testCase], [metric]);
 There is **ONE** mandatory and **FOUR** optional parameters when creating a `PatternMatchMetric`:
 
 - `pattern`: a string representing the regular expression pattern that the <Term py="actual_output" ts="actualOutput"/> must match.
-- [Optional] <Term py="ignore_case" ts="ignoreCase"/>: a boolean which when set to <Term py="True" ts="true"/>, performs case-sensitive pattern matching. Defaulted to <Term py="False" ts="false"/>.
+- [Optional] <Term py="ignore_case" ts="ignoreCase"/>: a boolean which when set to <Term py="True" ts="true"/>, performs case-insensitive pattern matching. Defaulted to <Term py="False" ts="false"/>.
 - [Optional] `threshold`: a number representing the minimum passing threshold. Can also be set to <Term py="None" ts="null"/> to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `1.0`.
 - [Optional] <Term py="verbose_mode" ts="verboseMode"/>: a boolean which when set to <Term py="True" ts="true"/>, prints the intermediate steps used to calculate said metric to the console, as outlined in the [How Is It Calculated](#how-is-it-calculated) section. Defaulted to <Term py="False" ts="false"/>.
 - [Optional] `flaky`: a boolean which when set to <Term py="True" ts="true"/>, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics). Defaulted to <Term py="False" ts="false"/>.

--- a/docs/content/docs/(rag)/metrics-faithfulness.mdx
+++ b/docs/content/docs/(rag)/metrics-faithfulness.mdx
@@ -179,13 +179,13 @@ await evaluate([testCase], [metric]);
 
 <Case id="python">
 
-There are **NINE** optional parameters when creating a `FaithfulnessMetric`:
+There are **TEN** optional parameters when creating a `FaithfulnessMetric`:
 
 </Case>
 
 <Case id="typescript">
 
-There are **EIGHT** optional parameters when creating a `FaithfulnessMetric`:
+There are **NINE** optional parameters when creating a `FaithfulnessMetric`:
 
 </Case>
 


### PR DESCRIPTION
**Describe the change**

I audited every "There are **N** … parameters when creating a `…Metric`" section in the metric docs against the real `__init__` signatures and fixed the statements that were wrong. Nothing here changes library behaviour; it only makes the docs say what the code does.

- **`metrics-json-correctness.mdx`** — the parameter section said it was describing a `PromptAlignmentMetric`. It also said `strict_mode` defaults to `False`, but `JsonCorrectnessMetric` defaults it to `True` (`deepeval/metrics/json_correctness/json_correctness.py`).
- **`multimodal-metrics-image-coherence.mdx`** — referred to the metric as `ImageCoherence` in three places; the exported class is `ImageCoherenceMetric`.
- **All five multimodal metric docs** (image coherence / editing / helpfulness / reference, text-to-image) passed `include_reason=True` in their Python samples, and image-editing / text-to-image also listed it as a parameter — but none of these constructors accept it, so copying the sample raises `TypeError: __init__() got an unexpected keyword argument 'include_reason'`. Dropped it and documented the `model` parameter these metrics do accept (it was missing from all five).
- **`metrics-pattern-match.mdx`** — `ignore_case=True` was described as performing *case-sensitive* matching; it compiles the pattern with `re.IGNORECASE`, i.e. case-insensitive (the FAQ further down the same page already says so).
- **`metrics-knowledge-retention.mdx`** — `async_mode` was missing from the parameter list; added it with the same python-only block the other metric docs use.
- **`metrics-faithfulness.mdx`** — the headers said nine (Python) / eight (TypeScript) optional parameters, but the list has ten / nine.

Header counts are updated wherever a list changed. I deliberately left `metrics-mcp-use.mdx` and `metrics-tool-correctness.mdx` alone because #2691 already fixes those headers.

One assumption to flag for reviewers: for the `strict_mode` default in the JSON-correctness doc I set both the Python and TypeScript terms to `True` / `true`. I verified the Python default; I could not check the TypeScript SDK.
