### PR TITLE
fix(metrics): honor include_reason in GoalAccuracy/ToolUse and use the argument-reason template

### DIFF
--- a/deepeval/metrics/goal_accuracy/goal_accuracy.py
+++ b/deepeval/metrics/goal_accuracy/goal_accuracy.py
@@ -256,6 +256,9 @@ class GoalAccuracyMetric(BaseConversationalMetric):
         plan_scores: List[PlanScore],
         multimodal: bool,
     ):
+        if self.include_reason is False:
+            return None
+
         goal_evaluations = ""
         for goal_score in goal_scores:
             goal_evaluations += (
@@ -290,6 +293,9 @@ class GoalAccuracyMetric(BaseConversationalMetric):
         plan_scores: List[PlanScore],
         multimodal: bool,
     ):
+        if self.include_reason is False:
+            return None
+
         goal_evaluations = ""
         for goal_score in goal_scores:
             goal_evaluations += (

--- a/deepeval/metrics/tool_use/tool_use.py
+++ b/deepeval/metrics/tool_use/tool_use.py
@@ -122,11 +122,15 @@ class ToolUseMetric(BaseConversationalMetric):
                         multimodal=test_case.multimodal,
                     )
                 )
-                self.reason = str(
-                    "\n".join(
-                        [tool_selection_reason, argument_correctness_reason]
+                reasons = [
+                    reason
+                    for reason in (
+                        tool_selection_reason,
+                        argument_correctness_reason,
                     )
-                )
+                    if reason
+                ]
+                self.reason = "\n".join(reasons) if reasons else None
 
                 self.verbose_logs = construct_verbose_logs(
                     self,
@@ -199,9 +203,15 @@ class ToolUseMetric(BaseConversationalMetric):
                     multimodal=test_case.multimodal,
                 )
             )
-            self.reason = str(
-                "\n".join([tool_selection_reason, argument_correctness_reason])
-            )
+            reasons = [
+                reason
+                for reason in (
+                    tool_selection_reason,
+                    argument_correctness_reason,
+                )
+                if reason
+            ]
+            self.reason = "\n".join(reasons) if reasons else None
 
             self.verbose_logs = construct_verbose_logs(
                 self,
@@ -372,6 +382,9 @@ class ToolUseMetric(BaseConversationalMetric):
         *,
         multimodal: bool,
     ):
+        if self.include_reason is False:
+            return None
+
         scores_and_reasons = ""
         for tool_use in tool_use_scores:
             scores_and_reasons += (
@@ -399,13 +412,16 @@ class ToolUseMetric(BaseConversationalMetric):
         *,
         multimodal: bool,
     ):
+        if self.include_reason is False:
+            return None
+
         scores_and_reasons = ""
         for tool_use in argument_correctness_scores:
             scores_and_reasons += (
                 f"\nScore: {tool_use.score} \nReason: {tool_use.reason} \n"
             )
         prompt = self._get_prompt(
-            "get_tool_selection_final_reason",
+            "get_tool_argument_final_reason",
             all_scores_and_reasons=scores_and_reasons,
             final_score=self.score,
             threshold=self.threshold,
@@ -422,6 +438,9 @@ class ToolUseMetric(BaseConversationalMetric):
     async def _a_generate_reason_for_tool_selection(
         self, tool_use_scores: List[ToolSelectionScore], *, multimodal: bool
     ):
+        if self.include_reason is False:
+            return None
+
         scores_and_reasons = ""
         for tool_use in tool_use_scores:
             scores_and_reasons += (
@@ -448,13 +467,16 @@ class ToolUseMetric(BaseConversationalMetric):
         *,
         multimodal: bool,
     ):
+        if self.include_reason is False:
+            return None
+
         scores_and_reasons = ""
         for tool_use in argument_correctness_scores:
             scores_and_reasons += (
                 f"\nScore: {tool_use.score} \nReason: {tool_use.reason} \n"
             )
         prompt = self._get_prompt(
-            "get_tool_selection_final_reason",
+            "get_tool_argument_final_reason",
             all_scores_and_reasons=scores_and_reasons,
             final_score=self.score,
             threshold=self.threshold,

--- a/tests/test_metrics/test_goal_accuracy_include_reason.py
+++ b/tests/test_metrics/test_goal_accuracy_include_reason.py
@@ -1,0 +1,91 @@
+"""Regression tests for GoalAccuracyMetric and include_reason.
+
+`include_reason` was accepted by the constructor but never consulted, so the
+final-reason LLM call was made in both the sync and async paths even when the
+user explicitly disabled it.
+
+These tests run with stub models, so they need no LLM provider API key.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics import GoalAccuracyMetric
+from deepeval.metrics.goal_accuracy.schema import GoalScore, PlanScore
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.test_case import ConversationalTestCase, Turn
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM that never calls out to a provider."""
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        raise AssertionError("generate should not be called in this test")
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        raise AssertionError("a_generate should not be called in this test")
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+class _SchemaStubLLM(_StubLLM):
+    """Answers the score prompts; the schema-less reason prompt must never come."""
+
+    def generate(self, prompt, schema=None, *args, **kwargs):
+        if schema is None:
+            raise AssertionError(
+                "the final-reason prompt must be skipped when "
+                "include_reason=False"
+            )
+        if schema.__name__ == "GoalScore":
+            return GoalScore(score=1.0, reason="goal met")
+        if schema.__name__ == "PlanScore":
+            return PlanScore(score=1.0, reason="plan followed")
+        raise AssertionError(f"unexpected schema requested: {schema.__name__}")
+
+    async def a_generate(self, prompt, schema=None, *args, **kwargs):
+        return self.generate(prompt, schema=schema, *args, **kwargs)
+
+
+_GOAL_SCORES = [GoalScore(score=1.0, reason="goal met")]
+_PLAN_SCORES = [PlanScore(score=1.0, reason="plan followed")]
+
+
+def _metric(**kwargs) -> GoalAccuracyMetric:
+    metric = GoalAccuracyMetric(model=_StubLLM(), **kwargs)
+    metric.score = 1.0
+    return metric
+
+
+def test_sync_generate_reason_respects_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert metric._generate_reason(_GOAL_SCORES, _PLAN_SCORES, False) is None
+
+
+def test_async_generate_reason_respects_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert (
+        asyncio.run(
+            metric._a_generate_reason(_GOAL_SCORES, _PLAN_SCORES, False)
+        )
+        is None
+    )
+
+
+def test_default_async_measure_skips_reason_when_disabled():
+    metric = GoalAccuracyMetric(model=_SchemaStubLLM(), include_reason=False)
+    test_case = ConversationalTestCase(
+        turns=[
+            Turn(role="user", content="Book me a table for two tonight."),
+            Turn(role="assistant", content="Done, your table is booked."),
+        ]
+    )
+    metric.measure(test_case, _show_indicator=False)
+
+    assert metric.score is not None
+    assert metric.reason is None

--- a/tests/test_metrics/test_tool_use_reason.py
+++ b/tests/test_metrics/test_tool_use_reason.py
@@ -1,0 +1,169 @@
+"""Regression tests for ToolUseMetric's final-reason generation.
+
+Two related defects:
+
+- `include_reason` was accepted by the constructor but never consulted, so
+  both final-reason LLM calls (tool selection and argument correctness) were
+  made even when the user explicitly disabled them.
+- The argument-correctness reason helpers rendered the tool-selection
+  template (`get_tool_selection_final_reason`) instead of the dedicated
+  `get_tool_argument_final_reason` template, so the argument half of every
+  reason was written by a prompt about tool choice.
+
+These tests run with stub models, so they need no LLM provider API key.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics import ToolUseMetric
+from deepeval.metrics.tool_use.schema import (
+    ArgumentCorrectnessScore,
+    Reason,
+    ToolSelectionScore,
+)
+from deepeval.models.base_model import DeepEvalBaseLLM
+from deepeval.test_case import ConversationalTestCase, ToolCall, Turn
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    """Minimal DeepEvalBaseLLM that never calls out to a provider."""
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs) -> str:
+        raise AssertionError("generate should not be called in this test")
+
+    async def a_generate(self, *args, **kwargs) -> str:
+        raise AssertionError("a_generate should not be called in this test")
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+class _CapturingLLM(_StubLLM):
+    """Records the prompt it was given and answers the reason schema."""
+
+    def __init__(self):
+        super().__init__()
+        self.prompts = []
+
+    def generate(self, prompt, schema=None, *args, **kwargs):
+        self.prompts.append(prompt)
+        assert schema is Reason
+        return Reason(reason="stub reason")
+
+    async def a_generate(self, prompt, schema=None, *args, **kwargs):
+        return self.generate(prompt, schema=schema, *args, **kwargs)
+
+
+class _SchemaStubLLM(_StubLLM):
+    """Answers the score prompts; the reason prompts must never come."""
+
+    def generate(self, prompt, schema=None, *args, **kwargs):
+        if schema is ToolSelectionScore:
+            return ToolSelectionScore(score=1.0, reason="right tool")
+        if schema is ArgumentCorrectnessScore:
+            return ArgumentCorrectnessScore(score=1.0, reason="right args")
+        raise AssertionError(
+            f"unexpected schema requested: {getattr(schema, '__name__', schema)} "
+            "(the reason prompts must be skipped when include_reason=False)"
+        )
+
+    async def a_generate(self, prompt, schema=None, *args, **kwargs):
+        return self.generate(prompt, schema=schema, *args, **kwargs)
+
+
+_AVAILABLE_TOOLS = [ToolCall(name="CheckDiscount")]
+_SELECTION_SCORES = [ToolSelectionScore(score=1.0, reason="right tool")]
+_ARGUMENT_SCORES = [ArgumentCorrectnessScore(score=1.0, reason="right args")]
+
+
+def _metric(model=None, **kwargs) -> ToolUseMetric:
+    metric = ToolUseMetric(
+        available_tools=_AVAILABLE_TOOLS, model=model or _StubLLM(), **kwargs
+    )
+    metric.score = 1.0
+    return metric
+
+
+def test_sync_reason_helpers_respect_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert (
+        metric._generate_reason_for_tool_selection(
+            _SELECTION_SCORES, multimodal=False
+        )
+        is None
+    )
+    assert (
+        metric._generate_reason_for_argument_correctness(
+            _ARGUMENT_SCORES, multimodal=False
+        )
+        is None
+    )
+
+
+def test_async_reason_helpers_respect_include_reason_false():
+    metric = _metric(include_reason=False)
+    assert (
+        asyncio.run(
+            metric._a_generate_reason_for_tool_selection(
+                _SELECTION_SCORES, multimodal=False
+            )
+        )
+        is None
+    )
+    assert (
+        asyncio.run(
+            metric._a_generate_reason_for_argument_correctness(
+                _ARGUMENT_SCORES, multimodal=False
+            )
+        )
+        is None
+    )
+
+
+def test_default_async_measure_skips_reasons_when_disabled():
+    metric = ToolUseMetric(
+        available_tools=_AVAILABLE_TOOLS,
+        model=_SchemaStubLLM(),
+        include_reason=False,
+    )
+    test_case = ConversationalTestCase(
+        turns=[
+            Turn(role="user", content="Do these shoes have a discount?"),
+            Turn(
+                role="assistant",
+                content="Let me check that for you.",
+                tools_called=[ToolCall(name="CheckDiscount")],
+            ),
+        ]
+    )
+    metric.measure(test_case, _show_indicator=False)
+
+    assert metric.score is not None
+    assert metric.reason is None
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+def test_argument_correctness_reason_uses_argument_template(use_async):
+    model = _CapturingLLM()
+    metric = _metric(model=model)
+
+    if use_async:
+        asyncio.run(
+            metric._a_generate_reason_for_argument_correctness(
+                _ARGUMENT_SCORES, multimodal=False
+            )
+        )
+    else:
+        metric._generate_reason_for_argument_correctness(
+            _ARGUMENT_SCORES, multimodal=False
+        )
+
+    assert len(model.prompts) == 1
+    prompt = model.prompts[0]
+    assert "Tool Argument Quality" in prompt
+    assert "**Tool Selection** evaluation" not in prompt


### PR DESCRIPTION
Follow-up to #3061: the same bug class in two more metrics, plus a wrong-template bug found while fixing it.

**Describe the bug**

1. `GoalAccuracyMetric` and `ToolUseMetric` accept `include_reason` and store it, but nothing ever reads it. The final-reason LLM calls — one for GoalAccuracy (`get_final_reason`), two for ToolUse (tool selection + argument correctness) — are made in both the sync and async paths even when the user passed `include_reason=False`.

2. `ToolUseMetric._generate_reason_for_argument_correctness` and its async twin render `get_tool_selection_final_reason`, the *tool selection* prompt ("summarizing the outcome of a **Tool Selection** evaluation"), so the argument-correctness half of every ToolUse reason is written by a prompt about tool choice. The bundle already ships a dedicated `get_tool_argument_final_reason` template ("**Tool Argument Quality** evaluation") for `ToolUseMetric`; nothing referenced it. Both templates take the same variables (`all_scores_and_reasons`, `final_score`, `threshold`), so switching the method name is the whole fix.

**The fix**

- Add the `include_reason` early return to every reason helper in both metrics, mirroring the convention the other metrics follow (guard inside the helper).
- Make ToolUse's reason composition tolerate the helpers returning `None` (`"\n".join([...])` would otherwise raise on `None`).
- Point the two argument-correctness helpers at `get_tool_argument_final_reason`.

The hunks don't overlap with #2968, which touches `_calculate_score`.

**Tests**

Two offline regression test files driven through stub models (no LLM calls, no API keys), same pattern as #3061 and `tests/test_metrics/test_turn_faithfulness_metric_empty_verdicts.py`:

- `test_goal_accuracy_include_reason.py`: sync/async helper-level `include_reason=False` tests, plus a default-configuration `measure()` test where the stub answers the goal/plan score prompts but fails the test if the schema-less reason prompt is ever sent.
- `test_tool_use_reason.py`: helper-level `include_reason=False` tests for all four reason helpers, a default-configuration `measure()` test whose stub answers the two score schemas but fails if the `Reason` schema is requested, and a parametrized sync/async test that captures the rendered argument-correctness prompt and asserts it is the "Tool Argument Quality" template rather than the "Tool Selection" one.

On current `main` all 8 tests fail; all 8 pass with this change. The rest of `tests/test_metrics` is unchanged: 171 passed, 271 skipped, 6 xfailed. `black==25.12.0 --check` (the CI pin) is clean on all four touched files.
