### PR TITLE
fix(dag): resolve competing scoring verdicts deterministically

### DIFF
--- a/deepeval/metrics/dag/runner.py
+++ b/deepeval/metrics/dag/runner.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from deepeval.metrics.dag.nodes import (
     BaseNode,
@@ -50,6 +58,60 @@ class _DeepAcyclicGraphRunner:
         self._verbose_log = (
             _mt_verbose_log if graph.multiturn else _st_verbose_log
         )
+        self._order = self._build_order()
+        self._score_events: List[Tuple[int, float, Optional[str]]] = []
+
+    def _build_order(self) -> Dict[Node, int]:
+        """Depth-first pre-order index for every node, roots in declaration order.
+
+        Used to pick a winner when more than one verdict assigns a score. This
+        is the order the synchronous traversal already visits nodes in, so
+        resolving on the highest index reproduces today's sync result exactly
+        while bringing the async result into line with it.
+        """
+        order: Dict[Node, int] = {}
+        seen: set = set()
+
+        def walk(node: Node) -> None:
+            if node in seen:
+                return
+            seen.add(node)
+            order[node] = len(order)
+            children = list(getattr(node, "children", None) or ())
+            child = getattr(node, "child", None)
+            if child is not None and isinstance(child, _NODE):
+                children.append(child)
+            for c in children:
+                walk(c)
+
+        for root in self.graph.root_nodes:
+            walk(root)
+        return order
+
+    def _record_score(
+        self, node: Node, score: float, reason: Optional[str]
+    ) -> None:
+        """Record a scoring verdict so a winner can be chosen deterministically.
+
+        The metric is still written on arrival, because
+        `VerdictNode._generate_reason` builds its prompt from `metric.score`.
+        What changes is that the last arrival no longer decides the result:
+        `_settle` re-applies the highest-ordered event once the traversal
+        finishes. Previously the surviving value was whichever branch completed
+        last, and `asyncio.gather` interleaves completion, so the same graph
+        with the same judgements scored differently under `async_mode=True`.
+        """
+        self._score_events.append(
+            (self._order.get(node, len(self._order)), score, reason)
+        )
+
+    def _settle(self, metric: Metric) -> None:
+        if not self._score_events:
+            return
+        _, score, reason = max(self._score_events, key=lambda e: e[0])
+        metric.score = score
+        if metric.include_reason and reason is not None:
+            metric.reason = reason
 
     def _check_remaining(self, node: Node) -> bool:
         self.remaining[node] -= 1
@@ -77,6 +139,11 @@ class _DeepAcyclicGraphRunner:
         metric.score = child_metric.score
         if metric.include_reason:
             metric.reason = child_metric.reason
+        self._record_score(
+            node,
+            child_metric.score,
+            child_metric.reason if metric.include_reason else None,
+        )
         metric._accrue_cost(child_metric.evaluation_cost)
         metric._accrue_tokens(
             child_metric.input_tokens, child_metric.output_tokens
@@ -86,6 +153,7 @@ class _DeepAcyclicGraphRunner:
     def run(self, metric: Metric, test_case: TestCase) -> None:
         for root in self.graph.root_nodes:
             self._visit(root, metric, test_case, 0)
+        self._settle(metric)
 
     def _visit(
         self, node: Node, metric: Metric, test_case: TestCase, depth: int
@@ -123,8 +191,14 @@ class _DeepAcyclicGraphRunner:
         if child is None:
             metric._verbose_steps.append(self._verbose_log(node, depth))
             metric.score = node.score / 10
-            if metric.include_reason:
-                metric.reason = node._generate_reason(metric=metric)
+            reason = (
+                node._generate_reason(metric=metric)
+                if metric.include_reason
+                else None
+            )
+            if reason is not None:
+                metric.reason = reason
+            self._record_score(node, node.score / 10, reason)
         elif isinstance(child, _NODE):
             self._visit(child, metric, test_case, depth)
         else:
@@ -138,6 +212,7 @@ class _DeepAcyclicGraphRunner:
                 for root in self.graph.root_nodes
             )
         )
+        self._settle(metric)
 
     async def _a_visit(
         self, node: Node, metric: Metric, test_case: TestCase, depth: int
@@ -179,8 +254,14 @@ class _DeepAcyclicGraphRunner:
         if child is None:
             metric._verbose_steps.append(self._verbose_log(node, depth))
             metric.score = node.score / 10
-            if metric.include_reason:
-                metric.reason = await node._a_generate_reason(metric=metric)
+            reason = (
+                await node._a_generate_reason(metric=metric)
+                if metric.include_reason
+                else None
+            )
+            if reason is not None:
+                metric.reason = reason
+            self._record_score(node, node.score / 10, reason)
         elif isinstance(child, _NODE):
             await self._a_visit(child, metric, test_case, depth)
         else:

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -1147,3 +1147,122 @@ class TestDAGMetric:
     def test_dag_metric_via_evaluate(self):
         metric = DAGMetric(name="Refund Period", dag=self._build_dag())
         evaluate([self._test_case()], [metric])
+
+
+class MultiScoringBranchModel(DeepEvalBaseLLM):
+    """Deterministic judge that sends every branch down its True arm."""
+
+    def __init__(self):
+        super().__init__(model="multi-scoring-branch-model")
+
+    def load_model(self):
+        return self
+
+    def generate(self, prompt, schema=None, **kwargs):
+        assert schema is not None
+        if schema.__name__ == "TaskNodeOutput":
+            return schema(output=["only-part"])
+        if schema.__name__ == "BinaryJudgementVerdict":
+            return schema(verdict=True, reason="yes")
+        if schema.__name__ == "MetricScoreReason":
+            return schema(reason="because")
+        raise AssertionError(f"Unexpected schema: {schema.__name__}")
+
+    async def a_generate(self, prompt, schema=None, **kwargs):
+        return self.generate(prompt, schema=schema, **kwargs)
+
+    def get_model_name(self):
+        return "multi-scoring-branch-model"
+
+
+def build_two_scoring_branch_dag(deep_first: bool) -> DeepAcyclicGraph:
+    """A DAG in which two verdicts both assign a score.
+
+    One branch is two judgements deep and scores 10, the other is one
+    judgement deep and scores 5. Both fire, so the result depends on how the
+    runner resolves competing verdicts.
+    """
+    inner = BinaryJudgementNode(
+        criteria="inner?",
+        children=[
+            VerdictNode(verdict=True, score=10),
+            VerdictNode(verdict=False, score=0),
+        ],
+    )
+    deep = BinaryJudgementNode(
+        criteria="outer?",
+        children=[
+            VerdictNode(verdict=True, child=inner),
+            VerdictNode(verdict=False, score=0),
+        ],
+    )
+    shallow = BinaryJudgementNode(
+        criteria="shallow?",
+        children=[
+            VerdictNode(verdict=True, score=5),
+            VerdictNode(verdict=False, score=0),
+        ],
+    )
+    root = TaskNode(
+        instructions="Split the output.",
+        output_label="Parts",
+        evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        children=[deep, shallow] if deep_first else [shallow, deep],
+    )
+    return DeepAcyclicGraph(root_nodes=[root])
+
+
+class TestCompetingScoringVerdicts:
+    """A score assigned by two branches must not depend on `async_mode`.
+
+    Both verdicts write to `metric.score`, so the surviving value used to be
+    whichever finished last. `asyncio.gather` interleaves completion, so the
+    same graph with the same judgements scored differently sync vs async.
+    """
+
+    @staticmethod
+    def _measure(dag: DeepAcyclicGraph, async_mode: bool) -> float:
+        metric = DAGMetric(
+            name="competing",
+            dag=dag,
+            model=MultiScoringBranchModel(),
+            async_mode=async_mode,
+        )
+        metric.measure(
+            LLMTestCase(input="in", actual_output="out"),
+            _show_indicator=False,
+        )
+        return metric.score
+
+    @pytest.mark.parametrize("deep_first", [True, False])
+    def test_sync_and_async_agree(self, deep_first):
+        sync = self._measure(build_two_scoring_branch_dag(deep_first), False)
+        asy = self._measure(build_two_scoring_branch_dag(deep_first), True)
+        assert sync == asy
+
+    @pytest.mark.parametrize("async_mode", [True, False])
+    def test_resolves_on_declaration_order(self, async_mode):
+        # The later branch in declaration order wins, which is what the
+        # synchronous traversal has always produced.
+        deep_first = build_two_scoring_branch_dag(True)
+        shallow_first = build_two_scoring_branch_dag(False)
+        assert self._measure(deep_first, async_mode) == 0.5
+        assert self._measure(shallow_first, async_mode) == 1.0
+
+    @pytest.mark.parametrize("async_mode", [True, False])
+    def test_single_scoring_branch_is_unaffected(self, async_mode):
+        shallow = BinaryJudgementNode(
+            criteria="shallow?",
+            children=[
+                VerdictNode(verdict=True, score=5),
+                VerdictNode(verdict=False, score=0),
+            ],
+        )
+        root = TaskNode(
+            instructions="Split the output.",
+            output_label="Parts",
+            evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+            children=[shallow],
+        )
+        dag = DeepAcyclicGraph(root_nodes=[root])
+        assert self._measure(dag, async_mode) == 0.5


### PR DESCRIPTION
Closes #3025.

## The bug

When more than one `VerdictNode` assigns a score, they all write to `metric.score` and the surviving value is whichever wrote last.

`_visit` traverses depth-first, so the last scoring verdict in declaration order wins. `_a_visit` uses `asyncio.gather`, which interleaves completion, so a different branch can win. Same graph, same deterministic judgements, different score:

```
declared                 sync  async
deep declared first       0.5    1.0
shallow declared first    1.0    1.0
```

Reproduced with a fake judge, so no API key and no nondeterminism from the model. The DAG has two branches that both fire: one two judgements deep scoring 10, one a single judgement deep scoring 5.

## The fix

Scoring verdicts are recorded with a depth-first pre-order index, and the winner is applied once the traversal finishes.

That index is the order `_visit` already walks the graph in, so resolving on the highest index reproduces the current sync result exactly and brings async into line with it. Sync behaviour is unchanged; async stops disagreeing with it.

`metric.score` is still written on arrival, because `VerdictNode._generate_reason` builds its prompt from it. Only the final resolution moved.

## Note on scope

This makes the result depend solely on how the DAG was written, which is the narrower of the two problems raised in the issue. It does not decide *which* branch ought to win when two can both score, or reject such graphs at build time. Those are design calls for the maintainers, and I have kept the existing sync answer rather than pick a new one.

## Tests

- sync and async agree, both declaration orders
- resolution follows declaration order, under both modes
- a graph with a single scoring branch is unaffected

`pytest tests/test_metrics/` passes: 185 passed, 278 skipped (no `OPENAI_API_KEY`), 6 xfailed. `black --line-length 80 --check` clean.