### PR TITLE
build(deps): make opentelemetry and grpcio optional via an otel extra

### DIFF
--- a/.github/workflows/full_test_core_for_pr.yml
+++ b/.github/workflows/full_test_core_for_pr.yml
@@ -84,7 +84,7 @@ jobs:
         run: poetry install --no-interaction --only main
       # Install dev dependencies
       - name: Install dev dependencies
-        run: poetry install --no-interaction --with dev
+        run: poetry install --no-interaction --with dev --extras otel
       #----------------------------------------------
       #              run test suite
       #----------------------------------------------

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -65,7 +65,7 @@ jobs:
       #    install dev dependencies (including chromadb and model deps)
       #----------------------------------------------
       - name: Install dev dependencies
-        run: poetry install --no-interaction --with dev
+        run: poetry install --no-interaction --with dev --extras otel
         
       #----------------------------------------------
       #              run test suite

--- a/.github/workflows/test_integrations.yml
+++ b/.github/workflows/test_integrations.yml
@@ -99,7 +99,7 @@ jobs:
           poetry run pip install -U "pydantic-ai-slim[openai]"
 
       - name: Install Project
-        run: poetry install --no-interaction --only main
+        run: poetry install --no-interaction --only main --extras otel
 
       - name: Run CrewAI Tests
         if: ${{ env.OPENAI_API_KEY != '' }}
@@ -136,7 +136,7 @@ jobs:
       - name: Install Dependencies (Pydantic AI)
         run: |
           poetry install --no-interaction --no-root --only main
-          poetry install --with integrations
+          poetry install --with integrations --extras otel
           # Pin to pydantic-ai-slim[openai] to avoid the meta-package's
           # mistral extra (mistralai is currently quarantined on PyPI;
           # see comment in pyproject.toml integrations group).
@@ -177,7 +177,7 @@ jobs:
       - name: Install Dependencies (LlamaIndex)
         run: |
           poetry install --no-interaction --no-root --only main
-          poetry install --with integrations
+          poetry install --with integrations --extras otel
           poetry run pip install -U llama-index
 
       - name: Run LlamaIndex Tests
@@ -295,7 +295,7 @@ jobs:
           poetry run pip install -U bedrock-agentcore strands-agents strands-agents-tools
 
       - name: Install Project
-        run: poetry install --no-interaction --only main
+        run: poetry install --no-interaction --only main --extras otel
 
       - name: Run AgentCore Tests
         if: ${{ env.OPENAI_API_KEY != '' }}
@@ -338,7 +338,7 @@ jobs:
           poetry run pip install -U strands-agents
 
       - name: Install Project
-        run: poetry install --no-interaction --only main
+        run: poetry install --no-interaction --only main --extras otel
 
       - name: Run Strands Tests
         if: ${{ env.OPENAI_API_KEY != '' }}

--- a/deepeval/integrations/agentcore/instrumentator.py
+++ b/deepeval/integrations/agentcore/instrumentator.py
@@ -92,7 +92,7 @@ def is_dependency_installed() -> bool:
     if not dependency_installed:
         raise ImportError(
             "Dependencies are not installed. Please install them with "
-            "`pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http`."
+            '`pip install "deepeval[otel]"`.'
         )
     return True
 

--- a/deepeval/integrations/agentcore/otel.py
+++ b/deepeval/integrations/agentcore/otel.py
@@ -45,7 +45,7 @@ def _require_opentelemetry() -> None:
     if not _opentelemetry_installed:
         raise ImportError(
             "OpenTelemetry SDK is not available. "
-            "Install it with: pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http"
+            'Install it with: pip install "deepeval[otel]"'
         )
 
 

--- a/deepeval/integrations/openinference/instrumentator.py
+++ b/deepeval/integrations/openinference/instrumentator.py
@@ -97,7 +97,7 @@ def is_dependency_installed() -> bool:
     if not dependency_installed:
         raise ImportError(
             "Dependencies are not installed. Please install them with "
-            "`pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http`."
+            '`pip install "deepeval[otel]"`.'
         )
     return True
 

--- a/deepeval/integrations/openinference/otel.py
+++ b/deepeval/integrations/openinference/otel.py
@@ -46,7 +46,7 @@ def _require_opentelemetry() -> None:
     if not _opentelemetry_installed:
         raise ImportError(
             "OpenTelemetry SDK is not available. "
-            "Install it with: pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http"
+            'Install it with: pip install "deepeval[otel]"'
         )
 
 

--- a/deepeval/integrations/pydantic_ai/instrumentator.py
+++ b/deepeval/integrations/pydantic_ai/instrumentator.py
@@ -108,8 +108,7 @@ def is_dependency_installed() -> bool:
     if not dependency_installed:
         raise ImportError(
             "Dependencies are not installed. Please install it with "
-            "`pip install pydantic-ai opentelemetry-sdk "
-            "opentelemetry-exporter-otlp-proto-http`."
+            '`pip install pydantic-ai "deepeval[otel]"`.'
         )
     return True
 

--- a/deepeval/integrations/pydantic_ai/otel.py
+++ b/deepeval/integrations/pydantic_ai/otel.py
@@ -22,7 +22,8 @@ except:
 def is_opentelemetry_available():
     if not opentelemetry_installed:
         raise ImportError(
-            "OpenTelemetry SDK is not available. Please install it with `pip install opentelemetry-sdk`."
+            "OpenTelemetry SDK is not available. Please install it with "
+            '`pip install "deepeval[otel]"`.'
         )
     return True
 

--- a/deepeval/integrations/strands/instrumentator.py
+++ b/deepeval/integrations/strands/instrumentator.py
@@ -100,7 +100,7 @@ def is_dependency_installed() -> bool:
     if not dependency_installed:
         raise ImportError(
             "Dependencies are not installed. Please install them with "
-            "`pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http`."
+            '`pip install "deepeval[otel]"`.'
         )
     return True
 

--- a/deepeval/integrations/strands/otel.py
+++ b/deepeval/integrations/strands/otel.py
@@ -55,7 +55,7 @@ def _require_opentelemetry() -> None:
     if not _opentelemetry_installed:
         raise ImportError(
             "OpenTelemetry SDK is not available. "
-            "Install it with: pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http"
+            'Install it with: pip install "deepeval[otel]"'
         )
 
 

--- a/deepeval/tracing/otel/context_aware_processor.py
+++ b/deepeval/tracing/otel/context_aware_processor.py
@@ -97,8 +97,7 @@ class ContextAwareSpanProcessor(_SpanProcessor):
         if not _OTEL_AVAILABLE:
             raise ImportError(
                 "opentelemetry SDK is not installed. Install with "
-                "`pip install opentelemetry-sdk "
-                "opentelemetry-exporter-otlp-proto-http`."
+                '`pip install "deepeval[otel]"`.'
             )
 
         self._api_key = api_key

--- a/deepeval/tracing/otel/exporter.py
+++ b/deepeval/tracing/otel/exporter.py
@@ -1,14 +1,35 @@
-from opentelemetry.trace.status import Status, StatusCode
-from opentelemetry.sdk.trace.export import (
-    SpanExportResult,
-    SpanExporter,
-    ReadableSpan,
-)
 from pydantic import ValidationError, BaseModel
 from typing import Any, Dict, List, Optional
 from collections import defaultdict
 import typing
 import json
+
+try:
+    from opentelemetry.trace.status import Status, StatusCode
+    from opentelemetry.sdk.trace.export import (
+        SpanExportResult,
+        SpanExporter,
+        ReadableSpan,
+    )
+
+    _OTEL_AVAILABLE = True
+except ImportError:
+    _OTEL_AVAILABLE = False
+
+    class SpanExporter:  # type: ignore[no-redef]
+        def export(self, spans, timeout_millis=30000):
+            pass
+
+        def shutdown(self):
+            pass
+
+        def force_flush(self, timeout_millis=30000):
+            return True
+
+    ReadableSpan = Any  # type: ignore[assignment]
+    Status = None  # type: ignore[assignment]
+    StatusCode = None  # type: ignore[assignment]
+    SpanExportResult = None  # type: ignore[assignment]
 
 from deepeval.prompt.prompt import Prompt
 from deepeval.telemetry import record_tracing_integration
@@ -100,6 +121,12 @@ class BaseSpanWrapper:
 class ConfidentSpanExporter(SpanExporter):
 
     def __init__(self, api_key: Optional[str] = None):
+        if not _OTEL_AVAILABLE:
+            raise ImportError(
+                "opentelemetry SDK is not installed. Install with "
+                '`pip install "deepeval[otel]"`.'
+            )
+
         record_tracing_integration(Integration.OTEL)
         peb.init_clock_bridge()
 

--- a/deepeval/tracing/otel/utils.py
+++ b/deepeval/tracing/otel/utils.py
@@ -2,7 +2,11 @@ import json
 from threading import Lock
 
 from typing import Dict, List, Optional, Tuple, Any
-from opentelemetry.sdk.trace.export import ReadableSpan
+
+try:
+    from opentelemetry.sdk.trace.export import ReadableSpan
+except ImportError:
+    ReadableSpan = Any  # type: ignore[assignment]
 
 try:
     from opentelemetry.attributes import BoundedAttributes

--- a/poetry.lock
+++ b/poetry.lock
@@ -2627,12 +2627,12 @@ version = "1.72.0"
 description = "Common protobufs used in Google APIs"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev", "integrations"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038"},
     {file = "googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 grpcio = {version = ">=1.44.0,<2.0.0", optional = true, markers = "extra == \"grpc\""}
@@ -2886,7 +2886,7 @@ version = "1.78.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "integrations"]
+groups = ["dev", "integrations"]
 files = [
     {file = "grpcio-1.78.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:7cc47943d524ee0096f973e1081cb8f4f17a4615f2116882a5f1416e4cfe92b5"},
     {file = "grpcio-1.78.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c3f293fdc675ccba4db5a561048cca627b5e7bd1c8a6973ffedabe7d116e22e2"},
@@ -3269,7 +3269,7 @@ files = [
     {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
     {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 zipp = ">=3.20"
@@ -6094,7 +6094,7 @@ files = [
     {file = "opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950"},
     {file = "opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 importlib-metadata = ">=6.0,<8.8.0"
@@ -6163,12 +6163,12 @@ version = "1.39.1"
 description = "OpenTelemetry Protobuf encoding"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "integrations"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde"},
     {file = "opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 opentelemetry-proto = "1.39.1"
@@ -6205,14 +6205,14 @@ gcp-auth = ["opentelemetry-exporter-credential-provider-gcp (>=0.59b0)"]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.39.1"
 description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
-optional = false
+optional = true
 python-versions = ">=3.9"
-groups = ["integrations"]
-markers = "python_version >= \"3.10\" and python_version < \"3.15\""
+groups = ["main", "integrations"]
 files = [
     {file = "opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985"},
     {file = "opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb"},
 ]
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 googleapis-common-protos = ">=1.52,<2.0"
@@ -6251,12 +6251,12 @@ version = "1.39.1"
 description = "OpenTelemetry Python Proto"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "integrations"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007"},
     {file = "opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 protobuf = ">=5.0,<7.0"
@@ -6291,7 +6291,7 @@ files = [
     {file = "opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c"},
     {file = "opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 opentelemetry-api = "1.39.1"
@@ -6309,7 +6309,7 @@ files = [
     {file = "opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb"},
     {file = "opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.dependencies]
 opentelemetry-api = "1.39.1"
@@ -7368,7 +7368,7 @@ version = "6.33.5"
 description = ""
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "integrations"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b"},
     {file = "protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c"},
@@ -7381,7 +7381,7 @@ files = [
     {file = "protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02"},
     {file = "protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [[package]]
 name = "ptyprocess"
@@ -11065,7 +11065,7 @@ files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
-markers = {integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
+markers = {main = "extra == \"otel\"", integrations = "python_version >= \"3.10\" and python_version < \"3.15\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
@@ -11190,8 +11190,9 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 
 [extras]
 inspect = ["pyperclip", "textual"]
+otel = ["opentelemetry-api", "opentelemetry-exporter-otlp-proto-http", "opentelemetry-sdk"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9, <4.0"
-content-hash = "01aa6352de506ef5ffdfa71c8c068af1ee42b1190219f4e6623de09c6227d724"
+content-hash = "813866a8bacfeb91b4d18fc0fa9652ebe7678a371323abb6e8e0f856327e0262"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,6 @@ setuptools = "*"
 wheel = "*"
 nest_asyncio = "*"
 tenacity = ">=8.0.0,<=10.0.0"
-opentelemetry-api = "^1.24.0"
-opentelemetry-sdk = "^1.24.0"
-grpcio = "^1.67.1"
 
 posthog = [
     { version = ">=5.4.0, <7.0.0", python = "<3.10" },
@@ -52,10 +49,18 @@ jinja2 = "*"
 
 textual = { version = ">=0.80,<2.0", optional = true }
 pyperclip = { version = "^1.8", optional = true }
+opentelemetry-api = { version = "^1.24.0", optional = true }
+opentelemetry-sdk = { version = "^1.24.0", optional = true }
+opentelemetry-exporter-otlp-proto-http = { version = "^1.24.0", optional = true }
 questionary = ">=2.0.0,<3.0.0"
 
 [tool.poetry.extras]
 inspect = ["textual", "pyperclip"]
+otel = [
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
+]
 
 [tool.poetry.group.dev.dependencies]
 twine = "5.1.1"

--- a/tests/test_core/test_packaging/test_optional_otel.py
+++ b/tests/test_core/test_packaging/test_optional_otel.py
@@ -1,0 +1,278 @@
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+OTEL_ROOTS = ("opentelemetry", "grpcio")
+ALLOWED_UNGUARDED = {"deepeval/tracing/otel/test_exporter.py"}
+
+
+def _extract_section(text: str, header: str):
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.strip() == header:
+            section = []
+            for line in lines[i + 1 :]:
+                if line.startswith("["):
+                    break
+                section.append(line)
+            return "\n".join(section)
+    return None
+
+
+def test_main_dependencies_exclude_opentelemetry_and_grpcio():
+    text = PYPROJECT_PATH.read_text(encoding="utf-8")
+
+    deps = _extract_section(text, "[tool.poetry.dependencies]")
+    assert deps is not None, "[tool.poetry.dependencies] section missing"
+    for line in deps.splitlines():
+        if "opentelemetry" in line or "grpcio" in line:
+            assert "optional = true" in line, (
+                f"otel/grpcio deps must be declared optional: "
+                f"{line.strip()}"
+            )
+    assert (
+        "grpcio" not in text
+    ), "grpcio must not appear anywhere in pyproject.toml"
+
+    extras = _extract_section(text, "[tool.poetry.extras]")
+    assert extras is not None, "[tool.poetry.extras] section missing"
+
+    otel_lines = []
+    in_otel = False
+    for line in extras.splitlines():
+        if re.match(r"^otel\s*=", line):
+            in_otel = True
+            otel_lines.append(line)
+        elif in_otel:
+            if re.match(r"^\w+\s*=", line):
+                break
+            otel_lines.append(line)
+    assert in_otel, "extras must declare an `otel` entry"
+    otel_block = "\n".join(otel_lines)
+    for pkg in (
+        "opentelemetry-api",
+        "opentelemetry-sdk",
+        "opentelemetry-exporter-otlp-proto-http",
+    ):
+        assert pkg in otel_block, f"otel extra must list {pkg}"
+
+
+_CHILD_SCRIPT = r"""
+import sys
+
+EXPECTED_ROOT = sys.argv[1]
+
+failures = []
+
+
+def check(label, fn):
+    try:
+        fn()
+    except Exception as exc:
+        failures.append(label)
+        print(f"[FAIL] {label} :: {type(exc).__name__}: {exc}")
+    else:
+        print(f"[PASS] {label}")
+
+
+def check_worktree_deepeval():
+    # Run first: pulling in deepeval may itself cache opentelemetry*
+    # submodules in sys.modules, which would silently bypass any
+    # meta_path blocker installed beforehand.
+    import deepeval
+
+    assert deepeval.__file__.startswith(EXPECTED_ROOT), (
+        f"expected worktree deepeval under {EXPECTED_ROOT}, "
+        f"got {deepeval.__file__}"
+    )
+
+
+check("worktree deepeval loaded", check_worktree_deepeval)
+
+for k in list(sys.modules):
+    root = k.split(".")[0]
+    if root in ("opentelemetry", "grpcio", "grpc"):
+        del sys.modules[k]
+
+import importlib.abc
+
+
+class _OtelBlocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".")[0] in ("opentelemetry", "grpcio", "grpc"):
+            raise ModuleNotFoundError(
+                f"import of {fullname!r} blocked by test", name=fullname
+            )
+        return None
+
+
+# Insert at the front: an appended finder runs after PathFinder, which
+# would still resolve a disk-installed opentelemetry/grpcio.
+sys.meta_path.insert(0, _OtelBlocker())
+
+
+def is_actionable_otel_import_error(exc):
+    msg = str(exc).lower()
+    return isinstance(exc, ImportError) and (
+        "deepeval[otel]" in msg or "opentelemetry" in msg
+    )
+
+
+def check_grpc_blocked():
+    try:
+        import grpc
+    except ModuleNotFoundError:
+        return
+    raise AssertionError("grpc import was not blocked")
+
+
+def make_exporter_raises_actionable(exporter):
+    try:
+        exporter.ConfidentSpanExporter()
+    except ImportError as exc:
+        assert "deepeval[otel]" in str(exc), (
+            f"ImportError missing 'deepeval[otel]': {exc}"
+        )
+        return
+    raise AssertionError("ConfidentSpanExporter() did not raise ImportError")
+
+
+def call_raises_actionable(callable_obj):
+    try:
+        callable_obj()
+    except Exception as exc:
+        if not is_actionable_otel_import_error(exc):
+            raise AssertionError(
+                f"expected actionable otel ImportError, got "
+                f"{type(exc).__name__}: {exc}"
+            )
+        return
+    raise AssertionError(f"{callable_obj} did not raise without otel")
+
+
+check("grpc import blocked (blocker sanity)", check_grpc_blocked)
+
+import importlib
+
+_modules = {}
+
+
+def _import_to_cache(label, module_name):
+    _modules[label] = importlib.import_module(module_name)
+
+
+check(
+    "import tracing.otel.exporter",
+    lambda: _import_to_cache("exporter", "deepeval.tracing.otel.exporter"),
+)
+check(
+    "import tracing.otel.utils",
+    lambda: _import_to_cache(
+        "utils", "deepeval.tracing.otel.utils"
+    ),
+)
+check(
+    "import tracing.otel.context_aware_processor",
+    lambda: _import_to_cache(
+        "casp", "deepeval.tracing.otel.context_aware_processor"
+    ),
+)
+
+check(
+    "ConfidentSpanExporter() raises deepeval[otel]",
+    lambda: make_exporter_raises_actionable(_modules["exporter"]),
+)
+
+check(
+    "import integrations.pydantic_ai",
+    lambda: _import_to_cache(
+        "pydantic_ai", "deepeval.integrations.pydantic_ai"
+    ),
+)
+check(
+    "import integrations.agentcore",
+    lambda: _import_to_cache("agentcore", "deepeval.integrations.agentcore"),
+)
+check(
+    "import integrations.strands",
+    lambda: _import_to_cache("strands", "deepeval.integrations.strands"),
+)
+
+check(
+    "instrument_pydantic_ai() actionable",
+    lambda: call_raises_actionable(_modules["pydantic_ai"].instrument_pydantic_ai),
+)
+check(
+    "instrument_agentcore() actionable",
+    lambda: call_raises_actionable(_modules["agentcore"].instrument_agentcore),
+)
+check(
+    "instrument_strands() actionable",
+    lambda: call_raises_actionable(_modules["strands"].instrument_strands),
+)
+
+if failures:
+    print(f"CHILD RESULT: {len(failures)} failure(s)")
+    sys.exit(1)
+print("CHILD RESULT: all checks passed")
+sys.exit(0)
+"""
+
+
+def test_otel_surfaces_import_and_fail_actionably_without_opentelemetry():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = (
+        str(REPO_ROOT)
+        + os.pathsep
+        + env.get("PYTHONPATH", "").rstrip(os.pathsep)
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", _CHILD_SCRIPT, str(REPO_ROOT)],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    output = result.stdout + "\n" + result.stderr
+    assert result.returncode == 0 and "[FAIL]" not in result.stdout, (
+        f"child rc={result.returncode}\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "CHILD RESULT: all checks passed" in output
+
+
+def _top_level_otel_violations():
+    violations = []
+    for path in sorted((REPO_ROOT / "deepeval").rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel in ALLOWED_UNGUARDED:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            names = []
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    names = [node.module]
+                    if node.level:
+                        names = []
+            for name in names:
+                if name.split(".")[0] in OTEL_ROOTS:
+                    violations.append(f"{rel}:{node.lineno} ({name})")
+    return violations
+
+
+def test_no_new_unguarded_top_level_otel_imports():
+    violations = _top_level_otel_violations()
+    assert violations == [], (
+        "unguarded module-level opentelemetry/grpcio imports outside "
+        f"allowlist {sorted(ALLOWED_UNGUARDED)}:\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
**Problem**

deepeval pins `opentelemetry-api`, `opentelemetry-sdk`, and `grpcio` as required dependencies, so installing it into a project that already uses different OpenTelemetry versions (LangChain / LlamaIndex / OpenTelemetry stacks) produces resolver conflicts.

Core never needs them: `import deepeval`, `evaluate()` / `assert_test()`, `LLMTestCase`, `EvaluationDataset`, the metrics, the pytest plugin, and `deepeval --help` all work with the three packages removed (verified in a clean venv). These requirements date back to internal New Relic analytics shipped via the OTLP-gRPC exporter (May 2024); both the analytics and the grpc-exporter dependency are gone, but the pins were never revisited.

**Change**

- Move `opentelemetry-api` / `opentelemetry-sdk` into a new optional extra: `pip install "deepeval[otel]"`.
- Drop `grpcio` entirely — nothing imports it unguarded (the only direct use, xAI retry handling, is already wrapped in try/except and xai-sdk is not a declared dependency).
- Declare `opentelemetry-exporter-otlp-proto-http` in the extra: `ContextAwareSpanProcessor` already imports it and told users to install it manually, but it was never declared.
- Guard the two remaining unguarded module-level OTel imports (`tracing/otel/exporter.py`, `tracing/otel/utils.py`) with the try/except pattern `context_aware_processor.py` already uses; constructing `ConfidentSpanExporter` without the SDK now raises an actionable `ImportError` naming `deepeval[otel]` instead of `ModuleNotFoundError` at import time. Same alignment for the openinference / pydantic_ai / agentcore / strands integration entry points.
- Install the extra in CI jobs exercising OTel surfaces (crewai, pydantic-ai, llama-index, agentcore, strands; core tracing jobs).
- New `tests/test_core/test_packaging/test_optional_otel.py`: dependency-layout assertions, an import-blocker simulation of no-OTel environments proving guarded modules import cleanly with actionable errors, and a tripwire against new unguarded top-level OTel imports.

**Behavior change**

Code that relies on OpenTelemetry being installed implicitly (tracing surfaces, tracing integrations) now requires `pip install "deepeval[otel]"`; failures name that exact command.

Closes #1815