### PR TITLE
feat(metrics): add KeywordCoverageMetric community metric

### DIFF
--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,11 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .keyword_coverage.keyword_coverage import (
+    KeywordCoverageMetric,
+)
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "KeywordCoverageMetric",
 ]

--- a/deepeval/metrics/community/keyword_coverage/__init__.py
+++ b/deepeval/metrics/community/keyword_coverage/__init__.py
@@ -1,0 +1,3 @@
+from .keyword_coverage import KeywordCoverageMetric
+
+__all__ = ["KeywordCoverageMetric"]

--- a/deepeval/metrics/community/keyword_coverage/keyword_coverage.py
+++ b/deepeval/metrics/community/keyword_coverage/keyword_coverage.py
@@ -1,0 +1,156 @@
+import re
+from typing import List, Optional
+
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.utils import (
+    check_llm_test_case_params,
+    construct_verbose_logs,
+)
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+
+class KeywordCoverageMetric(BaseMetric):
+    """Deterministic required-keyword coverage with a banned-term gate.
+
+    Scores the fraction of ``keywords`` (a required-phrase checklist) that appear
+    in ``actual_output``. This gives **partial credit** — unlike
+    ``ExactMatchMetric`` (whole-string equality) and ``PatternMatchMetric``
+    (a single all-or-nothing regex), both of which are binary.
+
+    If any ``forbidden`` phrase appears in the output, the metric **hard-fails**
+    with a score of ``0.0`` regardless of keyword coverage. This makes it a single
+    gate for the very common review requirement "must mention A, B and C, and must
+    NOT mention X or Y" (rubric coverage plus banned terms, e.g. leaked internal
+    codenames or competitor mentions).
+
+    The metric does not use an LLM: it is pure string matching, deterministic,
+    needs no API key, and costs nothing to run.
+
+    Scoring:
+
+        score = 0.0                                   if any forbidden term is present
+        score = (# keywords present) / (# keywords)   otherwise
+
+    With the default ``threshold`` of ``1.0``, every required keyword must be
+    present (and no forbidden term) for the test case to pass.
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        keywords: List[str],
+        forbidden: Optional[List[str]] = None,
+        ignore_case: bool = True,
+        whole_word: bool = False,
+        threshold: Optional[float] = 1.0,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+    ):
+        self.keywords = [k.strip() for k in (keywords or []) if k and k.strip()]
+        if not self.keywords:
+            raise ValueError(
+                "KeywordCoverageMetric requires at least one non-empty keyword."
+            )
+        self.forbidden = [
+            f.strip() for f in (forbidden or []) if f and f.strip()
+        ]
+        self.ignore_case = ignore_case
+        self.whole_word = whole_word
+        self.threshold = threshold
+        self.verbose_mode = verbose_mode
+        self.flaky = flaky
+
+    def _contains(self, text: str, term: str) -> bool:
+        if self.whole_word:
+            flags = re.IGNORECASE if self.ignore_case else 0
+            return re.search(rf"\b{re.escape(term)}\b", text, flags) is not None
+        if self.ignore_case:
+            return term.lower() in text.lower()
+        return term in text
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            None,
+            test_case.multimodal,
+        )
+
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            actual = test_case.actual_output.strip()
+
+            self.present = [
+                k for k in self.keywords if self._contains(actual, k)
+            ]
+            self.missing = [
+                k for k in self.keywords if not self._contains(actual, k)
+            ]
+            self.forbidden_present = [
+                f for f in self.forbidden if self._contains(actual, f)
+            ]
+
+            if self.forbidden_present:
+                self.score = 0.0
+                self.reason = "Forbidden term(s) present: " + ", ".join(
+                    repr(f) for f in self.forbidden_present
+                )
+            else:
+                self.score = len(self.present) / len(self.keywords)
+                if self.missing:
+                    self.reason = (
+                        f"Covered {len(self.present)}/{len(self.keywords)} "
+                        "required keywords; missing: "
+                        + ", ".join(repr(k) for k in self.missing)
+                    )
+                else:
+                    self.reason = (
+                        f"All {len(self.keywords)} required keywords present"
+                        + ("; no forbidden terms." if self.forbidden else ".")
+                    )
+
+            self.success = self.is_successful()
+
+            if self.verbose_mode:
+                self.verbose_logs = construct_verbose_logs(
+                    self,
+                    steps=[
+                        f"Required keywords: {self.keywords}",
+                        f"Present: {self.present}",
+                        f"Missing: {self.missing}",
+                        f"Forbidden present: {self.forbidden_present}",
+                        f"Score: {self.score:.2f}\nReason: {self.reason}",
+                    ],
+                )
+
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        return self.measure(
+            test_case,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        )
+
+    @property
+    def __name__(self):
+        return "Keyword Coverage"

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "community-metrics-overview",
     "metrics-citation-faithfulness",
+    "metrics-keyword-coverage",
     "metrics-agent-loop-detection",
     "metrics-tool-permission"
   ]

--- a/docs/content/docs/(community)/metrics-keyword-coverage.mdx
+++ b/docs/content/docs/(community)/metrics-keyword-coverage.mdx
@@ -1,0 +1,132 @@
+---
+id: metrics-keyword-coverage
+title: Keyword Coverage
+sidebar_label: Keyword Coverage
+languages: [python]
+---
+<MetricTagsDisplayer singleTurn={true} usesLLMs={false} referenceless={true} />
+
+The Keyword Coverage metric measures **what fraction of a required-phrase checklist appears** in your LLM application's `actual_output`, and **hard-fails if any banned phrase appears**. It is useful for rubric-style review requirements such as _"the answer must mention the refund window, the return address and the warranty — and must **not** mention any internal codename or competitor."_
+
+:::note
+The `KeywordCoverageMetric` does **not** rely on an LLM for evaluation. It uses pure **string matching**, so it is deterministic, needs no API key, and costs nothing to run.
+:::
+
+Unlike [`ExactMatchMetric`](/docs/metrics-exact-match) (whole-string equality) and [`PatternMatchMetric`](/docs/metrics-pattern-match) (a single all-or-nothing regex), which are **binary**, Keyword Coverage awards **partial credit** for the portion of the checklist that is covered.
+
+:::info
+`KeywordCoverageMetric` is a **community metric**, so it is not exported from `deepeval.metrics`. Import it explicitly:
+
+```python
+from deepeval.metrics.community import KeywordCoverageMetric
+```
+:::
+
+## Required Arguments
+
+To use the `KeywordCoverageMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
+
+- `input`
+- `actual_output`
+
+## Usage
+
+```python
+from deepeval.metrics.community import KeywordCoverageMetric
+from deepeval.test_case import LLMTestCase
+from deepeval import evaluate
+
+metric = KeywordCoverageMetric(
+    keywords=["30-day", "full refund", "return address"],
+    forbidden=["project-halo"],   # e.g. an internal codename that must never leak
+    ignore_case=True,
+    threshold=1.0,
+    verbose_mode=True,
+)
+
+test_case = LLMTestCase(
+    input="What's the return policy?",
+    actual_output="You get a 30-day full refund — just ship the item to our return address.",
+)
+
+# To run metric as a standalone
+# metric.measure(test_case)
+# print(metric.score, metric.reason)
+
+evaluate(test_cases=[test_case], metrics=[metric])
+```
+
+There is **ONE** mandatory and **FIVE** optional parameters when creating a `KeywordCoverageMetric`:
+
+- `keywords`: a list of strings, each a required phrase that should appear in the `actual_output`. Must contain at least one non-empty phrase.
+- [Optional] `forbidden`: a list of strings that must **not** appear in the `actual_output`. If any is present, the score is `0.0`. Defaulted to `None`.
+- [Optional] `ignore_case`: a boolean which when set to `True`, matches keywords and forbidden terms case-insensitively. Defaulted to `True`.
+- [Optional] `whole_word`: a boolean which when set to `True`, matches on word boundaries so `"cat"` does not match `"category"`. Defaulted to `False`.
+- [Optional] `threshold`: a number representing the minimum passing coverage fraction. Can also be set to `None` to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `1.0`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console. Defaulted to `False`.
+- [Optional] `flaky`: a boolean which when set to `True`, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics). Defaulted to `False`.
+
+### As a Standalone
+
+You can also run the `KeywordCoverageMetric` on a single test case as a standalone, one-off execution.
+
+```python
+...
+
+metric.measure(test_case)
+print(metric.score, metric.reason)
+```
+
+## How Is It Calculated?
+
+<Equation formula="\text{Keyword Coverage Score} = \begin{cases} 0 & \text{if any forbidden term is present}, \\ \dfrac{\text{number of required keywords present}}{\text{total number of required keywords}} & \text{otherwise} \end{cases}" />
+
+Membership is a case-normalized substring test by default, or a word-boundary match when `whole_word=True`. With the default `threshold` of `1.0`, every required keyword must be present (and no forbidden term) for the test case to pass; lower the `threshold` to accept partial coverage.
+
+## FAQs
+
+<FAQs
+  qas={[
+    {
+      question: "How is this different from Pattern Match or Exact Match?",
+      answer: (
+        <>
+          Exact Match and Pattern Match are <strong>binary</strong> (1 or 0):
+          Exact Match needs the whole output to equal an expected string, and
+          Pattern Match needs the whole output to match a single regex. Keyword
+          Coverage awards <strong>partial credit</strong> for the fraction of a
+          <em> checklist</em> that appears, and adds a banned-term gate in the same
+          metric.
+        </>
+      ),
+    },
+    {
+      question: "Does the Keyword Coverage metric call an LLM or cost money?",
+      answer: (
+        <>
+          No. It uses pure string matching — no model, no API key, zero token
+          cost, fully deterministic.
+        </>
+      ),
+    },
+    {
+      question: "What happens if a forbidden term appears?",
+      answer: (
+        <>
+          The score is <code>0.0</code> regardless of how many required keywords
+          are present — a forbidden term is treated as a hard failure.
+        </>
+      ),
+    },
+    {
+      question: "Why does 'cat' match 'category'?",
+      answer: (
+        <>
+          By default matching is substring-based. Set{" "}
+          <code>whole_word=True</code> to match only standalone words, so{" "}
+          <code>"cat"</code> no longer matches <code>"category"</code>.
+        </>
+      ),
+    },
+  ]}
+/>

--- a/tests/test_metrics/test_keyword_coverage_metric.py
+++ b/tests/test_metrics/test_keyword_coverage_metric.py
@@ -1,0 +1,92 @@
+"""Tests for the community KeywordCoverageMetric.
+
+The metric is fully deterministic (pure string matching, no LLM), so these run
+without an API key and cover passing, failing, and edge-case behavior.
+"""
+
+import pytest
+
+from deepeval.metrics.community import KeywordCoverageMetric
+from deepeval.test_case import LLMTestCase
+
+
+def _case(actual_output: str) -> LLMTestCase:
+    return LLMTestCase(input="q", actual_output=actual_output)
+
+
+class TestKeywordCoverageMetric:
+    def test_full_coverage_passes(self):
+        metric = KeywordCoverageMetric(
+            keywords=["refund", "30-day", "return address"]
+        )
+        metric.measure(
+            _case(
+                "You get a 30-day full refund; ship it to our return address."
+            )
+        )
+        assert metric.score == 1.0
+        assert metric.success is True
+
+    def test_partial_coverage_gives_fractional_score(self):
+        metric = KeywordCoverageMetric(
+            keywords=["refund", "30-day", "return address"]
+        )
+        metric.measure(_case("You get a full refund."))
+        assert metric.score == pytest.approx(1 / 3)
+        assert metric.success is False
+        assert "30-day" in metric.reason and "return address" in metric.reason
+
+    def test_forbidden_term_hard_fails_even_with_full_coverage(self):
+        metric = KeywordCoverageMetric(
+            keywords=["refund"],
+            forbidden=["INTERNAL-CODENAME"],
+        )
+        metric.measure(
+            _case("Refund approved. (INTERNAL-CODENAME: project-halo)")
+        )
+        assert metric.score == 0.0
+        assert metric.success is False
+        assert "INTERNAL-CODENAME" in metric.reason
+
+    def test_partial_threshold_can_pass(self):
+        metric = KeywordCoverageMetric(
+            keywords=["alpha", "bravo", "charlie", "delta"],
+            whole_word=True,
+            threshold=0.5,
+        )
+        metric.measure(_case("alpha and bravo only"))
+        assert metric.score == pytest.approx(0.5)
+        assert metric.success is True
+
+    def test_ignore_case_default_true(self):
+        metric = KeywordCoverageMetric(keywords=["Refund"])
+        metric.measure(_case("we issued a REFUND"))
+        assert metric.score == 1.0
+
+    def test_case_sensitive_when_ignore_case_false(self):
+        metric = KeywordCoverageMetric(keywords=["Refund"], ignore_case=False)
+        metric.measure(_case("we issued a refund"))
+        assert metric.score == 0.0
+
+    def test_whole_word_avoids_substring_false_positive(self):
+        substring = KeywordCoverageMetric(keywords=["cat"])
+        substring.measure(_case("the category is pets"))
+        assert substring.score == 1.0  # substring match (default)
+
+        whole = KeywordCoverageMetric(keywords=["cat"], whole_word=True)
+        whole.measure(_case("the category is pets"))
+        assert whole.score == 0.0  # no standalone 'cat'
+
+        whole.measure(_case("the cat is here"))
+        assert whole.score == 1.0
+
+    def test_empty_keywords_raises(self):
+        with pytest.raises(ValueError):
+            KeywordCoverageMetric(keywords=[])
+        with pytest.raises(ValueError):
+            KeywordCoverageMetric(keywords=["  ", ""])
+
+    def test_name(self):
+        assert (
+            KeywordCoverageMetric(keywords=["x"]).__name__ == "Keyword Coverage"
+        )


### PR DESCRIPTION
## What

Adds `KeywordCoverageMetric`, a deterministic (no-LLM) **community** metric. It scores the fraction of a required-keyword checklist that appears in `actual_output`, and **hard-fails to `0.0`** if any `forbidden` term appears.

```python
from deepeval.metrics.community import KeywordCoverageMetric
from deepeval.test_case import LLMTestCase

metric = KeywordCoverageMetric(
    keywords=["30-day", "full refund", "return address"],
    forbidden=["project-halo"],   # e.g. an internal codename that must never leak
)
metric.measure(LLMTestCase(
    input="What's the return policy?",
    actual_output="You get a 30-day full refund — just ship it to our return address.",
))
print(metric.score, metric.reason)  # 1.0  All 3 required keywords present; no forbidden terms.
```

## Why

The existing deterministic metrics are both **binary**:

- `ExactMatchMetric` — whole-string equality
- `PatternMatchMetric` — one all-or-nothing regex (`re.fullmatch`)

Neither awards **partial credit** for covering part of a checklist, and none combine "must include" with "must not include". `KeywordCoverageMetric` does both in one gate — a very common review requirement: *"the answer must mention the refund window, the return address and the warranty, and must NOT mention any internal codename or competitor."*

## Scoring

```
score = 0.0                                   if any forbidden term is present
score = (# keywords present) / (# keywords)   otherwise
```

Default `threshold=1.0` (every required keyword present, no forbidden term). Membership is a case-normalized substring test by default, or a word-boundary match with `whole_word=True`.

## Conventions followed

- Lives under `deepeval/metrics/community/keyword_coverage/` and is exported from `deepeval.metrics.community` (per the community-metric staging in `CONTRIBUTING.md`).
- Mirrors the deterministic-metric pattern (`pattern_match` / `exact_match`): no `schema.py` / `template.py`, since there is no LLM call.
- Docs page added under the **Community** section + `meta.json` sidebar entry.
- **9 deterministic tests** (full/partial coverage, forbidden hard-fail, partial threshold, case sensitivity, whole-word, empty-keywords `ValueError`, name) — **no API key required**, all green locally.
- Formatted with `black` (line-length 80).

Happy to adjust naming or scope to fit the roadmap.