### PR TITLE
docs: fix typos across guides, tutorials and integrations

### DIFF
--- a/docs/content/blog/deepeval-vs-ragas.mdx
+++ b/docs/content/blog/deepeval-vs-ragas.mdx
@@ -26,7 +26,7 @@ This means:
 
 ### 2. We care about your experience, a lot
 
-We care about the usability of DeepEval and wake up everyday thinking about how we can make either the codebase or documentation better to help our users do LLM evaluation better. In fact, everytime someone asks a question in [DeepEval's discord](https://discord.gg/a3K9c8GRGt), we always try to respond with not just an answer but a relevant link to the documentation that they can read more on. If there is no such relevant link that we can provide users, that means our documentation needs improving.
+We care about the usability of DeepEval and wake up everyday thinking about how we can make either the codebase or documentation better to help our users do LLM evaluation better. In fact, every time someone asks a question in [DeepEval's discord](https://discord.gg/a3K9c8GRGt), we always try to respond with not just an answer but a relevant link to the documentation that they can read more on. If there is no such relevant link that we can provide users, that means our documentation needs improving.
 
 In terms of the codebase, a recent example is we actually broke away DeepEval's red teaming (safety testing) features into a whole now package, called DeepTeam, which took around a month of work, just so users that primarily need LLM red teaming can work in that repo instead.
 

--- a/docs/content/blog/top-5-geval-use-cases.mdx
+++ b/docs/content/blog/top-5-geval-use-cases.mdx
@@ -148,7 +148,7 @@ The right tonality metric depends on the context. A medical assistant might prio
 
 Here are some commonly used tonality criteria:
 
-| Critera             | <div style={{width: "550px"}}>Description</div>                     |
+| Criteria             | <div style={{width: "550px"}}>Description</div>                     |
 | ------------------- | :------------------------------------------------------------------ |
 | **Professionalism** | Assesses the level of professionalism and expertise conveyed.       |
 | **Empathy**         | Measures the level of understanding and compassion in the response. |
@@ -192,7 +192,7 @@ When defining tonality criteria, focus on these key considerations:
 
 Safety can be broken down into more specific metrics depending on the type of risk you want to measure:
 
-| Critiera              | <div style={{width: "550px"}}>Description</div>                                                    |
+| Criteria              | <div style={{width: "550px"}}>Description</div>                                                    |
 | --------------------- | -------------------------------------------------------------------------------------------------- |
 | **PII Leakage**       | Detects personally identifiable information like names, emails, or phone numbers.                  |
 | **Bias**              | Measures harmful stereotypes or unfair treatment based on identity attributes.                     |

--- a/docs/content/blog/top-5-geval-use-cases.mdx
+++ b/docs/content/blog/top-5-geval-use-cases.mdx
@@ -355,7 +355,7 @@ test_case = LLMTestCase(input="...", actual_output="...")
 metric.measure(test_case)
 ```
 
-**G-Eval** is perfect for for subjective tasks like tone, helpfulness, or creativity. But as your evaluation logic becomes more rule-based or multi-step, G-Eval might not be enough.
+**G-Eval** is perfect for subjective tasks like tone, helpfulness, or creativity. But as your evaluation logic becomes more rule-based or multi-step, G-Eval might not be enough.
 
 That’s where **DAG** comes in. It lets you structure your evaluation into modular, objective steps—catching hallucinations early, applying precise thresholds, and making every decision traceable. By combining simple LLM judgments into a deterministic graph, DAG gives you control, consistency, transparency, and objectivity in all your evaluation pipelines.
 

--- a/docs/content/docs/(generate-goldens)/synthesizer-generate-from-docs.mdx
+++ b/docs/content/docs/(generate-goldens)/synthesizer-generate-from-docs.mdx
@@ -114,7 +114,7 @@ There are **SEVEN** optional parameters when creating a `ContextConstructionConf
 - [Optional] `encoding`: the encoding to use to decode plain text–based files (`.txt`, `.md`, `.markdown`, `.mdx`). Defaulted to autodetecting the encoding.
 - [Optional] `max_contexts_per_document`: the maximum number of contexts to be generated per document. Defaulted to 3.
 - [Optional] `min_contexts_per_document`: the minimum number of contexts to be generated per document. Defaulted to 1.
-- [Optional] `max_context_length`: specifies the number of of text chunks to be generated per context (context length). Defaulted to 3.
+- [Optional] `max_context_length`: specifies the number of text chunks to be generated per context (context length). Defaulted to 3.
 - [Optional] `min_context_length`: specifies the minimum number of text chunks to be generated per context (context length). Defaulted to 1.
 - [Optional] `chunk_size`: specifies the size of text chunks (in tokens) to be considered during [document parsing](#synthesizer-generate-from-docs#document-parsing). Defaulted to 1024.
 - [Optional] `chunk_overlap`: an int that determines the overlap size between consecutive text chunks during [document parsing](#synthesizer-generate-from-docs#document-parsing). Defaulted to 0.

--- a/docs/content/docs/benchmarks-introduction.mdx
+++ b/docs/content/docs/benchmarks-introduction.mdx
@@ -195,7 +195,7 @@ You'll notice although tasks and prompting techniques are configurable, scorers 
 
 ### Tasks
 
-A task for an LLM benchmark is a challenge or problem is designed to assess an LLM's capabilities on a specific area of focus. For example, you can specify which **subset** of the the `MMLU` benchmark to evaluate your LLM on by providing a list of `MMLUTASK`:
+A task for an LLM benchmark is a challenge or problem is designed to assess an LLM's capabilities on a specific area of focus. For example, you can specify which **subset** of the `MMLU` benchmark to evaluate your LLM on by providing a list of `MMLUTASK`:
 
 ```python
 from deepeval.benchmarks import MMLU

--- a/docs/content/guides/guides-answer-correctness-metric.mdx
+++ b/docs/content/guides/guides-answer-correctness-metric.mdx
@@ -60,7 +60,7 @@ correctness_metric = GEval(
 )
 ```
 
-If the expected output is unavailable, you can alternatively compare the actual output with the `CONTEXT`, which serves as the **ideal retrieval context** for a RAG application. This comparison comes with its own set of evaluation criterias, however, which we will explore in the following step.
+If the expected output is unavailable, you can alternatively compare the actual output with the `CONTEXT`, which serves as the **ideal retrieval context** for a RAG application. This comparison comes with its own set of evaluation criteria, however, which we will explore in the following step.
 
 ```python
 from deepeval.metrics import GEval

--- a/docs/content/integrations/vector-databases/weaviate.mdx
+++ b/docs/content/integrations/vector-databases/weaviate.mdx
@@ -33,7 +33,7 @@ To learn more about leveraging Weaviate as your retrieval engine, [visit this pa
   </div>
 </div>
 
-Youn can easily evaluate your **Weaviate** retriever with DeepEval to find the best hyperparameters for your Weaviate engine. This parameters include `with_limit` (top-K) and `vectorizer` (embedding model), among many others.
+You can easily evaluate your **Weaviate** retriever with DeepEval to find the best hyperparameters for your Weaviate engine. These parameters include `with_limit` (top-K) and `vectorizer` (embedding model), among many others.
 
 :::info
 You can quickly get started with Weaviate by running the following command in your CLI:

--- a/docs/content/tutorials/medical-chatbot/development.mdx
+++ b/docs/content/tutorials/medical-chatbot/development.mdx
@@ -6,7 +6,7 @@ languages: [python]
 ---
 
 In this section, we are going to create a **multi-turn** chatbot that can use various tools to diagnose and schedule appointments for users based on their symptoms.
-We will be using `langchain` and `qdrant` to build our chatbot, with functionalies including a:
+We will be using `langchain` and `qdrant` to build our chatbot, with functionalities including a:
 
 - **RAG pipeline** to retrieve medical knowledge to diagnose patients
 - **Custom tools** to create new appointments based on patient symptoms

--- a/docs/content/tutorials/medical-chatbot/evals-in-prod.mdx
+++ b/docs/content/tutorials/medical-chatbot/evals-in-prod.mdx
@@ -48,7 +48,7 @@ class MedicalChatbot:
     @tool
     @observe(metrics=[ContextualRelevancyMetric()], type="retriever")
     def query_engine(self, query: str) -> str:
-        """"A tool to retrive data on various diagnosis methods from gale encyclopedia"""
+        """"A tool to retrieve data on various diagnosis methods from gale encyclopedia"""
         # Give an appropriate description of the tool
         hits = self.client.search(
             collection_name="gale_encyclopedia",

--- a/docs/content/tutorials/medical-chatbot/evals-in-prod.mdx
+++ b/docs/content/tutorials/medical-chatbot/evals-in-prod.mdx
@@ -48,7 +48,7 @@ class MedicalChatbot:
     @tool
     @observe(metrics=[ContextualRelevancyMetric()], type="retriever")
     def query_engine(self, query: str) -> str:
-        """"A tool to retrieve data on various diagnosis methods from gale encyclopedia"""
+        """A tool to retrieve data on various diagnosis methods from gale encyclopedia"""
         # Give an appropriate description of the tool
         hits = self.client.search(
             collection_name="gale_encyclopedia",

--- a/docs/content/tutorials/medical-chatbot/improvement.mdx
+++ b/docs/content/tutorials/medical-chatbot/improvement.mdx
@@ -96,7 +96,7 @@ Use phrases like:
 Your goal is to support users with reliable, respectful healthcare guidance.
 ```
 
-We will now iterate over different models to see which one perfoms best for our chatbot.
+We will now iterate over different models to see which one performs best for our chatbot.
 
 ```python
 from deepeval.metrics import (

--- a/docs/content/tutorials/rag-qa-agent/evaluation.mdx
+++ b/docs/content/tutorials/rag-qa-agent/evaluation.mdx
@@ -235,7 +235,7 @@ You can also run `deepeval view` to see the results of evals on Confident AI:
 <ImageDisplayer src={ASSETS.tutorialRagQaAgentEvalResults} alt="RAG QA Agent Eval Results" />
 
 :::note
-If you remember the implementation of our RAG agent. There are too many hyperparameters that can change the behavious of our RAG application. Click here to see the [implementation of RAG Agent](https://deepeval.com/tutorials/rag-qa-agent/tutorial-rag-qa-development) once again.
+If you remember the implementation of our RAG agent. There are too many hyperparameters that can change the behavior of our RAG application. Click here to see the [implementation of RAG Agent](https://deepeval.com/tutorials/rag-qa-agent/tutorial-rag-qa-development) once again.
 :::
 
 In the next section, we'll see how we can improve the performance of our RAG agent by tweaking hyperparameters and using the evaluation results.

--- a/docs/content/tutorials/summarization-agent/evaluation.mdx
+++ b/docs/content/tutorials/summarization-agent/evaluation.mdx
@@ -44,7 +44,7 @@ For evaluating a summarization agent like ours, there is one main approach we ca
 
 ### Datasets
 
-Having to maintain a database to store meeting transcripts might not be feasible and accessing them everytime may also prove to be hard. In such cases, we can use `deepeval`'s [datasets](https://deepeval.com/docs/evaluation-datasets).
+Having to maintain a database to store meeting transcripts might not be feasible and accessing them every time may also prove to be hard. In such cases, we can use `deepeval`'s [datasets](https://deepeval.com/docs/evaluation-datasets).
 They are simply a collection of `Golden`s that can be stored in cloud and pulled anytime with just a few lines of code. They allow you to create test cases during run time by calling your LLM.
 
 <ImageDisplayer src={ASSETS.evaluationDataset} alt="Evaluation Dataset" />

--- a/docs/content/tutorials/summarization-agent/improvement.mdx
+++ b/docs/content/tutorials/summarization-agent/improvement.mdx
@@ -236,7 +236,7 @@ This raises an issue of which model to choose among the both as they each excel 
 
 In this situation, you can either use more test cases to run evaluations to get more data or use `deepeval`'s latest `ArenaGEval` to test which model is better among them by evaluating arena test cases. You can learn more about it [here](docs/metrics-arena-g-eval).
 
-**OR** alternatively, you can update your `MeetingSummarizer` to to use two different models for different tasks. Here's how you can do that:
+**OR** alternatively, you can update your `MeetingSummarizer` to use two different models for different tasks. Here's how you can do that:
 
 ```python {6-7,9-10,14,17,25,28,36,39}
 from deepeval.tracing import observe


### PR DESCRIPTION
Fifteen corrections across the docs.

Worth a second look:

- The G-Eval use-case tables have two different misspellings of the same column header — `Critera` and `Critiera` — both meant `Criteria`.
- `criterias` on the answer-correctness guide is already plural; changed to `criteria`.
- `behavious` -> `behavior`, matching the American spelling the docs use elsewhere (174 occurrences vs 31 British).

The rest of the spelling fixes: `Youn`, `functionalies`, `retrive`, `perfoms`, and two instances of `everytime` -> `every time`.

The second commit fixes four repeated words: "of the the MMLU benchmark", "perfect for for subjective tasks", "MeetingSummarizer to to use", and "the number of of text chunks".

One small grammar fix on the same line as the Weaviate typo: "This parameters include" -> "These parameters include".