### PR TITLE
chore: keep .scripts/release.py under the black line limit

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,8 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: bool
 
 
 TARGETS: Dict[str, Target] = {


### PR DESCRIPTION
`Py Lint` is currently failing on `main`.

```
$ black --check .          # black 25.1.0, repo pyproject (line-length 80)
would reformat .scripts/release.py
1 file would be reformatted, 991 files would be left unchanged.
```

The trailing comment on `Target.single_digit` runs past the 80-character limit, so every open PR inherits a red lint job that has nothing to do with its own changes.

Moved the comment onto its own line above the field. Black's own fix wraps the annotation instead:

```python
single_digit: (
    bool  # cap x.y.z at 9 and carry left, rather than plain semver
)
```

which reads worse for the same result, so I went with the comment move. Happy to switch to black's output if you'd rather the file be exactly what the tool emits.

`black --check .` is clean afterwards: 992 files unchanged. One line, no behaviour change.

Noticed while looking at the lint failure on #3114.