### PR TITLE
docs(seo): benchmark titles, RAGAS description, sitemap entry

### DIFF
--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -44,5 +44,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
     }),
   );
 
-  return [{ url: `${siteUrl}/`, lastModified: new Date() }, ...entries];
+  return [
+    { url: `${siteUrl}/`, lastModified: new Date() },
+    { url: `${siteUrl}/enterprise` },
+    ...entries,
+  ];
 }

--- a/docs/content/docs/(benchmarks)/benchmarks-gsm8k.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-gsm8k.mdx
@@ -1,6 +1,6 @@
 ---
 id: benchmarks-gsm8k
-title: GSM8K
+title: GSM8K Benchmark
 sidebar_label: GSM8K
 languages: [python]
 ---

--- a/docs/content/docs/(benchmarks)/benchmarks-hellaswag.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-hellaswag.mdx
@@ -1,6 +1,6 @@
 ---
 id: benchmarks-hellaswag
-title: HellaSwag
+title: HellaSwag Benchmark
 sidebar_label: HellaSwag
 languages: [python]
 ---

--- a/docs/content/docs/(benchmarks)/benchmarks-human-eval.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-human-eval.mdx
@@ -1,6 +1,6 @@
 ---
 id: benchmarks-human-eval
-title: HumanEval
+title: HumanEval Benchmark
 sidebar_label: HumanEval
 languages: [python]
 ---

--- a/docs/content/docs/(benchmarks)/benchmarks-ifeval.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-ifeval.mdx
@@ -1,6 +1,6 @@
 ---
 id: benchmarks-ifeval
-title: IFEval
+title: IFEval Benchmark
 sidebar_label: IFEval
 languages: [python]
 ---

--- a/docs/content/docs/(benchmarks)/benchmarks-mmlu.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-mmlu.mdx
@@ -1,6 +1,6 @@
 ---
 id: benchmarks-mmlu
-title: MMLU
+title: MMLU Benchmark
 sidebar_label: MMLU
 languages: [python]
 ---

--- a/docs/content/docs/(benchmarks)/benchmarks-truthful-qa.mdx
+++ b/docs/content/docs/(benchmarks)/benchmarks-truthful-qa.mdx
@@ -1,6 +1,6 @@
 ---
 id: benchmarks-truthful-qa
-title: TruthfulQA
+title: TruthfulQA Benchmark
 sidebar_label: TruthfulQA
 languages: [python]
 ---

--- a/docs/content/docs/(metrics-others)/metrics-ragas.mdx
+++ b/docs/content/docs/(metrics-others)/metrics-ragas.mdx
@@ -2,12 +2,13 @@
 id: metrics-ragas
 title: RAGAS Metrics
 sidebar_label: RAGAS
-description: Run the RAGAS metrics (faithfulness, answer relevancy, contextual precision, contextual recall) in deepeval and see how the averaged RAGAS score is computed.
 languages: [python]
 ---
 
 
-The RAGAS metric is the average of four distinct metrics:
+The RAGAS metric in `deepeval` is the average of four RAGAS metrics: answer relevancy, faithfulness, contextual precision, and contextual recall.
+
+The four metrics are:
 
 - `RAGASAnswerRelevancyMetric`
 - `RAGASFaithfulnessMetric`

--- a/docs/content/docs/(metrics-others)/metrics-ragas.mdx
+++ b/docs/content/docs/(metrics-others)/metrics-ragas.mdx
@@ -1,7 +1,8 @@
 ---
 id: metrics-ragas
-title: RAGAS
+title: RAGAS Metrics
 sidebar_label: RAGAS
+description: Run the RAGAS metrics (faithfulness, answer relevancy, contextual precision, contextual recall) in deepeval and see how the averaged RAGAS score is computed.
 languages: [python]
 ---
 

--- a/docs/content/docs/benchmarks-introduction.mdx
+++ b/docs/content/docs/benchmarks-introduction.mdx
@@ -1,7 +1,8 @@
 ---
 id: benchmarks-introduction
-title: Introduction to LLM Benchmarks
+title: "LLM Benchmarks: What They Measure and How to Run Them"
 sidebar_label: Introduction
+description: What LLM benchmarks measure, how MMLU, HumanEval, GSM8K, HellaSwag and TruthfulQA differ, and how to run any of them on your model in a few lines of deepeval.
 languages: [python]
 ---
 

--- a/docs/content/docs/benchmarks-introduction.mdx
+++ b/docs/content/docs/benchmarks-introduction.mdx
@@ -2,7 +2,6 @@
 id: benchmarks-introduction
 title: "LLM Benchmarks: What They Measure and How to Run Them"
 sidebar_label: Introduction
-description: What LLM benchmarks measure, how MMLU, HumanEval, GSM8K, HellaSwag and TruthfulQA differ, and how to run any of them on your model in a few lines of deepeval.
 languages: [python]
 ---
 

--- a/docs/content/docs/evaluation-unit-testing-in-ci-cd.mdx
+++ b/docs/content/docs/evaluation-unit-testing-in-ci-cd.mdx
@@ -7,7 +7,7 @@ languages: [python, typescript]
 
 import { ASSETS } from "@site/src/assets";
 
-Integrate LLM evaluations into your CI/CD pipeline with `deepeval` to catch regressions before they ship. `deepeval` plugs into <Term py="pytest" ts="vitest"/> via <Term py="assert_test()" ts="expect(testCase).toPass()"/> and the <Term py="deepeval test run" ts="npx deepeval test run"/> command, so every push (or every PR) runs the same evals you'd run locally — single-turn or multi-turn, end-to-end or component-level.
+Integrate LLM evaluations into your CI/CD pipeline with `deepeval` to catch regressions before they ship. `deepeval` plugs into <Term py="pytest" ts="vitest"/> via <Term py="assert_test()" ts="expect(testCase).toPass()"/> and the <Term py="deepeval test run" ts="npx deepeval test run"/> command, so every push (or every PR) runs the same evals you'd run locally — single-turn or multi-turn, end-to-end or component-level. For a walkthrough that compares runs against a baseline, see the [regression testing in CI/CD guide](/guides/guides-regression-testing-in-cicd).
 
 ## How It Works
 


### PR DESCRIPTION
Docs metadata only. Search Console window 20 Jul to 22 Aug 2026.

- Six benchmark pages: title adds "Benchmark". Queries with that word bring clicks on every page (MMLU 66, HumanEval 158, GSM8K 56, HellaSwag 63, TruthfulQA 16, IFEval 52). Bare name stays first; sidebar labels unchanged; the full title tag stays under Google's 600px cut.
- `benchmarks-introduction`: new title and description. "llm benchmark(s)" brings 175 clicks at position 8 to 14 with no query phrasing in the title. Benchmark names stay out of the title so it does not compete with the dedicated pages.
- `metrics-ragas`: title "RAGAS Metrics" and a real description (the old one was a body line cut at a colon; 12,586 impressions at 0.8% CTR).
- `sitemap.ts`: adds `/enterprise`, indexed but absent from the sitemap.
- CI/CD page links the regression-testing guide ("Discovered, currently not indexed").

`npx tsc --noEmit` and `npm run build` pass (628 pages).
- Update: the two `description` fields were removed after review, because the docs layout also prints that field as a subtitle under the H1 and no other docs page has one. Meta descriptions now come from the first-paragraph fallback in `docs/lib/source.ts`; the RAGAS opening line became a full sentence so that fallback is no longer cut at a colon. Verified in the local build.