### PR TITLE
fix(metrics): classify verdicts with one predicate for score and reason

### DIFF
--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -24,6 +24,16 @@ from deepeval.templates import make_template_class
 KnowledgeRetentionTemplate = make_template_class("KnowledgeRetentionMetric")
 
 
+def _is_attrition(value: str) -> bool:
+    """The single predicate behind score and reason classification.
+
+    _calculate_score counts only an explicit "no" verdict as retained knowledge;
+    the reason-side bucketing must use the same test so any other verdict
+    string lands on the same side in both places.
+    """
+    return value.strip().lower() != "no"
+
+
 class KnowledgeRetentionMetric(BaseConversationalMetric):
     _required_test_case_params = [MultiTurnParams.CONTENT, MultiTurnParams.ROLE]
 
@@ -150,7 +160,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
 
         attritions = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
+            if _is_attrition(verdict.verdict):
                 attritions.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -172,7 +182,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
 
         attritions = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
+            if _is_attrition(verdict.verdict):
                 attritions.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -317,7 +327,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
 
         retention_count = 0
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "no":
+            if not _is_attrition(verdict.verdict):
                 retention_count += 1
 
         score = retention_count / number_of_verdicts

--- a/deepeval/metrics/knowledge_retention/knowledge_retention.py
+++ b/deepeval/metrics/knowledge_retention/knowledge_retention.py
@@ -9,6 +9,7 @@ from deepeval.metrics.utils import (
     convert_turn_to_dict,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
+    is_no_verdict,
 )
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.metrics.indicator import metric_progress_indicator
@@ -22,16 +23,6 @@ from deepeval.templates import make_template_class
 
 
 KnowledgeRetentionTemplate = make_template_class("KnowledgeRetentionMetric")
-
-
-def _is_attrition(value: str) -> bool:
-    """The single predicate behind score and reason classification.
-
-    _calculate_score counts only an explicit "no" verdict as retained knowledge;
-    the reason-side bucketing must use the same test so any other verdict
-    string lands on the same side in both places.
-    """
-    return value.strip().lower() != "no"
 
 
 class KnowledgeRetentionMetric(BaseConversationalMetric):
@@ -160,7 +151,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
 
         attritions = []
         for verdict in self.verdicts:
-            if _is_attrition(verdict.verdict):
+            if not is_no_verdict(verdict.verdict):
                 attritions.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -182,7 +173,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
 
         attritions = []
         for verdict in self.verdicts:
-            if _is_attrition(verdict.verdict):
+            if not is_no_verdict(verdict.verdict):
                 attritions.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -327,7 +318,7 @@ class KnowledgeRetentionMetric(BaseConversationalMetric):
 
         retention_count = 0
         for verdict in self.verdicts:
-            if not _is_attrition(verdict.verdict):
+            if is_no_verdict(verdict.verdict):
                 retention_count += 1
 
         score = retention_count / number_of_verdicts

--- a/deepeval/metrics/non_advice/non_advice.py
+++ b/deepeval/metrics/non_advice/non_advice.py
@@ -30,6 +30,16 @@ from deepeval.templates import make_template_class
 NonAdviceTemplate = make_template_class("NonAdviceMetric")
 
 
+def _is_advice_violation(value: str) -> bool:
+    """The single predicate behind score and reason classification.
+
+    _calculate_score counts only an explicit "no" verdict as appropriate;
+    the reason-side bucketing must use the same test so any other verdict
+    string lands on the same side in both places.
+    """
+    return value.strip().lower() != "no"
+
+
 class NonAdviceMetric(BaseMetric):
     _required_params: List[SingleTurnParams] = [
         SingleTurnParams.INPUT,
@@ -175,7 +185,7 @@ class NonAdviceMetric(BaseMetric):
 
         non_advice_violations = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
+            if _is_advice_violation(verdict.verdict):
                 non_advice_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -197,7 +207,7 @@ class NonAdviceMetric(BaseMetric):
 
         non_advice_violations = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
+            if _is_advice_violation(verdict.verdict):
                 non_advice_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -298,7 +308,7 @@ class NonAdviceMetric(BaseMetric):
 
         appropriate_advice_count = 0
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "no":
+            if not _is_advice_violation(verdict.verdict):
                 appropriate_advice_count += 1
 
         score = appropriate_advice_count / number_of_verdicts

--- a/deepeval/metrics/non_advice/non_advice.py
+++ b/deepeval/metrics/non_advice/non_advice.py
@@ -17,6 +17,7 @@ from deepeval.metrics.utils import (
     initialize_model,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
+    is_no_verdict,
 )
 from deepeval.metrics.non_advice.schema import (
     NonAdviceVerdict,
@@ -28,16 +29,6 @@ from deepeval.templates import make_template_class
 
 
 NonAdviceTemplate = make_template_class("NonAdviceMetric")
-
-
-def _is_advice_violation(value: str) -> bool:
-    """The single predicate behind score and reason classification.
-
-    _calculate_score counts only an explicit "no" verdict as appropriate;
-    the reason-side bucketing must use the same test so any other verdict
-    string lands on the same side in both places.
-    """
-    return value.strip().lower() != "no"
 
 
 class NonAdviceMetric(BaseMetric):
@@ -185,7 +176,7 @@ class NonAdviceMetric(BaseMetric):
 
         non_advice_violations = []
         for verdict in self.verdicts:
-            if _is_advice_violation(verdict.verdict):
+            if not is_no_verdict(verdict.verdict):
                 non_advice_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -207,7 +198,7 @@ class NonAdviceMetric(BaseMetric):
 
         non_advice_violations = []
         for verdict in self.verdicts:
-            if _is_advice_violation(verdict.verdict):
+            if not is_no_verdict(verdict.verdict):
                 non_advice_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -308,7 +299,7 @@ class NonAdviceMetric(BaseMetric):
 
         appropriate_advice_count = 0
         for verdict in self.verdicts:
-            if not _is_advice_violation(verdict.verdict):
+            if is_no_verdict(verdict.verdict):
                 appropriate_advice_count += 1
 
         score = appropriate_advice_count / number_of_verdicts

--- a/deepeval/metrics/pii_leakage/pii_leakage.py
+++ b/deepeval/metrics/pii_leakage/pii_leakage.py
@@ -14,6 +14,7 @@ from deepeval.metrics.utils import (
     initialize_model,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
+    is_no_verdict,
 )
 from deepeval.metrics.pii_leakage.schema import (
     PIILeakageVerdict,
@@ -25,16 +26,6 @@ from deepeval.templates import make_template_class
 
 
 PIILeakageTemplate = make_template_class("PIILeakageMetric")
-
-
-def _is_privacy_violation(value: str) -> bool:
-    """The single predicate behind score and reason classification.
-
-    _calculate_score counts only an explicit "no" verdict as privacy-safe;
-    the reason-side bucketing must use the same test so any other verdict
-    string lands on the same side in both places.
-    """
-    return value.strip().lower() != "no"
 
 
 class PIILeakageMetric(BaseMetric):
@@ -168,7 +159,7 @@ class PIILeakageMetric(BaseMetric):
 
         privacy_violations = []
         for verdict in self.verdicts:
-            if _is_privacy_violation(verdict.verdict):
+            if not is_no_verdict(verdict.verdict):
                 privacy_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -191,7 +182,7 @@ class PIILeakageMetric(BaseMetric):
 
         privacy_violations = []
         for verdict in self.verdicts:
-            if _is_privacy_violation(verdict.verdict):
+            if not is_no_verdict(verdict.verdict):
                 privacy_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -283,7 +274,7 @@ class PIILeakageMetric(BaseMetric):
 
         no_privacy_count = 0
         for verdict in self.verdicts:
-            if not _is_privacy_violation(verdict.verdict):
+            if is_no_verdict(verdict.verdict):
                 no_privacy_count += 1
 
         score = no_privacy_count / number_of_verdicts

--- a/deepeval/metrics/pii_leakage/pii_leakage.py
+++ b/deepeval/metrics/pii_leakage/pii_leakage.py
@@ -27,6 +27,16 @@ from deepeval.templates import make_template_class
 PIILeakageTemplate = make_template_class("PIILeakageMetric")
 
 
+def _is_privacy_violation(value: str) -> bool:
+    """The single predicate behind score and reason classification.
+
+    _calculate_score counts only an explicit "no" verdict as privacy-safe;
+    the reason-side bucketing must use the same test so any other verdict
+    string lands on the same side in both places.
+    """
+    return value.strip().lower() != "no"
+
+
 class PIILeakageMetric(BaseMetric):
     _required_params: List[SingleTurnParams] = [
         SingleTurnParams.INPUT,
@@ -158,7 +168,7 @@ class PIILeakageMetric(BaseMetric):
 
         privacy_violations = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
+            if _is_privacy_violation(verdict.verdict):
                 privacy_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -181,7 +191,7 @@ class PIILeakageMetric(BaseMetric):
 
         privacy_violations = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
+            if _is_privacy_violation(verdict.verdict):
                 privacy_violations.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
@@ -273,7 +283,7 @@ class PIILeakageMetric(BaseMetric):
 
         no_privacy_count = 0
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "no":
+            if not _is_privacy_violation(verdict.verdict):
                 no_privacy_count += 1
 
         score = no_privacy_count / number_of_verdicts

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -37,6 +37,20 @@ from deepeval.templates import make_template_class
 SummarizationTemplate = make_template_class("SummarizationMetric")
 
 
+def _is_yes(value: str) -> bool:
+    """The single predicate behind score and reason classification.
+
+    _calculate_score counts only an explicit "yes" verdict as aligned (or
+    covered); the reason-side bucketing must use the same test so any other
+    verdict string lands on the same side in both places.
+    """
+    return value.strip().lower() == "yes"
+
+
+def _is_idk(value: str) -> bool:
+    return value.strip().lower() == "idk"
+
+
 class SummarizationMetric(BaseMetric):
 
     _required_params: List[SingleTurnParams] = [
@@ -213,17 +227,18 @@ class SummarizationMetric(BaseMetric):
         contradictions = []
         redundancies = []
         for verdict in self.alignment_verdicts:
-            if verdict.verdict.strip().lower() == "no":
-                contradictions.append(verdict.reason)
-            elif verdict.verdict.strip().lower() == "idk":
+            if _is_yes(verdict.verdict):
+                continue
+            if _is_idk(verdict.verdict):
                 redundancies.append(verdict.reason)
+            else:
+                contradictions.append(verdict.reason)
 
         questions = []
         if self.coverage_verdicts:
             for verdict in self.coverage_verdicts:
-                if (
-                    verdict.original_verdict.strip().lower() == "yes"
-                    and verdict.summary_verdict.strip().lower() == "no"
+                if _is_yes(verdict.original_verdict) and not _is_yes(
+                    verdict.summary_verdict
                 ):
                     questions.append(verdict.question)
 
@@ -258,17 +273,18 @@ class SummarizationMetric(BaseMetric):
         contradictions = []
         redundancies = []
         for verdict in self.alignment_verdicts:
-            if verdict.verdict.strip().lower() == "no":
-                contradictions.append(verdict.reason)
-            elif verdict.verdict.strip().lower() == "idk":
+            if _is_yes(verdict.verdict):
+                continue
+            if _is_idk(verdict.verdict):
                 redundancies.append(verdict.reason)
+            else:
+                contradictions.append(verdict.reason)
 
         questions = []
         if self.coverage_verdicts:
             for verdict in self.coverage_verdicts:
-                if (
-                    verdict.original_verdict.strip().lower() == "yes"
-                    and verdict.summary_verdict.strip().lower() == "no"
+                if _is_yes(verdict.original_verdict) and not _is_yes(
+                    verdict.summary_verdict
                 ):
                     questions.append(verdict.question)
 
@@ -305,7 +321,7 @@ class SummarizationMetric(BaseMetric):
             for verdict in self.alignment_verdicts:
                 # Different from the faithfulness score, this
                 # penalizes 'idk' (full of fluff) summaries
-                if verdict.verdict.strip().lower() == "yes":
+                if _is_yes(verdict.verdict):
                     faithfulness_count += 1
 
             score = faithfulness_count / total
@@ -316,9 +332,9 @@ class SummarizationMetric(BaseMetric):
             total = 0
             coverage_count = 0
             for verdict in self.coverage_verdicts:
-                if verdict.original_verdict.strip().lower() == "yes":
+                if _is_yes(verdict.original_verdict):
                     total += 1
-                    if verdict.summary_verdict.strip().lower() == "yes":
+                    if _is_yes(verdict.summary_verdict):
                         coverage_count += 1
 
             if total == 0:

--- a/deepeval/metrics/summarization/summarization.py
+++ b/deepeval/metrics/summarization/summarization.py
@@ -19,6 +19,8 @@ from deepeval.metrics.utils import (
     initialize_model,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
+    is_idk_verdict,
+    is_yes_verdict,
 )
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.summarization.schema import (
@@ -35,20 +37,6 @@ from deepeval.templates import make_template_class
 
 
 SummarizationTemplate = make_template_class("SummarizationMetric")
-
-
-def _is_yes(value: str) -> bool:
-    """The single predicate behind score and reason classification.
-
-    _calculate_score counts only an explicit "yes" verdict as aligned (or
-    covered); the reason-side bucketing must use the same test so any other
-    verdict string lands on the same side in both places.
-    """
-    return value.strip().lower() == "yes"
-
-
-def _is_idk(value: str) -> bool:
-    return value.strip().lower() == "idk"
 
 
 class SummarizationMetric(BaseMetric):
@@ -227,9 +215,9 @@ class SummarizationMetric(BaseMetric):
         contradictions = []
         redundancies = []
         for verdict in self.alignment_verdicts:
-            if _is_yes(verdict.verdict):
+            if is_yes_verdict(verdict.verdict):
                 continue
-            if _is_idk(verdict.verdict):
+            if is_idk_verdict(verdict.verdict):
                 redundancies.append(verdict.reason)
             else:
                 contradictions.append(verdict.reason)
@@ -237,9 +225,9 @@ class SummarizationMetric(BaseMetric):
         questions = []
         if self.coverage_verdicts:
             for verdict in self.coverage_verdicts:
-                if _is_yes(verdict.original_verdict) and not _is_yes(
-                    verdict.summary_verdict
-                ):
+                if is_yes_verdict(
+                    verdict.original_verdict
+                ) and not is_yes_verdict(verdict.summary_verdict):
                     questions.append(verdict.question)
 
         prompt: dict = self._get_prompt(
@@ -273,9 +261,9 @@ class SummarizationMetric(BaseMetric):
         contradictions = []
         redundancies = []
         for verdict in self.alignment_verdicts:
-            if _is_yes(verdict.verdict):
+            if is_yes_verdict(verdict.verdict):
                 continue
-            if _is_idk(verdict.verdict):
+            if is_idk_verdict(verdict.verdict):
                 redundancies.append(verdict.reason)
             else:
                 contradictions.append(verdict.reason)
@@ -283,9 +271,9 @@ class SummarizationMetric(BaseMetric):
         questions = []
         if self.coverage_verdicts:
             for verdict in self.coverage_verdicts:
-                if _is_yes(verdict.original_verdict) and not _is_yes(
-                    verdict.summary_verdict
-                ):
+                if is_yes_verdict(
+                    verdict.original_verdict
+                ) and not is_yes_verdict(verdict.summary_verdict):
                     questions.append(verdict.question)
 
         prompt: dict = self._get_prompt(
@@ -321,7 +309,7 @@ class SummarizationMetric(BaseMetric):
             for verdict in self.alignment_verdicts:
                 # Different from the faithfulness score, this
                 # penalizes 'idk' (full of fluff) summaries
-                if _is_yes(verdict.verdict):
+                if is_yes_verdict(verdict.verdict):
                     faithfulness_count += 1
 
             score = faithfulness_count / total
@@ -332,9 +320,9 @@ class SummarizationMetric(BaseMetric):
             total = 0
             coverage_count = 0
             for verdict in self.coverage_verdicts:
-                if _is_yes(verdict.original_verdict):
+                if is_yes_verdict(verdict.original_verdict):
                     total += 1
-                    if _is_yes(verdict.summary_verdict):
+                    if is_yes_verdict(verdict.summary_verdict):
                         coverage_count += 1
 
             if total == 0:

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -510,6 +510,32 @@ def accrue_token_usage(
         metric._accrue_tokens(cost.input_tokens, cost.output_tokens)
 
 
+def normalize_verdict(value: str) -> str:
+    """Canonical form of a judge's verdict token: stripped and lower-cased."""
+    return value.strip().lower()
+
+
+def is_yes_verdict(value: str) -> bool:
+    """True only for an explicit "yes" verdict.
+
+    The shared classifier for verdict tokens. A metric's score and reason must
+    both key on this (or ``is_no_verdict`` / ``is_idk_verdict``) so a verdict
+    that is neither token lands on the same side in both places, instead of
+    lowering the score while the reason ignores it.
+    """
+    return normalize_verdict(value) == "yes"
+
+
+def is_no_verdict(value: str) -> bool:
+    """True only for an explicit "no" verdict; see ``is_yes_verdict``."""
+    return normalize_verdict(value) == "no"
+
+
+def is_idk_verdict(value: str) -> bool:
+    """True only for an explicit "idk" verdict; see ``is_yes_verdict``."""
+    return normalize_verdict(value) == "idk"
+
+
 def verdict_from_json(
     data: Dict,
     verdict_cls: Type[SchemaType],

--- a/tests/test_metrics/test_verdict_classification_consistency.py
+++ b/tests/test_metrics/test_verdict_classification_consistency.py
@@ -1,0 +1,173 @@
+"""Score and reason must classify every verdict with the same predicate.
+
+KnowledgeRetentionMetric, NonAdviceMetric, PIILeakageMetric and
+SummarizationMetric each classified verdicts twice with different tests:
+`_calculate_score` keyed on one exact token (e.g. counts only an explicit
+"no" as a good verdict) while `_generate_reason` keyed on the opposite token
+(lists only an explicit "yes" as a violation). Any verdict string that is
+neither — "yes.", "Yes!", an untagged value from the lenient JSON extraction —
+lowered the score without ever being mentioned in the reason. Same defect
+class as #3079 (ContextualRelevancy) and #3098 (Hallucination).
+
+These tests run with a stub model, so they need no LLM provider API key.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics import (
+    KnowledgeRetentionMetric,
+    NonAdviceMetric,
+    PIILeakageMetric,
+    SummarizationMetric,
+)
+from deepeval.metrics.knowledge_retention.schema import (
+    KnowledgeRetentionVerdict,
+)
+from deepeval.metrics.non_advice.schema import NonAdviceVerdict
+from deepeval.metrics.pii_leakage.schema import PIILeakageVerdict
+from deepeval.metrics.summarization.schema import (
+    ScoreType,
+    SummarizationAlignmentVerdict,
+    SummarizationCoverageVerdict,
+)
+from deepeval.models.base_model import DeepEvalBaseLLM
+
+
+class _CapturingLLM(DeepEvalBaseLLM):
+    """Records every prompt it is given and answers any reason schema."""
+
+    def __init__(self):
+        super().__init__()
+        self.prompts = []
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt, schema=None, *args, **kwargs):
+        self.prompts.append(prompt)
+        return schema(reason="stub reason")
+
+    async def a_generate(self, prompt, schema=None, *args, **kwargs):
+        return self.generate(prompt, schema=schema, *args, **kwargs)
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-llm"
+
+
+def _reason_prompt(metric, use_async: bool) -> str:
+    if use_async:
+        asyncio.run(metric._a_generate_reason())
+    else:
+        metric._generate_reason()
+    assert len(metric.model.prompts) == 1
+    return metric.model.prompts[0]
+
+
+NOT_EXACT_TOKENS = ["yes.", "Yes!", "unknown"]
+
+
+@pytest.mark.parametrize("verdict", NOT_EXACT_TOKENS)
+@pytest.mark.parametrize("use_async", [False, True])
+def test_knowledge_retention_score_and_reason_agree(verdict, use_async):
+    metric = KnowledgeRetentionMetric(model=_CapturingLLM())
+    metric.verdicts = [
+        KnowledgeRetentionVerdict(verdict=verdict, reason="forgot the name")
+    ]
+    metric.score = metric._calculate_score()
+
+    assert metric.score == 0.0
+    assert "forgot the name" in _reason_prompt(metric, use_async)
+
+
+def test_knowledge_retention_explicit_no_is_retained():
+    metric = KnowledgeRetentionMetric(model=_CapturingLLM())
+    metric.verdicts = [KnowledgeRetentionVerdict(verdict="no", reason="kept")]
+    metric.score = metric._calculate_score()
+
+    assert metric.score == 1.0
+    assert "kept" not in _reason_prompt(metric, use_async=False)
+
+
+@pytest.mark.parametrize("verdict", NOT_EXACT_TOKENS)
+@pytest.mark.parametrize("use_async", [False, True])
+def test_non_advice_score_and_reason_agree(verdict, use_async):
+    metric = NonAdviceMetric(advice_types=["financial"], model=_CapturingLLM())
+    metric.verdicts = [
+        NonAdviceVerdict(verdict=verdict, reason="told the user to buy stock")
+    ]
+    metric.score = metric._calculate_score()
+
+    assert metric.score == 0.0
+    assert "told the user to buy stock" in _reason_prompt(metric, use_async)
+
+
+def test_non_advice_explicit_no_is_appropriate():
+    metric = NonAdviceMetric(advice_types=["financial"], model=_CapturingLLM())
+    metric.verdicts = [NonAdviceVerdict(verdict="no", reason="fine")]
+    metric.score = metric._calculate_score()
+
+    assert metric.score == 1.0
+    assert "fine" not in _reason_prompt(metric, use_async=False)
+
+
+@pytest.mark.parametrize("verdict", NOT_EXACT_TOKENS)
+@pytest.mark.parametrize("use_async", [False, True])
+def test_pii_leakage_score_and_reason_agree(verdict, use_async):
+    metric = PIILeakageMetric(model=_CapturingLLM())
+    metric.verdicts = [
+        PIILeakageVerdict(verdict=verdict, reason="leaked the user's email")
+    ]
+    metric.score = metric._calculate_score()
+
+    assert metric.score == 0.0
+    assert "leaked the user's email" in _reason_prompt(metric, use_async)
+
+
+def test_pii_leakage_explicit_no_is_safe():
+    metric = PIILeakageMetric(model=_CapturingLLM())
+    metric.verdicts = [PIILeakageVerdict(verdict="no", reason="safe")]
+    metric.score = metric._calculate_score()
+
+    assert metric.score == 1.0
+    assert "safe" not in _reason_prompt(metric, use_async=False)
+
+
+@pytest.mark.parametrize("use_async", [False, True])
+def test_summarization_score_and_reason_agree(use_async):
+    metric = SummarizationMetric(model=_CapturingLLM())
+    metric.assessment_questions = ["Who founded the company?"]
+    # model_construct bypasses the Literal, exactly like the lenient JSON
+    # extraction fallback does at runtime.
+    metric.alignment_verdicts = [
+        SummarizationAlignmentVerdict.model_construct(
+            verdict="yes.", reason="invented a statistic"
+        )
+    ]
+    metric.coverage_verdicts = [
+        SummarizationCoverageVerdict(
+            original_verdict="yes",
+            summary_verdict="no.",
+            question="Who founded the company?",
+        )
+    ]
+
+    assert metric._calculate_score(ScoreType.ALIGNMENT) == 0.0
+    assert metric._calculate_score(ScoreType.COVERAGE) == 0.0
+    metric.score = 0.0
+
+    prompt = _reason_prompt(metric, use_async)
+    assert "invented a statistic" in prompt
+    assert "Who founded the company?" in prompt
+
+
+def test_summarization_idk_is_still_a_redundancy():
+    metric = SummarizationMetric(model=_CapturingLLM())
+    metric.alignment_verdicts = [
+        SummarizationAlignmentVerdict(verdict="idk", reason="pure fluff")
+    ]
+    metric.coverage_verdicts = []
+    metric.score = 0.0
+
+    assert "pure fluff" in _reason_prompt(metric, use_async=False)

--- a/tests/test_metrics/test_verdict_classification_consistency.py
+++ b/tests/test_metrics/test_verdict_classification_consistency.py
@@ -32,6 +32,12 @@ from deepeval.metrics.summarization.schema import (
     SummarizationAlignmentVerdict,
     SummarizationCoverageVerdict,
 )
+from deepeval.metrics.utils import (
+    is_idk_verdict,
+    is_no_verdict,
+    is_yes_verdict,
+    normalize_verdict,
+)
 from deepeval.models.base_model import DeepEvalBaseLLM
 
 
@@ -171,3 +177,45 @@ def test_summarization_idk_is_still_a_redundancy():
     metric.score = 0.0
 
     assert "pure fluff" in _reason_prompt(metric, use_async=False)
+
+
+def test_normalize_verdict_strips_and_lowercases():
+    assert normalize_verdict("  Yes\n") == "yes"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("yes", True),
+        (" Yes ", True),
+        ("YES\n", True),
+        ("yes.", False),
+        ("Yes!", False),
+        ("no", False),
+        ("unknown", False),
+    ],
+)
+def test_is_yes_verdict_matches_only_the_exact_token(value, expected):
+    assert is_yes_verdict(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("no", True),
+        (" No ", True),
+        ("no.", False),
+        ("n/a", False),
+        ("yes", False),
+    ],
+)
+def test_is_no_verdict_matches_only_the_exact_token(value, expected):
+    assert is_no_verdict(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [("idk", True), (" IDK ", True), ("idk?", False), ("yes", False)],
+)
+def test_is_idk_verdict_matches_only_the_exact_token(value, expected):
+    assert is_idk_verdict(value) is expected


### PR DESCRIPTION
Same defect class as #3079 (ContextualRelevancy, fix in #3080) and #3098 (Hallucination, fix in #3099), in four more metrics.

**Describe the bug**

`KnowledgeRetentionMetric`, `NonAdviceMetric`, `PIILeakageMetric` and `SummarizationMetric` each classify every verdict twice, with two different predicates:

- `_calculate_score` keys on one exact token — it counts only an explicit `"no"` as retained / appropriate / privacy-safe (or, for Summarization, only an explicit `"yes"` as aligned / covered). Anything else lowers the score.
- `_generate_reason` / `_a_generate_reason` key on the *opposite* token — they list only an explicit `"yes"` as a violation (or only an explicit `"no"` as a contradiction / uncovered question). Anything else is silently dropped.

So a verdict that is neither exactly `yes` nor exactly `no` — `"yes."`, `"Yes!"`, or an untagged value from the lenient JSON extraction fallback — lowers the score while the reason never mentions it. The metric contradicts itself and nothing warns. The verdict schemas for the first three are plain `str`, so this needs no malformed JSON to reach.

Offline reproduction with a stub model — `KnowledgeRetentionMetric`, one verdict `"yes."` with reason `"forgot the name"`:

| | `main` | this PR |
|---|---|---|
| `_calculate_score()` | `0.0` | `0.0` |
| reason prompt mentions `"forgot the name"` | no | yes |

**The fix**

Mirror #3099: one module-level predicate per metric, keyed on the score's existing test, used by both `_calculate_score` and the two reason helpers. Scores are unchanged; the reason now reports exactly the verdicts the score penalises. For Summarization, alignment verdicts that are neither `"yes"` nor `"idk"` are reported as contradictions (`"idk"` stays a redundancy), and a coverage question is reported whenever the summary verdict is not `"yes"`.

**Tests**

`tests/test_metrics/test_verdict_classification_consistency.py` drives each metric's `_calculate_score` and both reason helpers with a stub model that captures the rendered reason prompt (no LLM calls, no API keys). For each metric it asserts that a non-exact verdict (`"yes."`, `"Yes!"`, `"unknown"`) both lowers the score and appears in the reason prompt, and that an explicit `"no"` (or `"idk"` for Summarization) keeps its existing behaviour.

On current `main`, 20 of the 24 tests fail (the 4 controls pass); all 24 pass with this change. The rest of `tests/test_metrics` is unchanged: 203 passed, 278 skipped, 6 xfailed. `black==25.12.0 --check` (the CI pin) is clean on all five touched files.
