### PR TITLE
fix(metrics): support score-only mode (threshold=None) in the RAGAS wrappers

### DIFF
--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -93,8 +93,8 @@ class RAGASContextualPrecisionMetric(BaseMetric):
 
         # Ragas only does dataset-level comparisons
         context_precision_score = scores["context_precision"][0]
-        self.success = context_precision_score >= self.threshold
         self.score = context_precision_score
+        self.success = self.is_successful()
         return self.score
 
     async def a_measure(
@@ -169,8 +169,8 @@ class RAGASContextualRecallMetric(BaseMetric):
         )
         scores = evaluate(dataset, [context_recall], llm=chat_model)
         context_recall_score = scores["context_recall"][0]
-        self.success = context_recall_score >= self.threshold
         self.score = context_recall_score
+        self.success = self.is_successful()
         return self.score
 
     @property
@@ -245,8 +245,8 @@ class RAGASContextualEntitiesRecall(BaseMetric):
             llm=chat_model,
         )
         contextual_entity_score = scores["context_entity_recall"][0]
-        self.success = contextual_entity_score >= self.threshold
         self.score = contextual_entity_score
+        self.success = self.is_successful()
         return self.score
 
     @property
@@ -397,8 +397,8 @@ class RAGASAnswerRelevancyMetric(BaseMetric):
             embeddings=self.embeddings,
         )
         answer_relevancy_score = scores["answer_relevancy"][0]
-        self.success = answer_relevancy_score >= self.threshold
         self.score = answer_relevancy_score
+        self.success = self.is_successful()
         return self.score
 
     @property
@@ -467,8 +467,8 @@ class RAGASFaithfulnessMetric(BaseMetric):
         )
         scores = evaluate(dataset, metrics=[faithfulness], llm=chat_model)
         faithfulness_score = scores["faithfulness"][0]
-        self.success = faithfulness_score >= self.threshold
         self.score = faithfulness_score
+        self.success = self.is_successful()
         return self.score
 
     @property
@@ -541,8 +541,9 @@ class RagasMetric(BaseMetric):
 
         ragas_score = sum(score_breakdown.values()) / len(score_breakdown)
 
-        self.success = ragas_score >= self.threshold
         self.score = ragas_score
+
+        self.success = self.is_successful()
         self.score_breakdown = score_breakdown
         return self.score
 

--- a/tests/test_metrics/test_ragas_score_only_mode.py
+++ b/tests/test_metrics/test_ragas_score_only_mode.py
@@ -1,0 +1,119 @@
+"""Regression tests for the RAGAS wrappers in score-only mode.
+
+Every RAGAS wrapper computed `self.success = score >= self.threshold`
+directly, so `threshold=None` (score-only mode, documented for all metrics)
+raised `TypeError: '>=' not supported between instances of 'float' and
+'NoneType'` after the evaluation had already run. Routing through
+`BaseMetric.is_successful()` gives the documented `success is None`.
+
+The ragas / datasets packages are stubbed in sys.modules, so the tests run
+without ragas, an LLM provider, or API keys.
+"""
+
+import sys
+import types
+
+import pytest
+
+import deepeval.metrics.ragas as ragas_module
+from deepeval.metrics.ragas import (
+    RAGASAnswerRelevancyMetric,
+    RAGASContextualEntitiesRecall,
+    RAGASContextualPrecisionMetric,
+    RAGASContextualRecallMetric,
+    RAGASFaithfulnessMetric,
+    RagasMetric,
+)
+from deepeval.test_case import LLMTestCase
+
+STUB_SCORE = 0.8
+SCORE_KEYS = [
+    "context_precision",
+    "context_recall",
+    "context_entity_recall",
+    "answer_relevancy",
+    "faithfulness",
+]
+
+
+@pytest.fixture
+def fake_ragas(monkeypatch):
+    monkeypatch.setenv("DEEPEVAL_TELEMETRY_OPT_OUT", "1")
+    monkeypatch.setattr(
+        ragas_module, "_check_langchain_available", lambda: None
+    )
+
+    ragas = types.ModuleType("ragas")
+    ragas.__version__ = "0.3.0"
+    ragas.evaluate = lambda dataset, metrics, llm, **kwargs: {
+        key: [STUB_SCORE] for key in SCORE_KEYS
+    }
+    metrics = types.ModuleType("ragas.metrics")
+    metrics.context_precision = object()
+    metrics.context_recall = object()
+    metrics.faithfulness = object()
+    metrics.ContextEntityRecall = lambda *args, **kwargs: object()
+    metrics.ResponseRelevancy = lambda *args, **kwargs: object()
+    ragas.metrics = metrics
+
+    datasets = types.ModuleType("datasets")
+
+    class Dataset:
+        @staticmethod
+        def from_dict(data):
+            return data
+
+    datasets.Dataset = Dataset
+
+    monkeypatch.setitem(sys.modules, "ragas", ragas)
+    monkeypatch.setitem(sys.modules, "ragas.metrics", metrics)
+    monkeypatch.setitem(sys.modules, "datasets", datasets)
+
+
+TEST_CASE = LLMTestCase(
+    input="What is the refund window?",
+    actual_output="30 days.",
+    expected_output="30 days.",
+    retrieval_context=["Refunds are accepted within 30 days."],
+)
+
+WRAPPERS = [
+    RAGASContextualPrecisionMetric,
+    RAGASContextualRecallMetric,
+    RAGASContextualEntitiesRecall,
+    RAGASAnswerRelevancyMetric,
+    RAGASFaithfulnessMetric,
+]
+
+
+@pytest.mark.parametrize("metric_cls", WRAPPERS)
+def test_wrapper_score_only_mode_does_not_raise(fake_ragas, metric_cls):
+    metric = metric_cls(threshold=None, model=object())
+
+    score = metric.measure(TEST_CASE)
+
+    assert score == STUB_SCORE
+    assert metric.score == STUB_SCORE
+    assert metric.success is None
+    assert metric.is_successful() is None
+
+
+@pytest.mark.parametrize("metric_cls", WRAPPERS)
+def test_wrapper_threshold_still_sets_success(fake_ragas, metric_cls):
+    metric = metric_cls(threshold=0.5, model=object())
+    metric.measure(TEST_CASE)
+    assert metric.success is True
+
+    metric = metric_cls(threshold=0.9, model=object())
+    metric.measure(TEST_CASE)
+    assert metric.success is False
+
+
+def test_ragas_metric_score_only_mode_does_not_raise(fake_ragas):
+    metric = RagasMetric(threshold=None, model=object())
+
+    score = metric.measure(TEST_CASE)
+
+    assert score == pytest.approx(STUB_SCORE)
+    assert metric.success is None
+    assert len(metric.score_breakdown) == len(WRAPPERS)


### PR DESCRIPTION
**Describe the bug**

Score-only mode (`threshold=None`, documented in the metrics introduction as available for any metric: "the metric has no pass/fail opinion — `metric.is_successful()` returns `None`") crashes in every RAGAS wrapper. The five sub-metrics and the aggregate `RagasMetric` compute success directly:

```python
self.success = context_precision_score >= self.threshold
```

so with `threshold=None` the call ends in `TypeError: '>=' not supported between instances of 'float' and 'NoneType'` — after the ragas evaluation has already run and been paid for.

**The fix**

Set `self.score` first and derive `self.success` from `BaseMetric.is_successful()`, which already implements score-only mode (`success is None` when the threshold is `None`) and the error path. Six sites, one line each; behaviour with a numeric threshold is unchanged.

**Tests**

`tests/test_metrics/test_ragas_score_only_mode.py` stubs the `ragas` and `datasets` modules in `sys.modules`, so it runs without ragas, an LLM provider, or API keys. It covers all five wrappers and the aggregate in score-only mode (score returned, `success is None`) and confirms a numeric threshold still sets `success` both ways.

On current `main`, the 6 score-only tests fail with the `TypeError` above and the 5 threshold controls pass; all 11 pass with this change. The rest of `tests/test_metrics` is unchanged: 190 passed, 278 skipped, 6 xfailed. `black==25.12.0 --check` (the CI pin) is clean on both touched files.
