### PR TITLE
fix: close per-call openai clients in gateway models

### DIFF
--- a/deepeval/models/llms/gateway_model.py
+++ b/deepeval/models/llms/gateway_model.py
@@ -25,6 +25,7 @@ Two layers live here:
     (settings keys, default base URL, auth headers).
 """
 
+import contextlib
 import inspect
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
@@ -195,43 +196,43 @@ class DeepEvalOpenAICompatibleModel(DeepEvalBaseGatewayModel):
     async def _a_generate(
         self, prompt: str, schema: Optional[BaseModel] = None
     ) -> Tuple[Union[str, BaseModel], Optional[float]]:
-        client = self.load_model(async_mode=True)
         messages = self._build_messages(prompt)
 
-        if schema:
-            # Try the gateway's native JSON-Schema structured output first.
-            try:
-                completion = await client.chat.completions.create(
-                    model=self.name,
-                    messages=messages,
-                    response_format=self._schema_response_format(schema),
-                    temperature=self.temperature,
-                    **self.generation_kwargs,
-                )
-                json_output = trim_and_load_json(
-                    completion.choices[0].message.content
-                )
-                cost = self.calculate_cost(
-                    completion.usage.prompt_tokens,
-                    completion.usage.completion_tokens,
-                    response=completion,
-                )
-                return schema.model_validate(json_output), cost
-            except Exception as e:
-                warnings.warn(
-                    f"Structured outputs not supported for model '{self.name}'. "
-                    f"Falling back to regular generation with JSON parsing. "
-                    f"Error: {str(e)}",
-                    UserWarning,
-                    stacklevel=3,
-                )
+        async with self._scoped_async_client() as client:
+            if schema:
+                # Try the gateway's native JSON-Schema structured output first.
+                try:
+                    completion = await client.chat.completions.create(
+                        model=self.name,
+                        messages=messages,
+                        response_format=self._schema_response_format(schema),
+                        temperature=self.temperature,
+                        **self.generation_kwargs,
+                    )
+                    json_output = trim_and_load_json(
+                        completion.choices[0].message.content
+                    )
+                    cost = self.calculate_cost(
+                        completion.usage.prompt_tokens,
+                        completion.usage.completion_tokens,
+                        response=completion,
+                    )
+                    return schema.model_validate(json_output), cost
+                except Exception as e:
+                    warnings.warn(
+                        f"Structured outputs not supported for model '{self.name}'. "
+                        f"Falling back to regular generation with JSON parsing. "
+                        f"Error: {str(e)}",
+                        UserWarning,
+                        stacklevel=3,
+                    )
 
-        completion = await client.chat.completions.create(
-            model=self.name,
-            messages=messages,
-            temperature=self.temperature,
-            **self.generation_kwargs,
-        )
+            completion = await client.chat.completions.create(
+                model=self.name,
+                messages=messages,
+                temperature=self.temperature,
+                **self.generation_kwargs,
+            )
         output = completion.choices[0].message.content
         cost = self.calculate_cost(
             completion.usage.prompt_tokens,
@@ -261,15 +262,15 @@ class DeepEvalOpenAICompatibleModel(DeepEvalBaseGatewayModel):
     def _generate_raw_response(
         self, prompt: str, top_logprobs: int = 5
     ) -> Tuple[object, Optional[float]]:
-        client = self.load_model(async_mode=False)
-        completion = client.chat.completions.create(
-            model=self.name,
-            messages=self._build_messages(prompt),
-            temperature=self.temperature,
-            logprobs=True,
-            top_logprobs=top_logprobs,
-            **self.generation_kwargs,
-        )
+        with self._scoped_sync_client() as client:
+            completion = client.chat.completions.create(
+                model=self.name,
+                messages=self._build_messages(prompt),
+                temperature=self.temperature,
+                logprobs=True,
+                top_logprobs=top_logprobs,
+                **self.generation_kwargs,
+            )
         cost = self.calculate_cost(
             completion.usage.prompt_tokens,
             completion.usage.completion_tokens,
@@ -280,15 +281,15 @@ class DeepEvalOpenAICompatibleModel(DeepEvalBaseGatewayModel):
     async def _a_generate_raw_response(
         self, prompt: str, top_logprobs: int = 5
     ) -> Tuple[object, Optional[float]]:
-        client = self.load_model(async_mode=True)
-        completion = await client.chat.completions.create(
-            model=self.name,
-            messages=self._build_messages(prompt),
-            temperature=self.temperature,
-            logprobs=True,
-            top_logprobs=top_logprobs,
-            **self.generation_kwargs,
-        )
+        async with self._scoped_async_client() as client:
+            completion = await client.chat.completions.create(
+                model=self.name,
+                messages=self._build_messages(prompt),
+                temperature=self.temperature,
+                logprobs=True,
+                top_logprobs=top_logprobs,
+                **self.generation_kwargs,
+            )
         cost = self.calculate_cost(
             completion.usage.prompt_tokens,
             completion.usage.completion_tokens,
@@ -304,14 +305,14 @@ class DeepEvalOpenAICompatibleModel(DeepEvalBaseGatewayModel):
     def _generate_samples(
         self, prompt: str, n: int, temperature: float
     ) -> Tuple[List[str], Optional[float]]:
-        client = self.load_model(async_mode=False)
-        response = client.chat.completions.create(
-            model=self.name,
-            messages=self._build_messages(prompt),
-            n=n,
-            temperature=temperature,
-            **self.generation_kwargs,
-        )
+        with self._scoped_sync_client() as client:
+            response = client.chat.completions.create(
+                model=self.name,
+                messages=self._build_messages(prompt),
+                n=n,
+                temperature=temperature,
+                **self.generation_kwargs,
+            )
         completions = [choice.message.content for choice in response.choices]
         cost = self.calculate_cost(
             response.usage.prompt_tokens,
@@ -417,6 +418,41 @@ class DeepEvalOpenAICompatibleModel(DeepEvalBaseGatewayModel):
 
     def load_model(self, async_mode: bool = False):
         return self._build_client(AsyncOpenAI if async_mode else OpenAI)
+
+    def _owns_http_client(self) -> bool:
+        """Whether clients built by this model own their HTTP transport.
+
+        When the user passes ``http_client`` through ``kwargs``, every client
+        this model builds wraps that same object; closing it would break
+        later calls, so its lifetime stays with the user.
+        """
+        return (self.kwargs or {}).get("http_client") is None
+
+    @contextlib.asynccontextmanager
+    async def _scoped_async_client(self):
+        """Yield a fresh ``AsyncOpenAI`` client scoped to a single call.
+
+        A new client is built per call, so it is closed again on exit, in the
+        event loop that created it. Leaving these clients to the GC leaks
+        connections and, once the creating loop is gone, produces
+        ``RuntimeError: Event loop is closed`` tracebacks (issue #3120).
+        """
+        client = self.load_model(async_mode=True)
+        if not self._owns_http_client():
+            yield client
+            return
+        async with client:
+            yield client
+
+    @contextlib.contextmanager
+    def _scoped_sync_client(self):
+        """Sync counterpart of ``_scoped_async_client``."""
+        client = self.load_model(async_mode=False)
+        if not self._owns_http_client():
+            yield client
+            return
+        with client:
+            yield client
 
     def _client_kwargs(self) -> Dict:
         kwargs = dict(self.kwargs or {})

--- a/tests/test_core/test_models/test_gateway_model.py
+++ b/tests/test_core/test_models/test_gateway_model.py
@@ -1,0 +1,166 @@
+"""Client lifecycle tests for `DeepEvalOpenAICompatibleModel`.
+
+Regression tests for https://github.com/confident-ai/deepeval/issues/3120:
+the gateway base builds a fresh ``OpenAI`` / ``AsyncOpenAI`` client for every
+call, and used to leave every one of them open. Leaked async clients are later
+collected by the GC, whose cleanup schedules ``aclose()`` against connections
+owned by an already-closed event loop, spraying
+``RuntimeError: Event loop is closed`` tracebacks into user output.
+
+These tests use real openai-SDK clients (only the HTTP ``create`` methods are
+stubbed) and assert that every client the model creates is closed again before
+the call returns.
+"""
+
+import httpx
+import pytest
+from unittest.mock import Mock, AsyncMock, patch
+
+from openai.resources.chat.completions import AsyncCompletions, Completions
+
+from deepeval.models.llms.openrouter_model import OpenRouterModel
+
+
+def _fake_completion():
+    completion = Mock()
+    completion.choices = [Mock(message=Mock(content="test response"))]
+    completion.usage.prompt_tokens = 10
+    completion.usage.completion_tokens = 20
+    return completion
+
+
+class _ClientRecordingModel(OpenRouterModel):
+    """OpenRouterModel that records every client ``load_model`` hands out."""
+
+    def __init__(self, *args, **kwargs):
+        self.created_clients = []
+        super().__init__(*args, **kwargs)
+
+    def load_model(self, async_mode: bool = False):
+        client = super().load_model(async_mode)
+        self.created_clients.append(client)
+        return client
+
+
+def _assert_all_clients_closed(model: _ClientRecordingModel):
+    assert model.created_clients, "expected at least one client to be created"
+    for client in model.created_clients:
+        assert client.is_closed(), (
+            "gateway model left an openai client open after the call; "
+            "clients must be closed in the event loop that created them "
+            "(issue #3120)"
+        )
+
+
+@pytest.fixture
+def model():
+    recording_model = _ClientRecordingModel(
+        model="openai/gpt-4o-mini", api_key="test-key"
+    )
+    # DeepEvalBaseLLM.__init__ stores one client as `self.model` for the
+    # lifetime of the instance; that one is referenced, not leaked. Only
+    # clients created per call are asserted on.
+    recording_model.created_clients.clear()
+    return recording_model
+
+
+class TestGatewayModelClientLifecycle:
+    """Every client a gateway call creates must be closed before it returns."""
+
+    async def test_a_generate_closes_async_client(self, model):
+        with patch.object(
+            AsyncCompletions,
+            "create",
+            new_callable=AsyncMock,
+            return_value=_fake_completion(),
+        ):
+            output, _ = await model.a_generate("test prompt")
+
+        assert output == "test response"
+        _assert_all_clients_closed(model)
+
+    def test_generate_closes_async_client_across_loops(self, model):
+        # Sync path: each call runs in its own short-lived asyncio.run()
+        # loop, which is exactly where leaked clients caused the GC-time
+        # "Event loop is closed" tracebacks. Two calls mimic back-to-back
+        # metrics with async_mode=False.
+        with patch.object(
+            AsyncCompletions,
+            "create",
+            new_callable=AsyncMock,
+            return_value=_fake_completion(),
+        ):
+            output, _ = model.generate("test prompt")
+            model.generate("another prompt")
+
+        assert output == "test response"
+        assert len(model.created_clients) == 2
+        _assert_all_clients_closed(model)
+
+    async def test_a_generate_raw_response_closes_async_client(self, model):
+        with patch.object(
+            AsyncCompletions,
+            "create",
+            new_callable=AsyncMock,
+            return_value=_fake_completion(),
+        ):
+            completion, _ = await model.a_generate_raw_response("test prompt")
+
+        assert completion.choices[0].message.content == "test response"
+        _assert_all_clients_closed(model)
+
+    def test_generate_raw_response_closes_sync_client(self, model):
+        with patch.object(
+            Completions, "create", return_value=_fake_completion()
+        ):
+            completion, _ = model.generate_raw_response("test prompt")
+
+        assert completion.choices[0].message.content == "test response"
+        _assert_all_clients_closed(model)
+
+    def test_generate_samples_closes_sync_client(self, model):
+        with patch.object(
+            Completions, "create", return_value=_fake_completion()
+        ):
+            samples, _ = model.generate_samples(
+                "test prompt", n=1, temperature=0.5
+            )
+
+        assert samples == ["test response"]
+        _assert_all_clients_closed(model)
+
+    def test_user_supplied_http_client_survives_repeated_calls(self):
+        # When the user passes their own http_client, every per-call openai
+        # client wraps that same transport; closing it after the first call
+        # would break every later call, so the model must leave it open.
+        http_client = httpx.Client()
+        try:
+            model = _ClientRecordingModel(
+                model="openai/gpt-4o-mini",
+                api_key="test-key",
+                http_client=http_client,
+            )
+            model.created_clients.clear()
+            with patch.object(
+                Completions, "create", return_value=_fake_completion()
+            ):
+                model.generate_raw_response("test prompt")
+                model.generate_raw_response("another prompt")
+
+            assert not http_client.is_closed
+        finally:
+            http_client.close()
+
+    async def test_a_generate_closes_async_client_on_error(self, model):
+        # Called directly (not through the retry-wrapped public method) so
+        # the assertion is independent of the provider retry policy.
+        with patch.object(
+            AsyncCompletions,
+            "create",
+            new_callable=AsyncMock,
+            side_effect=ValueError("boom"),
+        ):
+            with pytest.raises(ValueError):
+                await model._a_generate("test prompt")
+
+        _assert_all_clients_closed(model)

--- a/tests/test_core/test_models/test_openrouter_model.py
+++ b/tests/test_core/test_models/test_openrouter_model.py
@@ -310,7 +310,8 @@ class TestOpenRouterModel:
     @patch("deepeval.models.llms.gateway_model.OpenAI")
     def test_generate_raw_response(self, mock_openai_class, settings):
         """Test generate_raw_response method"""
-        mock_client = Mock()
+        # MagicMock: the model uses the client as a context manager.
+        mock_client = MagicMock()
         mock_openai_class.return_value = mock_client
         mock_completion = Mock()
         mock_completion.choices = [Mock(message=Mock(content="raw response"))]
@@ -338,7 +339,8 @@ class TestOpenRouterModel:
     @patch("deepeval.models.llms.gateway_model.OpenAI")
     def test_generate_samples(self, mock_openai_class, settings):
         """Test generate_samples method"""
-        mock_client = Mock()
+        # MagicMock: the model uses the client as a context manager.
+        mock_client = MagicMock()
         mock_openai_class.return_value = mock_client
         mock_response = Mock()
         mock_response.choices = [


### PR DESCRIPTION
Closes #3120.

## Problem

`DeepEvalOpenAICompatibleModel` (the base of `OpenRouterModel` and `PortkeyModel`) builds a fresh `OpenAI` / `AsyncOpenAI` client in every call path (`_a_generate`, `_a_generate_raw_response`, `_generate_raw_response`, `_generate_samples`) and never closes any of them.

The leaked async clients are later collected by the GC. When that happens while a different event loop is running, the openai SDK schedules `aclose()` against connections owned by the already-closed loop, and asyncio prints `RuntimeError: Event loop is closed` / "Task exception was never retrieved" tracebacks into user output. With `async_mode=False`, every metric call runs its own `asyncio.run()` loop, so back-to-back metrics in one process (the notebook case from the issue) hit this constantly.

## Fix

- New `_scoped_async_client()` / `_scoped_sync_client()` context managers next to `load_model`: each per-call client is closed on exit, in the event loop that created it. All four call sites use them.
- One deliberate exception: when the user passes their own `http_client` through kwargs, every per-call client wraps that same transport, and closing it would break every later call. `_owns_http_client()` guards this, so user-owned transports stay open.

The client stored as `self.model` by `DeepEvalBaseLLM.__init__` is untouched; it is referenced for the lifetime of the instance, not leaked.

## Tests

New `tests/test_core/test_models/test_gateway_model.py`: real openai-SDK clients with only `Completions.create` / `AsyncCompletions.create` stubbed, asserting every client the model creates is closed before the call returns. Covers all four call paths, the sync `asyncio.run()` wrapper across repeated calls, the error path, and the user-supplied `http_client` case.

On `main`, 6 of the 7 tests fail (clients left open); with this change all 7 pass. All 33 existing OpenRouter/Portkey tests pass. Two of them (`test_generate_raw_response`, `test_generate_samples`) mocked the sync client as a plain `Mock`; they now use `MagicMock` because the model uses the client as a context manager. `black` is clean.
