### PR TITLE
Fix grammar in metrics-ragas.mdx

### DIFF
--- a/docs/content/docs/(metrics-others)/metrics-ragas.mdx
+++ b/docs/content/docs/(metrics-others)/metrics-ragas.mdx
@@ -13,7 +13,7 @@ The RAGAS metric is the average of four distinct metrics:
 - `RAGASContextualPrecisionMetric`
 - `RAGASContextualRecallMetric`
 
-It provides a score to holistically evaluate of your RAG pipeline's generator and retriever.
+It provides a score to holistically evaluate your RAG pipeline's generator and retriever.
 
 :::info[WHAT'S THE DIFFERENCE?]
 The `RAGASMetric` uses the `ragas` library under the hood and are available on `deepeval` with the intention to allow users of `deepeval` can have access to `ragas` in `deepeval`'s ecosystem as well. They are implemented in an almost identical way to `deepeval`'s default RAG metrics. However there are a few differences, including but not limited to:


### PR DESCRIPTION
While reading the docs I noticed the error and thought it harmless to correct grammatical error in the description of the RAGAS metrics.