### PR TITLE
feat(metrics): add NumericMatchMetric community metric

### DIFF
--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,9 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .numeric_match.numeric_match import NumericMatchMetric
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "NumericMatchMetric",
 ]

--- a/deepeval/metrics/community/numeric_match/__init__.py
+++ b/deepeval/metrics/community/numeric_match/__init__.py
@@ -1,0 +1,3 @@
+from .numeric_match import NumericMatchMetric
+
+__all__ = ["NumericMatchMetric"]

--- a/deepeval/metrics/community/numeric_match/numeric_match.py
+++ b/deepeval/metrics/community/numeric_match/numeric_match.py
@@ -1,0 +1,248 @@
+import math
+import re
+from typing import List, Optional, Tuple
+
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.utils import (
+    check_llm_test_case_params,
+    construct_verbose_logs,
+)
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+
+# One numeric token: optional sign, optional currency symbol, an integer with
+# optional thousands separators / a decimal / a plain integer, an optional
+# scientific exponent, and a single optional trailing marker (percent or a
+# magnitude suffix). Kept deliberately conservative so it reads quantities out
+# of natural-language answers without swallowing arbitrary punctuation.
+_NUMBER_RE = re.compile(
+    r"""
+    (?P<sign>[+-]?)
+    [\$\u20ac\u00a3\u00a5]?\s?              # optional currency symbol
+    (?P<num>
+        \d{1,3}(?:,\d{3})+(?:\.\d+)?       # 1,234,567 or 1,200.50
+        | \d*\.\d+                         # 3.14 or .5
+        | \d+                              # 42
+    )
+    (?P<exp>[eE][+-]?\d+)?                  # 1.2e3
+    (?P<marker>%|[kKmMbBtT])?               # 12% or 1.2M
+    """,
+    re.VERBOSE,
+)
+
+_MAGNITUDE = {
+    "k": 1e3,
+    "m": 1e6,
+    "b": 1e9,
+    "t": 1e12,
+}
+
+
+class NumericMatchMetric(BaseMetric):
+    """Formatting-robust numeric agreement between ``actual_output`` and
+    ``expected_output``.
+
+    ``ExactMatchMetric`` and ``PatternMatchMetric`` compare strings, so a
+    numerically correct answer is silently scored wrong when the surface form
+    differs (``"1,200"`` vs ``"1200"``, ``"3.0"`` vs ``"3"``, ``"$1.2M"`` vs
+    ``"1200000"``, ``"12%"`` vs ``"12"``), and a wrong answer can be scored
+    right when a correct-looking number appears somewhere in a longer string.
+    ``NumericMatchMetric`` extracts the numeric quantities from both fields and
+    compares them by value under a configurable tolerance.
+
+    The score is the fraction of the numbers in ``expected_output`` that have a
+    tolerance-matching counterpart in ``actual_output`` (recall of the reference
+    numbers). With the default threshold of ``1.0`` every reference number must
+    be present. Matching is multiset-aware: each output number can satisfy at
+    most one reference number, so duplicates are not double-counted.
+
+    The metric is deterministic and uses no judge model, so it is reproducible
+    and adds no evaluation cost. When ``expected_output`` contains no numeric
+    value the metric is not applicable and raises ``ValueError`` rather than
+    fabricating a ``0.0`` or ``1.0``.
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+        SingleTurnParams.EXPECTED_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        threshold: Optional[float] = 1.0,
+        rel_tol: float = 1e-9,
+        abs_tol: float = 0.0,
+        parse_magnitude_suffixes: bool = False,
+        percent_as_fraction: bool = False,
+        include_reason: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+    ):
+        self.threshold = 1.0 if strict_mode else threshold
+        self.rel_tol = rel_tol
+        self.abs_tol = abs_tol
+        self.parse_magnitude_suffixes = parse_magnitude_suffixes
+        self.percent_as_fraction = percent_as_fraction
+        self.include_reason = include_reason
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+        self.flaky = flaky
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            None,
+            test_case.multimodal,
+        )
+
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            expected_numbers = self._extract_numbers(test_case.expected_output)
+            if not expected_numbers:
+                raise ValueError(
+                    "`expected_output` contains no numeric value, so "
+                    "NumericMatchMetric cannot score this test case. Use "
+                    "ExactMatchMetric or an LLM-judged metric for "
+                    "non-numeric references."
+                )
+            actual_numbers = self._extract_numbers(test_case.actual_output)
+
+            matched, missing, unmatched = self._match(
+                expected_numbers, actual_numbers
+            )
+            self.score = matched / len(expected_numbers)
+            self.reason = self._generate_reason(
+                len(expected_numbers), matched, missing, unmatched
+            )
+            self.success = self.is_successful()
+
+            if self.verbose_mode:
+                expected_str = self._format_numbers(expected_numbers)
+                actual_str = self._format_numbers(actual_numbers)
+                self.verbose_logs = construct_verbose_logs(
+                    self,
+                    steps=[
+                        f"Expected numbers: {expected_str}",
+                        f"Actual numbers: {actual_str}",
+                        f"Score: {self.score:.2f}",
+                        f"Reason: {self.reason}",
+                    ],
+                )
+
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        return self.measure(
+            test_case,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        )
+
+    def _extract_numbers(self, text: str) -> List[float]:
+        numbers: List[float] = []
+        for match in _NUMBER_RE.finditer(text):
+            value = self._parse_match(match)
+            if value is not None:
+                numbers.append(value)
+        return numbers
+
+    def _parse_match(self, match: "re.Match") -> Optional[float]:
+        sign = -1.0 if match.group("sign") == "-" else 1.0
+        raw = match.group("num").replace(",", "")
+        exp = match.group("exp") or ""
+        marker = match.group("marker")
+
+        try:
+            value = float(raw + exp)
+        except ValueError:
+            return None
+        value *= sign
+
+        if marker == "%":
+            if self.percent_as_fraction:
+                value /= 100.0
+        elif marker is not None:
+            if not self.parse_magnitude_suffixes:
+                # A trailing k/m/b/t was matched but suffix parsing is off, so
+                # the character is not part of the number: keep the bare value.
+                return value
+            value *= _MAGNITUDE[marker.lower()]
+
+        return value
+
+    def _match(
+        self, expected: List[float], actual: List[float]
+    ) -> Tuple[int, List[float], List[float]]:
+        remaining = list(actual)
+        matched = 0
+        missing: List[float] = []
+        for target in expected:
+            hit_index = None
+            for index, candidate in enumerate(remaining):
+                if math.isclose(
+                    target,
+                    candidate,
+                    rel_tol=self.rel_tol,
+                    abs_tol=self.abs_tol,
+                ):
+                    hit_index = index
+                    break
+            if hit_index is None:
+                missing.append(target)
+            else:
+                matched += 1
+                remaining.pop(hit_index)
+        return matched, missing, remaining
+
+    def _generate_reason(
+        self,
+        total_expected: int,
+        matched: int,
+        missing: List[float],
+        unmatched: List[float],
+    ) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+        parts = [
+            f"Matched {matched}/{total_expected} reference number(s) within "
+            f"tolerance (rel_tol={self.rel_tol}, abs_tol={self.abs_tol})."
+        ]
+        if missing:
+            missing_str = self._format_numbers(missing)
+            parts.append(f"Missing from output: {missing_str}.")
+        if unmatched:
+            unmatched_str = self._format_numbers(unmatched)
+            parts.append(f"Unmatched numbers in output: {unmatched_str}.")
+        return " ".join(parts)
+
+    @staticmethod
+    def _format_numbers(numbers: List[float]) -> str:
+        formatted = []
+        for number in numbers:
+            if number == int(number):
+                formatted.append(str(int(number)))
+            else:
+                formatted.append(repr(number))
+        return "[" + ", ".join(formatted) + "]"
+
+    @property
+    def __name__(self):
+        return "Numeric Match"

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "community-metrics-overview",
     "metrics-citation-faithfulness",
+    "metrics-numeric-match",
     "metrics-agent-loop-detection",
     "metrics-tool-permission"
   ]

--- a/docs/content/docs/(community)/metrics-numeric-match.mdx
+++ b/docs/content/docs/(community)/metrics-numeric-match.mdx
@@ -1,0 +1,68 @@
+---
+id: metrics-numeric-match
+title: Numeric Match
+sidebar_label: Numeric Match
+languages: [python]
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} referenceless={false} />
+
+The numeric match metric checks whether the numeric quantities in your LLM's `actual_output` agree by value with the numbers in `expected_output`, independent of surface formatting. It is deterministic and uses no judge model, so it is reproducible and adds no evaluation cost.
+
+:::info
+The `NumericMatchMetric` is a **community metric**, contributed and maintained by the `deepeval` community. Community metrics are not exported from `deepeval.metrics`, so import them explicitly from `deepeval.metrics.community` instead.
+:::
+
+:::note
+This metric complements [`ExactMatchMetric`](/docs/metrics-others) and [`PatternMatchMetric`](/docs/metrics-others), which compare strings. A numerically correct answer is silently scored wrong by string matching when the surface form differs (`"1,200"` vs `"1200"`, `"3.0"` vs `"3"`, `"$1.2M"` vs `"1200000"`, `"12%"` vs `"12"`), and a wrong answer can be scored right when a correct-looking number appears in a longer string. `NumericMatchMetric` compares the extracted numbers by value.
+:::
+
+## Required Arguments
+
+To use the `NumericMatchMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
+
+- `input`
+- `actual_output`
+- `expected_output`
+
+The score is the fraction of the numbers in `expected_output` that have a tolerance-matching counterpart in `actual_output` (recall of the reference numbers). Matching is multiset-aware, so a single output number cannot satisfy two reference numbers. When `expected_output` contains no numeric value the metric is not applicable and raises `ValueError` rather than returning a fabricated score.
+
+## Usage
+
+```python
+from deepeval import evaluate
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.community import NumericMatchMetric
+
+metric = NumericMatchMetric()
+test_case = LLMTestCase(
+    input="What was the quarterly revenue?",
+    # "$1,200,500" is numerically the same value as the reference below.
+    actual_output="Revenue was $1,200,500 for the quarter.",
+    expected_output="1200500",
+)
+
+# To run the metric as a standalone
+# metric.measure(test_case)
+# print(metric.score, metric.reason)
+
+evaluate(test_cases=[test_case], metrics=[metric])
+```
+
+## Parameters
+
+- `threshold`: the minimum score for the test case to pass. Defaulted to `1.0`, so every reference number must be present.
+- `rel_tol` and `abs_tol`: passed to `math.isclose` when comparing two numbers. Defaulted to `1e-9` and `0.0` (numerically exact). Loosen them to allow rounding differences, e.g. `abs_tol=0.5` or `rel_tol=0.01`.
+- `parse_magnitude_suffixes`: when `True`, a trailing `k`, `m`, `b`, or `t` multiplies the number (`"1.2M"` becomes `1200000`). Defaulted to `False` so unit letters are never misread as magnitudes.
+- `percent_as_fraction`: when `True`, a trailing `%` divides the number by 100 (`"12%"` becomes `0.12`). Defaulted to `False`, so `"12%"` parses to `12`.
+- `include_reason`: whether to build a reason listing matched, missing, and unmatched numbers. Defaulted to `True`.
+- `strict_mode`: forces the threshold to `1.0`. Defaulted to `False`.
+- `verbose_mode`: prints the extracted numbers and score. Defaulted to `False`.
+
+## How Is It Calculated?
+
+The metric extracts numeric tokens from `expected_output` and `actual_output`, normalizing thousands separators, decimals, signs, scientific notation, and currency symbols. Each reference number is matched greedily against an as-yet-unused output number under `math.isclose`. The final score is:
+
+```
+Numeric Match = Number of matched reference numbers / Total reference numbers
+```

--- a/tests/test_metrics/test_numeric_match_metric.py
+++ b/tests/test_metrics/test_numeric_match_metric.py
@@ -1,0 +1,129 @@
+import math
+
+import pytest
+
+from deepeval.metrics.community import NumericMatchMetric
+from deepeval.test_case import LLMTestCase
+
+
+def _case(expected: str, actual: str) -> LLMTestCase:
+    return LLMTestCase(
+        input="What is the value?",
+        actual_output=actual,
+        expected_output=expected,
+    )
+
+
+class TestNumericMatchMetric:
+    def test_thousands_separator_matches(self):
+        metric = NumericMatchMetric()
+        metric.measure(
+            _case("The total is 1,200 units.", "The total is 1200 units.")
+        )
+        assert metric.score == 1.0
+        assert metric.success is True
+
+    def test_trailing_zero_decimal_matches(self):
+        metric = NumericMatchMetric()
+        metric.measure(_case("3", "The answer is 3.0"))
+        assert metric.score == 1.0
+
+    def test_scientific_notation_matches(self):
+        metric = NumericMatchMetric()
+        metric.measure(_case("1200", "About 1.2e3"))
+        assert metric.score == 1.0
+
+    def test_currency_symbol_stripped(self):
+        metric = NumericMatchMetric()
+        metric.measure(_case("$1,200.50", "1200.5 dollars"))
+        assert metric.score == 1.0
+
+    def test_negative_sign_respected(self):
+        metric = NumericMatchMetric()
+        metric.measure(_case("-5", "the change was 5"))
+        assert metric.score == 0.0
+        assert metric.success is False
+
+    def test_percent_defaults_to_bare_number(self):
+        metric = NumericMatchMetric()
+        metric.measure(_case("12%", "12"))
+        assert metric.score == 1.0
+
+    def test_percent_as_fraction_option(self):
+        metric = NumericMatchMetric(percent_as_fraction=True)
+        metric.measure(_case("12%", "0.12"))
+        assert metric.score == 1.0
+
+    def test_magnitude_suffix_off_by_default(self):
+        metric = NumericMatchMetric()
+        metric.measure(_case("$1.2M", "1200000"))
+        assert metric.score == 0.0
+
+    def test_magnitude_suffix_on(self):
+        metric = NumericMatchMetric(parse_magnitude_suffixes=True)
+        metric.measure(_case("$1.2M", "1200000"))
+        assert metric.score == 1.0
+
+    def test_partial_recall_of_reference_numbers(self):
+        metric = NumericMatchMetric(threshold=0.5)
+        metric.measure(
+            _case("The trip cost 100 and took 3 days.", "It cost 100.")
+        )
+        assert metric.score == 0.5
+        assert metric.success is True
+        assert "3" in metric.reason
+
+    def test_extra_output_numbers_do_not_lower_recall(self):
+        metric = NumericMatchMetric()
+        metric.measure(_case("42", "The values were 7, 42, and 99."))
+        assert metric.score == 1.0
+
+    def test_duplicates_are_not_double_counted(self):
+        metric = NumericMatchMetric()
+        # Two reference 5s, but the output only provides one 5.
+        metric.measure(_case("5 and 5", "just one 5 here"))
+        assert metric.score == 0.5
+
+    def test_absolute_tolerance(self):
+        strict = NumericMatchMetric()
+        strict.measure(_case("100", "the reading was 100.4"))
+        assert strict.score == 0.0
+
+        lenient = NumericMatchMetric(abs_tol=0.5)
+        lenient.measure(_case("100", "the reading was 100.4"))
+        assert lenient.score == 1.0
+
+    def test_relative_tolerance(self):
+        metric = NumericMatchMetric(rel_tol=0.01)
+        metric.measure(_case("1000", "about 1005"))
+        assert metric.score == 1.0
+
+    def test_no_reference_number_is_unscorable(self):
+        metric = NumericMatchMetric()
+        with pytest.raises(ValueError, match="no numeric value"):
+            metric.measure(_case("no numbers here", "still nothing"))
+
+    def test_include_reason_false_suppresses_reason(self):
+        metric = NumericMatchMetric(include_reason=False)
+        metric.measure(_case("10", "10"))
+        assert metric.reason is None
+
+    def test_strict_mode_forces_full_match_threshold(self):
+        metric = NumericMatchMetric(threshold=0.5, strict_mode=True)
+        assert metric.threshold == 1.0
+        metric.measure(_case("1 and 2", "only 1"))
+        assert metric.score == 0.5
+        assert metric.success is False
+
+    @pytest.mark.asyncio
+    async def test_async_matches_sync(self):
+        metric = NumericMatchMetric()
+        score = await metric.a_measure(_case("1,000", "1000"))
+        assert score == 1.0
+        assert metric.score == 1.0
+
+    def test_extraction_handles_grouped_and_plain(self):
+        metric = NumericMatchMetric()
+        numbers = metric._extract_numbers("1,234,567 and 89 and 0.5")
+        assert numbers == [1234567.0, 89.0, 0.5]
+        assert math.isclose(numbers[-1], 0.5)


### PR DESCRIPTION
## Summary

Adds `NumericMatchMetric` under `deepeval/metrics/community/`, a deterministic metric that compares the numeric values in `actual_output` and `expected_output` by value rather than by string.

`ExactMatchMetric` and `PatternMatchMetric` compare strings, so a numerically correct answer is scored wrong when the surface form differs (`"1,200"` vs `"1200"`, `"3.0"` vs `"3"`, `"$1,200.50"` vs `"1200.5"`, `"12%"` vs `"12"`), and a wrong answer can be scored right when a correct-looking number appears in a longer string. This metric extracts numeric tokens from both fields (thousands separators, decimals, sign, scientific notation, currency symbols, optional `%` and magnitude suffixes) and matches them by value under a configurable tolerance.

Score is the fraction of reference numbers with a tolerance-matching counterpart in the output (multiset-aware, so duplicates are not double-counted). The metric uses no judge model, so it is reproducible and adds no evaluation cost. When `expected_output` has no numeric value it raises `ValueError` rather than returning a fabricated 0.0 or 1.0.

## Changes

- `deepeval/metrics/community/numeric_match/`: the metric.
- Export from `deepeval/metrics/community/__init__.py`.
- Docs page under the community section plus its `meta.json` entry.
- Tests covering formatting robustness, tolerance, partial recall, duplicates, the unscorable (no-reference-number) case, and sync/async parity.

## Test plan

- `pytest tests/test_metrics/test_numeric_match_metric.py` (19 tests, no API key required since the metric is deterministic).
