### PR TITLE
fix: accept documented log_hyperparameters decorator call forms

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/test_run/hyperparameters.py
+++ b/deepeval/test_run/hyperparameters.py
@@ -58,25 +58,31 @@ def process_hyperparameters(
     return processed_hyperparameters
 
 
-def log_hyperparameters(func):
-    test_run = global_test_run_manager.get_test_run()
+def log_hyperparameters(func=None, **logged_hyperparameters):
+    def decorator(fn):
+        test_run = global_test_run_manager.get_test_run()
 
-    def modified_hyperparameters():
-        base_hyperparameters = func()
-        return base_hyperparameters
+        def modified_hyperparameters():
+            base_hyperparameters = fn()
+            if not logged_hyperparameters:
+                return base_hyperparameters
+            merged = dict(logged_hyperparameters)
+            if isinstance(base_hyperparameters, dict):
+                merged.update(base_hyperparameters)
+            return merged
 
-    hyperparameters = process_hyperparameters(modified_hyperparameters())
-    test_run.hyperparameters = hyperparameters
-    global_test_run_manager.save_test_run(TEMP_FILE_PATH)
+        hyperparameters = process_hyperparameters(modified_hyperparameters())
+        test_run.hyperparameters = hyperparameters
+        global_test_run_manager.save_test_run(TEMP_FILE_PATH)
 
-    # Define the wrapper function that will be the actual decorator
-    def wrapper(*args, **kwargs):
-        # Optional: You can decide if you want to do something else here
-        # every time the decorated function is called
-        return func(*args, **kwargs)
+        def wrapper(*args, **kwargs):
+            return fn(*args, **kwargs)
 
-    # Return the wrapper function to be used as the decorator
-    return wrapper
+        return wrapper
+
+    if func is not None:
+        return decorator(func)
+    return decorator
 
 
 def process_prompts(

--- a/tests/test_core/test_run/test_log_hyperparameters.py
+++ b/tests/test_core/test_run/test_log_hyperparameters.py
@@ -1,0 +1,46 @@
+"""Documented @log_hyperparameters decorator forms must not raise TypeError."""
+
+import pytest
+
+import deepeval
+from deepeval.test_run import global_test_run_manager
+
+
+@pytest.fixture(autouse=True)
+def isolated_test_run():
+    global_test_run_manager.reset()
+    global_test_run_manager.create_test_run(identifier="log-hyperparameters")
+    yield
+    global_test_run_manager.reset()
+
+
+def test_log_hyperparameters_empty_call_logs_returned_dict():
+    @deepeval.log_hyperparameters()
+    def hyperparameters():
+        return {"temperature": 1}
+
+    test_run = global_test_run_manager.get_test_run()
+    assert test_run.hyperparameters == {"temperature": "1"}
+
+
+def test_log_hyperparameters_keyword_form_merges_decorator_kwargs():
+    @deepeval.log_hyperparameters(model="gpt-4", prompt_template="...")
+    def hyperparameters():
+        return {"temperature": 1, "chunk size": 500}
+
+    test_run = global_test_run_manager.get_test_run()
+    assert test_run.hyperparameters == {
+        "model": "gpt-4",
+        "prompt_template": "...",
+        "temperature": "1",
+        "chunk size": "500",
+    }
+
+
+def test_log_hyperparameters_bare_form_still_works():
+    @deepeval.log_hyperparameters
+    def hyperparameters():
+        return {"temperature": 1}
+
+    test_run = global_test_run_manager.get_test_run()
+    assert test_run.hyperparameters == {"temperature": "1"}


### PR DESCRIPTION
## Summary

`@deepeval.log_hyperparameters()` and `@deepeval.log_hyperparameters(model=..., prompt_template=...)` raised `TypeError` because `log_hyperparameters` only accepted a bare function argument. Both forms are used in the docs.

Make the decorator accept optional call/kwargs while keeping the existing bare `@deepeval.log_hyperparameters` form. Decorator kwargs are merged with the wrapped function’s returned dict (function values win on key clashes).

Fixes #3134

## Test plan

- [x] `pytest tests/test_core/test_run/test_log_hyperparameters.py`
- [x] empty `@log_hyperparameters()` logs the returned dict
- [x] keyword form merges decorator kwargs with the returned dict
- [x] bare `@log_hyperparameters` still works