### PR TITLE
fix: support documented log_hyperparameters forms

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/test_run/hyperparameters.py
+++ b/deepeval/test_run/hyperparameters.py
@@ -1,10 +1,12 @@
-from typing import Union, Dict, Optional, List
-from deepeval.test_run import global_test_run_manager
+from collections.abc import Callable
+from functools import wraps
+from typing import Dict, List, Optional, Union
+
+from deepeval.confident.api import is_confident
 from deepeval.prompt import Prompt
 from deepeval.prompt.api import PromptApi
-from deepeval.test_run.test_run import TEMP_FILE_PATH
-from deepeval.confident.api import is_confident
-from deepeval.test_run.test_run import PromptData
+from deepeval.test_run import global_test_run_manager
+from deepeval.test_run.test_run import TEMP_FILE_PATH, PromptData
 
 
 def process_hyperparameters(
@@ -58,25 +60,41 @@ def process_hyperparameters(
     return processed_hyperparameters
 
 
-def log_hyperparameters(func):
-    test_run = global_test_run_manager.get_test_run()
+def log_hyperparameters(
+    func: Optional[Callable] = None,
+    *,
+    model: Optional[str] = None,
+    prompt_template: Optional[str] = None,
+):
+    def register(f: Callable):
+        merged_hyperparameters = f()
 
-    def modified_hyperparameters():
-        base_hyperparameters = func()
-        return base_hyperparameters
+        if model is not None or prompt_template is not None:
+            if merged_hyperparameters is None:
+                merged_hyperparameters = {}
 
-    hyperparameters = process_hyperparameters(modified_hyperparameters())
-    test_run.hyperparameters = hyperparameters
-    global_test_run_manager.save_test_run(TEMP_FILE_PATH)
+            if isinstance(merged_hyperparameters, dict):
+                merged_hyperparameters = dict(merged_hyperparameters)
+                if model is not None:
+                    merged_hyperparameters["model"] = model
+                if prompt_template is not None:
+                    merged_hyperparameters["prompt template"] = prompt_template
 
-    # Define the wrapper function that will be the actual decorator
-    def wrapper(*args, **kwargs):
-        # Optional: You can decide if you want to do something else here
-        # every time the decorated function is called
-        return func(*args, **kwargs)
+        test_run = global_test_run_manager.get_test_run()
+        test_run.hyperparameters = process_hyperparameters(
+            merged_hyperparameters
+        )
+        global_test_run_manager.save_test_run(TEMP_FILE_PATH)
 
-    # Return the wrapper function to be used as the decorator
-    return wrapper
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    if func is None:
+        return register
+    return register(func)
 
 
 def process_prompts(

--- a/tests/test_core/test_run/test_log_hyperparameters.py
+++ b/tests/test_core/test_run/test_log_hyperparameters.py
@@ -1,0 +1,123 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import deepeval
+import deepeval.test_run.hyperparameters as hyperparameters_module
+from deepeval.test_run.test_run import TEMP_FILE_PATH
+
+
+@pytest.fixture
+def stub_test_run_manager(monkeypatch):
+    test_run = SimpleNamespace(hyperparameters=None)
+    manager = SimpleNamespace(
+        get_test_run=Mock(return_value=test_run),
+        save_test_run=Mock(),
+    )
+    monkeypatch.setattr(
+        hyperparameters_module,
+        "global_test_run_manager",
+        manager,
+    )
+    return test_run, manager
+
+
+def test_log_hyperparameters_supports_bare_decorator(stub_test_run_manager):
+    test_run, manager = stub_test_run_manager
+
+    @hyperparameters_module.log_hyperparameters
+    def hyperparameters(value="registered"):
+        return {"value": value}
+
+    assert test_run.hyperparameters == {"value": "registered"}
+    assert hyperparameters.__name__ == "hyperparameters"
+    assert hyperparameters("called") == {"value": "called"}
+    manager.save_test_run.assert_called_once_with(TEMP_FILE_PATH)
+
+
+def test_log_hyperparameters_supports_empty_call(stub_test_run_manager):
+    test_run, _ = stub_test_run_manager
+
+    @deepeval.log_hyperparameters()
+    def hyperparameters():
+        return {"chunk size": 500}
+
+    assert test_run.hyperparameters == {"chunk size": "500"}
+
+
+def test_log_hyperparameters_merges_decorator_parameters(
+    stub_test_run_manager,
+):
+    test_run, _ = stub_test_run_manager
+
+    @deepeval.log_hyperparameters(
+        model="gpt-4",
+        prompt_template="new prompt",
+    )
+    def hyperparameters():
+        return {
+            "model": "old-model",
+            "prompt template": "old prompt",
+            "temperature": 1,
+        }
+
+    assert test_run.hyperparameters == {
+        "model": "gpt-4",
+        "prompt template": "new prompt",
+        "temperature": "1",
+    }
+
+
+def test_log_hyperparameters_supports_model_without_prompt_template(
+    stub_test_run_manager,
+):
+    test_run, _ = stub_test_run_manager
+
+    @hyperparameters_module.log_hyperparameters(model="gpt-4")
+    def hyperparameters():
+        return {"temperature": 0}
+
+    assert test_run.hyperparameters == {
+        "model": "gpt-4",
+        "temperature": "0",
+    }
+
+
+def test_log_hyperparameters_preserves_none(stub_test_run_manager):
+    test_run, _ = stub_test_run_manager
+
+    @hyperparameters_module.log_hyperparameters()
+    def hyperparameters():
+        return None
+
+    assert test_run.hyperparameters is None
+
+
+def test_log_hyperparameters_merges_parameters_when_return_is_none(
+    stub_test_run_manager,
+):
+    test_run, _ = stub_test_run_manager
+
+    @hyperparameters_module.log_hyperparameters(model="gpt-4")
+    def hyperparameters():
+        return None
+
+    assert test_run.hyperparameters == {"model": "gpt-4"}
+
+
+def test_log_hyperparameters_rejects_non_dict_return(
+    stub_test_run_manager,
+):
+    _, manager = stub_test_run_manager
+
+    with pytest.raises(
+        TypeError,
+        match="Hyperparameters must be a dictionary or None",
+    ):
+
+        @hyperparameters_module.log_hyperparameters()
+        def hyperparameters():
+            return []
+
+    manager.save_test_run.assert_not_called()


### PR DESCRIPTION
## Summary

- support bare, empty-call, and keyword-argument forms of `log_hyperparameters`
- preserve decoration-time registration, historical decorator-argument precedence, and validation behavior
- preserve wrapped function metadata and add regression coverage

The keyword-argument form restores the earlier API contract; the empty-call form matches the current documentation.

## Testing

- `pytest -p no:rerunfailures tests/test_core/test_run -q` (29 passed)

Closes #3134