### PR TITLE
fix: format .scripts/release.py to satisfy black lint CI

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {


### PR DESCRIPTION
## Summary

`.scripts/release.py` is not formatted to the repo's pinned Black (25.12.0, line-length 80), so the `lint` workflow fails on `main` and on every open PR that re-runs it. This formats the file so `black --check .` passes again.

## Details

The `single_digit` field annotation on `Target` exceeds the 80-char line limit with its trailing comment, and Black 25.12.0 wraps it in parentheses. Formatting only, no behavior change.

## Test plan

- `black --version` reports 25.12.0
- Before: `black --check .` reports 1 file would be reformatted (`.scripts/release.py`)
- After: `black --check .` passes with all files unchanged
