### PR TITLE
fix(integrations/hugging_face): call convert_goldens_to_test_cases with the parameters it has

### DIFF
--- a/deepeval/integrations/hugging_face/utils.py
+++ b/deepeval/integrations/hugging_face/utils.py
@@ -51,6 +51,6 @@ def generate_test_cases(
 
     test_cases = convert_goldens_to_test_cases(
         goldens=evaluation_dataset.goldens,
-        dataset_alias=evaluation_dataset.alias,
+        _alias=evaluation_dataset._alias,
     )
     return test_cases


### PR DESCRIPTION
## Problem

`DeepEvalHuggingFaceCallback.on_epoch_end` calls `generate_test_cases`, whose last statement is:

```python
# deepeval/integrations/hugging_face/utils.py:52
test_cases = convert_goldens_to_test_cases(
    goldens=evaluation_dataset.goldens,
    dataset_alias=evaluation_dataset.alias,
)
```

Neither `evaluation_dataset.alias` nor the `dataset_alias=` parameter exists:

* `EvaluationDataset` is a dataclass whose `__init__` sets `self._alias`. It exposes exactly two properties — `goldens` and `test_cases` — so `.alias` is an `AttributeError`, raised while evaluating the argument, before the call happens.
* `convert_goldens_to_test_cases(goldens, _alias=None, _id=None)` has no `dataset_alias` parameter, so even with the attribute resolved the call is a `TypeError`.

Every epoch of a `DeepEvalHuggingFaceCallback`-instrumented training run therefore dies at `on_epoch_end`, after the generation loop has already spent a full pass running the model over the dataset.

## Why it went unnoticed

`deepeval/integrations/hugging_face/tests/test_callbacks.py` imports `DeepEvalHuggingFaceCallback` but never drives an epoch boundary, so the statement is never executed.

## Sibling baselines

The other two call sites in the repo are correct, which is what pins the intended signature:

| call site | call |
|---|---|
| `deepeval/dataset/dataset.py:984` | `convert_goldens_to_test_cases(response.goldens, alias, response.id)` |
| `deepeval/optimizer/scorer/scorer.py:295` | `convert_goldens_to_test_cases([golden])` |
| `deepeval/integrations/hugging_face/utils.py:52` | **`(goldens=..., dataset_alias=...)`  ← the only broken one** |

`_alias` is likewise the accessor every other reader uses (`dataset.py` lines 165, 199, 215, 1105, 1137).

## Fix

```diff
     test_cases = convert_goldens_to_test_cases(
         goldens=evaluation_dataset.goldens,
-        dataset_alias=evaluation_dataset.alias,
+        _alias=evaluation_dataset._alias,
     )
```

## Verification

Ran the real `generate_test_cases` from this file against a real `EvaluationDataset`, with only the HF `model`/`tokenizer` stubbed (this code path uses them purely as `tokenizer(prompt, **args)` / `model.generate(ids)` / `tokenizer.decode(...)`):

```
hasattr(ds, "alias") = False

--- unpatched (current main) ---
AttributeError: 'EvaluationDataset' object has no attribute 'alias'

--- patched ---
n test cases: 1
input        : what is 2+2?
actual_output: stub answer
```

Argument binding was additionally checked by rebuilding `convert_goldens_to_test_cases`'s signature from its own AST and replaying this call site's real argument shape against it: unpatched → `TypeError: got an unexpected keyword argument 'dataset_alias'`; patched → binds.

`black --line-length 80` and `ruff check` are clean on the changed file.

## Deliberately not changed

`convert_goldens_to_test_cases` assigns `_dataset_alias` / `_dataset_id` / `_dataset_rank` through `LLMTestCase(...)` keyword arguments, but those are pydantic `PrivateAttr` fields, so the constructor drops them and the stamps stay `None`. That is pre-existing and identical for the already-correct `dataset.py` call site, so it is out of scope here — this PR only stops the crash. Happy to open a separate PR for the private-attr stamping if you want it fixed.

I also left `_id` unset rather than adding `_id=evaluation_dataset._id`, to keep the change to exactly what the original statement was trying to express.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
