### PR TITLE
fix(metrics): honor include_reason in ToolCorrectness

### DIFF
--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -353,6 +353,9 @@ class ToolCorrectnessMetric(BaseMetric):
         tool_calling_reason,
         tool_selection_reason,
     ):
+        if self.include_reason is False:
+            return None
+
         final_reason = "[\n"
         final_reason += "\t Tool Calling Reason: " + tool_calling_reason + "\n"
         final_reason += (

--- a/tests/test_metrics/test_tool_correctness_include_reason.py
+++ b/tests/test_metrics/test_tool_correctness_include_reason.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import pytest
+
+from deepeval.metrics import ToolCorrectnessMetric
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase, ToolCall
+
+
+class _StubLLM(DeepEvalBaseLLM):
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, *args, **kwargs):
+        raise AssertionError("LLM should not be called")
+
+    async def a_generate(self, *args, **kwargs):
+        raise AssertionError("LLM should not be called")
+
+    def get_model_name(self, *args, **kwargs):
+        return "stub-llm"
+
+
+def _test_case() -> LLMTestCase:
+    return LLMTestCase(
+        input="Check the weather",
+        actual_output="get_weather({})",
+        tools_called=[ToolCall(name="get_weather")],
+        expected_tools=[ToolCall(name="get_weather")],
+    )
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
+@pytest.mark.parametrize(
+    ("include_reason", "expects_reason"),
+    [(False, False), (True, True)],
+)
+def test_include_reason_controls_reason(
+    async_mode: bool, include_reason: bool, expects_reason: bool
+):
+    metric = ToolCorrectnessMetric(
+        model=_StubLLM(),
+        async_mode=async_mode,
+        include_reason=include_reason,
+    )
+
+    if async_mode:
+        asyncio.run(metric.a_measure(_test_case(), _show_indicator=False))
+    else:
+        metric.measure(_test_case(), _show_indicator=False)
+
+    assert metric.score == 1.0
+    assert (metric.reason is not None) is expects_reason
+    if expects_reason:
+        assert "All expected tools ['get_weather'] were called" in metric.reason


### PR DESCRIPTION
## What changed

`ToolCorrectnessMetric` was still generating a reason when `include_reason=False`.

This updates both the synchronous and asynchronous measurement paths to skip reason generation and leave `reason` as `None`. I kept the change limited to this metric and added regression tests for both paths.

## Testing

- ToolCorrectness tests: 4 passed, 7 skipped because `OPENAI_API_KEY` is not configured
- Full metrics suite: 183 passed, 278 skipped, 6 expected failures