### PR TITLE
fix(tool-correctness): score repeated tool calls correctly

### DIFF
--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -452,11 +452,16 @@ class ToolCorrectnessMetric(BaseMetric):
     # Non exact matching score
     def _calculate_non_exact_match_score(self) -> float:
         total_score = 0.0
-        matched_called_tools = set()
+        # Track matched calls by index rather than by value: ToolCall equality is
+        # value-based, so two genuinely distinct calls of the same tool are equal
+        # and a value set would let one match consume both, under-scoring an agent
+        # that correctly calls the same tool more than once.
+        matched_called_indices = set()
         for expected_tool in self.expected_tools:
             best_score = 0.0
-            for called_tool in self.tools_called:
-                if called_tool in matched_called_tools:
+            best_called_index = None
+            for index, called_tool in enumerate(self.tools_called):
+                if index in matched_called_indices:
                     continue
                 if (
                     expected_tool.name == called_tool.name
@@ -478,10 +483,10 @@ class ToolCorrectnessMetric(BaseMetric):
                         match_score = 0.0
                     if match_score > best_score:
                         best_score = match_score
-                        best_called_tool = called_tool
+                        best_called_index = index
             if best_score > 0:
                 total_score += best_score
-                matched_called_tools.add(best_called_tool)
+                matched_called_indices.add(best_called_index)
         return (
             1.0
             if not self.expected_tools and not self.tools_called

--- a/tests/test_metrics/test_tool_correctness_metric.py
+++ b/tests/test_metrics/test_tool_correctness_metric.py
@@ -128,3 +128,32 @@ class TestToolCorrectnessMetricType:
         metric.measure(test_case, _show_indicator=False)
 
         assert metric.score == 1.0
+
+
+class TestToolCorrectnessMetricDuplicates:
+    """Repeated tool calls must not be under-scored (regression for #3141)."""
+
+    def test_duplicate_expected_calls_all_made_score_one(self):
+        metric = ToolCorrectnessMetric(async_mode=False)
+        test_case = LLMTestCase(
+            input="Search twice",
+            actual_output="search(); search()",
+            tools_called=[ToolCall(name="search"), ToolCall(name="search")],
+            expected_tools=[ToolCall(name="search"), ToolCall(name="search")],
+        )
+        metric.measure(test_case, _show_indicator=False)
+
+        assert metric.score == 1.0
+        assert metric.success is True
+
+    def test_duplicate_expected_but_only_one_made_scores_partial(self):
+        metric = ToolCorrectnessMetric(async_mode=False)
+        test_case = LLMTestCase(
+            input="Search twice",
+            actual_output="search()",
+            tools_called=[ToolCall(name="search")],
+            expected_tools=[ToolCall(name="search"), ToolCall(name="search")],
+        )
+        metric.measure(test_case, _show_indicator=False)
+
+        assert metric.score == 0.5


### PR DESCRIPTION
## What

Fix `ToolCorrectnessMetric` under-scoring an agent that correctly calls the same tool more than once, in the default (non-exact, non-ordered) mode.

## Why

`_calculate_non_exact_match_score` deduplicated matched calls with a `set` of `ToolCall`, whose equality is value-based (name + input_parameters + output). Two genuinely distinct calls of the same tool are therefore equal, so the first match consumed both and the second expected call found nothing to match. An agent that correctly called the same tool twice scored 0.5 instead of 1.0. Details and a repro are in #3141.

## Change

- Track matched calls by their index in `tools_called` (identity) rather than a value set, so a second distinct-but-equal call can still match a second expected call. The exact-match and ordering (LCS) paths were already position based and are unchanged.
- Add regression tests: two expected-and-made duplicate calls score 1.0; only one made scores 0.5.

Verified locally against deepeval 4.2.0: the duplicate case goes from 0.5 to 1.0, distinct tools stay 1.0, and a genuinely missing duplicate correctly stays 0.5.

Fixes #3141
