### PR TITLE
fix(evaluate): respect print_results across evaluation output

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -1,6 +1,7 @@
 from asyncio import Task
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Union, Literal
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
 import json
@@ -59,6 +60,7 @@ from deepeval.utils import (
     convert_keys_to_snake_case,
     get_or_create_event_loop,
     open_browser,
+    suppress_evaluation_output,
 )
 from deepeval.test_run import (
     global_test_run_manager,
@@ -76,6 +78,31 @@ if TYPE_CHECKING:
 
 
 valid_file_types = ["csv", "json", "jsonl"]
+
+
+def _iterate_with_output_control(iterator: Iterator, print_results: bool):
+    """Advance DeepEval's iterator quietly without muting caller code.
+
+    ``evals_iterator`` yields control to user application code between items.
+    A suppression context spanning that yield would leak into the caller, so
+    enter it only while advancing or closing the internal iterator.
+    """
+    output_context = (
+        nullcontext if print_results else suppress_evaluation_output
+    )
+    try:
+        while True:
+            with output_context():
+                try:
+                    item = next(iterator)
+                except StopIteration:
+                    return
+            yield item
+    finally:
+        close = getattr(iterator, "close", None)
+        if close is not None:
+            with output_context():
+                close()
 
 
 def _parse_column(df, col_name, parse):
@@ -1600,6 +1627,12 @@ class EvaluationDataset:
         if async_config is None:
             async_config: AsyncConfig = AsyncConfig()
 
+        if not display_config.print_results:
+            display_config = replace(
+                display_config,
+                show_indicator=False,
+            )
+
         if not self.goldens or len(self.goldens) == 0:
             raise ValueError("Unable to evaluate dataset with no goldens.")
         goldens = self.goldens
@@ -1610,7 +1643,7 @@ class EvaluationDataset:
 
             if async_config.run_async:
                 loop = get_or_create_event_loop()
-                for golden in a_execute_agentic_test_cases_from_loop(
+                internal_iterator = a_execute_agentic_test_cases_from_loop(
                     goldens=goldens,
                     identifier=identifier,
                     loop=loop,
@@ -1620,11 +1653,9 @@ class EvaluationDataset:
                     cache_config=cache_config,
                     error_config=error_config,
                     async_config=async_config,
-                ):
-                    yield golden
-
+                )
             else:
-                for golden in execute_agentic_test_cases_from_loop(
+                internal_iterator = execute_agentic_test_cases_from_loop(
                     goldens=goldens,
                     trace_metrics=metrics,
                     display_config=display_config,
@@ -1632,9 +1663,13 @@ class EvaluationDataset:
                     error_config=error_config,
                     test_results=test_results,
                     identifier=identifier,
-                ):
-                    yield golden
+                )
 
+            for golden in _iterate_with_output_control(
+                iter(internal_iterator),
+                print_results=display_config.print_results,
+            ):
+                yield golden
             end_time = time.perf_counter()
             run_duration = end_time - start_time
             if display_config.print_results:
@@ -1661,7 +1696,12 @@ class EvaluationDataset:
                             f"Invalid file type: {display_config.file_type}"
                         )
 
-            test_run = global_test_run_manager.get_test_run()
+            with (
+                suppress_evaluation_output()
+                if not display_config.print_results
+                else nullcontext()
+            ):
+                test_run = global_test_run_manager.get_test_run()
             if hyperparameters is not None or test_run.hyperparameters is None:
                 test_run.hyperparameters = process_hyperparameters(
                     hyperparameters
@@ -1675,9 +1715,15 @@ class EvaluationDataset:
             # save test run
             global_test_run_manager.save_test_run(TEMP_FILE_PATH)
 
-            res = global_test_run_manager.wrap_up_test_run(
-                run_duration, display_table=False
-            )
+            with (
+                suppress_evaluation_output()
+                if not display_config.print_results
+                else nullcontext()
+            ):
+                res = global_test_run_manager.wrap_up_test_run(
+                    run_duration,
+                    display_table=False,
+                )
             if isinstance(res, tuple):
                 confident_link, test_run_id = res
             else:

--- a/deepeval/evaluate/configs.py
+++ b/deepeval/evaluate/configs.py
@@ -19,7 +19,9 @@ class AsyncConfig:
 
 @dataclass
 class DisplayConfig:
+    # Progress indicators are shown only while print_results is enabled.
     show_indicator: bool = True
+    # Master switch for evaluate()/evals_iterator() terminal output.
     print_results: bool = True
     verbose_mode: Optional[bool] = None
     display_option: Optional[TestRunResultDisplay] = TestRunResultDisplay.ALL

--- a/deepeval/evaluate/evaluate.py
+++ b/deepeval/evaluate/evaluate.py
@@ -1,4 +1,6 @@
 import warnings
+from contextlib import nullcontext
+from dataclasses import replace
 from typing import (
     TYPE_CHECKING,
     List,
@@ -41,6 +43,7 @@ from deepeval.utils import (
     should_skip_on_missing_params,
     should_use_cache,
     should_verbose_print,
+    suppress_evaluation_output,
     get_identifier,
 )
 from deepeval.telemetry import Entrypoint, capture_evaluation_run
@@ -206,6 +209,18 @@ def evaluate(
     )
     check_valid_test_cases_type(test_cases)
 
+    if display_config is None:
+        display_config = DisplayConfig()
+
+    # ``print_results=False`` is the master switch for user-facing output.
+    # Keep the caller's config immutable while disabling progress indicators
+    # in the derived config passed through the execution stack.
+    if not display_config.print_results:
+        display_config = replace(
+            display_config,
+            show_indicator=False,
+        )
+
     if mcp_servers is not None:
         mcp_servers = normalize_mcp_servers(mcp_servers)
         validate_mcp_servers(mcp_servers)
@@ -228,30 +243,35 @@ def evaluate(
                     )
                 )
 
-        with capture_evaluation_run(Entrypoint.EVALUATE):
-            if async_config.run_async:
-                loop = get_or_create_event_loop()
-                test_results = loop.run_until_complete(
-                    a_execute_test_cases(
+        evaluation_output_context = (
+            suppress_evaluation_output()
+            if not display_config.print_results
+            else nullcontext()
+        )
+        with evaluation_output_context:
+            with capture_evaluation_run(Entrypoint.EVALUATE):
+                if async_config.run_async:
+                    loop = get_or_create_event_loop()
+                    test_results = loop.run_until_complete(
+                        a_execute_test_cases(
+                            test_cases,
+                            metrics,
+                            identifier=identifier,
+                            error_config=error_config,
+                            display_config=display_config,
+                            cache_config=cache_config,
+                            async_config=async_config,
+                        )
+                    )
+                else:
+                    test_results = execute_test_cases(
                         test_cases,
                         metrics,
                         identifier=identifier,
                         error_config=error_config,
                         display_config=display_config,
                         cache_config=cache_config,
-                        async_config=async_config,
                     )
-                )
-            else:
-                test_results = execute_test_cases(
-                    test_cases,
-                    metrics,
-                    identifier=identifier,
-                    error_config=error_config,
-                    display_config=display_config,
-                    cache_config=cache_config,
-                )
-
         end_time = time.perf_counter()
         run_duration = end_time - start_time
         if display_config.print_results:
@@ -279,7 +299,12 @@ def evaluate(
                         f"Invalid file type: {display_config.file_type}"
                     )
 
-        test_run = global_test_run_manager.get_test_run()
+        with (
+            suppress_evaluation_output()
+            if not display_config.print_results
+            else nullcontext()
+        ):
+            test_run = global_test_run_manager.get_test_run()
         if hyperparameters is not None or test_run.hyperparameters is None:
             test_run.hyperparameters = process_hyperparameters(hyperparameters)
             test_run.prompts = process_prompts(hyperparameters)
@@ -312,9 +337,15 @@ def evaluate(
                 test_run_id=None,
             )
 
-        res = global_test_run_manager.wrap_up_test_run(
-            run_duration, display_table=False
-        )
+        with (
+            suppress_evaluation_output()
+            if not display_config.print_results
+            else nullcontext()
+        ):
+            res = global_test_run_manager.wrap_up_test_run(
+                run_duration,
+                display_table=False,
+            )
         if isinstance(res, tuple):
             confident_link, test_run_id = res
         else:
@@ -358,9 +389,10 @@ def evaluate(
             body=body,
         )
         if link:
-            console = Console()
-            console.print(
-                "✅ Evaluation successfully pushed to Confident AI! View at "
-                f"[link={link}]{link}[/link]"
-            )
+            if display_config.print_results:
+                console = Console()
+                console.print(
+                    "✅ Evaluation successfully pushed to Confident AI! View at "
+                    f"[link={link}]{link}[/link]"
+                )
             open_browser(link)

--- a/deepeval/evaluate/execute/_common.py
+++ b/deepeval/evaluate/execute/_common.py
@@ -22,6 +22,7 @@ from deepeval.utils import (
     format_error_text,
     are_timeouts_disabled,
     get_gather_timeout_seconds,
+    should_print_evaluation_output,
 )
 from deepeval.metrics import (
     BaseMetric,
@@ -71,6 +72,8 @@ def _log_gather_timeout(
     exc: Optional[BaseException] = None,
     pending: Optional[int] = None,
 ) -> None:
+    if not should_print_evaluation_output():
+        return
     settings = get_settings()
     if are_timeouts_disabled():
         logger.warning(

--- a/deepeval/evaluate/execute/agentic.py
+++ b/deepeval/evaluate/execute/agentic.py
@@ -30,6 +30,7 @@ from deepeval.errors import DeepEvalError
 from deepeval.utils import (
     format_error_text,
     get_gather_timeout,
+    should_print_evaluation_output,
 )
 from deepeval.metrics import (
     BaseMetric,
@@ -59,16 +60,14 @@ from deepeval.utils import add_pbar, update_pbar
 from deepeval.tracing.types import TraceSpanStatus
 from deepeval.tracing.api import TraceSpanApiStatus
 from deepeval.config.settings import get_settings
-
-logger = logging.getLogger(__name__)
-
-
 from deepeval.evaluate.execute._common import (
     _skip_metrics_for_error,
     _trace_error,
     filter_duplicate_results,
     log_prompt,
 )
+
+logger = logging.getLogger(__name__)
 
 
 async def _a_execute_agentic_test_case(
@@ -213,6 +212,7 @@ async def _a_execute_agentic_test_case(
             if (
                 logger.isEnabledFor(logging.DEBUG)
                 and get_settings().DEEPEVAL_VERBOSE_MODE
+                and should_print_evaluation_output()
             ):
                 logger.debug(
                     "Skipping DFS: empty trace or no root spans (trace=%s)",

--- a/deepeval/evaluate/execute/e2e.py
+++ b/deepeval/evaluate/execute/e2e.py
@@ -66,16 +66,14 @@ from deepeval.evaluate.utils import (
 from deepeval.utils import add_pbar, update_pbar, custom_console
 from deepeval.tracing.types import TestCaseMetricPair
 from deepeval.config.settings import get_settings
-
-logger = logging.getLogger(__name__)
-
-
 from deepeval.evaluate.execute._common import (
     _await_with_outer_deadline,
     _execute_metric,
     _log_gather_timeout,
     _timeout_msg,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def execute_test_cases(
@@ -543,7 +541,6 @@ async def _a_execute_llm_test_cases(
     progress: Optional[Progress] = None,
     pbar_id: Optional[int] = None,
 ):
-    logger.info("in _a_execute_llm_test_cases")
     pbar_test_case_id = add_pbar(
         progress,
         f"    🎯 Evaluating test case #{count}",

--- a/deepeval/evaluate/execute/loop.py
+++ b/deepeval/evaluate/execute/loop.py
@@ -48,6 +48,7 @@ from deepeval.utils import (
     format_error_text,
     get_per_task_timeout_seconds,
     get_gather_timeout,
+    should_print_evaluation_output,
 )
 from deepeval.telemetry import record_golden
 from deepeval.metrics import BaseMetric
@@ -79,10 +80,6 @@ from deepeval.tracing.types import (
 )
 from deepeval.tracing.api import TraceSpanApiStatus
 from deepeval.config.settings import get_settings
-
-logger = logging.getLogger(__name__)
-
-
 from deepeval.evaluate.execute._common import (
     _await_with_outer_deadline,
     _execute_metric,
@@ -99,6 +96,8 @@ from deepeval.evaluate.execute.agentic import (
     _a_execute_agentic_test_case,
 )
 from deepeval.evaluate.execute.e2e import _evaluate_test_case_pairs
+
+logger = logging.getLogger(__name__)
 
 
 def _span_subtree_has_metrics(span: BaseSpan) -> bool:
@@ -643,7 +642,10 @@ def a_execute_agentic_test_cases_from_loop(
                                     _mark_trace_error(trace, root, msg)
                                     break
 
-                if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                if (
+                    get_settings().DEEPEVAL_DEBUG_ASYNC
+                    and display_config.print_results
+                ):
                     # Using info level here to make it easy to spot these logs.
                     golden_name = meta.get("golden_name")
                     duration = time.perf_counter() - meta.get(
@@ -757,41 +759,46 @@ def a_execute_agentic_test_cases_from_loop(
 
                 _log_gather_timeout(logger, exc=e, pending=len(pending))
 
-                # Log the elapsed time for each task that was pending
-                for t in pending:
-                    meta = task_meta.get(t, {})
-                    start_time = meta.get("started", time.perf_counter())
-                    elapsed_time = time.perf_counter() - start_time
+                if display_config.print_results:
+                    # Log the elapsed time for each task that was pending
+                    for t in pending:
+                        meta = task_meta.get(t, {})
+                        start_time = meta.get("started", time.perf_counter())
+                        elapsed_time = time.perf_counter() - start_time
 
-                    # Determine if it was a per task or gather timeout based on task's elapsed time
-                    if not settings.DEEPEVAL_DISABLE_TIMEOUTS:
-                        timeout_type = (
-                            "per-task"
-                            if elapsed_time >= get_per_task_timeout_seconds()
-                            else "gather"
-                        )
-                        logger.info(
-                            "  - PENDING %s elapsed_time=%.2fs timeout_type=%s meta=%s",
-                            t.get_name(),
-                            elapsed_time,
-                            timeout_type,
-                            meta,
-                        )
-                    else:
-                        logger.info(
-                            "  - PENDING %s elapsed_time=%.2fs meta=%s",
-                            t.get_name(),
-                            elapsed_time,
-                            meta,
-                        )
+                        # Determine if it was a per task or gather timeout based on task's elapsed time
+                        if not settings.DEEPEVAL_DISABLE_TIMEOUTS:
+                            timeout_type = (
+                                "per-task"
+                                if elapsed_time
+                                >= get_per_task_timeout_seconds()
+                                else "gather"
+                            )
+                            logger.info(
+                                "  - PENDING %s elapsed_time=%.2fs timeout_type=%s meta=%s",
+                                t.get_name(),
+                                elapsed_time,
+                                timeout_type,
+                                meta,
+                            )
+                        else:
+                            logger.info(
+                                "  - PENDING %s elapsed_time=%.2fs meta=%s",
+                                t.get_name(),
+                                elapsed_time,
+                                meta,
+                            )
 
-                    if loop.get_debug() and get_settings().DEEPEVAL_DEBUG_ASYNC:
-                        frames = t.get_stack(limit=6)
-                        if frames:
-                            logger.info("    stack:")
-                            for fr in frames:
-                                for line in traceback.format_stack(fr):
-                                    logger.info("      " + line.rstrip())
+                        if (
+                            loop.get_debug()
+                            and get_settings().DEEPEVAL_DEBUG_ASYNC
+                        ):
+                            frames = t.get_stack(limit=6)
+                            if frames:
+                                logger.info("    stack:")
+                                for fr in frames:
+                                    for line in traceback.format_stack(fr):
+                                        logger.info("      " + line.rstrip())
 
                 # Cancel and drain the tasks
                 for t in pending:
@@ -821,7 +828,10 @@ def a_execute_agentic_test_cases_from_loop(
                     and not t.done()
                 ]
 
-                if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                if (
+                    get_settings().DEEPEVAL_DEBUG_ASYNC
+                    and display_config.print_results
+                ):
                     if len(leftovers) > 0:
                         logger.warning(
                             "[deepeval] %d stray task(s) not tracked; cancelling...",
@@ -843,7 +853,10 @@ def a_execute_agentic_test_cases_from_loop(
                         )
                     except RuntimeError:
                         # If the loop is closing here, just continue
-                        if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                        if (
+                            get_settings().DEEPEVAL_DEBUG_ASYNC
+                            and display_config.print_results
+                        ):
                             logger.warning(
                                 "[deepeval] failed to drain stray tasks because loop is closing"
                             )
@@ -976,6 +989,7 @@ async def _a_evaluate_traces(
             if (
                 logger.isEnabledFor(logging.DEBUG)
                 and get_settings().DEEPEVAL_VERBOSE_MODE
+                and should_print_evaluation_output()
             ):
                 logger.debug(
                     "Skipping trace %s: no golden association found in eval_session",

--- a/deepeval/evaluate/inspect_prompt.py
+++ b/deepeval/evaluate/inspect_prompt.py
@@ -2,17 +2,19 @@
 
 Gated so it never fires unexpectedly. The prompt only appears when ALL of:
 
-    1. ``DisplayConfig.inspect_after_run`` is True (the default; set False
+    1. ``DisplayConfig.print_results`` is True. A quiet evaluation must not
+       print or block on an interactive prompt.
+    2. ``DisplayConfig.inspect_after_run`` is True (the default; set False
        to disable for a single call).
-    2. The ``DEEPEVAL_NO_INSPECT_PROMPT`` env var is not truthy
+    3. The ``DEEPEVAL_NO_INSPECT_PROMPT`` env var is not truthy
        (escape hatch for CI / non-interactive scripts that own their own
        stdin and shouldn't be hijacked).
-    3. ``sys.stdout.isatty()`` — skip in pipes, file redirects, and most
+    4. ``sys.stdout.isatty()`` — skip in pipes, file redirects, and most
        CI runners. A no-TTY ``input()`` would block forever or raise
        EOFError when the parent process exits.
-    4. ``TestRunManager.last_saved_path`` points to an existing file
+    5. ``TestRunManager.last_saved_path`` points to an existing file
        (defends against read-only envs and hidden-dir write failures).
-    5. The run has at least one ``LLMApiTestCase.trace`` set.
+    6. The run has at least one ``LLMApiTestCase.trace`` set.
        ``deepeval inspect`` is a trace-tree TUI; runs that only produced
        metric scores would render an empty viewer (and ``load_test_run``
        raises ``NoTracesError`` in that case anyway).
@@ -107,6 +109,8 @@ def _should_prompt(
     test_run_manager: "TestRunManager",
     display_config: "DisplayConfig",
 ) -> bool:
+    if not getattr(display_config, "print_results", True):
+        return False
     if not getattr(display_config, "inspect_after_run", True):
         return False
     if os.environ.get(_DISABLE_ENV_VAR, "").strip().lower() in _TRUTHY:

--- a/deepeval/evaluate/local_store.py
+++ b/deepeval/evaluate/local_store.py
@@ -79,7 +79,9 @@ def resolve_test_run_path(target_dir: Path) -> Path:
         n += 1
 
 
-def write_rolling_test_run(test_run: TestRun) -> Optional[Path]:
+def write_rolling_test_run(
+    test_run: TestRun, print_results: bool = True
+) -> Optional[Path]:
     """Overwrite `.deepeval/.latest_run_full.json` with `test_run`.
 
     Returns `None` (silently) on read-only env or write failure so a failed
@@ -96,10 +98,11 @@ def write_rolling_test_run(test_run: TestRun) -> Optional[Path]:
         _dump(test_run, path)
         return path
     except Exception as e:
-        print(
-            f"Warning: failed to write rolling snapshot to {path}: {e}",
-            file=sys.stderr,
-        )
+        if print_results:
+            print(
+                f"Warning: failed to write rolling snapshot to {path}: {e}",
+                file=sys.stderr,
+            )
         return None
 
 

--- a/deepeval/evaluate/utils.py
+++ b/deepeval/evaluate/utils.py
@@ -325,7 +325,6 @@ def validate_evaluate_inputs(
                 if isinstance(
                     test_case, ConversationalTestCase
                 ) and not isinstance(metric, BaseConversationalMetric):
-                    print(type(metric))
                     raise ValueError(
                         f"Metric {metric.__name__} is not a valid metric for ConversationalTestCase."
                     )

--- a/deepeval/metrics/indicator.py
+++ b/deepeval/metrics/indicator.py
@@ -16,7 +16,7 @@ from deepeval.metrics import (
 from deepeval.test_case import LLMTestCase, ConversationalTestCase
 from deepeval.test_run.cache import CachedTestCase, Cache
 from deepeval.telemetry import record_metric
-from deepeval.utils import update_pbar
+from deepeval.utils import update_pbar, should_print_evaluation_output
 from deepeval.config.settings import get_settings
 
 logger = logging.getLogger(__name__)
@@ -255,7 +255,8 @@ async def safe_a_measure(
         update_pbar(progress, pbar_eval_id)
 
     except asyncio.CancelledError:
-        logger.info("caught asyncio.CancelledError")
+        if should_print_evaluation_output():
+            logger.info("caught asyncio.CancelledError")
 
         # treat cancellation as a timeout so we still emit a MetricData
         metric.error = (
@@ -298,6 +299,7 @@ async def safe_a_measure(
         if ignore_errors:
             metric.error = str(e)
             metric.success = False  # Assuming you want to set success to False
-            logger.info("a metric was marked as errored")
+            if should_print_evaluation_output():
+                logger.info("a metric was marked as errored")
         else:
             raise

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -19,7 +19,11 @@ from typing import (
 from deepeval.errors import (
     MissingTestCaseParamsError,
 )
-from deepeval.utils import convert_to_multi_modal_array, serialize_to_json
+from deepeval.utils import (
+    convert_to_multi_modal_array,
+    serialize_to_json,
+    should_print_evaluation_output,
+)
 from deepeval.config.settings import get_settings
 from deepeval.models import (
     DeepEvalBaseLLM,
@@ -262,7 +266,7 @@ def construct_verbose_logs(metric: BaseMetric, steps: List[str]) -> str:
         # don't add new line for penultimate step
         if i < len(steps) - 2:
             verbose_logs += " \n \n"
-    if metric.verbose_mode:
+    if metric.verbose_mode and should_print_evaluation_output():
         # only print reason and score for deepeval
         print_verbose_logs(metric.__name__, verbose_logs + f"\n \n{steps[-1]}")
 

--- a/deepeval/test_run/cache.py
+++ b/deepeval/test_run/cache.py
@@ -14,6 +14,7 @@ from deepeval.utils import (
     delete_file_if_exists,
     is_read_only_env,
     serialize,
+    should_print_evaluation_output,
 )
 from deepeval.metrics import BaseMetric
 from deepeval.constants import HIDDEN_DIR
@@ -193,19 +194,21 @@ class TestRunCacheManager:
                         file
                     )
             except Exception as e:
-                print(
-                    f"In save_cached_test_run, temp={to_temp}, Error saving test run to disk {e}",
-                    file=sys.stderr,
-                )
+                if should_print_evaluation_output():
+                    print(
+                        f"In save_cached_test_run, temp={to_temp}, Error saving test run to disk {e}",
+                        file=sys.stderr,
+                    )
         else:
             try:
                 with portalocker.Lock(self.cache_file_name, mode="w") as file:
                     self.cached_test_run = self.cached_test_run.save(file)
             except Exception as e:
-                print(
-                    f"In save_cached_test_run, temp={to_temp}, Error saving test run to disk {e}",
-                    file=sys.stderr,
-                )
+                if should_print_evaluation_output():
+                    print(
+                        f"In save_cached_test_run, temp={to_temp}, Error saving test run to disk {e}",
+                        file=sys.stderr,
+                    )
 
     def create_cached_test_run(self, temp: bool = False):
         if self.disable_write_cache or portalocker is None:
@@ -242,10 +245,11 @@ class TestRunCacheManager:
                     except Exception:
                         should_create_cached_test_run = True
             except portalocker.exceptions.LockException as e:
-                print(
-                    f"In get_cached_test_run, temp={from_temp}, Lock acquisition failed: {e}",
-                    file=sys.stderr,
-                )
+                if should_print_evaluation_output():
+                    print(
+                        f"In get_cached_test_run, temp={from_temp}, Lock acquisition failed: {e}",
+                        file=sys.stderr,
+                    )
 
             if should_create_cached_test_run:
                 self.create_cached_test_run(temp=from_temp)
@@ -272,10 +276,11 @@ class TestRunCacheManager:
                         should_create_cached_test_run = True
 
             except portalocker.exceptions.LockException as e:
-                print(
-                    f"In get_cached_test_run, temp={from_temp}, Lock acquisition failed: {e}",
-                    file=sys.stderr,
-                )
+                if should_print_evaluation_output():
+                    print(
+                        f"In get_cached_test_run, temp={from_temp}, Lock acquisition failed: {e}",
+                        file=sys.stderr,
+                    )
 
             if should_create_cached_test_run:
                 self.create_cached_test_run(temp=from_temp)
@@ -297,10 +302,11 @@ class TestRunCacheManager:
             with portalocker.Lock(self.cache_file_name, mode="w") as file:
                 self.temp_cached_test_run = self.temp_cached_test_run.save(file)
         except Exception as e:
-            print(
-                f"In wrap_up_cached_test_run, Error saving test run to disk, {e}",
-                file=sys.stderr,
-            )
+            if should_print_evaluation_output():
+                print(
+                    f"In wrap_up_cached_test_run, Error saving test run to disk, {e}",
+                    file=sys.stderr,
+                )
         finally:
             delete_file_if_exists(self.temp_cache_file_name)
 

--- a/deepeval/test_run/test_run.py
+++ b/deepeval/test_run/test_run.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from contextlib import nullcontext
 import os
 import json
 from pathlib import Path
@@ -30,6 +31,8 @@ from deepeval.utils import (
     shorten,
     format_turn,
     len_short,
+    should_print_evaluation_output,
+    suppress_evaluation_output,
 )
 from deepeval.test_run.cache import global_test_run_cache_manager
 from deepeval.telemetry import (
@@ -544,10 +547,11 @@ class TestRunManager:
                 json.JSONDecodeError,
                 portalocker.exceptions.LockException,
             ) as e:
-                print(
-                    f"Warning: Could not load test run from disk: {e}",
-                    file=sys.stderr,
-                )
+                if should_print_evaluation_output():
+                    print(
+                        f"Warning: Could not load test run from disk: {e}",
+                        file=sys.stderr,
+                    )
 
         return self.test_run
 
@@ -626,10 +630,11 @@ class TestRunManager:
                 json.JSONDecodeError,
                 portalocker.exceptions.LockException,
             ) as e:
-                print(
-                    f"Warning: Could not update test run on disk: {e}",
-                    file=sys.stderr,
-                )
+                if should_print_evaluation_output():
+                    print(
+                        f"Warning: Could not update test run on disk: {e}",
+                        file=sys.stderr,
+                    )
                 if self.test_run is None:
                     # guarantee a valid in-memory run so the update can proceed.
                     # never destroy in-memory state on I/O failure.
@@ -913,12 +918,17 @@ class TestRunManager:
         )
         print(table)
 
-    def post_test_run(self, test_run: TestRun) -> Optional[Tuple[str, str]]:
+    def post_test_run(
+        self, test_run: TestRun, print_results: Optional[bool] = None
+    ) -> Optional[Tuple[str, str]]:
+        if print_results is None:
+            print_results = should_print_evaluation_output()
         if (
             len(test_run.test_cases) == 0
             and len(test_run.conversational_test_cases) == 0
         ):
-            print("No test cases found, unable to upload to Confident AI.")
+            if print_results:
+                print("No test cases found, unable to upload to Confident AI.")
             return
 
         api = Api()
@@ -939,7 +949,7 @@ class TestRunManager:
         initial_batch = all_test_cases_to_process[:BATCH_SIZE]
         remaining_test_cases_to_process = all_test_cases_to_process[BATCH_SIZE:]
 
-        if len(remaining_test_cases_to_process) > 0:
+        if print_results and len(remaining_test_cases_to_process) > 0:
             console.print(
                 "Sending a large test run to Confident, this might take a bit longer than usual..."
             )
@@ -1039,21 +1049,24 @@ class TestRunManager:
                 message = f"Unexpected error when sending some test cases. Incomplete test run available at {link}"
                 raise Exception(message) from e
 
-        console.print(
-            "[rgb(5,245,141)]✓[/rgb(5,245,141)] Done 🎉! View results on "
-            f"[link={link}]{link}[/link]"
-        )
+        if print_results:
+            console.print(
+                "[rgb(5,245,141)]✓[/rgb(5,245,141)] Done 🎉! View results on "
+                f"[link={link}]{link}[/link]"
+            )
         self.save_final_test_run_link(link)
         open_browser(link)
         return link, res.id
 
-    def save_test_run_locally(self):
+    def save_test_run_locally(self, print_results: Optional[bool] = None):
         """Persist the current TestRun to disk.
 
         Always writes a rolling snapshot to `.deepeval/.latest_run_full.json`.
         Additionally writes a timestamped `test_run_<YYYYMMDD_HHMMSS>.json` to
         `results_folder` (or `DEEPEVAL_RESULTS_FOLDER`) when set.
         """
+        if print_results is None:
+            print_results = should_print_evaluation_output()
         if self.test_run is None:
             return
 
@@ -1063,7 +1076,9 @@ class TestRunManager:
             write_test_run,
         )
 
-        rolling_path = write_rolling_test_run(self.test_run)
+        rolling_path = write_rolling_test_run(
+            self.test_run, print_results=print_results
+        )
         if rolling_path is not None:
             self.last_saved_path = rolling_path
 
@@ -1075,39 +1090,60 @@ class TestRunManager:
             return
 
         if target_dir.exists() and target_dir.is_file():
-            print(
-                f"❌ Error: results_folder={target_dir} already exists and is a file.\n"
-                "Detailed results won't be saved. Please specify a folder or an available path."
-            )
+            if print_results:
+                print(
+                    f"❌ Error: results_folder={target_dir} already exists and is a file.\n"
+                    "Detailed results won't be saved. Please specify a folder or an available path."
+                )
             return
 
         try:
             path = write_test_run(target_dir, self.test_run)
             self.last_saved_path = path
-            print(f"Test run saved at {path}")
+            if print_results:
+                print(f"Test run saved at {path}")
         except Exception as e:
-            print(
-                f"Warning: failed to save test run to {target_dir}: {e}",
-                file=sys.stderr,
-            )
+            if print_results:
+                print(
+                    f"Warning: failed to save test run to {target_dir}: {e}",
+                    file=sys.stderr,
+                )
 
     def wrap_up_test_run(
         self,
         runDuration: float,
         display_table: bool = True,
         display: Optional[TestRunResultDisplay] = TestRunResultDisplay.ALL,
+        print_results: Optional[bool] = None,
     ) -> Optional[Tuple[str, str]]:
-        test_run = self.get_test_run()
+        if print_results is None:
+            print_results = should_print_evaluation_output()
+        with (
+            suppress_evaluation_output() if not print_results else nullcontext()
+        ):
+            test_run = self.get_test_run()
         if test_run is None:
-            print("Test Run is empty, please try again.")
-            delete_file_if_exists(self.temp_file_path)
+            if print_results:
+                print("Test Run is empty, please try again.")
+            with (
+                suppress_evaluation_output()
+                if not print_results
+                else nullcontext()
+            ):
+                delete_file_if_exists(self.temp_file_path)
             return
         elif (
             len(test_run.test_cases) == 0
             and len(test_run.conversational_test_cases) == 0
         ):
-            print("No test cases found, please try again.")
-            delete_file_if_exists(self.temp_file_path)
+            if print_results:
+                print("No test cases found, please try again.")
+            with (
+                suppress_evaluation_output()
+                if not print_results
+                else nullcontext()
+            ):
+                delete_file_if_exists(self.temp_file_path)
             return
 
         # Mark the run as the official if requested via the `--official` CLI flag or `evaluate(official=True)`.
@@ -1121,7 +1157,7 @@ class TestRunManager:
         # which the dashboard can render. Just warn so it's not mistaken
         # for a successful run.
         valid_scores = test_run.construct_metrics_scores()
-        if valid_scores == 0:
+        if print_results and valid_scores == 0:
             console.print(
                 "\n[bold yellow]⚠ WARNING:[/bold yellow] All metrics errored "
                 "across every test case — no metric scores were recorded. "
@@ -1136,52 +1172,65 @@ class TestRunManager:
             global_test_run_cache_manager.disable_write_cache = not bool(
                 get_is_running_deepeval()
             )
-        global_test_run_cache_manager.wrap_up_cached_test_run()
+        with (
+            suppress_evaluation_output() if not print_results else nullcontext()
+        ):
+            global_test_run_cache_manager.wrap_up_cached_test_run()
 
-        if display_table:
+        if print_results and display_table:
             self.display_results_table(test_run, display)
 
-        if test_run.hyperparameters is None:
-            console.print(
-                "\n[bold yellow]⚠ WARNING:[/bold yellow] No hyperparameters logged.\n"
-                "» [bold blue][link=https://deepeval.com/docs/evaluation-prompts]Log hyperparameters[/link][/bold blue] to attribute prompts and models to your test runs.\n\n"
-                + "=" * 80
-            )
-        else:
-            if not test_run.prompts:
+        if print_results:
+            if test_run.hyperparameters is None:
                 console.print(
-                    "\n[bold yellow]⚠ WARNING:[/bold yellow] No prompts logged.\n"
-                    "» [bold blue][link=https://deepeval.com/docs/evaluation-prompts]Log prompts[/link][/bold blue] to evaluate and optimize your prompt templates and models.\n\n"
+                    "\n[bold yellow]⚠ WARNING:[/bold yellow] No hyperparameters logged.\n"
+                    "» [bold blue][link=https://deepeval.com/docs/evaluation-prompts]Log hyperparameters[/link][/bold blue] to attribute prompts and models to your test runs.\n\n"
                     + "=" * 80
                 )
             else:
-                console.print("\n[bold green]✓ Prompts Logged[/bold green]\n")
-                self._render_prompts_panels(prompts=test_run.prompts)
+                if not test_run.prompts:
+                    console.print(
+                        "\n[bold yellow]⚠ WARNING:[/bold yellow] No prompts logged.\n"
+                        "» [bold blue][link=https://deepeval.com/docs/evaluation-prompts]Log prompts[/link][/bold blue] to evaluate and optimize your prompt templates and models.\n\n"
+                        + "=" * 80
+                    )
+                else:
+                    console.print(
+                        "\n[bold green]✓ Prompts Logged[/bold green]\n"
+                    )
+                    self._render_prompts_panels(prompts=test_run.prompts)
 
-        self.save_test_run_locally()
-        delete_file_if_exists(self.temp_file_path)
-        confident_enabled = is_confident()
-        if confident_enabled and self.disable_request is False:
-            return self.post_test_run(test_run)
-        else:
-            self.save_test_run(
-                LATEST_TEST_RUN_FILE_PATH,
-                save_under_key=LATEST_TEST_RUN_DATA_KEY,
-            )
-            token_cost = (
-                f"{test_run.evaluation_cost} USD"
-                if test_run.evaluation_cost
-                else "None"
-            )
-            capture_login_prompt_shown(LoginPromptSurface.POST_EVAL)
-            console.print(
-                f"\n\n[rgb(5,245,141)]✓[/rgb(5,245,141)] Evaluation completed 🎉! (time taken: {round(runDuration, 2)}s | token cost: {token_cost})\n"
-                f"» Test Results ({test_run.test_passed + test_run.test_failed} total tests):\n",
-                f"  » Pass Rate: {round((test_run.test_passed / (test_run.test_passed + test_run.test_failed)) * 100, 2)}% | Passed: [bold green]{test_run.test_passed}[/bold green] | Failed: [bold red]{test_run.test_failed}[/bold red]\n\n",
-                "=" * 80,
-                "\n\n» Want to share evals with your team, or a place for your test cases to live? ❤️ 🏡\n"
-                "  » Run [bold]'deepeval view'[/bold] to analyze and save testing results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n",
-            )
+        # Suppressing output must not skip persistence, cache finalization, or
+        # uploading the run. A scoped context also keeps public methods with
+        # legacy override signatures callable without new keyword arguments.
+        with (
+            suppress_evaluation_output() if not print_results else nullcontext()
+        ):
+            self.save_test_run_locally()
+            delete_file_if_exists(self.temp_file_path)
+            confident_enabled = is_confident()
+            if confident_enabled and self.disable_request is False:
+                return self.post_test_run(test_run)
+            else:
+                self.save_test_run(
+                    LATEST_TEST_RUN_FILE_PATH,
+                    save_under_key=LATEST_TEST_RUN_DATA_KEY,
+                )
+                if print_results:
+                    token_cost = (
+                        f"{test_run.evaluation_cost} USD"
+                        if test_run.evaluation_cost
+                        else "None"
+                    )
+                    capture_login_prompt_shown(LoginPromptSurface.POST_EVAL)
+                    console.print(
+                        f"\n\n[rgb(5,245,141)]✓[/rgb(5,245,141)] Evaluation completed 🎉! (time taken: {round(runDuration, 2)}s | token cost: {token_cost})\n"
+                        f"» Test Results ({test_run.test_passed + test_run.test_failed} total tests):\n",
+                        f"  » Pass Rate: {round((test_run.test_passed / (test_run.test_passed + test_run.test_failed)) * 100, 2)}% | Passed: [bold green]{test_run.test_passed}[/bold green] | Failed: [bold red]{test_run.test_failed}[/bold red]\n\n",
+                        "=" * 80,
+                        "\n\n» Want to share evals with your team, or a place for your test cases to live? ❤️ 🏡\n"
+                        "  » Run [bold]'deepeval view'[/bold] to analyze and save testing results on [rgb(106,0,255)]Confident AI[/rgb(106,0,255)].\n\n",
+                    )
 
     def get_latest_test_run_data(self) -> Optional[TestRun]:
         try:

--- a/deepeval/utils.py
+++ b/deepeval/utils.py
@@ -11,7 +11,9 @@ import nest_asyncio
 import uuid
 import math
 import logging
+import pydantic
 
+from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import Enum
 from importlib import import_module
@@ -29,11 +31,29 @@ from deepeval.config.utils import (
     set_env_bool,
 )
 
+
+_evaluation_output_suppressed: ContextVar[bool] = ContextVar(
+    "deepeval_evaluation_output_suppressed", default=False
+)
+
+
+@contextmanager
+def suppress_evaluation_output():
+    """Temporarily suppress terminal output owned by an evaluation run."""
+    token = _evaluation_output_suppressed.set(True)
+    try:
+        yield
+    finally:
+        _evaluation_output_suppressed.reset(token)
+
+
+def should_print_evaluation_output() -> bool:
+    return not _evaluation_output_suppressed.get()
+
+
 #####################
 # Pydantic Compat   #
 #####################
-
-import pydantic
 
 PYDANTIC_V2 = pydantic.VERSION.startswith("2")
 
@@ -482,7 +502,8 @@ def delete_file_if_exists(file_path):
         if os.path.exists(file_path):
             os.remove(file_path)
     except Exception as e:
-        print(f"An error occurred: {e}")
+        if should_print_evaluation_output():
+            print(f"An error occurred: {e}")
 
 
 def softmax(x):

--- a/docs/content/docs/evaluation-flags-and-configs.mdx
+++ b/docs/content/docs/evaluation-flags-and-configs.mdx
@@ -83,7 +83,7 @@ Metrics for a given test case are dispatched concurrently up to `maxConcurrent`,
 
 ### Display Configs
 
-The `DisplayConfig` controls how results and intermediate execution steps are displayed during `evaluate()`.
+The `DisplayConfig` controls how results and intermediate execution steps are displayed during `evaluate()` and `evals_iterator()`.
 
 <Switch>
 
@@ -101,7 +101,7 @@ There are **TEN** optional parameters when creating a `DisplayConfig`:
 - [Optional] `verbose_mode`: a optional boolean which when **IS NOT** `None`, overrides each [metric's `verbose_mode` value](/docs/metrics-introduction#debugging-a-metric). Defaulted to `None`.
 - [Optional] `display`: a str of either `"all"`, `"failing"` or `"passing"`, which allows you to selectively decide which type of test cases to display as the final result. Defaulted to `"all"`.
 - [Optional] `show_indicator`: a boolean which when set to `True`, shows the evaluation progress indicator for each individual metric. Defaulted to `True`.
-- [Optional] `print_results`: a boolean which when set to `True`, prints the result of each evaluation. Defaulted to `True`.
+- [Optional] `print_results`: the master switch for user-facing terminal output. Set it to `False` to suppress result tables, progress indicators, metric verbose logs, completion messages, and the interactive inspect prompt. Persistence, uploads, and other non-terminal side effects still run. Defaulted to `True`.
 - [Optional] `results_folder`: a string path to a directory where each call to `evaluate()` (or `evals_iterator()`) will be persisted as a `test_run_<YYYYMMDD_HHMMSS>.json` file. Defaulted to `None` (no local save). See [Saving test runs locally](#saving-test-runs-locally) below.
 - [Optional] `results_subfolder`: an optional string that, when set together with `results_folder`, nests the `test_run_*.json` files under `results_folder/results_subfolder/`. Defaulted to `None` (flat layout).
 - [Optional] `truncate_passing_cases`: a boolean which when set to `True`, truncates the terminal output of passing test cases. Defaulted to `True`.

--- a/tests/test_core/test_evaluation/test_end_to_end/test_skip_reset.py
+++ b/tests/test_core/test_evaluation/test_end_to_end/test_skip_reset.py
@@ -141,6 +141,9 @@ class TestSkipResetTrue:
                 async_config=_QUIET_ASYNC,
             )
             mock_wrap_up.assert_called_once()
+            args, kwargs = mock_wrap_up.call_args
+            assert len(args) == 1
+            assert kwargs == {"display_table": False}
 
     def test_skip_reset_true_returns_no_confident_link(self):
         result = evaluate(

--- a/tests/test_core/test_evaluation/test_local_store.py
+++ b/tests/test_core/test_evaluation/test_local_store.py
@@ -1,6 +1,7 @@
 """Unit + integration tests for deepeval/evaluate/local_store.py."""
 
 import json
+import importlib
 import re
 import threading
 from pathlib import Path
@@ -18,6 +19,9 @@ from deepeval.test_run.test_run import (
     TestRun as _TestRun,
     TestRunManager as _TestRunManager,
 )
+
+
+_local_store_module = importlib.import_module("deepeval.evaluate.local_store")
 
 
 FILENAME_RE = re.compile(r"^test_run_\d{8}_\d{6}(?:_(\d+))?\.json$")
@@ -190,6 +194,38 @@ class TestTestRunManagerLocalStoreIntegration:
 
         files = list(tmp_path.glob("test_run_*.json"))
         assert len(files) == 1
+
+    def test_quiet_save_still_writes_without_output(
+        self, tmp_path: Path, capsys
+    ):
+        mgr = _TestRunManager()
+        mgr.set_test_run(_make_test_run(hyperparameters={"t": 0}))
+        mgr.configure_local_store(results_folder=str(tmp_path))
+
+        mgr.save_test_run_locally(print_results=False)
+
+        assert len(list(tmp_path.glob("test_run_*.json"))) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_quiet_save_suppresses_rolling_snapshot_error(
+        self, monkeypatch, capsys
+    ):
+        mgr = _TestRunManager()
+        mgr.set_test_run(_make_test_run(hyperparameters={"t": 0}))
+        monkeypatch.delenv("DEEPEVAL_RESULTS_FOLDER", raising=False)
+
+        def fail_dump(*args, **kwargs):
+            raise OSError("read-only test path")
+
+        monkeypatch.setattr(_local_store_module, "_dump", fail_dump)
+
+        mgr.save_test_run_locally(print_results=False)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
 
     def test_subfolder_nests(self, tmp_path: Path):
         mgr = _TestRunManager()

--- a/tests/test_core/test_evaluation/test_print_results.py
+++ b/tests/test_core/test_evaluation/test_print_results.py
@@ -1,0 +1,372 @@
+"""Regression tests for DisplayConfig.print_results output control."""
+
+import asyncio
+import importlib
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from deepeval.dataset import EvaluationDataset, Golden
+from deepeval.evaluate import evaluate
+from deepeval.evaluate.configs import AsyncConfig, DisplayConfig, ErrorConfig
+from deepeval.evaluate.execute._common import _log_gather_timeout
+from deepeval.evaluate.inspect_prompt import _should_prompt
+from deepeval.metrics import BaseMetric, ExactMatchMetric
+from deepeval.test_case import LLMTestCase
+from deepeval.test_run import global_test_run_manager
+from deepeval.utils import (
+    should_print_evaluation_output,
+    suppress_evaluation_output,
+)
+
+
+class _AlwaysPassMetric(BaseMetric):
+    """Deterministic metric that always scores 1.0. No LLM calls."""
+
+    def __init__(self):
+        self.threshold = 0.5
+        self.strict_mode = False
+
+    @property
+    def __name__(self):
+        return "AlwaysPass"
+
+    def measure(self, test_case):
+        self.success = True
+        self.score = 1.0
+        return self.score
+
+    async def a_measure(self, test_case):
+        return self.measure(test_case)
+
+    def is_successful(self):
+        return self.success
+
+
+class _AlwaysFailMetric(_AlwaysPassMetric):
+    def measure(self, test_case, *args, **kwargs):
+        raise RuntimeError("simulated metric failure")
+
+    async def a_measure(self, test_case, *args, **kwargs):
+        raise RuntimeError("simulated metric failure")
+
+
+_QUIET_DISPLAY = DisplayConfig(print_results=False)
+_QUIET_ASYNC = AsyncConfig(run_async=False)
+_evaluate_module = importlib.import_module("deepeval.evaluate.evaluate")
+_execute_module = importlib.import_module("deepeval.evaluate.execute")
+_inspect_prompt_module = importlib.import_module(
+    "deepeval.evaluate.inspect_prompt"
+)
+
+
+def _make_case(label: str) -> LLMTestCase:
+    return LLMTestCase(input=f"input-{label}", actual_output=f"output-{label}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_test_run_manager():
+    global_test_run_manager.reset()
+    yield
+    global_test_run_manager.reset()
+
+
+class TestPrintResults:
+    @pytest.mark.parametrize("run_async", [False, True])
+    def test_false_suppresses_all_output(self, capsys, run_async):
+        display_config = DisplayConfig(print_results=False)
+        evaluate(
+            test_cases=[_make_case("quiet")],
+            metrics=[_AlwaysPassMetric()],
+            display_config=display_config,
+            async_config=AsyncConfig(run_async=run_async),
+        )
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+        assert display_config.show_indicator is True
+
+    def test_true_preserves_default_output(self, capsys):
+        evaluate(
+            test_cases=[_make_case("visible")],
+            metrics=[_AlwaysPassMetric()],
+            display_config=DisplayConfig(
+                show_indicator=False, print_results=True
+            ),
+            async_config=_QUIET_ASYNC,
+        )
+
+        captured = capsys.readouterr()
+        assert "Evaluation completed" in captured.out
+
+    def test_false_overrides_metric_verbose_output(self, capsys):
+        metric = ExactMatchMetric(verbose_mode=True)
+        test_case = LLMTestCase(
+            input="input",
+            actual_output="same",
+            expected_output="same",
+        )
+        evaluate(
+            test_cases=[test_case],
+            metrics=[metric],
+            display_config=DisplayConfig(
+                print_results=False, verbose_mode=True
+            ),
+            async_config=_QUIET_ASYNC,
+        )
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+        assert metric.verbose_mode is True
+
+        evaluate(
+            test_cases=[test_case],
+            metrics=[metric],
+            display_config=DisplayConfig(show_indicator=False),
+            async_config=_QUIET_ASYNC,
+        )
+        assert "Exact Match Verbose Logs" in capsys.readouterr().out
+
+    def test_false_suppresses_evaluation_owned_logging(self, caplog):
+        caplog.set_level(logging.INFO, logger="deepeval.metrics.indicator")
+
+        evaluate(
+            test_cases=[_make_case("failing")],
+            metrics=[_AlwaysFailMetric()],
+            display_config=_QUIET_DISPLAY,
+            async_config=AsyncConfig(run_async=True),
+            error_config=ErrorConfig(ignore_errors=True),
+        )
+
+        indicator_records = [
+            record
+            for record in caplog.records
+            if record.name == "deepeval.metrics.indicator"
+        ]
+        assert indicator_records == []
+
+    def test_quiet_async_iterator_callback_ignores_caller_context(
+        self, caplog, settings
+    ):
+        """Task callbacks stay quiet after the iterator yields to user code."""
+        with settings.edit(persist=False):
+            settings.DEEPEVAL_DEBUG_ASYNC = True
+
+        logger_name = "deepeval.evaluate.execute"
+        caplog.set_level(logging.INFO, logger=logger_name)
+        loop = asyncio.new_event_loop()
+
+        try:
+            asyncio.set_event_loop(loop)
+            iterator = _execute_module.a_execute_agentic_test_cases_from_loop(
+                goldens=[Golden(input="quiet callback")],
+                trace_metrics=[_AlwaysPassMetric()],
+                test_results=[],
+                loop=loop,
+                display_config=DisplayConfig(
+                    show_indicator=False, print_results=False
+                ),
+                async_config=AsyncConfig(run_async=True),
+                error_config=ErrorConfig(
+                    ignore_errors=True, skip_on_missing_params=True
+                ),
+            )
+
+            golden = next(iterator)
+            assert should_print_evaluation_output() is True
+
+            async def failing_app(_):
+                raise RuntimeError("quiet callback failure")
+
+            task = asyncio.create_task(failing_app(golden.input))
+            try:
+                iterator.send(task)
+            except StopIteration:
+                pass
+            for _ in iterator:
+                pass
+
+            evaluation_records = [
+                record
+                for record in caplog.records
+                if record.name.startswith(logger_name)
+            ]
+            assert evaluation_records == []
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+    def test_output_context_suppresses_timeout_logging(self, caplog):
+        logger = logging.getLogger("deepeval.tests.quiet_timeout")
+        caplog.set_level(logging.WARNING, logger=logger.name)
+
+        with suppress_evaluation_output():
+            _log_gather_timeout(logger, pending=1)
+
+        assert [
+            record for record in caplog.records if record.name == logger.name
+        ] == []
+
+        _log_gather_timeout(logger, pending=1)
+        assert (
+            len(
+                [
+                    record
+                    for record in caplog.records
+                    if record.name == logger.name
+                ]
+            )
+            == 1
+        )
+
+    def test_false_disables_tty_inspect_prompt(self, tmp_path, monkeypatch):
+        saved_path = tmp_path / "run.json"
+        saved_path.write_text("{}", encoding="utf-8")
+        manager = SimpleNamespace(
+            last_saved_path=saved_path,
+            test_run=SimpleNamespace(
+                test_cases=[SimpleNamespace(trace=object())]
+            ),
+        )
+        monkeypatch.delenv("DEEPEVAL_NO_INSPECT_PROMPT", raising=False)
+        monkeypatch.setattr(
+            _inspect_prompt_module.sys.stdout, "isatty", lambda: True
+        )
+
+        assert _should_prompt(manager, _QUIET_DISPLAY) is False
+
+    def test_metric_collection_quiet_mode_suppresses_confirmation(
+        self, monkeypatch, capsys
+    ):
+        class FakeApi:
+            def send_request(self, **kwargs):
+                return {}, "https://example.test/evaluations/quiet"
+
+        opened_links = []
+        monkeypatch.setattr(_evaluate_module, "Api", FakeApi)
+        monkeypatch.setattr(
+            _evaluate_module, "open_browser", opened_links.append
+        )
+
+        evaluate(
+            test_cases=[_make_case("metric-collection")],
+            metric_collection="collection-123",
+            display_config=_QUIET_DISPLAY,
+        )
+
+        assert opened_links == ["https://example.test/evaluations/quiet"]
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    @pytest.mark.parametrize("run_async", [False, True])
+    def test_evals_iterator_uses_derived_config_without_muting_caller(
+        self, monkeypatch, capsys, run_async
+    ):
+        supplied_config = DisplayConfig(print_results=False, verbose_mode=True)
+        metric = ExactMatchMetric(verbose_mode=True)
+        seen_configs = []
+        internal_output_states = []
+
+        def fake_execute_agentic_test_cases_from_loop(
+            *, goldens, trace_metrics, display_config, **kwargs
+        ):
+            seen_configs.append(display_config)
+            for golden in goldens:
+                internal_output_states.append(should_print_evaluation_output())
+                yield golden
+                internal_output_states.append(should_print_evaluation_output())
+
+        execute_name = (
+            "a_execute_agentic_test_cases_from_loop"
+            if run_async
+            else "execute_agentic_test_cases_from_loop"
+        )
+        monkeypatch.setattr(
+            _execute_module,
+            execute_name,
+            fake_execute_agentic_test_cases_from_loop,
+        )
+        dataset = EvaluationDataset(goldens=[Golden(input="input")])
+        legacy_wrap_calls = []
+
+        def legacy_wrap_up(run_duration, display_table=True):
+            legacy_wrap_calls.append(
+                (
+                    run_duration,
+                    display_table,
+                    should_print_evaluation_output(),
+                )
+            )
+
+        with patch.object(
+            global_test_run_manager,
+            "wrap_up_test_run",
+            side_effect=legacy_wrap_up,
+        ) as mock_wrap_up:
+            iterator = dataset.evals_iterator(
+                metrics=[metric],
+                display_config=supplied_config,
+                async_config=AsyncConfig(run_async=run_async),
+            )
+            yielded = [next(iterator)]
+            assert should_print_evaluation_output() is True
+            print("caller output remains visible")
+            with pytest.raises(StopIteration):
+                next(iterator)
+
+        assert len(yielded) == 1
+        assert internal_output_states == [False, False]
+        assert seen_configs[0].show_indicator is False
+        assert seen_configs[0].verbose_mode is True
+        assert supplied_config.show_indicator is True
+        assert supplied_config.verbose_mode is True
+        assert metric.verbose_mode is True
+        _, kwargs = mock_wrap_up.call_args
+        assert kwargs == {"display_table": False}
+        assert len(legacy_wrap_calls) == 1
+        assert legacy_wrap_calls[0][0] >= 0
+        assert legacy_wrap_calls[0][1:] == (False, False)
+        captured = capsys.readouterr()
+        assert captured.out == "caller output remains visible\n"
+        assert captured.err == ""
+
+    def test_evals_iterator_suppresses_span_metric_verbose_logs(
+        self, monkeypatch, capsys
+    ):
+        span_metric = ExactMatchMetric(verbose_mode=True)
+        test_case = LLMTestCase(
+            input="input",
+            actual_output="same",
+            expected_output="same",
+        )
+
+        def fake_execute_agentic_test_cases_from_loop(*, goldens, **kwargs):
+            span_metric.measure(test_case, _show_indicator=False)
+            yield from goldens
+
+        monkeypatch.setattr(
+            _execute_module,
+            "execute_agentic_test_cases_from_loop",
+            fake_execute_agentic_test_cases_from_loop,
+        )
+        dataset = EvaluationDataset(goldens=[Golden(input="input")])
+        with patch.object(
+            global_test_run_manager, "wrap_up_test_run", return_value=None
+        ):
+            list(
+                dataset.evals_iterator(
+                    metrics=None,
+                    display_config=DisplayConfig(print_results=False),
+                    async_config=_QUIET_ASYNC,
+                )
+            )
+
+        assert span_metric.verbose_mode is True
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""

--- a/tests/test_core/test_run/test_run_manager.py
+++ b/tests/test_core/test_run/test_run_manager.py
@@ -2,11 +2,15 @@ import os
 import portalocker
 
 import deepeval.test_run.test_run as tr_mod
+import deepeval.test_run.cache as cache_mod
+import deepeval.utils as utils_mod
 
 from types import SimpleNamespace
 
 from deepeval.test_case import LLMTestCase
 from deepeval.test_run.test_run import TestRunManager, LLMApiTestCase
+from deepeval.test_run.cache import CachedTestRun
+from deepeval.utils import suppress_evaluation_output
 from tests.test_core.helpers import _make_fake_portalocker
 from tests.test_core.stubs import RecordingPortalockerLock
 
@@ -150,3 +154,141 @@ def test_save_test_run_with_save_under_key_flushes_and_syncs(
         fsync_calls
     ), "save_test_run(..., save_under_key=...) should call os.fsync(file.fileno())"
     assert fsync_calls[-1] == f.fileno()
+
+
+def test_post_test_run_quiet_mode_uploads_without_output(monkeypatch, capsys):
+    class FakeApi:
+        def send_request(self, **kwargs):
+            return {"id": "run-123"}, "https://example.test/runs/run-123"
+
+    manager = TestRunManager()
+    test_run = tr_mod.TestRun(
+        testCases=[
+            LLMApiTestCase(
+                name="quiet-upload",
+                input="input",
+                actualOutput="output",
+                success=True,
+                metricsData=[],
+            )
+        ]
+    )
+    saved_links = []
+    opened_links = []
+    monkeypatch.setattr(tr_mod, "Api", FakeApi)
+    monkeypatch.setattr(manager, "save_final_test_run_link", saved_links.append)
+    monkeypatch.setattr(tr_mod, "open_browser", opened_links.append)
+
+    result = manager.post_test_run(test_run, print_results=False)
+
+    assert result == ("https://example.test/runs/run-123", "run-123")
+    assert saved_links == ["https://example.test/runs/run-123"]
+    assert opened_links == ["https://example.test/runs/run-123"]
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_quiet_wrap_up_supports_legacy_manager_override_signatures(
+    monkeypatch, capsys
+):
+    class LegacyManager(TestRunManager):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def save_test_run_locally(self):
+            self.calls.append("save")
+
+        def post_test_run(self, test_run):
+            self.calls.append("post")
+            return "https://example.test/runs/legacy", "legacy-run"
+
+    manager = LegacyManager()
+    manager.set_test_run(
+        tr_mod.TestRun(
+            testCases=[
+                LLMApiTestCase(
+                    name="legacy-override",
+                    input="input",
+                    actualOutput="output",
+                    success=True,
+                    metricsData=[],
+                )
+            ]
+        )
+    )
+    monkeypatch.setattr(tr_mod, "is_confident", lambda: True)
+    monkeypatch.setattr(tr_mod, "delete_file_if_exists", lambda path: None)
+    monkeypatch.setattr(
+        tr_mod.global_test_run_cache_manager,
+        "wrap_up_cached_test_run",
+        lambda: None,
+    )
+
+    result = manager.wrap_up_test_run(
+        0.1, display_table=False, print_results=False
+    )
+
+    assert result == ("https://example.test/runs/legacy", "legacy-run")
+    assert manager.calls == ["save", "post"]
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_quiet_wrap_up_suppresses_temp_file_delete_error(
+    tmp_path, monkeypatch, capsys
+):
+    temp_path = tmp_path / "temp-run.json"
+    temp_path.write_text("{}", encoding="utf-8")
+    manager = TestRunManager()
+    manager.temp_file_path = str(temp_path)
+    manager.set_test_run(tr_mod.TestRun())
+
+    def fail_to_remove(path):
+        raise OSError("simulated delete failure")
+
+    monkeypatch.setattr(utils_mod.os, "remove", fail_to_remove)
+
+    manager.wrap_up_test_run(0.1, display_table=False, print_results=False)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    utils_mod.delete_file_if_exists(temp_path)
+    assert "simulated delete failure" in capsys.readouterr().out
+
+
+def test_evaluation_output_context_suppresses_cache_io_error(
+    monkeypatch, capsys
+):
+    class FailingLock:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            raise OSError("simulated cache failure")
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    manager = cache_mod.TestRunCacheManager()
+    manager.disable_write_cache = False
+    manager.cached_test_run = CachedTestRun()
+    monkeypatch.setattr(
+        cache_mod,
+        "portalocker",
+        SimpleNamespace(Lock=FailingLock),
+    )
+
+    with suppress_evaluation_output():
+        manager.save_cached_test_run()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    manager.save_cached_test_run()
+    assert "simulated cache failure" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #769.

## Problem

`DisplayConfig(print_results=False)` currently suppresses the final result table, but several other DeepEval-owned output paths remain active. Depending on the evaluation path, callers can still see metric banners and progress indicators, verbose metric logs, completion and login prompts, local persistence or cache diagnostics, upload confirmations, the interactive inspect prompt, and evaluation logger messages.

This makes `evaluate()` and `EvaluationDataset.evals_iterator()` difficult to embed in applications that own their terminal or logging output.

## Changes

- Treat `print_results=False` as the output control for both `evaluate()` and `evals_iterator()`.
- Derive a display config with progress indicators disabled without mutating the caller-supplied `DisplayConfig`.
- Use scoped evaluation-output state so nested metric, cache, persistence, and finalization paths can honor quiet mode without changing their functional side effects.
- Suppress DeepEval-owned verbose logs and evaluation logger messages while quiet mode is active.
- Keep persistence, cache finalization, Confident AI uploads, saved links, and browser-opening behavior unchanged.
- Suppress completion messages, upload confirmations, local-save diagnostics, and the post-run inspect prompt.
- Preserve compatibility with existing `TestRunManager` subclasses whose overrides use the previous method signatures.
- Advance the internal `evals_iterator()` generator under quiet state without leaking that state into caller code between yielded goldens.
- Gate async iterator task-callback diagnostics directly on the run's display config, including after control has returned to caller code.
- Remove the stray evaluation debug log and validation debug print.
- Document `print_results` as the evaluation-output switch.

## Verification

- `pytest -q tests/test_core/test_evaluation/test_print_results.py` — 12 passed.
- `pytest -q tests/test_core/test_evaluation tests/test_core/test_run` — 198 passed, 18 skipped.
- Black 25.12.0 on all 19 changed Python files — passed.
- Ruff 0.13.0 on the changed implementation and test files — passed. Two touched files retain five pre-existing F401 findings and pass the same check with F401 excluded.
- `git diff --check` — passed.
- A broader `pytest -q tests/test_core` run completed with 1418 passed and 62 skipped. Its 21 failures require optional local dependencies or services unavailable in this environment: pandas-backed dataset tests, document chunker integrations, and the local Ollama embedding client. None are in the touched evaluation/test-run paths.

The regression coverage includes synchronous and asynchronous `evaluate()`, failing async metrics, verbose metric output, cache and persistence error paths, upload side effects, TTY inspect prompting, legacy `TestRunManager` overrides, and both synchronous and asynchronous iterator context boundaries.

## CI status

All 12 executable title, test, and integration checks passed on this head. The repository-wide Black job remains red only because it would reformat `.scripts/release.py`, which this PR does not modify; the same lint workflow is already failing on the exact base `main` SHA ([base run](https://github.com/confident-ai/deepeval/actions/runs/33154525461)). Vercel separately reports that fork deployment authorization is required.

## Related open work

PR #3044 adds a pytest terminal-summary renderer and will need to preserve each run's `print_results` intent if it is merged later. PR #2910 touches the same async-loop cleanup area and may require a small rebase, but its exception-propagation fix is independent of this change.
