### PR TITLE
feat(metrics): add SetMatchMetric community metric

### DIFF
--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,9 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .set_match.set_match import SetMatchMetric
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "SetMatchMetric",
 ]

--- a/deepeval/metrics/community/set_match/__init__.py
+++ b/deepeval/metrics/community/set_match/__init__.py
@@ -1,0 +1,3 @@
+from .set_match import SetMatchMetric
+
+__all__ = ["SetMatchMetric"]

--- a/deepeval/metrics/community/set_match/set_match.py
+++ b/deepeval/metrics/community/set_match/set_match.py
@@ -1,0 +1,191 @@
+import json
+import re
+from typing import List, Optional, Set
+
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.utils import (
+    check_llm_test_case_params,
+    construct_verbose_logs,
+)
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+
+# Default separators used to split a plain-text list into items: commas,
+# semicolons, and newlines. A leading bullet or numbered-list marker is
+# stripped from each item after splitting.
+_DEFAULT_SPLIT_RE = re.compile(r"[,\n;]+")
+_LIST_MARKER_RE = re.compile(r"^\s*(?:[-*\u2022]|\d+[.)])\s*")
+
+
+class SetMatchMetric(BaseMetric):
+    """Order-insensitive set agreement between ``actual_output`` and
+    ``expected_output``.
+
+    ``ExactMatchMetric`` compares whole strings, so a multi-item answer is
+    silently scored wrong whenever the order differs, an item is duplicated,
+    or spacing/case varies (``"apple, banana"`` vs ``"Banana and apple"``),
+    even though the underlying set of answers is identical. ``SetMatchMetric``
+    parses both fields into a set of normalized items and scores their overlap
+    with precision, recall, or F1.
+
+    The metric is deterministic and uses no judge model, so it is reproducible
+    and adds no evaluation cost. When ``expected_output`` parses to no items
+    the metric is not applicable and raises ``ValueError`` rather than
+    fabricating a ``0.0`` or ``1.0``.
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+        SingleTurnParams.EXPECTED_OUTPUT,
+    ]
+
+    def __init__(
+        self,
+        threshold: Optional[float] = 1.0,
+        mode: str = "f1",
+        case_sensitive: bool = False,
+        parse_json_arrays: bool = True,
+        include_reason: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+    ):
+        if mode not in ("f1", "recall", "precision"):
+            raise ValueError(
+                "`mode` must be one of 'f1', 'recall', or 'precision', "
+                f"got {mode!r}."
+            )
+        self.threshold = 1.0 if strict_mode else threshold
+        self.mode = mode
+        self.case_sensitive = case_sensitive
+        self.parse_json_arrays = parse_json_arrays
+        self.include_reason = include_reason
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+        self.flaky = flaky
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            None,
+            test_case.multimodal,
+        )
+
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            expected = self._parse_items(test_case.expected_output)
+            if not expected:
+                raise ValueError(
+                    "`expected_output` parses to no items, so "
+                    "SetMatchMetric cannot score this test case. Use "
+                    "ExactMatchMetric or an LLM-judged metric for "
+                    "non-list references."
+                )
+            actual = self._parse_items(test_case.actual_output)
+
+            matched = expected & actual
+            missing = expected - actual
+            extra = actual - expected
+            self.score = self._score(len(matched), len(expected), len(actual))
+            self.reason = self._generate_reason(matched, missing, extra)
+            self.success = self.is_successful()
+
+            if self.verbose_mode:
+                self.verbose_logs = construct_verbose_logs(
+                    self,
+                    steps=[
+                        f"Expected items: {self._format_items(expected)}",
+                        f"Actual items: {self._format_items(actual)}",
+                        f"Mode: {self.mode}",
+                        f"Score: {self.score:.2f}",
+                        f"Reason: {self.reason}",
+                    ],
+                )
+
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        return self.measure(
+            test_case,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        )
+
+    def _parse_items(self, text: str) -> Set[str]:
+        items: Set[str] = set()
+        for raw in self._split(text):
+            normalized = self._normalize(raw)
+            if normalized:
+                items.add(normalized)
+        return items
+
+    def _split(self, text: str) -> List[str]:
+        stripped = text.strip()
+        if self.parse_json_arrays and stripped.startswith("["):
+            try:
+                loaded = json.loads(stripped)
+            except ValueError:
+                loaded = None
+            if isinstance(loaded, list):
+                return [self._stringify(element) for element in loaded]
+        return _DEFAULT_SPLIT_RE.split(text)
+
+    @staticmethod
+    def _stringify(element) -> str:
+        if isinstance(element, str):
+            return element
+        return json.dumps(element, sort_keys=True)
+
+    def _normalize(self, item: str) -> str:
+        cleaned = _LIST_MARKER_RE.sub("", item).strip()
+        if not self.case_sensitive:
+            cleaned = cleaned.lower()
+        return cleaned
+
+    def _score(self, matched: int, n_expected: int, n_actual: int) -> float:
+        recall = matched / n_expected if n_expected else 0.0
+        precision = matched / n_actual if n_actual else 0.0
+        if self.mode == "recall":
+            return recall
+        if self.mode == "precision":
+            return precision
+        if precision + recall == 0.0:
+            return 0.0
+        return 2 * precision * recall / (precision + recall)
+
+    def _generate_reason(
+        self, matched: Set[str], missing: Set[str], extra: Set[str]
+    ) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+        parts = [f"Matched {len(matched)} item(s); mode={self.mode}."]
+        if missing:
+            parts.append(f"Missing from output: {self._format_items(missing)}.")
+        if extra:
+            parts.append(f"Extra in output: {self._format_items(extra)}.")
+        return " ".join(parts)
+
+    @staticmethod
+    def _format_items(items: Set[str]) -> str:
+        return "{" + ", ".join(repr(item) for item in sorted(items)) + "}"
+
+    @property
+    def __name__(self):
+        return "Set Match"

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "community-metrics-overview",
     "metrics-citation-faithfulness",
+    "metrics-set-match",
     "metrics-agent-loop-detection",
     "metrics-tool-permission"
   ]

--- a/docs/content/docs/(community)/metrics-set-match.mdx
+++ b/docs/content/docs/(community)/metrics-set-match.mdx
@@ -1,0 +1,72 @@
+---
+id: metrics-set-match
+title: Set Match
+sidebar_label: Set Match
+languages: [python]
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} referenceless={false} />
+
+The set match metric checks whether the items in your LLM's `actual_output` agree as a set with the items in `expected_output`, independent of order, duplication, and surface formatting. It is deterministic and uses no judge model, so it is reproducible and adds no evaluation cost.
+
+:::info
+The `SetMatchMetric` is a **community metric**, contributed and maintained by the `deepeval` community. Community metrics are not exported from `deepeval.metrics`, so import them explicitly from `deepeval.metrics.community` instead.
+:::
+
+:::note
+This metric complements [`ExactMatchMetric`](/docs/metrics-others), which compares whole strings. A multi-item answer is silently scored wrong by string matching whenever the order differs, an item is duplicated, or spacing and case vary (`"apple, banana"` vs `"Banana and apple"`), even though the underlying set is identical. `SetMatchMetric` parses both fields into normalized item sets and scores their overlap.
+:::
+
+## Required Arguments
+
+To use the `SetMatchMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
+
+- `input`
+- `actual_output`
+- `expected_output`
+
+Items are parsed by splitting on commas, semicolons, and newlines (a JSON array is parsed directly when the field is one), stripping any leading bullet or numbered-list marker, and normalizing case unless `case_sensitive` is set. When `expected_output` parses to no items the metric is not applicable and raises `ValueError` rather than returning a fabricated score.
+
+## Usage
+
+```python
+from deepeval import evaluate
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.community import SetMatchMetric
+
+metric = SetMatchMetric()
+test_case = LLMTestCase(
+    input="Which countries border Germany?",
+    # Same set as the reference, different order, casing, and delimiter.
+    actual_output="Poland, FRANCE, Austria, Belgium",
+    expected_output="Belgium, Austria; France, Poland",
+)
+
+# To run the metric as a standalone
+# metric.measure(test_case)
+# print(metric.score, metric.reason)
+
+evaluate(test_cases=[test_case], metrics=[metric])
+```
+
+## Parameters
+
+- `threshold`: the minimum score for the test case to pass. Defaulted to `1.0`, so the sets must match exactly.
+- `mode`: which overlap statistic to report, one of `"f1"`, `"recall"`, or `"precision"`. Defaulted to `"f1"`. Use `"recall"` to ask only whether every reference item appears, or `"precision"` to penalize extra items.
+- `case_sensitive`: when `True`, items are compared without lowercasing. Defaulted to `False`.
+- `parse_json_arrays`: when `True`, a field that is a JSON array (`["a", "b"]`) is parsed as its elements rather than split on punctuation. Defaulted to `True`.
+- `include_reason`: whether to build a reason listing matched, missing, and extra items. Defaulted to `True`.
+- `strict_mode`: forces the threshold to `1.0`. Defaulted to `False`.
+- `verbose_mode`: prints the parsed item sets and score. Defaulted to `False`.
+
+## How Is It Calculated?
+
+The metric parses `expected_output` and `actual_output` into normalized item sets, then counts the matched items (the set intersection). With `matched`, the reference size `|expected|`, and the output size `|actual|`:
+
+```
+precision = matched / |actual|
+recall    = matched / |expected|
+f1        = 2 * precision * recall / (precision + recall)
+```
+
+The reported score is whichever of these `mode` selects. The default `mode="f1"` with `threshold=1.0` passes only when the two sets are identical after normalization.

--- a/tests/test_metrics/test_set_match_metric.py
+++ b/tests/test_metrics/test_set_match_metric.py
@@ -1,0 +1,159 @@
+"""Deterministic, key-free tests for the community SetMatchMetric."""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics.community import SetMatchMetric
+from deepeval.test_case import LLMTestCase
+
+
+def _case(actual: str, expected: str) -> LLMTestCase:
+    return LLMTestCase(
+        input="List the items.",
+        actual_output=actual,
+        expected_output=expected,
+    )
+
+
+def test_order_insensitive_exact_match():
+    metric = SetMatchMetric()
+    score = metric.measure(_case("banana, apple", "apple, banana"))
+    assert score == 1.0
+    assert metric.success is True
+
+
+def test_case_insensitive_by_default():
+    metric = SetMatchMetric()
+    assert metric.measure(_case("Apple, BANANA", "apple, banana")) == 1.0
+
+
+def test_case_sensitive_flag_distinguishes():
+    metric = SetMatchMetric(mode="recall", case_sensitive=True)
+    # "Apple" != "apple" under case sensitivity, so only "banana" matches.
+    assert metric.measure(_case("Apple, banana", "apple, banana")) == 0.5
+
+
+def test_whitespace_is_stripped():
+    metric = SetMatchMetric()
+    assert metric.measure(_case("  apple ,  banana ", "apple,banana")) == 1.0
+
+
+def test_duplicates_do_not_change_set():
+    metric = SetMatchMetric()
+    assert metric.measure(_case("apple, apple, banana", "apple, banana")) == 1.0
+
+
+def test_semicolon_and_newline_delimiters():
+    metric = SetMatchMetric()
+    assert (
+        metric.measure(_case("apple; banana\ncherry", "apple, banana, cherry"))
+        == 1.0
+    )
+
+
+def test_bullet_and_number_markers_stripped():
+    metric = SetMatchMetric()
+    actual = "- apple\n- banana\n- cherry"
+    expected = "1. apple\n2. banana\n3. cherry"
+    assert metric.measure(_case(actual, expected)) == 1.0
+
+
+def test_json_array_parsing():
+    metric = SetMatchMetric()
+    assert metric.measure(_case('["apple", "banana"]', "banana, apple")) == 1.0
+
+
+def test_json_array_parsing_can_be_disabled():
+    metric = SetMatchMetric(parse_json_arrays=False)
+    # With JSON parsing off the brackets/quotes stay part of the tokens, so
+    # the sets do not line up and the score drops below 1.0.
+    assert metric.measure(_case('["apple", "banana"]', "apple, banana")) < 1.0
+
+
+def test_partial_overlap_f1():
+    metric = SetMatchMetric()
+    # expected {a,b,c,d}, actual {a,b,x}: matched 2.
+    # recall=0.5, precision=2/3, f1=2*pr/(p+r).
+    score = metric.measure(_case("a, b, x", "a, b, c, d"))
+    assert score == pytest.approx(0.5714285714, abs=1e-6)
+
+
+def test_mode_recall():
+    metric = SetMatchMetric(mode="recall")
+    assert metric.measure(_case("a, b, x", "a, b, c, d")) == 0.5
+
+
+def test_mode_precision():
+    metric = SetMatchMetric(mode="precision")
+    assert metric.measure(_case("a, b, x", "a, b, c, d")) == pytest.approx(
+        2 / 3
+    )
+
+
+def test_extra_items_lower_precision_not_recall():
+    recall_metric = SetMatchMetric(mode="recall")
+    precision_metric = SetMatchMetric(mode="precision")
+    case = _case("apple, banana, cherry, extra", "apple, banana, cherry")
+    assert recall_metric.measure(case) == 1.0
+    assert precision_metric.measure(case) == pytest.approx(0.75)
+
+
+def test_no_overlap_scores_zero():
+    metric = SetMatchMetric()
+    assert metric.measure(_case("x, y", "a, b")) == 0.0
+    assert metric.success is False
+
+
+def test_empty_expected_raises():
+    metric = SetMatchMetric()
+    with pytest.raises(ValueError, match="no items"):
+        metric.measure(_case("apple, banana", "   "))
+
+
+def test_actual_with_no_items_scores_zero():
+    # An empty-string actual_output is rejected centrally by the framework, so
+    # this exercises the "actual parses to no items" path with whitespace.
+    metric = SetMatchMetric()
+    assert metric.measure(_case("   ", "apple, banana")) == 0.0
+    assert metric.success is False
+
+
+def test_include_reason_false():
+    metric = SetMatchMetric(include_reason=False)
+    metric.measure(_case("a, b", "a, c"))
+    assert metric.reason is None
+
+
+def test_reason_lists_missing_and_extra():
+    metric = SetMatchMetric()
+    metric.measure(_case("apple, orange", "apple, banana"))
+    assert "banana" in metric.reason  # missing from output
+    assert "orange" in metric.reason  # extra in output
+
+
+def test_threshold_controls_success():
+    metric = SetMatchMetric(threshold=0.5)
+    # f1 for {a,b,x} vs {a,b,c,d} is ~0.571, above 0.5.
+    assert metric.measure(_case("a, b, x", "a, b, c, d")) >= 0.5
+    assert metric.success is True
+
+
+def test_strict_mode_forces_threshold_one():
+    metric = SetMatchMetric(threshold=0.1, strict_mode=True)
+    assert metric.threshold == 1.0
+    metric.measure(_case("a, b, x", "a, b, c, d"))
+    assert metric.success is False
+
+
+def test_invalid_mode_raises():
+    with pytest.raises(ValueError, match="mode"):
+        SetMatchMetric(mode="jaccard")
+
+
+def test_async_parity():
+    metric = SetMatchMetric()
+    case = _case("a, b, x", "a, b, c, d")
+    sync_score = metric.measure(case)
+    async_score = asyncio.run(metric.a_measure(case))
+    assert sync_score == async_score


### PR DESCRIPTION
## Summary

Adds `SetMatchMetric`, a deterministic community metric that scores multi-item and extraction answers as a set, independent of order, duplication, case, and delimiter. `ExactMatchMetric` compares whole strings, so a correct set of answers is silently scored wrong when the order differs or an item is duplicated. `SetMatchMetric` parses both fields into normalized item sets and scores their overlap with precision, recall, or F1.

Like `NumericMatchMetric`, it uses no judge model (reproducible, zero cost) and raises `ValueError` when `expected_output` parses to no items rather than fabricating a score.

## Details

- Splits on commas, semicolons, and newlines (and parses JSON arrays), strips leading list markers, and normalizes case unless `case_sensitive` is set.
- `mode` selects `f1` (default), `recall`, or `precision`; `threshold` defaults to `1.0` (exact set match).
- Registered under `deepeval.metrics.community` with a docs page.

## Test plan

- `tests/test_metrics/test_set_match_metric.py`: 22 deterministic tests covering order/case/duplicate/delimiter robustness, JSON arrays, all three modes, threshold, empty-reference `ValueError`, and reason contents. All green; `black` clean on the new files.

Note: the repo-wide `lint` job is currently red on every open PR because `.scripts/release.py` on `main` is unformatted; that break is fixed by #3137, not by this PR. This PR's own files pass `black`.
