### PR TITLE
fix(confident): reject organization API keys with actionable error

### DIFF
--- a/deepeval/confident/api.py
+++ b/deepeval/confident/api.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import re
 from typing import Optional, Any, NamedTuple, Union, Tuple
 import aiohttp
 import requests
@@ -209,6 +210,12 @@ def _sanitize_body(obj):
     return obj
 
 
+def _is_organization_key(api_key: str) -> bool:
+    return bool(
+        re.match(r"^confident_(?:us|eu)_org_", api_key.strip(), re.IGNORECASE)
+    )
+
+
 class Api:
     def __init__(
         self,
@@ -221,6 +228,15 @@ class Api:
         if not api_key:
             raise ValueError(
                 f"No Confident API key found. Please run `deepeval login` or set the {CONFIDENT_API_KEY_ENV_VAR} environment variable in the CLI."
+            )
+
+        api_key = api_key.strip()
+        if _is_organization_key(api_key):
+            raise ConfidentApiError(
+                "Invalid API key: organization API keys cannot be used to upload test runs. "
+                "Use a project API key from Project Settings > API Keys. "
+                "Run `deepeval diagnose` to check your current key and region. "
+                "See https://confident-ai.com/docs for details."
             )
 
         self.api_key = api_key

--- a/tests/test_core/test_confident_org_key_validation.py
+++ b/tests/test_core/test_confident_org_key_validation.py
@@ -1,0 +1,58 @@
+import pytest
+from deepeval.confident.api import Api, _is_organization_key
+from deepeval.confident.types import ConfidentApiError
+
+
+def test_is_organization_key_detects_org_scope():
+    assert _is_organization_key("confident_us_org_abc123")
+    assert _is_organization_key("confident_eu_org_abc123")
+    assert _is_organization_key("CONFIDENT_US_ORG_ABC")  # case insensitive
+    assert _is_organization_key("  confident_us_org_abc123  ")  # stripped
+
+
+def test_is_organization_key_allows_project_keys():
+    assert not _is_organization_key("confident_us_proj_abc123")
+    assert not _is_organization_key("confident_eu_proj_abc123")
+    assert not _is_organization_key("confident_us_global_abc")
+    assert not _is_organization_key("random_key")
+    assert not _is_organization_key("")
+
+
+def test_api_rejects_organization_key():
+    with pytest.raises(
+        ConfidentApiError, match="organization API keys cannot be used"
+    ):
+        Api(api_key="confident_us_org_test123")
+
+    with pytest.raises(
+        ConfidentApiError, match="organization API keys cannot be used"
+    ):
+        Api(api_key="confident_eu_org_test123")
+
+
+def test_api_rejects_org_key_with_whitespace():
+    with pytest.raises(
+        ConfidentApiError, match="organization API keys cannot be used"
+    ):
+        Api(api_key="  confident_us_org_test123  ")
+
+
+def test_api_accepts_project_key(monkeypatch):
+    # Use project key - should not raise org error (may fail on network later, but init should succeed)
+    # Mock get_base_api_url to avoid network
+    monkeypatch.setattr(
+        "deepeval.confident.api.get_base_api_url",
+        lambda: "https://api.confident-ai.com",
+    )
+    api = Api(api_key="confident_us_proj_test123")
+    assert api.api_key == "confident_us_proj_test123"
+
+
+def test_api_strips_whitespace_from_key(monkeypatch):
+    monkeypatch.setattr(
+        "deepeval.confident.api.get_base_api_url",
+        lambda: "https://api.confident-ai.com",
+    )
+    api = Api(api_key="  confident_us_proj_test123  ")
+    assert api.api_key == "confident_us_proj_test123"
+    assert api._headers["CONFIDENT-API-KEY"] == "confident_us_proj_test123"


### PR DESCRIPTION
Fixes #2876

Using an organization API key (`confident_{us,eu}_org_*`) succeeds at `deepeval login` but fails at upload with a generic `Invalid API key`. This rejects those keys early with an actionable error pointing to a project API key from Project Settings > API Keys and `deepeval diagnose`.