### PR TITLE
docs: document public metric result access

### DIFF
--- a/docs/content/docs/evaluation-end-to-end-single-turn.mdx
+++ b/docs/content/docs/evaluation-end-to-end-single-turn.mdx
@@ -253,7 +253,7 @@ from deepeval import evaluate
 from deepeval.metrics import AnswerRelevancyMetric, FaithfulnessMetric
 ...
 
-evaluate(
+evaluation_result = evaluate(
     test_cases=test_cases,
     metrics=[AnswerRelevancyMetric(), FaithfulnessMetric()],
 )
@@ -268,6 +268,31 @@ There are **TWO** mandatory and **FIVE** optional parameters when calling `evalu
 - [Optional] `display_config`: a `DisplayConfig` controlling console output. See [display configs](/docs/evaluation-flags-and-configs#display-configs).
 - [Optional] `error_config`: an `ErrorConfig` controlling how errors are handled. See [error configs](/docs/evaluation-flags-and-configs#error-configs).
 - [Optional] `cache_config`: a `CacheConfig` controlling caching behavior. See [cache configs](/docs/evaluation-flags-and-configs#cache-configs).
+
+#### Read per-test-case metric results
+
+`evaluate()` returns an `EvaluationResult`. Its `test_results` attribute
+contains one `TestResult` for each evaluated case, and each test result exposes
+its metric outcomes through `metrics_data`:
+
+```python
+for test_result in evaluation_result.test_results:
+    for metric_data in test_result.metrics_data or []:
+        print(
+            test_result.input,
+            metric_data.name,
+            metric_data.score,
+            metric_data.threshold,
+            metric_data.success,
+            metric_data.reason,
+            metric_data.error,
+        )
+```
+
+Use this `EvaluationResult` → `test_results` → `metrics_data` path when an
+application needs per-case scores or reasons. If you need to retain results
+outside the current process, translate these public objects into your own
+versioned schema.
 
 </Case>
 

--- a/docs/content/docs/evaluation-flags-and-configs.mdx
+++ b/docs/content/docs/evaluation-flags-and-configs.mdx
@@ -287,6 +287,14 @@ There are **TWO** optional parameters:
 
 Results are keyed by test case content plus metric configuration, so a cached result is only reused when both are unchanged. The <Term py="write_cache" ts="writeCache"/> parameter writes to disk and so you should disable it if that is causing any errors in your environment.
 
+:::caution[Cache files are not a public API]
+The JSON files in `.deepeval` that back caching and CLI workflows are internal
+implementation details. Their names and serialized shape can change between
+releases, so do not parse them in application integrations. In Python, read
+per-case metric values from the `EvaluationResult` returned by `evaluate()`,
+using `evaluation_result.test_results` and each test result's `metrics_data`.
+:::
+
 ## Hyperparameters
 
 Log the model, prompt, and other configuration values with each test run so you can compare runs side-by-side on Confident AI and identify the best combination.

--- a/tests/test_core/test_evaluation/test_public_metric_results.py
+++ b/tests/test_core/test_evaluation/test_public_metric_results.py
@@ -1,0 +1,60 @@
+import pytest
+
+from deepeval import evaluate
+from deepeval.evaluate import AsyncConfig, CacheConfig, DisplayConfig
+from deepeval.evaluate.types import EvaluationResult
+from deepeval.metrics import ExactMatchMetric
+from deepeval.test_case import LLMTestCase
+from deepeval.test_run import global_test_run_manager
+
+
+@pytest.fixture(autouse=True)
+def _reset_test_run_manager():
+    global_test_run_manager.reset()
+    yield
+    global_test_run_manager.reset()
+
+
+def test_evaluate_exposes_per_case_metric_results_offline():
+    result = evaluate(
+        test_cases=[
+            LLMTestCase(
+                input="matching",
+                actual_output="same",
+                expected_output="same",
+            ),
+            LLMTestCase(
+                input="different",
+                actual_output="actual",
+                expected_output="expected",
+            ),
+        ],
+        metrics=[ExactMatchMetric()],
+        async_config=AsyncConfig(run_async=False),
+        cache_config=CacheConfig(write_cache=False, use_cache=False),
+        display_config=DisplayConfig(
+            show_indicator=False,
+            print_results=False,
+            inspect_after_run=False,
+        ),
+    )
+
+    assert isinstance(result, EvaluationResult)
+    assert len(result.test_results) == 2
+
+    matching_result, different_result = result.test_results
+    assert matching_result.input == "matching"
+    assert different_result.input == "different"
+    assert matching_result.metrics_data is not None
+    assert different_result.metrics_data is not None
+
+    matching_metric = matching_result.metrics_data[0]
+    different_metric = different_result.metrics_data[0]
+    assert matching_metric.name == "Exact Match"
+    assert matching_metric.score == 1.0
+    assert matching_metric.success is True
+    assert different_metric.name == "Exact Match"
+    assert different_metric.score == 0.0
+    assert different_metric.success is False
+    assert isinstance(matching_metric.reason, str)
+    assert isinstance(different_metric.reason, str)


### PR DESCRIPTION
## Summary
- document `EvaluationResult.test_results[*].metrics_data` as the supported path for reading per-test-case metric scores
- show how to access metric name, score, threshold, success, reason, and error
- clarify that local cache JSON files are internal implementation details
- add an offline contract test for the public object path

## Motivation
Users should not need to parse `.deepeval` cache files to consume per-test-case metric results. This addresses the question in #3126 while avoiding a stability commitment for internal cache serialization.

## Verification
- focused evaluation tests: 17 passed
- Black: passed
- Ruff: passed
- `git diff --check`: passed

Addresses #3126.