### PR TITLE
fix: don't corrupt valid JSON string values in models copy of trim_and_load_json

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/models/llms/utils.py
+++ b/deepeval/models/llms/utils.py
@@ -17,12 +17,17 @@ def trim_and_load_json(
         input_string = input_string + "}"
         end = len(input_string)
     jsonStr = input_string[start:end] if start != -1 and end != 0 else ""
-    jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)
     try:
         return json.loads(jsonStr)
     except json.JSONDecodeError:
-        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
-        raise DeepEvalError(error_str)
+        # Some models emit a trailing comma before a closing ] or }. Strip it
+        # and retry, but only after a direct parse fails, so valid JSON string
+        # values containing ", ]" or ", }" are never corrupted (see #2701).
+        try:
+            return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
+        except json.JSONDecodeError:
+            error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+            raise DeepEvalError(error_str)
     except Exception as e:
         raise Exception(f"An unexpected error occurred: {str(e)}")
 

--- a/tests/test_core/test_trim_and_load_json.py
+++ b/tests/test_core/test_trim_and_load_json.py
@@ -1,9 +1,9 @@
 """Regression tests for trimAndLoadJson trailing-comma handling.
 
-Both the metrics and dataset copies stripped ``,\\s*`` before a closing ``]``/``}``
-unconditionally, which corrupted valid JSON whose string values happened to
-contain ``", ]"`` or ``", }"``. The cleanup must only run as a fallback when a
-direct parse fails.
+The metrics, dataset, and models/llms copies stripped ``,\\s*`` before a closing
+``]``/``}`` unconditionally, which corrupted valid JSON whose string values
+happened to contain ``", ]"`` or ``", }"``. The cleanup must only run as a
+fallback when a direct parse fails.
 """
 
 import json
@@ -11,29 +11,37 @@ import json
 import pytest
 
 from deepeval.dataset.utils import trimAndLoadJson as trim_dataset
+from deepeval.errors import DeepEvalError
 from deepeval.metrics.utils import trimAndLoadJson as trim_metrics
+from deepeval.models.llms.utils import trim_and_load_json as trim_models
 
-TRIM_FNS = [trim_metrics, trim_dataset]
+# Each copy raises a different error type on unparseable input.
+TRIM_FNS = [
+    (trim_metrics, ValueError),
+    (trim_dataset, ValueError),
+    (trim_models, DeepEvalError),
+]
 
 
-@pytest.mark.parametrize("trim", TRIM_FNS)
+@pytest.mark.parametrize("trim", [fn for fn, _ in TRIM_FNS])
 @pytest.mark.parametrize(
     "raw",
     [
         '{"reason": "found items A, B, ] then stopped"}',
         '{"note": "the set is {x, y, } here"}',
+        '{"a": 1}',
     ],
 )
 def test_valid_json_string_values_are_preserved(trim, raw):
     assert trim(raw) == json.loads(raw)
 
 
-@pytest.mark.parametrize("trim", TRIM_FNS)
+@pytest.mark.parametrize("trim", [fn for fn, _ in TRIM_FNS])
 def test_trailing_comma_is_still_stripped(trim):
     assert trim('{"a": [1, 2, ]}') == {"a": [1, 2]}
 
 
-@pytest.mark.parametrize("trim", TRIM_FNS)
-def test_invalid_json_still_raises(trim):
-    with pytest.raises(ValueError):
+@pytest.mark.parametrize("trim,exc", TRIM_FNS)
+def test_invalid_json_still_raises(trim, exc):
+    with pytest.raises(exc):
         trim("not json at all {[")


### PR DESCRIPTION
## Description

`deepeval/models/llms/utils.py::trim_and_load_json` still had the same trailing-comma bug we fixed in #2701. That PR patched the copies in `metrics/utils.py` and `dataset/utils.py`, but missed this third one. Since it's imported by every model backend to parse generated output, a metric whose `reason`/`verdict` free-text contains `, }` or `, ]` would get silently corrupted.

The fix is the same approach as #2701: try `json.loads` directly first, and only run the comma-stripping regex when the direct parse fails. Valid JSON is never touched; malformed output with a trailing comma is still recovered.

I also extended the existing regression test file to cover all three copies instead of just two.

## Root cause

```python
# before
jsonStr = re.sub(r",\s*([\]}])", r"\1", jsonStr)   # runs unconditionally
try:
    return json.loads(jsonStr)
```

```python
# after
try:
    return json.loads(jsonStr)
except json.JSONDecodeError:
    return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))   # only on failure
```

## Test plan

Added the `models/llms` copy to `tests/test_core/test_trim_and_load_json.py` and ran it locally:

```
$ poetry run pytest tests/test_core/test_trim_and_load_json.py -q
15 passed, 471 warnings in 0.51s
```

Also verified the exact reproduction from the issue:

```python
from deepeval.models.llms.utils import trim_and_load_json
assert trim_and_load_json('{"reason": "score is 1,} good"}') == {"reason": "score is 1,} good"}
# passes now; used to drop the comma and return {"reason": "score is 1} good"}
```

Fixes #2770
