### PR TITLE
docs: clarify stochastic judge measurement semantics

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/evaluate/configs.py
+++ b/deepeval/evaluate/configs.py
@@ -37,6 +37,15 @@ class DisplayConfig:
 
 @dataclass
 class CacheConfig:
+    """Cache behaviour for ``evaluate()``.
+
+    ``use_cache=True`` replays a prior ``MetricData`` when test-case content
+    and metric configuration are unchanged and skips ``_execute_metric``. For
+    stochastic judges three cached runs are one measurement replayed three
+    times — disable the cache (``use_cache=False``) when you need independent
+    repeated measurements.
+    """
+
     write_cache: bool = True
     use_cache: bool = False
 

--- a/deepeval/metrics/base_metric.py
+++ b/deepeval/metrics/base_metric.py
@@ -69,6 +69,9 @@ class BaseMetric(PromptMixin):
     output_tokens: Optional[int] = None
     verbose_logs: Optional[str] = None
     skipped = False
+    # ``flaky`` is a user declaration that this metric must not decide
+    # pass/fail (checked in ``LLMApiTestCase.update_metric_data``). It is
+    # not an observed instability signal across repeated measurements.
     flaky: bool = False
     requires_trace: bool = False
     model: Optional[DeepEvalBaseLLM] = None
@@ -141,6 +144,8 @@ class BaseConversationalMetric(PromptMixin):
     output_tokens: Optional[int] = None
     verbose_logs: Optional[str] = None
     skipped = False
+    # ``flaky`` is a user declaration that this metric must not decide
+    # pass/fail. It is not an observed instability signal.
     flaky: bool = False
     model: Optional[DeepEvalBaseLLM] = None
     using_native_model: Optional[bool] = None

--- a/docs/content/docs/evaluation-flags-and-configs.mdx
+++ b/docs/content/docs/evaluation-flags-and-configs.mdx
@@ -287,6 +287,28 @@ There are **TWO** optional parameters:
 
 Results are keyed by test case content plus metric configuration, so a cached result is only reused when both are unchanged. The <Term py="write_cache" ts="writeCache"/> parameter writes to disk and so you should disable it if that is causing any errors in your environment.
 
+:::caution[Cache replays a prior measurement — it is not a re-measurement]
+With <Term py="use_cache=True" ts="useCache: true"/> and an unchanged metric configuration, `evaluate()` reuses the cached `MetricData` and skips `_execute_metric` entirely. Three runs with caching enabled can therefore be **one measurement replayed three times**, not three independent samples. To collect genuine repeated measurements of the same case (for example to estimate variance of a stochastic judge), disable the cache (`CacheConfig(use_cache=False)` or omit `-c` / `--use-cache`). Use caching for cost saving, not for variance estimation.
+:::
+
+## Measurement semantics for stochastic judges
+
+LLM judges (for example `GEval` with logprob-weighted scoring) are stochastic: re-running the **same unchanged test case** can move the score across the threshold. With threshold `0.6`, scores `0.62 / 0.58 / 0.61` give two passes and one fail for the same case.
+
+deepeval's contract for this situation is explicit:
+
+- **One run = one measurement.** A case's verdict (`success`) is computed inside a single run as a logical AND over its non-flaky metrics (`LLMApiTestCase.update_metric_data` in `deepeval/test_run/api.py`). There is no cross-run holder on `TestRun` — fields such as `test_cases`, `metrics_scores`, `identifier`, `hyperparameters` and `test_passed / test_failed` describe only that run.
+- **Re-runs are new measurements, not reconciled versions of one verdict.** There is no canonical "first run" or "latest run" verdict across runs. Each `TestRun` (`test_run_<YYYYMMDD_HHMMSS>.json` or `.deepeval/.latest_run_full.json`) is self-contained. If you need variance, treat the set of runs as a distribution, not as noise to be collapsed silently.
+- **Storage.** By default `TestRunManager.save_test_run_locally` keeps a rolling snapshot at `.deepeval/.latest_run_full.json`; the next run overwrites it. Set `results_folder` / `DEEPEVAL_RESULTS_FOLDER` to retain timestamped `test_run_*.json` files per run, so per-case variance can be audited after the fact rather than re-litigated from memory.
+- **Vocabulary: `flaky` is a declaration, not an observation.** `BaseMetric.flaky` / `BaseConversationalMetric.flaky` means "this metric must not decide pass/fail" and is checked in `update_metric_data` and `metrics/utils.py:check_at_least_one_metric_has_threshold`. It does **not** mean "this case was observed to be unstable". A future stability signal needs distinct terminology.
+- **Auditability.** Judge traces (`MetricData.score`, `reason`, and logprobs where `GEval` uses them) are retained per run inside each `TestRun` artifact. Keeping them — at minimum for cases whose runs disagree across the threshold — is what lets a flaky CI gate be diagnosed after the fact.
+
+**Future opt-in n-runs reporting (not yet implemented).** The intended additive shape, if added, will stay out of the single-run path:
+
+- For each case, run the thresholded metric *n* times as real measurements (cache bypassed) and record pass rate, score mean and spread (std, min/max), and a flag when the threshold falls inside the observed spread.
+- Summarize each case as one of three states — `always-passed`, `always-failed`, `mixed` — rather than collapsing `mixed` implicitly. The chosen collapse rule for `mixed` (for example `mixed → fail` for deliverability vs `mixed → pass` for capability ceiling) will be written into the run artifact so `deepeval compare` and `--fail-on-regression` gates are checkable.
+- A pass rate over small *n* has its own uncertainty: `2/3` is not meaningfully different from `1/3` or `3/3`. The honest levers for a stable gate are more runs or an explicit margin around the threshold, not a single re-run.
+
 ## Hyperparameters
 
 Log the model, prompt, and other configuration values with each test run so you can compare runs side-by-side on Confident AI and identify the best combination.

--- a/tests/test_core/test_run/test_stochastic_measurement_semantics.py
+++ b/tests/test_core/test_run/test_stochastic_measurement_semantics.py
@@ -1,0 +1,124 @@
+"""Offline regression for #3110: stochastic judge measurement semantics.
+
+Each ``TestRun`` is one measurement; re-runs are new measurements with no
+cross-run holder. ``flaky`` is a user declaration, not an observed instability
+signal, and cached runs are replays that must be bypassed for genuine
+re-measurement. Tests below are deterministic and require no LLM calls.
+"""
+
+import pytest
+import statistics
+
+from deepeval.evaluate.configs import CacheConfig
+from deepeval.test_run.api import LLMApiTestCase
+from deepeval.test_run.test_run import TestRun
+from deepeval.tracing.api import MetricData
+
+
+def make_metric_data(success, score=None, flaky: bool = False) -> MetricData:
+    return MetricData(name="GEval", success=success, score=score, flaky=flaky)
+
+
+def make_api_case(name: str = "case") -> LLMApiTestCase:
+    return LLMApiTestCase(name=name, input="hello", order=0)
+
+
+def test_one_run_is_one_measurement_no_cross_run_holder():
+    """Two independent runs of the same case have isolated verdicts.
+
+    There is no field on TestRun or LLMApiTestCase that points at another
+    run — each run's ``success`` is computed only from its own metric_data
+    via the AND-fold in ``update_metric_data``.
+    """
+    c1 = make_api_case()
+    c1.update_metric_data(make_metric_data(True, score=0.62))
+    c2 = make_api_case()
+    c2.update_metric_data(make_metric_data(False, score=0.58))
+
+    assert c1.success is True
+    assert c2.success is False
+    # No cross-run attribute exists
+    assert not hasattr(c1, "previous_run")
+    assert not hasattr(c2, "previous_run")
+    # TestRun itself has no cross-run pointer either
+    tr = TestRun(identifier="run-1")
+    assert not hasattr(tr, "previous_run")
+    assert not hasattr(tr, "linked_runs")
+
+
+def test_stochastic_scores_straddle_threshold_produce_distribution_not_canonical_verdict():
+    """Scores 0.62/0.58/0.61 against threshold 0.6 yield a distribution.
+
+    The useful artifact is pass-rate + spread, not a single canonical boolean.
+    """
+    threshold = 0.6
+    scores = [0.62, 0.58, 0.61]
+    successes = [s >= threshold for s in scores]
+    assert successes == [True, False, True]
+    pass_rate = sum(successes) / len(successes)
+    assert pass_rate == pytest.approx(2 / 3)
+    mean = statistics.mean(scores)
+    stdev = statistics.pstdev(scores)
+    assert mean == pytest.approx(0.603333, rel=1e-3)
+    assert stdev > 0
+    # threshold inside observed spread flags a flickering case
+    assert min(scores) < threshold < max(scores)
+    # Three-state summary
+    if all(successes):
+        state = "always-passed"
+    elif not any(successes):
+        state = "always-failed"
+    else:
+        state = "mixed"
+    assert state == "mixed"
+
+
+def test_threshold_inside_spread_flag():
+    """Helper logic for the future opt-in n-runs reporting."""
+    def threshold_inside_spread(scores, threshold):
+        return min(scores) < threshold < max(scores)
+
+    assert threshold_inside_spread([0.62, 0.58, 0.61], 0.6) is True
+    assert threshold_inside_spread([0.9, 0.92, 0.88], 0.6) is False
+    assert threshold_inside_spread([0.1, 0.2, 0.15], 0.6) is False
+    # Degenerate: single measurement has no spread
+    assert threshold_inside_spread([0.62], 0.6) is False
+
+
+def test_flaky_is_declaration_not_observed_instability():
+    """``flaky=True`` never decides pass/fail, regardless of success value."""
+    c = make_api_case()
+    c.update_metric_data(make_metric_data(False, flaky=True))
+    assert c.success is None
+    # A later non-flaky pass still decides
+    c.update_metric_data(make_metric_data(True, flaky=False))
+    assert c.success is True
+    # But even a failing flaky does not override the prior pass
+    c.update_metric_data(make_metric_data(False, flaky=True))
+    assert c.success is True
+    # MetricData is still retained for auditability
+    assert len(c.metrics_data) == 3
+    assert c.metrics_data[0].flaky is True
+
+
+def test_cache_bypass_required_for_true_re_measurement():
+    """Defaults ensure re-runs are real measurements, not cache replays."""
+    cfg = CacheConfig()
+    assert cfg.use_cache is False
+    assert cfg.write_cache is True
+    # Docstring must clarify the replay vs re-measurement distinction
+    assert "replays" in CacheConfig.__doc__ or "replay" in CacheConfig.__doc__.lower()
+    assert "stochastic" in CacheConfig.__doc__.lower() or "measurement" in CacheConfig.__doc__.lower()
+
+
+def test_case_verdict_is_and_fold_not_canonical_merge():
+    """Within one run, success folds by AND; across runs there is no fold."""
+    c = make_api_case()
+    c.update_metric_data(make_metric_data(True, score=0.62))
+    c.update_metric_data(make_metric_data(True, score=0.61))
+    assert c.success is True
+    c.update_metric_data(make_metric_data(False, score=0.58))
+    assert c.success is False
+    # Further True cannot revive it — AND semantics
+    c.update_metric_data(make_metric_data(True, score=0.9))
+    assert c.success is False

--- a/tests/test_core/test_run/test_stochastic_measurement_semantics.py
+++ b/tests/test_core/test_run/test_stochastic_measurement_semantics.py
@@ -75,6 +75,7 @@ def test_stochastic_scores_straddle_threshold_produce_distribution_not_canonical
 
 def test_threshold_inside_spread_flag():
     """Helper logic for the future opt-in n-runs reporting."""
+
     def threshold_inside_spread(scores, threshold):
         return min(scores) < threshold < max(scores)
 
@@ -107,8 +108,14 @@ def test_cache_bypass_required_for_true_re_measurement():
     assert cfg.use_cache is False
     assert cfg.write_cache is True
     # Docstring must clarify the replay vs re-measurement distinction
-    assert "replays" in CacheConfig.__doc__ or "replay" in CacheConfig.__doc__.lower()
-    assert "stochastic" in CacheConfig.__doc__.lower() or "measurement" in CacheConfig.__doc__.lower()
+    assert (
+        "replays" in CacheConfig.__doc__
+        or "replay" in CacheConfig.__doc__.lower()
+    )
+    assert (
+        "stochastic" in CacheConfig.__doc__.lower()
+        or "measurement" in CacheConfig.__doc__.lower()
+    )
 
 
 def test_case_verdict_is_and_fold_not_canonical_merge():


### PR DESCRIPTION
Fixes #3110

Stochastic judges can straddle the threshold across re-runs, leaving the canonical verdict undefined. Clarify that one evaluate() run is one measurement with no cross-run holder, document that caching replays a prior measurement and that flaky is a declaration not an observed instability, and note the additive opt-in n-runs shape as future work.