### PR TITLE
fix: strip verdict whitespace before comparing in recall/relevancy metrics

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/contextual_recall/contextual_recall.py
+++ b/deepeval/metrics/contextual_recall/contextual_recall.py
@@ -200,7 +200,7 @@ class ContextualRecallMetric(BaseMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in self.verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)
@@ -230,7 +230,7 @@ class ContextualRecallMetric(BaseMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in self.verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)
@@ -260,7 +260,7 @@ class ContextualRecallMetric(BaseMetric):
 
         justified_sentences = 0
         for verdict in self.verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 justified_sentences += 1
 
         score = justified_sentences / number_of_verdicts

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -204,7 +204,7 @@ class ContextualRelevancyMetric(BaseMetric):
         relevant_statements = []
         for verdicts in self.verdicts_list:
             for verdict in verdicts.verdicts:
-                if verdict.verdict.lower() == "no":
+                if verdict.verdict.strip().lower() == "no":
                     irrelevant_statements.append(verdict.reason)
                 else:
                     relevant_statements.append(verdict.statement)
@@ -234,7 +234,7 @@ class ContextualRelevancyMetric(BaseMetric):
         relevant_statements = []
         for verdicts in self.verdicts_list:
             for verdict in verdicts.verdicts:
-                if verdict.verdict.lower() == "no":
+                if verdict.verdict.strip().lower() == "no":
                     irrelevant_statements.append(verdict.reason)
                 else:
                     relevant_statements.append(verdict.statement)
@@ -262,7 +262,7 @@ class ContextualRelevancyMetric(BaseMetric):
         for verdicts in self.verdicts_list:
             for verdict in verdicts.verdicts:
                 total_verdicts += 1
-                if verdict.verdict.lower() == "yes":
+                if verdict.verdict.strip().lower() == "yes":
                     relevant_statements += 1
 
         if total_verdicts == 0:

--- a/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
+++ b/deepeval/metrics/turn_contextual_recall/turn_contextual_recall.py
@@ -403,7 +403,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)
@@ -440,7 +440,7 @@ class TurnContextualRecallMetric(BaseConversationalMetric):
         supportive_reasons = []
         unsupportive_reasons = []
         for verdict in verdicts:
-            if verdict.verdict.lower() == "yes":
+            if verdict.verdict.strip().lower() == "yes":
                 supportive_reasons.append(verdict.reason)
             else:
                 unsupportive_reasons.append(verdict.reason)

--- a/tests/test_metrics/test_verdict_whitespace.py
+++ b/tests/test_metrics/test_verdict_whitespace.py
@@ -1,0 +1,88 @@
+"""Regression tests: verdict comparisons must ignore surrounding whitespace.
+
+Three metrics compared the raw verdict string (``verdict.verdict.lower()``)
+before scoring, so a model that emitted ``"yes "`` instead of ``"yes"`` was
+counted the wrong way and the score collapsed (e.g. 0.75 -> 0.0) instead of
+drifting. Every other verdict comparison in the repo already called
+``.strip().lower()``; these were the outliers.
+
+Drives the full ``measure()`` flow with a stub model so the verdicts take the
+same path a real run does, rather than assigning to ``metric.verdicts``.
+"""
+
+import json
+
+from deepeval.metrics import ContextualRecallMetric
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+VERDICTS_PAYLOAD = {
+    "verdicts": [
+        {"verdict": "yes", "reason": "supported"},
+        {"verdict": "yes", "reason": "supported"},
+        {"verdict": "no", "reason": "not supported"},
+        {"verdict": "yes", "reason": "supported"},
+    ]
+}
+
+REASON_PAYLOAD = {"reason": "stub"}
+
+
+class StubModel(DeepEvalBaseLLM):
+    """Returns a canned verdicts payload, optionally padding every "yes" with a
+    trailing space — the exact whitespace that tripped the old comparisons."""
+
+    def __init__(self, pad: bool):
+        self.pad = pad
+        super().__init__()
+
+    def load_model(self):
+        return self
+
+    def get_model_name(self):
+        return "stub"
+
+    def generate(self, prompt, schema=None, **kwargs):
+        if schema is None:
+            return json.dumps(REASON_PAYLOAD)
+        if schema.__name__ == "Verdicts":
+            data = VERDICTS_PAYLOAD
+            if self.pad:
+                data = {
+                    "verdicts": [
+                        {**v, "verdict": "yes "} if v["verdict"] == "yes" else v
+                        for v in VERDICTS_PAYLOAD["verdicts"]
+                    ]
+                }
+            return schema(**data)
+        return schema(**REASON_PAYLOAD)
+
+    async def a_generate(self, prompt, schema=None, **kwargs):
+        return self.generate(prompt, schema=schema, **kwargs)
+
+
+def measure_contextual_recall(pad: bool) -> float:
+    case = LLMTestCase(
+        input="q",
+        actual_output="a",
+        expected_output="s1. s2. s3. s4.",
+        retrieval_context=["c1", "c2"],
+    )
+    metric = ContextualRecallMetric(
+        model=StubModel(pad=pad),
+        async_mode=False,
+        include_reason=False,
+    )
+    metric.measure(case, _show_indicator=False)
+    return metric.score
+
+
+def test_contextual_recall_unpadded_verdicts_score_half():
+    # 3 of 4 verdicts are "yes" -> 0.75 regardless of padding.
+    assert measure_contextual_recall(pad=False) == 0.75
+
+
+def test_contextual_recall_padded_verdicts_score_half():
+    # Regression: "yes " used to drop the score to 0.0 because the comparison
+    # did not strip whitespace before checking against "yes".
+    assert measure_contextual_recall(pad=True) == 0.75


### PR DESCRIPTION
## Summary

Fixes #3057.

The `ContextualRecallMetric`, `ContextualRelevancyMetric`, and `TurnContextualRecallMetric` compared the raw verdict string (`verdict.verdict.lower()`) instead of stripping it first, so a few verdicts like `"yes "` were counted the wrong way. In the worst case the score collapsed from `0.75` to `0.0` with no error raised.

The repo already compares verdicts with `.strip().lower()` in 70 places; these eight were the outliers. This brings them in line:

- `ContextualRecallMetric`: `== "yes"` now strips first, so a padded relevant verdict is no longer dropped (score stays at `0.75`).
- `ContextualRelevancyMetric`: the `"no"` checks in the two reason paths are fixed too, so a padded irrelevant verdict no longer gets filed as relevant in the explanation.
- `TurnContextualRecallMetric`: same `== "yes"` handling as ContextualRecall.

## Tests

Added `tests/test_metrics/test_verdict_whitespace.py`, which drives the full `measure()` flow with a stub model (rather than assigning verdicts directly). Verified red before green:

- with the regression, the padded case scored `0.0` (test failed);
- with the fix, both padded and unpadded cases score `0.75` (tests pass).

No other behavior changed.