### PR TITLE
fix: return async evaluation results in input order

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/evaluate/execute/e2e.py
+++ b/deepeval/evaluate/execute/e2e.py
@@ -444,7 +444,7 @@ async def a_execute_test_cases(
                 await asyncio.sleep(async_config.throttle_value)
 
             try:
-                await asyncio.wait_for(
+                ordered_results = await asyncio.wait_for(
                     asyncio.gather(*tasks),
                     timeout=get_gather_timeout(),
                 )
@@ -458,6 +458,9 @@ async def a_execute_test_cases(
 
                 if not error_config.ignore_errors:
                     raise
+
+            else:
+                return ordered_results
 
     else:
         for test_case in test_cases:
@@ -511,7 +514,7 @@ async def a_execute_test_cases(
             await asyncio.sleep(async_config.throttle_value)
 
         try:
-            await asyncio.wait_for(
+            ordered_results = await asyncio.wait_for(
                 asyncio.gather(*tasks),
                 timeout=get_gather_timeout(),
             )
@@ -523,6 +526,8 @@ async def a_execute_test_cases(
             await asyncio.gather(*tasks, return_exceptions=True)
             if not error_config.ignore_errors:
                 raise
+        else:
+            return ordered_results
 
     return test_results
 
@@ -654,6 +659,8 @@ async def _a_execute_llm_test_cases(
         test_results.append(create_test_result(api_test_case))
         update_pbar(progress, pbar_id)
 
+    return create_test_result(api_test_case)
+
 
 async def _a_execute_conversational_test_cases(
     metrics: List[Union[BaseMetric, BaseConversationalMetric]],
@@ -741,6 +748,8 @@ async def _a_execute_conversational_test_cases(
 
         test_results.append(create_test_result(api_test_case))
         update_pbar(progress, pbar_id)
+
+    return create_test_result(api_test_case)
 
 
 async def _evaluate_test_case_pairs(

--- a/tests/test_core/test_evaluation/test_execute/test_execute_result_order.py
+++ b/tests/test_core/test_evaluation/test_execute/test_execute_result_order.py
@@ -1,0 +1,73 @@
+import asyncio
+import time
+
+import pytest
+
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+from deepeval.evaluate import execute as execute_module
+from deepeval.evaluate.configs import (
+    ErrorConfig,
+    DisplayConfig,
+    CacheConfig,
+    AsyncConfig,
+)
+
+
+class _DelayByInputMetric(BaseMetric):
+    """
+    Stub metric whose async delay (in seconds) is driven by the test case's
+    input value. With concurrent execution, tasks that ask for a shorter delay
+    finish before longer ones, so completion order differs from input order.
+    """
+
+    threshold = 0.0
+    name = "_DelayByInputMetric"
+
+    def __init__(self):
+        self.skipped = False
+        self.error = None
+        self.success = False
+        self.score = None
+        self.reason = None
+
+    def measure(self, test_case, *_args, **_kwargs):
+        time.sleep(float(test_case.input))
+        self.success = True
+
+    async def a_measure(self, test_case, *_args, **_kwargs):
+        await asyncio.sleep(float(test_case.input))
+        self.success = True
+
+    def is_successful(self) -> bool:
+        return bool(self.success)
+
+
+@pytest.mark.asyncio
+async def test_async_results_preserve_input_order():
+    """
+    Regression test for #1034: a_execute_test_cases must return results in the
+    same order as the input test cases, not in completion order. Here the 0.1s
+    case finishes well before the 0.3s one, so an executor that collects results
+    as tasks complete would return a reversed list.
+    """
+    inputs = ["0.3", "0.2", "0.1"]
+    test_cases = [LLMTestCase(input=s, actual_output="out" + s) for s in inputs]
+
+    metric = _DelayByInputMetric()
+
+    display_config = DisplayConfig(show_indicator=False, verbose_mode=False)
+    cache_config = CacheConfig(write_cache=False, use_cache=False)
+    error_config = ErrorConfig(ignore_errors=True, skip_on_missing_params=False)
+    async_config = AsyncConfig(max_concurrent=3, throttle_value=0)
+
+    results = await execute_module.a_execute_test_cases(
+        test_cases=test_cases,
+        metrics=[metric],
+        error_config=error_config,
+        display_config=display_config,
+        cache_config=cache_config,
+        async_config=async_config,
+    )
+
+    assert [r.input for r in results] == inputs


### PR DESCRIPTION
## Summary

When evaluating with the parallel (async) executor, `deepeval.evaluate()` returned results in **completion order** rather than the order the test cases were passed in. `_a_execute_llm_test_cases` / `_a_execute_conversational_test_cases` each append their result to a shared list as the underlying task finishes, so with `max_concurrent > 1` the returned `List[TestResult]` is ordered by wall-clock finish time.

This is annoying (and sometimes outright wrong) when you need to map results back to the input cases — for example evaluating two model predictions side by side, or joining results to per-case metadata.

## Change

`a_execute_test_cases` now collects the per-task results from `asyncio.gather`, which preserves task creation order (== input order), and returns those instead of the completion-ordered shared list.

- `_a_execute_llm_test_cases` and `_a_execute_conversational_test_cases` now also return their `TestResult` (the existing append to the shared list is preserved unchanged).
- On gather timeout the previous fallback (`test_results`) is still returned, and `ignore_errors=False` still re-raises as before.

The timeout paths and TestRun persistence are unchanged.

## Test

Added a regression test `test_execute_result_order.py` that uses a stub metric whose async delay is driven by `test_case.input`. With `max_concurrent=3`, the 0.1s case finishes first and the 0.3s case last — i.e. completion order is the reverse of input order — and the test asserts the executor returns them in input order.

Verified against `main` (the test fails there) and after the fix (passes). All tests in `tests/test_core/test_evaluation/` pass.

Fixes #1034