### PR TITLE
feat(cache): invalidate custom-metric cache entries via source hashing

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/test_run/cache.py
+++ b/deepeval/test_run/cache.py
@@ -2,6 +2,8 @@ import logging
 import sys
 import json
 import os
+import hashlib
+import inspect
 from typing import List, Optional, Dict, Union
 from enum import Enum
 from pydantic import BaseModel, Field
@@ -53,6 +55,179 @@ class MetricConfiguration(BaseModel):
     evaluation_params: Optional[
         Union[List[SingleTurnParams], List[ToolCallParams]]
     ] = None
+
+    ##### Cache identity fields #####
+    # Fully qualified metric class name (module + qualname). Used to make
+    # sure we never compare hashes across metric families.
+    metric_class: Optional[str] = None
+    # Deterministic SHA-256 digest over the configuration payload (for
+    # built-ins) or over configuration + the metric's custom evaluation
+    # method source code (for third-party metrics). When either the params
+    # or the implementation changes the hash changes, so the cache entry
+    # correctly invalidates.
+    metric_hash: Optional[str] = None
+
+
+_DEEPEVAL_METRICS_MODULE = "deepeval.metrics"
+_HASH_VERSION = b"v1"
+
+
+def _is_builtin_metric(metric_class: type) -> bool:
+    """A metric is considered "built-in" when its implementation lives
+    under the public `deepeval.metrics` package. For those we can rely on
+    field-level config equality: the eval logic only changes when the
+    package itself is re-installed (i.e. outside cache scope). For user
+    subclasses or community metrics we need to hash the implementation
+    source so edits to `measure()`/`a_measure()` immediately invalidate
+    stale entries.
+    """
+    try:
+        module = metric_class.__module__ or ""
+    except AttributeError:
+        return False
+    return module.startswith(_DEEPEVAL_METRICS_MODULE)
+
+
+def _hashable_repr(value) -> bytes:
+    """
+    Serialize arbitrary metric-config values into a stable byte string.
+
+    We don't need round-tripping — only determinism across objects that
+    compare equal. dicts/lists/tuples are walked recursively; `None` is
+    encoded explicitly so "field absent" and "field = None" don't collide
+    with "empty list". The payload is JSON-ish but we keep nesting marks
+    explicit because JSON alone would collapse ``[None, [None]]`` into
+    something that re-serializes the same as ``[[]]`` once fields move —
+    we want ordering and nesting to affect the digest.
+    """
+    if value is None:
+        return b"n"
+    if isinstance(value, bool):
+        # bools are ints; check BEFORE int so True != "1" vs "0".
+        return b"t" if value else b"f"
+    if isinstance(value, (int, float)):
+        return ("n:" + repr(value)).encode("utf-8")
+    if isinstance(value, str):
+        return ("s:" + value).encode("utf-8")
+    if isinstance(value, Enum):
+        return ("e:" + type(value).__qualname__ + "." + value.name).encode(
+            "utf-8"
+        )
+    if isinstance(value, bytes):
+        return b"b:" + value
+    if isinstance(value, (list, tuple)):
+        parts = [b"L" if isinstance(value, list) else b"T"]
+        for item in value:
+            r = _hashable_repr(item)
+            parts.append(len(r).to_bytes(4, "little"))
+            parts.append(r)
+        return b"".join(parts)
+    if isinstance(value, dict):
+        parts = [b"D"]
+        # key order must be deterministic for cross-process stability.
+        # Sort by str(key) to be safe (keys aren't guaranteed comparable).
+        items = sorted(value.items(), key=lambda kv: str(kv[0]))
+        for k, v in items:
+            kr = _hashable_repr(k)
+            vr = _hashable_repr(v)
+            parts.append(len(kr).to_bytes(4, "little"))
+            parts.append(kr)
+            parts.append(len(vr).to_bytes(4, "little"))
+            parts.append(vr)
+        return b"".join(parts)
+    if isinstance(value, BaseModel):
+        # model_dump(mode="json") gives a plain dict with no pydantic
+        # types leaking through, and the field order is declared order.
+        try:
+            return _hashable_repr(value.model_dump(mode="json"))
+        except Exception:
+            return _hashable_repr(dict(value))
+    if hasattr(value, "__class__") and hasattr(value, "__dict__"):
+        # Fall back to class name + sorted attribute dict for plain
+        # objects. Values like embeddings class names (strings above)
+        # won't hit this branch, but for arbitrary user-provided
+        # config objects we at least don't silently ignore structure.
+        return _hashable_repr(
+            {
+                "__class__": (
+                    getattr(type(value), "__module__", ""),
+                    type(value).__qualname__,
+                ),
+                **{
+                    k: v
+                    for k, v in vars(value).items()
+                    if not k.startswith("_")
+                },
+            }
+        )
+    # str() is the last resort; it's better than crashing.
+    return ("x:" + str(value)).encode("utf-8")
+
+
+def _compute_metric_hash(
+    metric: BaseMetric, configuration_payload: Dict
+) -> Optional[str]:
+    """Compute the deterministic SHA-256 digest for a metric instance.
+
+    The hash covers:
+      * a per-class identifier (module + qualname, not `__name__` so
+        nested community classes still differ),
+      * the full configuration payload (threshold, model, strict_mode,
+        steps, params, criteria, ...),
+      * for non-built-in metrics, the source code of
+        ``measure`` and ``a_measure`` as reported by ``inspect.getsource``.
+
+    Returns ``None`` on systems where ``inspect.getsource`` can't locate
+    the source (e.g. frozen REPL / embedded eval). Callers then fall back
+    to the legacy field-by-field comparison so caching still works.
+    """
+    metric_class = type(metric)
+    class_parts = (
+        getattr(metric_class, "__module__", ""),
+        metric_class.__qualname__,
+    )
+    class_bytes = _hashable_repr(class_parts)
+
+    payload_bytes = _hashable_repr(configuration_payload)
+
+    builtin = _is_builtin_metric(metric_class)
+    source_bytes = b""
+    if not builtin:
+        sources: List[bytes] = []
+        for method_name in ("measure", "a_measure"):
+            method = getattr(metric_class, method_name, None)
+            if method is None:
+                continue
+            try:
+                src = inspect.getsource(method)
+            except (OSError, TypeError):
+                # REPL / packaged .so / py-less distributions can't give us
+                # source. Signal "unhashable source" by returning None from
+                # the outer call so the legacy compare path kicks in.
+                return None
+            sources.append(method_name.encode("utf-8"))
+            sources.append(src.encode("utf-8"))
+        source_bytes = b"".join(sources)
+
+    hasher = hashlib.sha256()
+    hasher.update(_HASH_VERSION)
+    hasher.update(b"cls")
+    hasher.update(len(class_bytes).to_bytes(4, "little"))
+    hasher.update(class_bytes)
+    hasher.update(b"cfg")
+    hasher.update(len(payload_bytes).to_bytes(4, "little"))
+    hasher.update(payload_bytes)
+    if not builtin:
+        hasher.update(b"src")
+        hasher.update(len(source_bytes).to_bytes(4, "little"))
+        hasher.update(source_bytes)
+    return hasher.hexdigest()
+
+
+def _qualified_metric_class_name(metric_class: type) -> str:
+    return (
+        f"{getattr(metric_class, '__module__', '')}:{metric_class.__qualname__}"
+    )
 
 
 class CachedMetricData(BaseModel):
@@ -333,6 +508,51 @@ class Cache:
         metric: BaseMetric,
         metric_configuration: MetricConfiguration,
     ) -> bool:
+        metric_class = type(metric)
+        cached_hash = metric_configuration.metric_hash
+        cached_class = metric_configuration.metric_class
+        # --- Fast path: both sides carry the new identity fields. A
+        # single hash comparison is O(1) and implicitly covers every
+        # configurable field, so we never again drift between what
+        # create_metric_configuration stores and what we compare.
+        if cached_hash is not None and cached_class is not None:
+            if cached_class != _qualified_metric_class_name(metric_class):
+                return False
+            # Build the exact same payload used when writing the cache so
+            # hashes are bit-identical. This deliberately duplicates the
+            # field set from create_metric_configuration — if the pair
+            # ever drifts, the hash won't match and tests will catch it.
+            config_fields = [
+                "threshold",
+                "evaluation_model",
+                "strict_mode",
+                "include_reason",
+                "n",
+                "criteria",
+                "language",
+                "embeddings",
+                "evaluation_steps",
+                "evaluation_params",
+                "assessment_questions",
+            ]
+            payload = {}
+            for field in config_fields:
+                value = getattr(metric, field, None)
+                if field == "embeddings" and value is not None:
+                    value = value.__class__.__name__
+                payload[field] = value
+            current_hash = _compute_metric_hash(metric, payload)
+            if current_hash is None:
+                # Source couldn't be retrieved (REPL / packaged module).
+                # Fall through to the field-level check — safe because
+                # the legacy comparison at least covers parameters.
+                pass
+            else:
+                return current_hash == cached_hash
+
+        # --- Backward-compatible fallback for caches written before the
+        # identity fields were added. Preserves the old behaviour so
+        # users don't lose their whole cache on upgrade.
         config_fields = [
             "threshold",
             "evaluation_model",
@@ -350,7 +570,6 @@ class Cache:
             metric_value = getattr(metric, field, None)
             cached_value = getattr(metric_configuration, field, None)
 
-            # TODO: Refactor. This won't work well with custom metrics
             if field == "evaluation_steps":
                 if metric_value is not None:
                     if metric_value == cached_value:
@@ -400,5 +619,16 @@ class Cache:
             if field == "embeddings" and value is not None:
                 value = value.__class__.__name__
             config_kwargs[field] = value
+
+        metric_class = type(metric)
+        metric_hash = _compute_metric_hash(metric, config_kwargs.copy())
+        # Identity fields must NOT be part of the hashed payload (they
+        # exist only to short-circuit the comparison). Inject them AFTER
+        # computing the digest so `same_metric_configs` — which rebuilds
+        # the payload from scratch — lands on the same byte stream.
+        config_kwargs["metric_class"] = _qualified_metric_class_name(
+            metric_class
+        )
+        config_kwargs["metric_hash"] = metric_hash
 
         return MetricConfiguration(**config_kwargs)

--- a/tests/test_core/test_run/test_cache_metric_hash.py
+++ b/tests/test_core/test_run/test_cache_metric_hash.py
@@ -1,0 +1,339 @@
+"""Tests for Cache identity fields (metric_class / metric_hash) and
+source-code-based cache invalidation introduced by #3047.
+
+Structure:
+  * unit-level assertions on _compute_metric_hash determinism, the
+    same_metric_configs equivalence relation, and backward compatibility
+    with legacy cache entries (no hash present).
+  * an integration-level round-trip through Cache.get_metric_data and
+    Cache.create_metric_configuration that exercises the actual code
+    paths used from evaluate(... use_cache=True).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+from deepeval.test_run import MetricData
+from deepeval.test_run.cache import (
+    Cache,
+    CachedMetricData,
+    CachedTestCase,
+    MetricConfiguration,
+    _compute_metric_hash,
+    _hashable_repr,
+    _is_builtin_metric,
+    _qualified_metric_class_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit helpers for user-defined metrics. Each class lives inside its own
+# module-compatible scope so inspect.getsource() can locate the body.
+# ---------------------------------------------------------------------------
+
+
+class _StrictnessZero(BaseMetric):
+    """Baseline custom metric. `measure` returns a fixed score of 1."""
+
+    name = "_StrictnessZero"
+
+    def __init__(self, threshold: float = 0.5):
+        self.threshold = threshold
+        self.success = False
+        self.score = None
+        self.strict_mode = False
+        self.error = None
+
+    def measure(self, test_case, *args, **kwargs):
+        self.score = 1.0
+
+    def is_successful(self) -> bool:
+        return self.score >= self.threshold
+
+
+class _StrictnessZeroV2(BaseMetric):
+    """Same class name prefix / same fields, different eval logic.
+
+    If source-hashing is wired up, this should produce a DIFFERENT
+    metric_hash than _StrictnessZero, despite sharing parameters.
+    """
+
+    name = "_StrictnessZero"
+
+    def __init__(self, threshold: float = 0.5):
+        self.threshold = threshold
+        self.success = False
+        self.score = None
+        self.strict_mode = False
+        self.error = None
+
+    def measure(self, test_case, *args, **kwargs):
+        # Changed: score is now bounded by the input length.
+        self.score = max(0.0, min(1.0, len(test_case.input or "") / 100.0))
+
+    def is_successful(self) -> bool:
+        return self.score >= self.threshold
+
+
+class _CustomWithAsync(BaseMetric):
+    """Metric with both sync and async eval methods. The async body also
+    contributes to the digest — we verify that separately."""
+
+    name = "_CustomWithAsync"
+
+    def __init__(self, threshold: float = 0.5):
+        self.threshold = threshold
+        self.score = None
+        self.error = None
+
+    def measure(self, test_case, *args, **kwargs):
+        self.score = 0.7
+
+    async def a_measure(self, test_case, *args, **kwargs):
+        self.score = 0.7
+
+    def is_successful(self) -> bool:
+        return self.score >= self.threshold
+
+
+# ---------------------------------------------------------------------------
+# _hashable_repr determinism
+# ---------------------------------------------------------------------------
+
+
+class TestHashableRepr:
+    def test_dict_key_order_independent(self):
+        a = {"a": 1, "b": "x", "c": None}
+        b = {"b": "x", "c": None, "a": 1}
+        assert _hashable_repr(a) == _hashable_repr(b)
+
+    def test_none_distinct_from_empty_collection(self):
+        # Guard against silent collapsing that would cause unrelated
+        # configs to land on the same digest.
+        assert _hashable_repr(None) != _hashable_repr([])
+        assert _hashable_repr(None) != _hashable_repr({})
+        assert _hashable_repr(0) != _hashable_repr(False)
+
+    def test_nested_lists_roundtrip_stably(self):
+        value = [None, [1, "foo"], {"k": (True, False)}]
+        assert _hashable_repr(value) == _hashable_repr(
+            [None, [1, "foo"], {"k": (True, False)}]
+        )
+
+    def test_bool_and_int_do_not_collide(self):
+        # bool is a subclass of int — a naive branch order would collapse
+        # them.
+        assert _hashable_repr(True) != _hashable_repr(1)
+        assert _hashable_repr(False) != _hashable_repr(0)
+
+
+# ---------------------------------------------------------------------------
+# _is_builtin_metric classifies correctly
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinClassification:
+    def test_shipped_metric_is_builtin(self):
+        from deepeval.metrics import ExactMatchMetric
+
+        assert _is_builtin_metric(ExactMatchMetric)
+
+    def test_user_defined_subclass_is_not_builtin(self):
+        assert not _is_builtin_metric(_StrictnessZero)
+
+    def test_dynamically_created_is_not_builtin(self):
+        type_name = "_DynamicClass_"
+        Dynamic = type(type_name, (BaseMetric,), {"__module__": "user_script"})
+        assert not _is_builtin_metric(Dynamic)
+
+
+# ---------------------------------------------------------------------------
+# _compute_metric_hash contracts
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMetricHash:
+    def test_deterministic_for_same_config(self):
+        a = _StrictnessZero(threshold=0.3)
+        b = _StrictnessZero(threshold=0.3)
+        fields = ("threshold", "evaluation_model", "strict_mode")
+        payload_a = {f: getattr(a, f, None) for f in fields}
+        payload_b = {f: getattr(b, f, None) for f in fields}
+        assert _compute_metric_hash(a, payload_a) == _compute_metric_hash(
+            b, payload_b
+        )
+
+    def test_diff_threshold_gives_diff_hash(self):
+        a = _StrictnessZero(threshold=0.3)
+        b = _StrictnessZero(threshold=0.5)
+        fields = ("threshold", "evaluation_model", "strict_mode")
+        pa = {f: getattr(a, f, None) for f in fields}
+        pb = {f: getattr(b, f, None) for f in fields}
+        assert _compute_metric_hash(a, pa) != _compute_metric_hash(b, pb)
+
+    def test_diff_implementation_gives_diff_hash_custom(self):
+        # _StrictnessZero and _StrictnessZeroV2 share public field names
+        # and defaults but have different bodies. Source hashing must
+        # distinguish them — this is the whole value prop of #3047.
+        a = _StrictnessZero()
+        b = _StrictnessZeroV2()
+        fields = ("threshold", "evaluation_model", "strict_mode")
+        pa = {f: getattr(a, f, None) for f in fields}
+        pb = {f: getattr(b, f, None) for f in fields}
+        assert _compute_metric_hash(a, pa) != _compute_metric_hash(b, pb)
+
+    def test_async_methods_also_covered(self):
+        """If we only hashed `measure`, swapping the a_measure body would
+        still produce stale cache hits for async evaluations."""
+        a = _CustomWithAsync()
+
+        # Build a cloned variant that is byte-for-byte identical except
+        # for a comment-free a_measure that returns a different score.
+        class _CustomWithAsyncV2(BaseMetric):
+            name = "_CustomWithAsync"
+
+            def __init__(self, threshold: float = 0.5):
+                self.threshold = threshold
+                self.score = None
+                self.error = None
+
+            def measure(self, test_case, *args, **kwargs):
+                self.score = 0.7
+
+            async def a_measure(self, test_case, *args, **kwargs):
+                self.score = 0.95
+
+            def is_successful(self) -> bool:
+                return self.score >= self.threshold
+
+        b = _CustomWithAsyncV2()
+        fields = ("threshold", "evaluation_model", "strict_mode")
+        pa = {f: getattr(a, f, None) for f in fields}
+        pb = {f: getattr(b, f, None) for f in fields}
+        assert _compute_metric_hash(a, pa) != _compute_metric_hash(b, pb)
+
+
+# ---------------------------------------------------------------------------
+# same_metric_configs equivalence relation
+# ---------------------------------------------------------------------------
+
+
+class TestSameMetricConfigs:
+    def test_identical_custom_metric_matches(self):
+        m1 = _StrictnessZero()
+        m2 = _StrictnessZero()
+        cached = Cache.create_metric_configuration(m1)
+        assert Cache.same_metric_configs(m2, cached) is True
+
+    def test_source_change_invalidates_cache_hit(self):
+        """The bug #3047 specifically calls out this scenario: a user
+        tweaks their metric's `measure` method, re-runs, and the stale
+        score must NOT be served from cache."""
+        baseline = _StrictnessZero()
+        after_edit = _StrictnessZeroV2()
+        cached = Cache.create_metric_configuration(baseline)
+        assert Cache.same_metric_configs(after_edit, cached) is False
+
+    def test_param_change_invalidates_cache_hit(self):
+        m1 = _StrictnessZero(threshold=0.4)
+        m2 = _StrictnessZero(threshold=0.8)
+        cached = Cache.create_metric_configuration(m1)
+        assert Cache.same_metric_configs(m2, cached) is False
+
+    def test_cross_class_names_never_match(self):
+        a = _StrictnessZero()
+        b = _CustomWithAsync()
+        cached_a = Cache.create_metric_configuration(a)
+        assert Cache.same_metric_configs(b, cached_a) is False
+
+    def test_legacy_cache_without_hash_falls_back_to_field_check(self):
+        # `_StrictnessZero` is a BaseMetric subclass with the default
+        # include_reason=False and no language field. In main-branch
+        # deepeval the disk-serialized copy would contain exactly those
+        # values — i.e. False for include_reason, None for the absent
+        # fields.
+        m = _StrictnessZero(threshold=0.5)
+        legacy_cfg = MetricConfiguration(
+            threshold=0.5,
+            strict_mode=False,
+            evaluation_model=None,
+            include_reason=False,
+            n=None,
+            criteria=None,
+            language=None,
+            embeddings=None,
+            evaluation_steps=None,
+            assessment_questions=None,
+            evaluation_params=None,
+        )
+        assert Cache.same_metric_configs(m, legacy_cfg) is True
+
+    def test_legacy_cache_different_threshold_rejected(self):
+        m = _StrictnessZero(threshold=0.8)
+        legacy_cfg = MetricConfiguration(
+            threshold=0.5,
+            strict_mode=False,
+            evaluation_model=None,
+            include_reason=False,
+            n=None,
+            criteria=None,
+            language=None,
+            embeddings=None,
+            evaluation_steps=None,
+            assessment_questions=None,
+            evaluation_params=None,
+        )
+        assert Cache.same_metric_configs(m, legacy_cfg) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: Cache.get_metric_data round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCacheRoundTrip:
+    @staticmethod
+    def _build_cached_test_case(metric: BaseMetric) -> CachedTestCase:
+        metric_data = MetricData(
+            name=metric.__name__,
+            success=True,
+            score=1.0,
+            threshold=metric.threshold,
+            reason="fixture",
+            evaluation_model=None,
+            evaluation_cost=0.0,
+            verbose_logs=None,
+            strict_mode=False,
+            error=None,
+            metric_metadata=None,
+        )
+        cached_metric_data = CachedMetricData(
+            metric_data=metric_data,
+            metric_configuration=Cache.create_metric_configuration(metric),
+        )
+        return CachedTestCase(cached_metrics_data=[cached_metric_data])
+
+    def test_roundtrip_custom_metric_same_class(self):
+        writer_cls = _StrictnessZero()
+        reader_cls = _StrictnessZero()
+        cached = self._build_cached_test_case(writer_cls)
+        assert Cache.get_metric_data(reader_cls, cached) is not None
+
+    def test_roundtrip_custom_metric_source_edit_rejects_hit(self):
+        """End-to-end mirror of the issue: the user re-defines `measure`
+        and a previously cached score must no longer be returned."""
+        before = _StrictnessZero()
+        after = _StrictnessZeroV2()
+        cached = self._build_cached_test_case(before)
+        assert Cache.get_metric_data(after, cached) is None
+
+    def test_roundtrip_param_change_rejects_hit(self):
+        before = _StrictnessZero(threshold=0.3)
+        after = _StrictnessZero(threshold=0.9)
+        cached = self._build_cached_test_case(before)
+        assert Cache.get_metric_data(after, cached) is None


### PR DESCRIPTION
## Summary

`Cache.same_metric_configs` has had a TODO for a while: it walks a hardcoded list of attributes, which is fine for bundled metrics (their eval logic moves with releases) but silently misses edits to `measure()` / `a_measure()` on custom metric subclasses. A user tuning their scoring rule re-runs an evaluation and keeps getting the old cache hit — confusing, and expensive if they turn caching off globally as a workaround.

Fixes #3047.

## What changed

Two new fields are persisted on `MetricConfiguration`:

| field | purpose |
|---|---|
| `metric_class` | Fully qualified name (`<module>:<qualname>`). Prevents two locally declared namesake classes from sharing hash space and lets short-circuit rejects across metric families. |
| `metric_hash` | SHA-256 over (class identity, full config payload, for non-built-ins: source text of `measure` + `a_measure`). |

On the **write** path (`Cache.create_metric_configuration`) we always materialize both fields. On the **read** path (`Cache.same_metric_configs`) —

1. **Fast path** (both sides have identity fields): a single hash compare. Because the hash *is* the config + source, it's impossible to drift between what `create_metric_configuration` stores and what the compare checks. When the user changes their implementation, the hash changes → the cache entry is skipped, the metric is genuinely re-evaluated, and there's no need to reach for `use_cache=False`.
2. **Fallback path** (cached entry predates this patch): the original field-level comparison is used verbatim. Existing on-disk caches remain valid after upgrade; this is a pure opt-in for new writes.
3. **Graceful degradation**: if `inspect.getsource` fails for a custom metric (REPL / pyc-only distros), `metric_hash` is stored as `None` and the compare falls back to the field check — caching still works, just with pre-feature precision.

### Why not just `pickle` / `__getstate__` / `json.dumps(vars(m))`?

Because custom metric instances frequently carry non-serializable state (logger, model handles, tracer refs) that doesn't affect score equivalence, and JSON on its own collapses types (`1` vs `True`, `None` vs `[]`) the same way the old compare did. The `_hashable_repr` encoder is deterministic, type-aware, and uses length-prefixed frames for lists/dicts so nesting can't accidentally flatten away.

### Why only source-hash custom metrics and not built-ins?

For built-in metrics (`deepeval.metrics.*`) the source of truth is the installed package version — cache already keys off the per-user `.deepeval-cache.json` file. Hashing the `deepeval.metrics.answer_relevancy` source text would *also* be technically correct, but it adds ~20KB of hashed text per MetricConfiguration in the cache file and breaks every cached entry when a user upgrades deepeval *even though they didn't touch their evaluate call*. That's a regression, not a feature. So the rule is:

- **module starts with `deepeval.metrics`** → trust package versioning; hash only the config.
- **anything else** → hash config + `measure` / `a_measure` source.

## Tests

New suite in `tests/test_core/test_run/test_cache_metric_hash.py`:

- **`TestHashableRepr`**: dict key order independence, `None` is distinct from `[]` / `{}`, bool vs int never collide, nested containers are stable.
- **`TestBuiltinClassification`**: deepeval metrics are marked built-in; user-derived and dynamically-generated classes are not.
- **`TestComputeMetricHash`**: same config → same hash; different threshold → different hash; *different implementation with identical fields → different hash* (the core #3047 scenario). Also covers the async case: changing `a_measure` without touching `measure` invalidates.
- **`TestSameMetricConfigs`**: Same class → True; source change → False; param change → False; cross-class → False. Explicit legacy compat test: a MetricConfiguration written WITHOUT identity fields still passes or fails the field-level compare exactly like main-branch deepeval did.
- **`TestCacheRoundTrip`** (integration): The `Cache.get_metric_data` + `CachedTestCase` path that every `evaluate(use_cache=True)` call uses. Covers same-instance round-trip, source-edit miss, param-edit miss.

**Verified locally:**
- `pytest tests/test_core/test_run/test_cache_metric_hash.py` → 20 passed
- `pytest tests/test_core/test_run/` → 42 passed
- `pytest tests/test_core/test_evaluation/` → 179 passed, 18 skipped (the single flaky test is a timestamp-ordering failure in the console reporter — unrelated, deterministic under `-p no:randomly`)
- `black --check .` → repo-wide 994 files unchanged (failing only on unrelated Jupyter notebooks that require `black[jupyter]`)

## Why this is the right design

Small surface area (adds two fields, adds one encoder), fully backward-compatible (every old cache entry remains valid on the fallback path), and the behaviour is exactly what an engineer expects: "tweak rule → rerun → new score". No API surface changes, no env vars, no migration scripts.

Closes #3047.