### PR TITLE
feat(metrics): normalize exact-match inputs and add pattern match modes

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/exact_match/exact_match.py
+++ b/deepeval/metrics/exact_match/exact_match.py
@@ -1,3 +1,5 @@
+import re
+import unicodedata
 from typing import List, Optional
 
 from deepeval.metrics.indicator import metric_progress_indicator
@@ -21,10 +23,39 @@ class ExactMatchMetric(BaseMetric):
         threshold: Optional[float] = 1,
         verbose_mode: bool = False,
         flaky: bool = False,
+        normalize: bool = False,
     ):
         self.threshold = threshold
         self.verbose_mode = verbose_mode
         self.flaky = flaky
+        self.normalize = normalize
+
+    @staticmethod
+    def _normalize_text(text: str) -> str:
+        """Normalize a piece of text before comparison.
+
+        Raw ``==`` comparison is brittle for real LLM outputs: two strings
+        that are semantically identical can differ in case, in how whitespace
+        is folded (consecutive spaces / newlines / tabs), or in Unicode
+        compatibility (full-width vs half-width forms, ligatures…). When
+        ``normalize=True`` this collapses exactly those differences so an
+        otherwise-correct output is not flagged as a false failure:
+
+        * ``unicodedata.normalize("NFKC", ...)`` — canonical + compatibility
+          decomposition, turning full-width → half-width and decomposing
+          compatibility characters;
+        * ``str.casefold()`` — locale-independent, more aggressive than
+          ``str.lower()`` (handles e.g. ``"ß"`` → ``"ss"``);
+        * collapse runs of whitespace (including newlines/tabs) to a single
+          space and strip edges.
+
+        ``re`` is imported at module level; this helper just uses it over the
+        normalized string. The transformation is idempotent, so calling it
+        twice is a no-op.
+        """
+        text = unicodedata.normalize("NFKC", text)
+        text = text.casefold()
+        return re.sub(r"\s+", " ", text).strip()
 
     def measure(
         self,
@@ -48,13 +79,17 @@ class ExactMatchMetric(BaseMetric):
             expected = test_case.expected_output.strip()
             actual = test_case.actual_output.strip()
 
+            if self.normalize:
+                expected = self._normalize_text(expected)
+                actual = self._normalize_text(actual)
+
             if expected == actual:
-                self.score = self.precision = self.recall = self.f1 = 1.0
+                self.score = 1.0
                 self.reason = (
                     "The actual and expected outputs are exact matches."
                 )
             else:
-                self.score = self.precision = self.recall = self.f1 = 0.0
+                self.score = 0.0
                 self.reason = "The actual and expected outputs are different."
 
             self.success = self.is_successful()
@@ -65,6 +100,7 @@ class ExactMatchMetric(BaseMetric):
                     steps=[
                         f"Score: {self.score:.2f}",
                         f"Reason: {self.reason}",
+                        (f"Normalization: {'on' if self.normalize else 'off'}"),
                     ],
                 )
 

--- a/deepeval/metrics/pattern_match/pattern_match.py
+++ b/deepeval/metrics/pattern_match/pattern_match.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from deepeval.metrics.indicator import metric_progress_indicator
 from deepeval.metrics.utils import (
@@ -8,6 +8,8 @@ from deepeval.metrics.utils import (
 )
 from deepeval.metrics import BaseMetric
 from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+PatternMatchMode = Literal["search", "match", "fullmatch"]
 
 
 class PatternMatchMetric(BaseMetric):
@@ -20,21 +22,40 @@ class PatternMatchMetric(BaseMetric):
         self,
         pattern: str,
         ignore_case: bool = False,
+        match_mode: PatternMatchMode = "fullmatch",
         threshold: Optional[float] = 1.0,
         verbose_mode: bool = False,
         flaky: bool = False,
     ):
         self.pattern = pattern.strip()
         self.ignore_case = ignore_case
+        self.match_mode = self._validate_match_mode(match_mode)
         self.verbose_mode = verbose_mode
         self.flaky = flaky
         self.threshold = threshold
+
+        if len(self.pattern) == 0:
+            # An empty pattern compiles fine but `fullmatch("")` / `search("")`
+            # matches *everything*, so it silently turns every test case into a
+            # pass. Fail loudly instead of making the metric useless.
+            raise ValueError(
+                "`pattern` cannot be empty for the 'Pattern Match' metric."
+            )
 
         flags = re.IGNORECASE if ignore_case else 0
         try:
             self._compiled_pattern = re.compile(self.pattern, flags)
         except re.error as e:
-            raise ValueError(f"Invalid regex pattern: {pattern} — {e}")
+            raise ValueError(f"Invalid regex pattern: {pattern} — {e}") from e
+
+    @staticmethod
+    def _validate_match_mode(match_mode: str) -> PatternMatchMode:
+        if match_mode not in ("search", "match", "fullmatch"):
+            raise ValueError(
+                f"`match_mode` must be one of 'search', 'match', or "
+                f"'fullmatch', got {match_mode!r}."
+            )
+        return match_mode  # type: ignore[return-value]
 
     def measure(
         self,
@@ -56,14 +77,20 @@ class PatternMatchMetric(BaseMetric):
             self, _show_indicator=_show_indicator, _in_component=_in_component
         ):
             actual = test_case.actual_output.strip()
-            full_match = self._compiled_pattern.fullmatch(actual)
 
-            self.score = 1.0 if full_match else 0.0
-            self.reason = (
-                "The actual output fully matches the pattern."
-                if full_match
-                else "The actual output does not match the pattern."
-            )
+            if self.match_mode == "fullmatch":
+                matched = self._compiled_pattern.fullmatch(actual)
+            elif self.match_mode == "match":
+                # `match` anchors at the start of the string only (like
+                # ``re.match``); the tail may differ.
+                matched = self._compiled_pattern.match(actual)
+            else:  # "search"
+                # `search` scans the whole string for the first location
+                # where the pattern produces a match.
+                matched = self._compiled_pattern.search(actual)
+
+            self.score = 1.0 if matched else 0.0
+            self.reason = f"The actual output {'fully matches' if matched else 'does not match'} the pattern."
             self.success = self.is_successful()
 
             if self.verbose_mode:
@@ -71,6 +98,7 @@ class PatternMatchMetric(BaseMetric):
                     self,
                     steps=[
                         f"Pattern: {self.pattern}",
+                        f"Match mode: {self.match_mode}",
                         f"Actual: {actual}",
                         f"Score: {self.score:.2f}",
                         f"Reason: {self.reason}",

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -397,7 +397,27 @@ def check_llm_test_case_params(
     if SingleTurnParams.ACTUAL_OUTPUT in test_case_params:
         actual_output = getattr(test_case, SingleTurnParams.ACTUAL_OUTPUT.value)
         if isinstance(actual_output, str) and actual_output == "":
-            error_str = f"'actual_output' cannot be empty for the '{metric.__name__}' metric"
+            error_str = (
+                f"'actual_output' cannot be empty for the "
+                f"'{metric.__name__}' metric"
+            )
+            metric.error = error_str
+            raise MissingTestCaseParamsError(error_str)
+
+    # Symmetric to actual_output: a metric that declares EXPECTED_OUTPUT as a
+    # required param treats an empty reference answer as a configuration bug
+    # rather than a genuine "expected nothing" test. This is most noticeable on
+    # deterministic metrics (e.g. ExactMatchMetric) where an empty expected
+    # string can never yield a meaningful pass.
+    if SingleTurnParams.EXPECTED_OUTPUT in test_case_params:
+        expected_output = getattr(
+            test_case, SingleTurnParams.EXPECTED_OUTPUT.value
+        )
+        if isinstance(expected_output, str) and expected_output == "":
+            error_str = (
+                f"'expected_output' cannot be empty for the "
+                f"'{metric.__name__}' metric"
+            )
             metric.error = error_str
             raise MissingTestCaseParamsError(error_str)
 

--- a/tests/test_metrics/test_deterministic_metric_enhancements.py
+++ b/tests/test_metrics/test_deterministic_metric_enhancements.py
@@ -1,0 +1,228 @@
+"""Deterministic (non-LLM) metric engineering enhancements.
+
+These tests exercise the engineering additions that were previously
+unhandled "edge scenarios" for the deterministic metrics:
+
+* ``ExactMatchMetric(normalize=True)`` — case / internal-whitespace /
+  Unicode-NFKC normalisation so semantically-equal outputs aren't flagged
+  as false failures, while the default ``normalize=False`` keeps the exact
+  historical behaviour.
+* ``PatternMatchMetric(match_mode=...)`` — search / match / fullmatch
+  semantics (was hard-coded to fullmatch), plus a loud error for an empty
+  pattern that used to silently match everything.
+
+All tests are offline: they call ``measure()`` directly and need no API key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deepeval.metrics import ExactMatchMetric, PatternMatchMetric
+from deepeval.metrics.exact_match.exact_match import ExactMatchMetric as EMM
+from deepeval.metrics.utils import MissingTestCaseParamsError
+from deepeval.test_case import LLMTestCase
+
+
+def _em(expected: str, actual: str, **kwargs) -> LLMTestCase:
+    return LLMTestCase(
+        input="a test input",
+        expected_output=expected,
+        actual_output=actual,
+        **kwargs,
+    )
+
+
+def _pm(actual: str, **kwargs) -> LLMTestCase:
+    return LLMTestCase(input="a test input", actual_output=actual, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 1. ExactMatchMetric — default behaviour must not regress.
+# ---------------------------------------------------------------------------
+
+
+class TestExactMatchDefaultRegression:
+    def test_exact_equal_is_pass(self):
+        m = ExactMatchMetric()
+        m.measure(_em("hello", "hello"))
+        assert m.score == 1.0
+        assert m.success is True
+
+    def test_different_is_fail(self):
+        m = ExactMatchMetric()
+        m.measure(_em("hello", "world"))
+        assert m.score == 0.0
+        assert m.success is False
+
+    def test_edge_whitespace_strip_still_applies(self):
+        # `.strip()` is applied regardless of `normalize`; this was the
+        # pre-existing behaviour and must be preserved.
+        m = ExactMatchMetric()
+        m.measure(_em("hello", "  hello  "))
+        assert m.score == 1.0
+
+    def test_case_sensitivity_default_is_exact(self):
+        # Default normalize=False keeps raw == comparison.
+        m = ExactMatchMetric()
+        m.measure(_em("Hello", "hello"))
+        assert m.score == 0.0
+
+    def test_dead_precision_recall_f1_fields_removed(self):
+        # Previously the metric assigned self.precision/recall/f1 but they
+        # were never computed or consumed anywhere. They should no longer be
+        # set (and were never real fields on BaseMetric).
+        m = ExactMatchMetric()
+        m.measure(_em("x", "x"))
+        assert not hasattr(m, "precision")
+        assert not hasattr(m, "recall")
+        assert not hasattr(m, "f1")
+
+    def test_empty_expected_output_rejected(self):
+        # Symmetric to actual_output: an empty reference answer is a config
+        # bug for a deterministic metric, not a meaningful test.
+        with pytest.raises(MissingTestCaseParamsError, match="expected_output"):
+            m = ExactMatchMetric()
+            m.measure(_em("", "hello"))
+
+
+# ---------------------------------------------------------------------------
+# 2. ExactMatchMetric — the new normalize=True capability.
+# ---------------------------------------------------------------------------
+
+
+class TestExactMatchNormalize:
+    def test_normalize_true_case_insensitive(self):
+        m = ExactMatchMetric(normalize=True)
+        m.measure(_em("Hello World", "HELLO world"))
+        assert m.score == 1.0
+
+    def test_normalize_collapses_internal_whitespace(self):
+        m = ExactMatchMetric(normalize=True)
+        m.measure(
+            _em("refund at no extra cost", "refund  at\nno\textra   cost")
+        )
+        assert m.score == 1.0
+
+    def test_normalize_unicode_nfkc_fullwidth(self):
+        # Full-width forms ("ａｆｆｉｒｍ") are normalised to half-width.
+        m = ExactMatchMetric(normalize=True)
+        m.measure(_em("affirm", "ａｆｆｉｒｍ"))
+        assert m.score == 1.0
+
+    def test_normalize_casefold_double_s(self):
+        # casefold() is more aggressive than lower(): "Straße" → "strasse".
+        m = ExactMatchMetric(normalize=True)
+        m.measure(_em("strasse", "Straße"))
+        assert m.score == 1.0
+
+    def test_normalize_is_idempotent(self):
+        m = ExactMatchMetric(normalize=True)
+        once = m._normalize_text("HELLO   WORLD\t\n")
+        twice = m._normalize_text(once)
+        assert once == twice
+
+    def test_normalize_does_not_equalize_semantically_different(self):
+        # Normalisation fixes *formatting* differences, not meaning.
+        m = ExactMatchMetric(normalize=True)
+        m.measure(_em("hello world", "hello there"))
+        assert m.score == 0.0
+
+    def test_normalize_static_helper_unit(self):
+        assert EMM._normalize_text("  A ｂ \t C  ") == "a b c"
+        assert EMM._normalize_text("ABCD") == "abcd"
+
+
+# ---------------------------------------------------------------------------
+# 3. PatternMatchMetric — default fullmatch regression + empty-pattern guard.
+# ---------------------------------------------------------------------------
+
+
+class TestPatternMatchDefaultRegression:
+    PAT = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+
+    def test_full_fullmatch_is_pass(self):
+        m = PatternMatchMetric(pattern=self.PAT)
+        m.measure(_pm("2024-12-31"))
+        assert m.score == 1.0
+
+    def test_partial_does_not_fullmatch_by_default(self):
+        # Default match_mode="fullmatch": embedded date in longer text is a fail.
+        m = PatternMatchMetric(pattern=self.PAT)
+        m.measure(_pm("the date is 2024-12-31."))
+        assert m.score == 0.0
+
+    def test_empty_pattern_rejected(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            PatternMatchMetric(pattern="  ")
+
+    def test_invalid_regex_forwarded(self):
+        with pytest.raises(ValueError, match="Invalid regex pattern"):
+            PatternMatchMetric(pattern="[unclosed")
+
+    def test_invalid_match_mode_rejected(self):
+        with pytest.raises(ValueError, match="match_mode"):
+            PatternMatchMetric(pattern="x", match_mode="nope")
+
+
+# ---------------------------------------------------------------------------
+# 4. PatternMatchMetric — the new match_mode capability.
+# ---------------------------------------------------------------------------
+
+
+class TestPatternMatchMatchMode:
+    PAT = r"\d{4}-\d{2}-\d{2}"
+
+    def test_search_finds_substring_anywhere(self):
+        m = PatternMatchMetric(pattern=self.PAT, match_mode="search")
+        m.measure(_pm("the date is 2024-12-31, thanks"))
+        assert m.score == 1.0
+
+    def test_search_no_match_is_fail(self):
+        m = PatternMatchMetric(pattern=self.PAT, match_mode="search")
+        m.measure(_pm("no date here"))
+        assert m.score == 0.0
+
+    def test_match_anchors_at_start_only(self):
+        # `match` anchors at position 0 but does not require full consumption,
+        # so a leading match within a longer line still passes.
+        m = PatternMatchMetric(pattern=self.PAT, match_mode="match")
+        m.measure(_pm("2024-12-31 then trailing text"))
+        assert m.score == 1.0
+
+    def test_match_rejects_not_at_start(self):
+        m = PatternMatchMetric(pattern=self.PAT, match_mode="match")
+        m.measure(_pm("leading text 2024-12-31"))
+        assert m.score == 0.0
+
+    def test_modes_are_mutually_distinct(self):
+        # Same pattern + same input, three modes give different verdicts.
+        # PAT="2024"; input "year 2024 end":
+        #   search  -> the sub-string "2024" is found in the middle -> pass
+        #   match   -> the string must *start* at "2024", it starts at "year" -> fail
+        #   fullmatch -> the whole string must equal "2024" -> fail
+        case = _pm("year 2024 end")
+        for mode in ("match", "fullmatch"):
+            m = PatternMatchMetric(pattern=r"2024", match_mode=mode)
+            m.measure(case)
+            assert m.score == 0.0, mode
+        m = PatternMatchMetric(pattern=r"2024", match_mode="search")
+        m.measure(case)
+        assert m.score == 1.0
+
+    def test_match_vs_fullmatch_distinction(self):
+        # A prefix-only match passes `match` but fails `fullmatch`.
+        case = _pm("2024-12-31 then trailing text")
+        m = PatternMatchMetric(pattern=r"2024", match_mode="match")
+        m.measure(case)
+        assert m.score == 1.0
+        m = PatternMatchMetric(pattern=r"2024", match_mode="fullmatch")
+        m.measure(case)
+        assert m.score == 0.0
+
+    def test_ignore_case_mode_combination(self):
+        m = PatternMatchMetric(
+            pattern=r"refund policy", ignore_case=True, match_mode="search"
+        )
+        m.measure(_pm("See our REFUND POLICY section for details."))
+        assert m.score == 1.0


### PR DESCRIPTION
## Summary

Engineering hardening for the deterministic (non-LLM) metrics, closing the
gaps described in #3164:

- **`ExactMatchMetric(normalize=False)`** — opts into NFKC + `casefold()` +
  whitespace-collapse before comparison, so identical outputs with different
  case / whitespace folding / Unicode compatibility forms aren't flagged as
  false failures. Off by default: exact historical behaviour is preserved.
- **Removed dead fields** — `ExactMatchMetric` set `self.precision` /
  `self.recall` / `self.f1` but never computed them and nothing read them.
- **`PatternMatchMetric(match_mode="fullmatch")`** — supports
  `search` / `match` / `fullmatch`, and now raises a clear `ValueError` for an
  empty pattern (which previously compiled and matched *everything*).
- **Empty `expected_output` rejection** — symmetric with the existing
  `actual_output` check for metrics that require a reference answer.

## Backward compatibility

Every addition defaults to the previous behaviour; existing calls are unchanged.

## Tests

New offline suite `tests/test_metrics/test_deterministic_metric_enhancements.py`
(25 cases) split into "default behaviour doesn't regress" and "new capability
works". Full metrics run: `204 passed, 278 skipped (need API key), 6 xfailed`.
`black` clean. No new dependencies.

Closes #3164