### PR TITLE
fix(metrics): strip markdown code fence before JsonCorrectness validation

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/json_correctness/json_correctness.py
+++ b/deepeval/metrics/json_correctness/json_correctness.py
@@ -1,4 +1,5 @@
 from typing import List, Optional, Union, Type
+import re
 from pydantic import BaseModel, ValidationError
 
 from deepeval.test_case import (
@@ -20,6 +21,20 @@ from deepeval.utils import get_or_create_event_loop, serialize_to_json
 from deepeval.templates import make_template_class
 
 DEFAULT_CORRECT_REASON = "The generated Json matches and is syntactically correct to the expected schema."
+
+
+def _strip_code_fence(text: str) -> str:
+    """Strip a surrounding markdown code fence so the inner JSON reaches pydantic.
+
+    LLM eval outputs very frequently wrap JSON in a fenced code block
+    (````` ```json ... ``` `````). Feeding that whole string to
+    ``model_validate_json`` fails even though the contained JSON is perfectly
+    valid, a false negative. We only alter the input when the *entire* string
+    is a fence, so plain JSON and non-JSON text pass through unchanged
+    (backward compatible).
+    """
+    match = re.fullmatch(r"\s*```(?:json)?\s*([\s\S]*?)\s*```\s*", text)
+    return match.group(1) if match else text
 
 
 JsonCorrectnessTemplate = make_template_class("JsonCorrectnessMetric")
@@ -93,7 +108,7 @@ class JsonCorrectnessMetric(BaseMetric):
                 valid_json = True
                 try:
                     self.expected_schema.model_validate_json(
-                        test_case.actual_output
+                        _strip_code_fence(test_case.actual_output)
                     )
                 except ValidationError:
                     valid_json = False
@@ -142,7 +157,7 @@ class JsonCorrectnessMetric(BaseMetric):
             valid_json = True
             try:
                 self.expected_schema.model_validate_json(
-                    test_case.actual_output
+                    _strip_code_fence(test_case.actual_output)
                 )
             except ValidationError:
                 valid_json = False

--- a/tests/test_metrics/test_json_correctness_fence.py
+++ b/tests/test_metrics/test_json_correctness_fence.py
@@ -1,0 +1,117 @@
+"""Offline tests for JsonCorrectnessMetric's code-fence handling.
+
+JsonCorrectnessMetric previously fed ``actual_output`` straight into
+``model_validate_json``. LLM eval outputs are very commonly wrapped in a
+markdown code fence (````` ```json ... ``` `````); in that case a *valid* JSON
+was scored as invalid — a false negative. We now strip an enclosing fence
+before validation.
+
+These tests are fully offline: ``async_mode=False`` + ``include_reason=False``
+so no LLM interaction is required, and a tiny local pydantic schema is used.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from deepeval.metrics import JsonCorrectnessMetric
+from deepeval.metrics.json_correctness.json_correctness import (
+    _strip_code_fence,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+def _stub_model() -> DeepEvalBaseLLM:
+    m = MagicMock(spec=DeepEvalBaseLLM)
+    m.get_model_name.return_value = "mock-llm"
+    m.supports_multimodal.return_value = False
+    return m
+
+
+def _make_metric() -> JsonCorrectnessMetric:
+    return JsonCorrectnessMetric(
+        expected_schema=User,
+        model=_stub_model(),
+        async_mode=False,
+        include_reason=False,
+        strict_mode=False,
+        threshold=0.5,
+    )
+
+
+def _case(actual_output: str) -> LLMTestCase:
+    return LLMTestCase(input="q", actual_output=actual_output)
+
+
+# ---------------------------------------------------------------------------
+# 1. The stripping helper itself.
+# ---------------------------------------------------------------------------
+
+
+class TestStripCodeFence:
+    def test_strips_json_fence(self):
+        out = _strip_code_fence('```json\n{"name":"A","age":1}\n```')
+        assert out == '{"name":"A","age":1}'
+
+    def test_strips_bare_fence(self):
+        out = _strip_code_fence('```\n{"name":"A","age":1}\n```')
+        assert out == '{"name":"A","age":1}'
+
+    def test_strips_fence_with_leading_blank_lines(self):
+        out = _strip_code_fence('\n\n```json\n{"name":"A","age":1}\n```\n')
+        assert out == '{"name":"A","age":1}'
+
+    def test_plain_json_passthrough(self):
+        s = '{"name":"A","age":1}'
+        assert _strip_code_fence(s) == s
+
+    def test_non_json_text_passthrough(self):
+        s = "the answer is no"
+        assert _strip_code_fence(s) == s
+
+    def test_fence_not_at_boundaries_passthrough(self):
+        # ````` ``` ``` ``^ inside a sentence should not be treated as a fence.
+        s = 'prefix\n```json\n{"age":1}\n```'
+        assert _strip_code_fence(s) == s
+
+
+# ---------------------------------------------------------------------------
+# 2. End-to-end score through the metric (offline).
+# ---------------------------------------------------------------------------
+
+
+class TestJsonCorrectnessFence:
+    def test_fenced_valid_json_now_passes(self):
+        m = _make_metric()
+        m.measure(_case('```json\n{"name":"Alice","age":30}\n```'))
+        assert m.score == 1.0
+
+    def test_plain_valid_json_still_passes(self):
+        m = _make_metric()
+        m.measure(_case('{"name":"Alice","age":30}'))
+        assert m.score == 1.0
+
+    def test_plain_invalid_json_still_fails(self):
+        m = _make_metric()
+        m.measure(_case('{"name":"Alice","age":"not-an-int"}'))
+        assert m.score == 0.0
+
+    def test_fenced_invalid_json_still_fails(self):
+        # The strip must not turn an invalid body into a pass.
+        m = _make_metric()
+        m.measure(_case('```json\n{"name":"Alice","age":"x"}\n```'))
+        assert m.score == 0.0
+
+    def test_non_json_text_unchanged_fails(self):
+        m = _make_metric()
+        m.measure(_case("sorry, I can't do that"))
+        assert m.score == 0.0


### PR DESCRIPTION
## Summary

`JsonCorrectnessMetric` now strips an enclosing markdown code-fence before
`model_validate_json`, so a valid JSON the LLM wrapped in ```` ```json ... ``` ````
no longer scores as invalid. Fixes #3166.

Only strips when the entire string is a fence — plain JSON and non-JSON text
pass through unchanged (backward compatible). Keeps pydantic schema
validation; does not reuse `trim_and_load_json` (which is object-only and
maintained for other callers).

## Backward compatibility

`_strip_code_fence` returns the input unchanged unless the whole string is a
fence, so existing pure-JSON / free-text inputs behave exactly as before.

## Tests

New offline suite `tests/test_metrics/test_json_correctness_fence.py` (11 cases;
stub model, `include_reason=False`, no API key): the stripping helper plus
end-to-end scores covering fenced/plain × valid/invalid combinations.
Full metrics run: `215 passed, 278 skipped (need API key), 6 xfailed`.
`black` clean. No new dependencies.

Closes #3166