### PR TITLE
feat(metrics): short-circuit ContextualPrecision on degenerate inputs

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/contextual_precision/contextual_precision.py
+++ b/deepeval/metrics/contextual_precision/contextual_precision.py
@@ -117,6 +117,11 @@ class ContextualPrecisionMetric(BaseMetric):
                     test_case.retrieval_context
                 )
 
+                if self._try_degenerate_short_circuit(
+                    expected_output, grouped_retrieval_context
+                ):
+                    return self.score
+
                 self.verdicts: List[cpschema.ContextualPrecisionVerdict] = (
                     self._generate_verdicts(
                         input,
@@ -170,6 +175,11 @@ class ContextualPrecisionMetric(BaseMetric):
             grouped_retrieval_context = self._group_retrieval_contexts(
                 test_case.retrieval_context
             )
+
+            if self._try_degenerate_short_circuit(
+                expected_output, grouped_retrieval_context
+            ):
+                return self.score
 
             self.verdicts: List[cpschema.ContextualPrecisionVerdict] = (
                 await self._a_generate_verdicts(
@@ -359,6 +369,59 @@ class ContextualPrecisionMetric(BaseMetric):
         # Calculate weighted cumulative precision
         score = sum_weighted_precision_at_k / relevant_nodes_count
         return 0 if self.strict_mode and score < self.threshold else score
+
+    def _try_degenerate_short_circuit(
+        self,
+        expected_output: Optional[str],
+        retrieval_context: List[str],
+    ) -> bool:
+        """Resolve degenerate inputs deterministically, skipping the LLM.
+
+        Contextual precision ranks how early *relevant* chunks appear in the
+        retrieval context. When there is no context to rank, or no expected
+        output to judge relevance against, there is nothing an LLM could
+        inspect that would change a 0 verdict. Sending these cases to the eval
+        model wastes latency/cost and produces non-deterministic results (the
+        LLM may invent relevance for empty input). We short-circuit to a fixed,
+        explainable outcome instead.
+
+        Returns ``True`` if the case was handled (score/verdicts/reason set).
+        """
+        has_context = bool(retrieval_context)
+        has_expected = not (
+            isinstance(expected_output, str) and not expected_output.strip()
+        )
+
+        if has_context and has_expected:
+            return False
+
+        self.verdicts = []
+        self.score = 0
+        self.success = self.is_successful()
+        if self.include_reason:
+            if not has_context:
+                reason = (
+                    "Contextual precision could not be measured: the retrieval "
+                    "context is empty. There are no chunks whose relevance "
+                    "should be ranked, so the score is 0."
+                )
+            else:
+                reason = (
+                    "Contextual precision could not be measured: the expected "
+                    "output is empty. There is no expected output to judge "
+                    "chunk relevance against, so the score is 0."
+                )
+        else:
+            reason = None
+        self.reason = reason
+        self.verbose_logs = construct_verbose_logs(
+            self,
+            steps=[
+                "Verdicts: []",
+                f"Score: 0\nReason: {reason}",
+            ],
+        )
+        return True
 
     @property
     def __name__(self):

--- a/tests/test_metrics/test_contextual_precision_degenerate_inputs.py
+++ b/tests/test_metrics/test_contextual_precision_degenerate_inputs.py
@@ -1,0 +1,117 @@
+"""Offline tests for ContextualPrecisionMetric's degenerate-input handling.
+
+Contextual precision ranks how early *relevant* chunks appear in the retrieval
+context. When there is no context to rank, or no expected output to judge
+relevance against, the answer is trivially 0. Previously the metric still
+round-tripped through the eval LLM for these cases — wasting latency/cost and
+producing non-deterministic results. We now short-circuit to a fixed,
+explainable outcome.
+
+These tests are fully offline: a stub ``DeepEvalBaseLLM`` is used and its
+``generate``/``a_generate`` are wired to raise, proving the short-circuit path
+never touches the LLM.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from deepeval.metrics import ContextualPrecisionMetric
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+
+def _stub_model() -> DeepEvalBaseLLM:
+    m = MagicMock(spec=DeepEvalBaseLLM)
+    m.get_model_name.return_value = "mock-llm"
+    m.supports_multimodal.return_value = False
+    # If any code path reaches the LLM for a degenerate input, fail loudly.
+    m.generate.side_effect = AssertionError("LLM called on degenerate input")
+    m.a_generate.side_effect = AssertionError("LLM called on degenerate input")
+    return m
+
+
+def _make_metric() -> ContextualPrecisionMetric:
+    return ContextualPrecisionMetric(
+        model=_stub_model(),
+        async_mode=False,
+        include_reason=True,
+        strict_mode=False,
+        threshold=0.5,
+    )
+
+
+def _case(expected_output: str, retrieval_context) -> LLMTestCase:
+    return LLMTestCase(
+        input="q",
+        expected_output=expected_output,
+        retrieval_context=retrieval_context,
+    )
+
+
+class TestDegenerateShortCircuit:
+    @pytest.mark.parametrize(
+        "expected_output,retrieval_context",
+        [
+            pytest.param("Some answer.", [], id="empty-context"),
+            pytest.param(
+                "", ["A great context sentence."], id="empty-expected"
+            ),
+            pytest.param("   ", ["A context."], id="blank-expected"),
+        ],
+    )
+    def test_degenerate_inputs_short_circuit_to_zero(
+        self, expected_output, retrieval_context
+    ):
+        metric = _make_metric()
+        score = metric.measure(_case(expected_output, retrieval_context))
+        assert score == 0.0
+        assert metric.score == 0.0
+        assert metric.verdicts == []
+        assert metric.success is False
+        assert metric.reason is not None
+        assert "could not be measured" in metric.reason
+
+    def test_sync_and_async_agree(self):
+        sync = _make_metric()
+        sync.measure(_case("Some answer.", []))
+        async_metric = ContextualPrecisionMetric(
+            model=_stub_model(),
+            async_mode=True,
+            include_reason=True,
+        )
+        score = async_metric.measure(_case("Some answer.", []))
+        assert score == sync.score == 0.0
+
+    def test_include_reason_false_still_short_circuits(self):
+        metric = ContextualPrecisionMetric(
+            model=_stub_model(),
+            async_mode=False,
+            include_reason=False,
+        )
+        metric.measure(_case("Some answer.", []))
+        assert metric.score == 0.0
+        assert metric.reason is None
+
+    def test_non_degenerate_is_not_empty(self):
+        metric = _make_metric()
+        helper = metric._try_degenerate_short_circuit
+        assert (
+            helper(
+                expected_output="A real answer.",
+                retrieval_context=["A real context sentence."],
+            )
+            is False
+        )
+
+
+class TestLLMNotContacted:
+    def test_empty_context_never_calls_generate(self):
+        metric = _make_metric()  # generate/a_generate raise if invoked
+        assert metric.measure(_case("Some answer.", [])) == 0.0
+
+    def test_empty_expected_never_calls_a_generate(self):
+        metric = ContextualPrecisionMetric(model=_stub_model(), async_mode=True)
+        assert metric.measure(_case("", ["A context sentence."])) == 0.0


### PR DESCRIPTION
Closes #3170

### Why
`ContextualPrecisionMetric` ranks how early *relevant* chunks appear in the retrieval context. Two degenerate inputs make the answer trivially 0:

1. **Empty `retrieval_context`** — there are no chunks to rank.
2. **Empty/whitespace `expected_output`** — there is nothing to judge relevance against.

Today the metric still sends these cases to the eval LLM: wasted latency/cost and, worse, **non-deterministic** results (an LLM may invent relevance for empty input). `retrieval_context=[]` is already permitted by param validation, so this path is reachable.

### Change
Short-circuit in both `measure` (sync) and `a_measure` (async):

- If `retrieval_context` is empty **or** `expected_output` is empty/whitespace → score `0`, empty verdicts, and a deterministic reason (only when `include_reason=True`), **without** invoking the LLM.
- Normal inputs are untouched: they run the exact same LLM verdict pipeline as before.

Implementation is kept in a single helper `_try_degenerate_short_circuit(...)` shared by both branches. **Backward compatible** — default behavior for valid inputs is unchanged.

### Verification
- New offline tests (`tests/test_metrics/test_contextual_precision_degenerate_inputs.py`): the stub LLM's `generate`/`a_generate` are wired to `assert`-raise, proving degenerate cases never contact the LLM.
  - degenerate inputs → score `0`, empty verdicts, non-flaky reason
  - sync and async agree
  - `include_reason=False` still short-circuits (reason `None`)
  - non-degenerate input **does not** short-circuit
- `pytest` on the touched/relevant suites: **78 passed** (incl. metric-success regression).
- `black` clean on changed files.

### Notes
Includes a separate `chore:` formatting commit for `.scripts/release.py` so the repo's black 25.12.0 lint CI is green (upstream blocker already reported in #3169).