### PR TITLE
feat(json_correctness): schema-less offline JSON validation

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/json_correctness/json_correctness.py
+++ b/deepeval/metrics/json_correctness/json_correctness.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional, Union, Type
 from pydantic import BaseModel, ValidationError
 
@@ -20,6 +21,8 @@ from deepeval.utils import get_or_create_event_loop, serialize_to_json
 from deepeval.templates import make_template_class
 
 DEFAULT_CORRECT_REASON = "The generated Json matches and is syntactically correct to the expected schema."
+DEFAULT_CORRECT_REASON_NO_SCHEMA = "The generated output is valid JSON."
+DEFAULT_INCORRECT_REASON_NO_SCHEMA = "The generated output is not valid JSON."
 
 
 JsonCorrectnessTemplate = make_template_class("JsonCorrectnessMetric")
@@ -33,7 +36,7 @@ class JsonCorrectnessMetric(BaseMetric):
 
     def __init__(
         self,
-        expected_schema: BaseModel,
+        expected_schema: Optional[BaseModel] = None,
         model: Optional[Union[str, DeepEvalBaseLLM]] = None,
         threshold: Optional[float] = 0.5,
         async_mode: bool = True,
@@ -55,6 +58,40 @@ class JsonCorrectnessMetric(BaseMetric):
         self.expected_schema = expected_schema
         self.evaluation_model = self.model.get_model_name()
         self.evaluation_template = evaluation_template
+
+    def _validates_as_json(self, actual_output: str) -> bool:
+        """Return whether ``actual_output`` is valid.
+
+        In schema mode (``expected_schema`` set) the output must parse and
+        validate against the pydantic schema. In schema-less mode
+        (``expected_schema=None``) the output only needs to be *parseable* JSON
+        — a fully deterministic, offline JSON well-formedness check that needs
+        no LLM.
+
+        Empty / whitespace-only / non-JSON strings fail both paths.
+        """
+        if self.expected_schema is not None:
+            try:
+                self.expected_schema.model_validate_json(actual_output)
+                return True
+            except ValidationError:
+                return False
+        try:
+            json.loads(actual_output)
+            return True
+        except (ValueError, TypeError):
+            return False
+
+    def _deterministic_reason(self, valid_json: bool) -> Optional[str]:
+        """Schema-less reason — never invokes the LLM, so this mode is fully
+        deterministic and works with no API key configured."""
+        if not self.include_reason:
+            return None
+        return (
+            DEFAULT_CORRECT_REASON_NO_SCHEMA
+            if valid_json
+            else DEFAULT_INCORRECT_REASON_NO_SCHEMA
+        )
 
     def measure(
         self,
@@ -90,13 +127,7 @@ class JsonCorrectnessMetric(BaseMetric):
                     )
                 )
             else:
-                valid_json = True
-                try:
-                    self.expected_schema.model_validate_json(
-                        test_case.actual_output
-                    )
-                except ValidationError:
-                    valid_json = False
+                valid_json = self._validates_as_json(test_case.actual_output)
 
                 self.score = 1 if valid_json else 0
                 self.reason = self.generate_reason(test_case.actual_output)
@@ -139,13 +170,7 @@ class JsonCorrectnessMetric(BaseMetric):
             _show_indicator=_show_indicator,
             _in_component=_in_component,
         ):
-            valid_json = True
-            try:
-                self.expected_schema.model_validate_json(
-                    test_case.actual_output
-                )
-            except ValidationError:
-                valid_json = False
+            valid_json = self._validates_as_json(test_case.actual_output)
 
             self.score = 1 if valid_json else 0
             self.reason = await self.a_generate_reason(test_case.actual_output)
@@ -165,6 +190,9 @@ class JsonCorrectnessMetric(BaseMetric):
             return None
 
         is_valid_json = self.score == 1
+        if self.expected_schema is None:
+            # Schema-less mode never invokes the LLM.
+            return self._deterministic_reason(is_valid_json)
         if is_valid_json:
             return DEFAULT_CORRECT_REASON
 
@@ -190,6 +218,9 @@ class JsonCorrectnessMetric(BaseMetric):
             return None
 
         is_valid_json = self.score == 1
+        if self.expected_schema is None:
+            # Schema-less mode never invokes the LLM.
+            return self._deterministic_reason(is_valid_json)
         if is_valid_json:
             return DEFAULT_CORRECT_REASON
 

--- a/tests/test_metrics/test_json_correctness_schema_less.py
+++ b/tests/test_metrics/test_json_correctness_schema_less.py
@@ -1,0 +1,159 @@
+from pydantic import BaseModel
+
+import pytest
+
+from deepeval.errors import MissingTestCaseParamsError
+from deepeval.metrics.json_correctness.json_correctness import (
+    JsonCorrectnessMetric,
+    DEFAULT_CORRECT_REASON_NO_SCHEMA,
+    DEFAULT_INCORRECT_REASON_NO_SCHEMA,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+
+class _StubModel(DeepEvalBaseLLM):
+    """Minimal judge: the schema-less mode never invokes the LLM, so this model
+    only needs to exist for construction."""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-model"
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "schema-less mode must never call the LLM; got prompt: %s" % prompt
+        )
+
+    async def a_generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "schema-less mode must never call the LLM; got prompt: %s" % prompt
+        )
+
+
+class CarSchema(BaseModel):
+    make: str
+    year: int
+    electric: bool
+
+
+def _make_metric(**kwargs) -> JsonCorrectnessMetric:
+    return JsonCorrectnessMetric(model=_StubModel(), **kwargs)
+
+
+def _measure(
+    metric: JsonCorrectnessMetric, actual_output: str
+) -> JsonCorrectnessMetric:
+    test_case = LLMTestCase(
+        input="Please return a JSON object.",
+        actual_output=actual_output,
+    )
+    metric.measure(test_case)
+    return metric
+
+
+class TestJsonCorrectnessSchemaLess:
+    """Offline, no-LLM tests for the schema-less `expected_schema=None` mode.
+
+    These never need an API key: schema-less mode is fully deterministic and
+    never invokes the LLM.
+    """
+
+    # ---- default behaviour doesn't regress (schema mode intact) ----
+
+    def test_schema_mode_still_validates(self):
+        metric = _make_metric(expected_schema=CarSchema)
+        assert metric.expected_schema is CarSchema
+        assert metric._validates_as_json(
+            '{"make": "Tesla", "year": 2023, "electric": true}'
+        )
+        assert not metric._validates_as_json('{"make": "Tesla"}')
+
+    def test_measure_with_schema_valid_scores_one(self):
+        metric = _measure(
+            _make_metric(expected_schema=CarSchema, async_mode=False),
+            '{"make": "Tesla", "year": 2023, "electric": true}',
+        )
+        assert metric.score == 1
+
+    def test_schema_mode_invalid_does_not_validate(self):
+        # In schema mode the metric validates against the pydantic schema; an
+        # object missing a required field is rejected. (This is the pre-existing
+        # default behaviour, exercised offline against the helper.)
+        assert not JsonCorrectnessMetric(
+            model=_StubModel(), expected_schema=CarSchema
+        )._validates_as_json('{"make": "Tesla"}')
+        assert JsonCorrectnessMetric(
+            model=_StubModel(), expected_schema=CarSchema
+        )._validates_as_json(
+            '{"make": "Tesla", "year": 2023, "electric": true}'
+        )
+
+    # ---- new capability: schema-less mode ----
+
+    def test_schemeless_valid_json_scores_one(self):
+        metric = _measure(
+            _make_metric(async_mode=False),
+            '{"make": "Tesla", "year": 2023, "electric": true}',
+        )
+        assert metric.score == 1
+        assert metric.reason == DEFAULT_CORRECT_REASON_NO_SCHEMA
+        assert metric.success is True
+
+    def test_schemeless_invalid_json_scores_zero(self):
+        metric = _measure(
+            _make_metric(async_mode=False),
+            '{"make": "Tesla"',
+        )
+        assert metric.score == 0
+        assert metric.reason == DEFAULT_INCORRECT_REASON_NO_SCHEMA
+        assert metric.success is False
+
+    def test_schemeless_empty_string_fails(self):
+        # Empty actual_output is rejected by the shared param validation before
+        # the metric runs, so an empty string can never be scored as valid JSON.
+        metric = _make_metric(async_mode=False)
+        with pytest.raises(MissingTestCaseParamsError):
+            _measure(metric, "")
+        assert metric.score is None
+
+    def test_schemeless_whitespace_only_fails(self):
+        metric = _measure(_make_metric(async_mode=False), "   \n\t ")
+        assert metric.score == 0
+
+    def test_schemeless_non_json_text_fails(self):
+        metric = _measure(_make_metric(async_mode=False), "not json at all")
+        assert metric.score == 0
+
+    def test_schemeless_parseable_primitives_accepted(self):
+        # Any well-formed JSON value is valid, not just objects.
+        for raw in ['"a string"', "123", "true", "null", "[1, 2, 3]"]:
+            metric = _measure(_make_metric(async_mode=False), raw)
+            assert metric.score == 1, raw
+
+    def test_schemeless_include_reason_false(self):
+        metric = _measure(
+            _make_metric(async_mode=False, include_reason=False),
+            '{"a": 1}',
+        )
+        assert metric.score == 1
+        assert metric.reason is None
+
+    def test_schemeless_async_mode(self):
+        metric = _measure(
+            _make_metric(async_mode=True),
+            '{"a": 1}',
+        )
+        assert metric.score == 1
+        assert metric.reason == DEFAULT_CORRECT_REASON_NO_SCHEMA
+
+    def test_schemeless_async_invalid(self):
+        metric = _measure(_make_metric(async_mode=True), "{bad")
+        assert metric.score == 0
+        assert metric.reason == DEFAULT_INCORRECT_REASON_NO_SCHEMA
+
+    def test_verbose_logs_built(self):
+        metric = _measure(_make_metric(async_mode=False), '{"a": 1}')
+        assert metric.verbose_logs is not None


### PR DESCRIPTION
## Summary

This PR makes `JsonCorrectnessMetric.expected_schema` optional (closes #3177). When `expected_schema=None`, the metric performs a pure **`json.loads` well-formedness check** instead of requiring a pydantic schema and an LLM call:

- **Schema-less mode** — `actual_output` is scored `1.0` if it parses as JSON, `0.0` otherwise (empty / whitespace-only / non-JSON fail). The reason is a fixed constant, so **no API key and no LLM** are needed — fully deterministic and CI-friendly.
- **Schema mode unchanged** — supplying `expected_schema` keeps the exact existing validation + LLM reason path.

## What changed

- `expected_schema: BaseModel` → `expected_schema: Optional[BaseModel] = None`.
- Added `_validates_as_json()` helper that dispatches on whether a schema is set (pydantic `model_validate_json` vs `json.loads`).
- Added `_deterministic_reason()` returning fixed constant reasons for the schema-less path.
- `measure` / `a_measure` / `generate_reason` / `a_generate_reason` route the schema-less path deterministically without invoking the LLM.

## Backward compatibility

Fully backward compatible. `expected_schema` was previously a required positional arg; all existing call sites that pass a schema keep the identical behaviour. The new default (`None`) only affects code that previously would have crashed with a missing-argument error.

## Tests

New offline suite `tests/test_metrics/test_json_correctness_schema_less.py` (13 cases) split into:
- **Default behaviour doesn't regress** — schema-mode validation/scores still work.
- **New capability works** — schema-less valid/invalid JSON, parseable primitives (`"str"`, `123`, `true`, `null`, `[1,2,3]`), empty/whitespace/non-JSON rejection, `include_reason=False`, both sync and async, and verbose-logs construction.

Results:
```
13 passed (offline, no API key)
black clean
No new dependencies
```

## Docs

No docs change: behaviour is additive and the metric's contract is otherwise unchanged.