### PR TITLE
fix(tool_correctness): score repeated calls of the same tool in non-exact mode

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -452,11 +452,18 @@ class ToolCorrectnessMetric(BaseMetric):
     # Non exact matching score
     def _calculate_non_exact_match_score(self) -> float:
         total_score = 0.0
-        matched_called_tools = set()
+        # Track matched calls by their position in ``tools_called`` rather than
+        # by value. ``ToolCall.__eq__``/``__hash__`` are value-based (name +
+        # input_parameters + output), so two *distinct* calls of the same tool
+        # compare equal. Deduplicating by value would then drop every call after
+        # the first, under-scoring any expected call of that tool from the second
+        # one on (e.g. 2 identical expected tools / 2 made -> 0.5 instead of 1.0).
+        matched_called_indices = set()
         for expected_tool in self.expected_tools:
             best_score = 0.0
-            for called_tool in self.tools_called:
-                if called_tool in matched_called_tools:
+            best_called_index = None
+            for called_index, called_tool in enumerate(self.tools_called):
+                if called_index in matched_called_indices:
                     continue
                 if (
                     expected_tool.name == called_tool.name
@@ -478,10 +485,10 @@ class ToolCorrectnessMetric(BaseMetric):
                         match_score = 0.0
                     if match_score > best_score:
                         best_score = match_score
-                        best_called_tool = called_tool
+                        best_called_index = called_index
             if best_score > 0:
                 total_score += best_score
-                matched_called_tools.add(best_called_tool)
+                matched_called_indices.add(best_called_index)
         return (
             1.0
             if not self.expected_tools and not self.tools_called

--- a/tests/test_metrics/test_tool_correctness_duplicate_calls.py
+++ b/tests/test_metrics/test_tool_correctness_duplicate_calls.py
@@ -1,0 +1,104 @@
+from typing import Optional, Union
+
+from deepeval.test_case import LLMTestCase, ToolCall
+from deepeval.metrics import ToolCorrectnessMetric
+from deepeval.models import DeepEvalBaseLLM
+
+
+class _StubModel(DeepEvalBaseLLM):
+    """The default (non-exact, unordered) scoring path and, with no
+    ``available_tools``, the whole ``measure`` run never invoke the LLM. This
+    model only needs to exist so the metric can be built without an API key."""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-model"
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "duplicate-call scoring must not call the LLM; got prompt: %s"
+            % prompt
+        )
+
+    async def a_generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "duplicate-call scoring must not call the LLM; got prompt: %s"
+            % prompt
+        )
+
+
+def _measure(
+    called: list, expected: list, *, evaluation_params=None
+) -> ToolCorrectnessMetric:
+    test_case = LLMTestCase(
+        input="call the tools",
+        actual_output="done",
+        tools_called=called,
+        expected_tools=expected,
+    )
+    metric = ToolCorrectnessMetric(
+        async_mode=False,
+        model=_StubModel(),
+        evaluation_params=evaluation_params or [],
+    )
+    metric.measure(test_case, _show_indicator=False)
+    return metric
+
+
+def _search() -> ToolCall:
+    return ToolCall(name="search")
+
+
+class TestToolCorrectnessDuplicateCalls:
+    """Regression tests for value-based dedup dropping repeated tool calls.
+
+    ``ToolCall.__eq__``/``__hash__`` compare ``(name, input_parameters,
+    output)`` only, so two genuinely distinct calls of the same tool compare
+    equal. The non-exact scorer must therefore match expected calls against
+    called calls *positionally* (one used call per expected call, even when the
+    calls are value-identical) instead of deduplicating by value.
+    """
+
+    def test_two_identical_calls_both_expected_scores_one(self):
+        # Regresses: used to score 0.5 because the second `search` was treated
+        # as already consumed by the value-based dedup.
+        metric = _measure([_search(), _search()], [_search(), _search()])
+        assert metric.score == 1.0
+        assert metric.success is True
+
+    def test_only_one_of_two_expected_made_scores_half(self):
+        # The correct down-scoring must be preserved: only one call happened.
+        metric = _measure([_search()], [_search(), _search()])
+        assert metric.score == 0.5
+
+    def test_one_expected_twice_called_scores_one(self):
+        metric = _measure([_search(), _search()], [_search()])
+        assert metric.score == 1.0
+
+    def test_distinct_tools_still_score_one(self):
+        # Backward compatibility: distinct tools are unaffected.
+        metric = _measure(
+            [ToolCall(name="a"), ToolCall(name="b")],
+            [ToolCall(name="a"), ToolCall(name="b")],
+        )
+        assert metric.score == 1.0
+
+    def test_duplicates_share_matching_input_parameters(self):
+        # Duplicate calls carrying the expected parameters match individually.
+        with_params = ToolCall(name="search", input_parameters={"q": "x"})
+        metric = _measure(
+            [with_params, with_params],
+            [with_params, with_params],
+            evaluation_params=[],
+        )
+        assert metric.score == 1.0
+
+    def test_empty_lists_score_one(self):
+        metric = _measure([], [])
+        assert metric.score == 1.0
+
+    def test_missing_entirely_scores_zero(self):
+        metric = _measure([], [_search()])
+        assert metric.score == 0.0


### PR DESCRIPTION
## Summary

Fixes #3141.

`ToolCorrectnessMetric` under-scored an agent that correctly called the **same tool more than once** in the default (non-exact, unordered) mode. `_calculate_non_exact_match_score` deduplicated matched calls with a **value-based** `set`:

```python
matched_called_tools = set()
...
    if called_tool in matched_called_tools:
        continue
```

Because `ToolCall.__eq__`/`__hash__` compare only `(name, input_parameters, output)`, two genuinely distinct calls of the same tool compare equal. The first match added that value to the set, so every later distinct-but-equal call was treated as already consumed — e.g. 2 expected `search` calls / 2 made scored `0.5` instead of `1.0`.

## Change

Track matched calls by their **position** in `tools_called` (a set of indices) instead of by value. Each expected tool now consumes at most one actual call, even when the calls are value-identical, while the "one called call per expected call" semantics are preserved.

This is fully **deterministic** (no LLM involved in the scorer) and confined to the default path; the exact-match and LCS (ordering) scorers were already correct for duplicates.

## Backward compatibility

- Distinct tools (`a`, `b`) → unchanged (`1.0`).
- Empty expected/called → unchanged (`1.0`).
- Only one of two expected duplicate calls made → still `0.5`.

## Tests

New `tests/test_metrics/test_tool_correctness_duplicate_calls.py` (7 cases) covering the regression, the preserved down-scoring, mixed calls, and backward-compatible empty/distinct cases — all deterministic, no API key required.

```
7 passed
```

Also verified the existing `test_tool_correctness_metric.py` suite shows no failures, and both touched files are `black`-clean.