### PR TITLE
fix(role_violation): enforce strict mode threshold of 1

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/role_violation/role_violation.py
+++ b/deepeval/metrics/role_violation/role_violation.py
@@ -52,7 +52,10 @@ class RoleViolationMetric(BaseMetric):
                 "Role parameter is required. Please specify the expected role (e.g., 'helpful assistant', 'customer service agent', etc.)"
             )
 
-        self.threshold = 0 if strict_mode else threshold
+        # Strict mode requires perfect adherence (score == 1.0). Using 0 here
+        # would make even a failed check (score 0.0 >= 0) pass, so this metric
+        # must mirror every other metric and default strict threshold to 1.
+        self.threshold = 1 if strict_mode else threshold
         self.role = role
         self.model, self.using_native_model = initialize_model(model)
         self.evaluation_model = self.model.get_model_name()

--- a/tests/test_metrics/test_role_violation_strict_mode.py
+++ b/tests/test_metrics/test_role_violation_strict_mode.py
@@ -1,0 +1,79 @@
+from deepeval.metrics import RoleViolationMetric
+from deepeval.metrics.role_violation.schema import RoleViolationVerdict
+from deepeval.models import DeepEvalBaseLLM
+
+
+class _StubModel(DeepEvalBaseLLM):
+    """The strict-mode behavior under test is the threshold initialization and
+    the deterministic ``_calculate_score``, neither of which needs an LLM."""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-model"
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError("strict-mode test must not call the LLM")
+
+    async def a_generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError("strict-mode test must not call the LLM")
+
+
+def _make_metric(
+    strict_mode: bool, threshold: float = 0.5
+) -> RoleViolationMetric:
+    return RoleViolationMetric(
+        role="helpful assistant",
+        model=_StubModel(),
+        strict_mode=strict_mode,
+        threshold=threshold,
+        async_mode=False,
+        include_reason=False,
+    )
+
+
+def _score(metric: RoleViolationMetric, verdicts) -> tuple:
+    metric.verdicts = [
+        RoleViolationVerdict(verdict=v, reason=r) for v, r in verdicts
+    ]
+    metric.score = metric._calculate_score()
+    return metric.score, metric.is_successful()
+
+
+class TestRoleViolationStrictMode:
+    def test_strict_mode_sets_threshold_to_one(self):
+        # Regresses: strict_mode initialized threshold to 0, so a failing
+        # check (0.0 >= 0) still reported success.
+        assert _make_metric(strict_mode=True).threshold == 1
+
+    def test_default_threshold_preserved(self):
+        assert _make_metric(strict_mode=False).threshold == 0.5
+
+    def test_explicit_threshold_preserved_when_not_strict(self):
+        assert _make_metric(strict_mode=False, threshold=0.8).threshold == 0.8
+
+    def test_strict_mode_fails_on_role_violation(self):
+        metric = _make_metric(strict_mode=True)
+        score, success = _score(metric, [("yes", "broke character")])
+        assert score == 0.0
+        assert success is False
+
+    def test_strict_mode_passes_without_violation(self):
+        metric = _make_metric(strict_mode=True)
+        score, success = _score(metric, [("no", "stayed in role")])
+        assert score == 1.0
+        assert success is True
+
+    def test_non_strict_still_fails_on_role_violation(self):
+        metric = _make_metric(strict_mode=False)
+        score, success = _score(metric, [("yes", "broke character")])
+        assert score == 0.0
+        assert success is False
+
+    def test_no_violations_always_scores_one(self):
+        for strict in (True, False):
+            metric = _make_metric(strict_mode=strict)
+            score, success = _score(metric, [])
+            assert score == 1.0
+            assert success is True


### PR DESCRIPTION
## Summary

Fixes #2901.

`RoleViolationMetric` did not enforce `strict_mode` correctly. It initialized:

```python
self.threshold = 0 if strict_mode else threshold
```

so the base-class success check `self.score >= self.threshold` passed even when a role violation was detected (`0.0 >= 0`). Every other metric defaults its strict threshold to `1`; this was the only outlier, causing strict mode to always succeed.

## Change

```python
self.threshold = 1 if strict_mode else threshold
```

Strict mode now requires perfect adherence (`score == 1.0`). The deterministic `_calculate_score` is unchanged.

## Backward compatibility

- Default (`strict_mode=False`) keeps the caller's threshold (`0.5` default) → unchanged.
- Explicit non-strict threshold preserved.
- Empty verdicts / no violations still score `1.0`.

## Tests

New `tests/test_metrics/test_role_violation_strict_mode.py` (7 cases) verifying the threshold initialization and the threshold/`is_successful` interplay with and without a role violation — all deterministic, no API key required.

```
7 passed
```

The existing `test_role_violation_metric.py` suite shows no failures (skipped without an API key), and both touched files are `black`-clean.