### PR TITLE
fix(tool_correctness): return the score on the default async path

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -96,6 +96,11 @@ class ToolCorrectnessMetric(BaseMetric):
                         _in_component=_in_component,
                     )
                 )
+                # a_measure populates ``self.score``, so the default (async)
+                # path must return it too; otherwise ``measure()`` silently
+                # returns None and breaks callers that consume the return value
+                # (e.g. ``float(metric.measure(tc))`` in the prompt optimizer).
+                return self.score
             else:
                 self.tools_called: List[ToolCall] = test_case.tools_called
                 self.expected_tools: List[ToolCall] = test_case.expected_tools

--- a/tests/test_metrics/test_tool_correctness_async_returns_score.py
+++ b/tests/test_metrics/test_tool_correctness_async_returns_score.py
@@ -1,0 +1,95 @@
+import asyncio
+
+from deepeval.metrics import ToolCorrectnessMetric
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase, ToolCall
+
+
+class _StubModel(DeepEvalBaseLLM):
+    """ToolCorrectness never invokes the model when ``available_tools`` is
+    unset, so the model only needs to exist for construction."""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-model"
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "measure() must not call the LLM; got prompt: %s" % prompt
+        )
+
+    async def a_generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "measure() must not call the LLM; got prompt: %s" % prompt
+        )
+
+
+def _test_case() -> LLMTestCase:
+    return LLMTestCase(
+        input="query the web",
+        actual_output="done",
+        tools_called=[ToolCall(name="search")],
+        expected_tools=[ToolCall(name="search")],
+    )
+
+
+def _metric(async_mode: bool = True) -> ToolCorrectnessMetric:
+    return ToolCorrectnessMetric(
+        model=_StubModel(),
+        async_mode=async_mode,
+        include_reason=False,
+    )
+
+
+class TestToolCorrectnessMeasureReturnsScore:
+    def test_default_async_mode_measure_returns_score(self):
+        # Regresses #3088: with async_mode left at its default (True),
+        # measure() previously returned None even though self.score was set.
+        metric = _metric()
+        result = metric.measure(_test_case(), _show_indicator=False)
+        assert metric.score == 1.0
+        assert result == 1.0
+        assert isinstance(result, float)
+
+    def test_default_async_mode_is_async_mode(self):
+        assert _metric().async_mode is True
+
+    def test_sync_mode_measure_returns_score(self):
+        metric = _metric(async_mode=False)
+        result = metric.measure(_test_case(), _show_indicator=False)
+        assert metric.score == 1.0
+        assert result == 1.0
+
+    def test_a_measure_returns_score(self):
+        metric = _metric()
+        result = asyncio.run(
+            metric.a_measure(_test_case(), _show_indicator=False)
+        )
+        assert result == 1.0
+
+    def test_returned_value_is_float_convertible(self):
+        # The prompt optimizer does float(metric.measure(tc)); None breaks it.
+        metric = _metric()
+        result = metric.measure(_test_case(), _show_indicator=False)
+        assert float(result) == 1.0
+
+    def test_async_score_matches_sync_score(self):
+        async_score = _metric().measure(_test_case(), _show_indicator=False)
+        sync_score = _metric(async_mode=False).measure(
+            _test_case(), _show_indicator=False
+        )
+        assert async_score == sync_score == 1.0
+
+    def test_mismatch_scores_zero_and_returns_zero(self):
+        tc = LLMTestCase(
+            input="q",
+            actual_output="a",
+            tools_called=[ToolCall(name="search")],
+            expected_tools=[ToolCall(name="browse")],
+        )
+        metric = _metric()
+        result = metric.measure(tc, _show_indicator=False)
+        assert metric.score == 0.0
+        assert result == 0.0


### PR DESCRIPTION
## Summary

Fixes #3088.

`ToolCorrectnessMetric.measure()` returned `None` when `async_mode` was left at its default (`True`). The `return self.score` statement only lived inside the sync (`else`) branch, so the async branch ran `a_measure()` and then fell through to an implicit `None`.

```python
if self.async_mode:
    loop.run_until_complete(self.a_measure(...))
    # no return -> None
else:
    ...
    return self.score
```

`metric.score` was always populated correctly; only the return value was lost. This broke callers that consume the return value — e.g. `deepeval/optimizer/scorer/scorer.py` calls `measure()` then `float(result)`, which raised `TypeError` on the default path.

## Change

Return `self.score` from the async branch after `a_measure()` completes, matching the sync branch and `a_measure()` itself (and the `-> float` annotation on `BaseMetric.measure`).

## Backward compatibility

- Return value on the default path changes from `None` to the score. No caller legitimately relied on `None` (it could not satisfy the metrics' own `-> float` contract), and the metric's attributes/state are unchanged.
- Sync path and `a_measure()` unchanged.

## Tests

New `tests/test_metrics/test_tool_correctness_async_returns_score.py` (7 cases). Four of them fail on the pre-fix code (`None`/`TypeError`), confirming they capture the regression; they exercise the metric with no model calls (`available_tools` unset). Verified: default async returns `1.0` (float), sync returns `1.0`, `a_measure` returns `1.0`, mismatch scores `0.0` and is returned.

```
7 passed
```

Existing `test_tool_correctness_metric.py` shows no failures (skipped without an API key), and the repo is `black`-clean (`993 files would be left unchanged`).