### PR TITLE
fix(contextual_relevancy): keep score and reason on the same verdict classification

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
+++ b/deepeval/metrics/contextual_relevancy/contextual_relevancy.py
@@ -60,6 +60,42 @@ def _contextual_relevancy_verdict_kwargs(multimodal: bool) -> Dict[str, str]:
 ContextualRelevancyTemplate = make_template_class("ContextualRelevancyMetric")
 
 
+def _verdict_is_relevant(verdict: Optional[str]) -> bool:
+    """Normalize a verdict token and decide whether it is affirmative.
+
+    Scores and reasons must classify every verdict identically, otherwise a
+    corrupted token falls on opposite sides of the two branches and the metric
+    contradicts itself (e.g. ``"yes."`` dragged the score down while the reason
+    called the statements relevant). Normalizing surrounding whitespace and
+    trailing punctuation keeps ``yes.`` / ``Yes `` / ``YES!`` equivalent to
+    ``yes``; anything else (``no``, ``maybe``, ``yes<garbage>``) is treated as
+    not relevant by both paths.
+    """
+    if verdict is None:
+        return False
+    return verdict.strip().rstrip(".,;:!?").lower() == "yes"
+
+
+def _split_relevant_irrelevant(
+    verdicts_list: List[ContextualRelevancyVerdicts],
+) -> tuple:
+    """Partition statements by the shared verdict predicate.
+
+    ``_calculate_score`` and the reason generation both consume this same
+    classification, so a verdict can never be scored one way and reasoned about
+    the opposite way.
+    """
+    relevant_statements = []
+    irrelevant_statements = []
+    for verdicts in verdicts_list:
+        for verdict in verdicts.verdicts:
+            if _verdict_is_relevant(verdict.verdict):
+                relevant_statements.append(verdict.statement)
+            else:
+                irrelevant_statements.append(verdict.reason)
+    return relevant_statements, irrelevant_statements
+
+
 class ContextualRelevancyMetric(BaseMetric):
     _required_params: List[SingleTurnParams] = [
         SingleTurnParams.INPUT,
@@ -200,14 +236,9 @@ class ContextualRelevancyMetric(BaseMetric):
         if self.include_reason is False:
             return None
 
-        irrelevant_statements = []
-        relevant_statements = []
-        for verdicts in self.verdicts_list:
-            for verdict in verdicts.verdicts:
-                if verdict.verdict.lower() == "no":
-                    irrelevant_statements.append(verdict.reason)
-                else:
-                    relevant_statements.append(verdict.statement)
+        relevant_statements, irrelevant_statements = _split_relevant_irrelevant(
+            self.verdicts_list
+        )
 
         prompt: dict = self._get_prompt(
             "generate_reason",
@@ -230,14 +261,9 @@ class ContextualRelevancyMetric(BaseMetric):
         if self.include_reason is False:
             return None
 
-        irrelevant_statements = []
-        relevant_statements = []
-        for verdicts in self.verdicts_list:
-            for verdict in verdicts.verdicts:
-                if verdict.verdict.lower() == "no":
-                    irrelevant_statements.append(verdict.reason)
-                else:
-                    relevant_statements.append(verdict.statement)
+        relevant_statements, irrelevant_statements = _split_relevant_irrelevant(
+            self.verdicts_list
+        )
 
         prompt: dict = self._get_prompt(
             "generate_reason",
@@ -262,7 +288,7 @@ class ContextualRelevancyMetric(BaseMetric):
         for verdicts in self.verdicts_list:
             for verdict in verdicts.verdicts:
                 total_verdicts += 1
-                if verdict.verdict.lower() == "yes":
+                if _verdict_is_relevant(verdict.verdict):
                     relevant_statements += 1
 
         if total_verdicts == 0:

--- a/tests/test_metrics/test_contextual_relevancy_verdict_normalization.py
+++ b/tests/test_metrics/test_contextual_relevancy_verdict_normalization.py
@@ -1,0 +1,115 @@
+import pytest
+
+from deepeval.metrics import ContextualRelevancyMetric
+from deepeval.metrics.contextual_relevancy.contextual_relevancy import (
+    _split_relevant_irrelevant,
+    _verdict_is_relevant,
+)
+from deepeval.metrics.contextual_relevancy.schema import (
+    ContextualRelevancyVerdict,
+    ContextualRelevancyVerdicts,
+)
+from deepeval.models import DeepEvalBaseLLM
+
+
+class _StubModel(DeepEvalBaseLLM):
+    """The behavior under test (verdict classification and scoring) never calls
+    the LLM; the model only needs to exist for construction."""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-model"
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "verdict-classification test must not call the LLM"
+        )
+
+    async def a_generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "verdict-classification test must not call the LLM"
+        )
+
+
+def _verdicts_list(entries) -> list:
+    return [
+        ContextualRelevancyVerdicts(
+            verdicts=[
+                ContextualRelevancyVerdict(statement=s, verdict=v, reason=r)
+                for (s, v, r) in entries
+            ]
+        )
+    ]
+
+
+def _score(entries) -> float:
+    metric = ContextualRelevancyMetric(
+        model=_StubModel(), async_mode=False, include_reason=False
+    )
+    metric.verdicts_list = _verdicts_list(entries)
+    return metric._calculate_score()
+
+
+class TestVerdictNormalization:
+    def test_verdict_is_relevant_matrix(self):
+        # The exact corrupted tokens reported in #3079.
+        relevant = ["yes", "yes.", "Yes ", "YES!", "  yes  "]
+        not_relevant = ["no", "no.", "No", "maybe", "yes\u0578", None, ""]
+        for token in relevant:
+            assert _verdict_is_relevant(token) is True, repr(token)
+        for token in not_relevant:
+            assert _verdict_is_relevant(token) is False, repr(token)
+
+    def test_score_counts_normalized_yes_as_relevant(self):
+        # Regresses #3079: all four verdicts were "yes." which previously
+        # scored 0.00 (the reason called them relevant).
+        score = _score(
+            [
+                ("s1", "yes.", None),
+                ("s2", "yes.", None),
+                ("s3", "yes", None),
+                ("s4", "Yes!", None),
+            ]
+        )
+        assert score == 1.0
+
+    def test_score_mixed_yes_and_no(self):
+        # Backward compatibility for well-formed verdicts.
+        score = _score(
+            [
+                ("s1", "yes", None),
+                ("s2", "yes.", None),
+                ("s3", "no", None),
+            ]
+        )
+        assert score == pytest.approx(2 / 3)
+
+    def test_score_ignores_ambiguous_tokens(self):
+        score = _score(
+            [
+                ("s1", "maybe", None),
+                ("s2", "yes", None),
+            ]
+        )
+        assert score == 0.5
+
+    def test_reason_buckets_agree_with_score(self):
+        # A verdict must never be scored as irrelevant yet reasoned as relevant
+        # (or vice versa). The reason path is built from the same predicate.
+        relevant, irrelevant = _split_relevant_irrelevant(
+            _verdicts_list(
+                [
+                    ("s_yes_punct", "yes.", "keep"),
+                    ("s_no", "no", "drop"),
+                    ("s_ambiguous", "maybe", None),
+                    ("s_yes", "YES", "keep2"),
+                ]
+            )
+        )
+        assert relevant == ["s_yes_punct", "s_yes"]
+        assert irrelevant == ["drop", None]
+
+    def test_no_verdicts_scores_zero(self):
+        assert _score([]) == 0.0


### PR DESCRIPTION
## Summary

Fixes #3079.

`ContextualRelevancyMetric` classified each verdict twice with two different predicates:

- `_calculate_score` counted a statement as relevant only when `verdict.lower() == "yes"` — everything else was **irrelevant**.
- `_generate_reason` / `_a_generate_reason` filed a statement as irrelevant only when `verdict.lower() == "no"` — everything else (including `"yes."`, `"yes<garbage>"`, `None`) was **relevant**.

So any verdict that was neither exactly `yes` nor exactly `no` landed on opposite sides of the two branches: it dragged the score down while the reason insisted the statements were relevant. The metric contradicted itself silently.

## Change

Introduce a single shared predicate and a single partition helper:

- `_verdict_is_relevant(verdict)` — normalizes surrounding whitespace and trailing punctuation (`.,;:!?`) before lower-casing, so `yes.`, `Yes `, `YES!` are equivalent to `yes`; `no`, `maybe`, `yes<garbage>`, `None` are not relevant.
- `_split_relevant_irrelevant(verdicts_list)` — partitions statements once, using that predicate.
- `_calculate_score` and both reason generators consume the same helper, so score and reason can never disagree.

## Backward compatibility

- `yes` / `no` verdicts: identical behavior (score and reason unchanged).
- Normalized-but-well-formed tokens (`yes.`, `Yes `) now score as relevant instead of being mis-scored as `0.00` while the reason calls them relevant — this is the bug fix.
- Empty verdict list still scores `0`.

## Tests

New `tests/test_metrics/test_contextual_relevancy_verdict_normalization.py` (6 cases): the exact corrupted tokens from the issue (`yes.`, `Yes `, `YES!`, `maybe`, `yes\u0578`), score counting, mixed well-formed verdicts, ambiguous tokens, and the structural score/reason agreement. All deterministic, no API key required.

```
6 passed
```

Existing `test_contextual_relevancy_metric.py` shows no failures (skipped without an API key), and the repo is `black`-clean.