### PR TITLE
fix(hallucination): keep score and reason on the same verdict classification

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/hallucination/hallucination.py
+++ b/deepeval/metrics/hallucination/hallucination.py
@@ -27,6 +27,22 @@ from deepeval.templates import make_template_class
 HallucinationTemplate = make_template_class("HallucinationMetric")
 
 
+def _is_contradiction(verdict: Optional[str]) -> bool:
+    """Return whether a (possibly malformed) verdict marks a contradiction.
+
+    The judge's raw completion is pulled with regex-based extraction that does
+    not round-trip through the ``Literal["yes", "no"]`` validation, so verdict
+    strings can arrive with surrounding whitespace or trailing punctuation
+    (e.g. ``"no."``, ``" no "``). The score and the reason must classify every
+    verdict identically; sharing one predicate guarantees they cannot disagree.
+    A normalized ``"no"`` is a contradiction; anything else (``"yes."``,
+    ``None``) is not.
+    """
+    if verdict is None:
+        return False
+    return verdict.strip().rstrip(".,;:!?").lower() == "no"
+
+
 class HallucinationMetric(BaseMetric):
     _required_params: List[SingleTurnParams] = [
         SingleTurnParams.INPUT,
@@ -161,10 +177,10 @@ class HallucinationMetric(BaseMetric):
         factual_alignments = []
         contradictions = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
-                factual_alignments.append(verdict.reason)
-            else:
+            if _is_contradiction(verdict.verdict):
                 contradictions.append(verdict.reason)
+            else:
+                factual_alignments.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
             "generate_reason",
@@ -188,10 +204,10 @@ class HallucinationMetric(BaseMetric):
         factual_alignments = []
         contradictions = []
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() == "yes":
-                factual_alignments.append(verdict.reason)
-            else:
+            if _is_contradiction(verdict.verdict):
                 contradictions.append(verdict.reason)
+            else:
+                factual_alignments.append(verdict.reason)
 
         prompt: dict = self._get_prompt(
             "generate_reason",
@@ -253,7 +269,7 @@ class HallucinationMetric(BaseMetric):
 
         factually_aligned_count = 0
         for verdict in self.verdicts:
-            if verdict.verdict.strip().lower() != "no":
+            if not _is_contradiction(verdict.verdict):
                 factually_aligned_count += 1
 
         score = factually_aligned_count / number_of_verdicts

--- a/tests/test_metrics/test_hallucination_verdict_normalization.py
+++ b/tests/test_metrics/test_hallucination_verdict_normalization.py
@@ -1,0 +1,102 @@
+import pytest
+
+from deepeval.metrics import HallucinationMetric
+from deepeval.metrics.hallucination.hallucination import _is_contradiction
+from deepeval.metrics.hallucination.schema import HallucinationVerdict
+from deepeval.models import DeepEvalBaseLLM
+
+
+class _StubModel(DeepEvalBaseLLM):
+    """The behavior under test (verdict classification and scoring) never calls
+    the LLM; the model only needs to exist for construction."""
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        return "stub-model"
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "verdict-classification test must not call the LLM"
+        )
+
+    async def a_generate(self, prompt: str, **kwargs) -> str:
+        raise AssertionError(
+            "verdict-classification test must not call the LLM"
+        )
+
+
+def _verdict(verdict: str) -> HallucinationVerdict:
+    # model_construct bypasses the Literal["yes", "no"] validation so we can
+    # inject the malformed tokens the lenient JSON extraction can produce.
+    return HallucinationVerdict.model_construct(
+        verdict=verdict, reason="reason-%s" % verdict
+    )
+
+
+def _score(*verdicts: str) -> float:
+    metric = HallucinationMetric(
+        model=_StubModel(), async_mode=False, include_reason=False
+    )
+    metric.verdicts = [_verdict(v) for v in verdicts]
+    return metric._calculate_score()
+
+
+def _reason_buckets(metric: HallucinationMetric) -> tuple:
+    # Re-implement the bucket split exactly as the reason generators do, so we
+    # can assert structural agreement with _calculate_score.
+    factual_alignments = []
+    contradictions = []
+    for verdict in metric.verdicts:
+        if _is_contradiction(verdict.verdict):
+            contradictions.append(verdict.reason)
+        else:
+            factual_alignments.append(verdict.reason)
+    return factual_alignments, contradictions
+
+
+class TestHallucinationVerdictNormalization:
+    def test_is_contradiction_matrix(self):
+        contradiction = ["no", "no.", "No ", "NO!", "  no  "]
+        aligned = ["yes", "yes.", "Yes ", "maybe", "yes\u0578", None, ""]
+        for token in contradiction:
+            assert _is_contradiction(token) is True, repr(token)
+        for token in aligned:
+            assert _is_contradiction(token) is False, repr(token)
+
+    def test_malformed_yes_scores_aligned(self):
+        # Regresses #3098: "yes." scored as aligned (0 hallucinations) but the
+        # reason listed it as a contradiction. Now both agree it is aligned.
+        assert _score("yes.") == 1.0
+
+    def test_malformed_no_counts_as_contradiction(self):
+        # "no." is semantically a contradiction; it must drag the score down.
+        assert _score("no.") == 0.0
+
+    def test_mixed_verdicts_score(self):
+        # Backward compatibility for well-formed verdicts.
+        assert _score("yes", "yes", "no") == pytest.approx(2 / 3)
+
+    def test_reason_buckets_agree_with_score(self):
+        metric = HallucinationMetric(
+            model=_StubModel(), async_mode=False, include_reason=False
+        )
+        metric.verdicts = [
+            _verdict("yes."),  # aligned (score counts it, reason must too)
+            _verdict("no"),  # contradiction
+            _verdict("maybe"),  # aligned (not an explicit "no")
+        ]
+        factual, contradictions = _reason_buckets(metric)
+        assert factual == ["reason-yes.", "reason-maybe"]
+        assert contradictions == ["reason-no"]
+        # The classification used by the score matches the reason buckets.
+        score = metric._calculate_score()
+        assert score == pytest.approx(len(factual) / len(metric.verdicts))
+
+    def test_empty_verdicts_score_one(self):
+        metric = HallucinationMetric(
+            model=_StubModel(), async_mode=False, include_reason=False
+        )
+        metric.verdicts = []
+        assert metric._calculate_score() == 1.0


### PR DESCRIPTION
## Summary

Fixes #3098.

`HallucinationMetric` classified verdicts with two different predicates, so the score and the generated reason could disagree for the same verdict:

- `_calculate_score` counted a hallucination only when `verdict.strip().lower() == "no"` — anything else (e.g. `"no."`, `" maybe "`) counted as **factually aligned**.
- `_generate_reason` / `_a_generate_reason` filed `== "yes"` into `factual_alignments` and put **everything else** — including malformed tokens like `"yes."`, `" no "` — into `contradictions`.

The malformed tokens are reachable because the judge's raw completion is pulled by regex-based extraction that does not round-trip through the `Literal["yes", "no"]` validation. So `"no."` scored as aligned (1.0) while the reason for the same run listed it as a contradiction.

## Change

Introduce a single shared predicate `_is_contradiction(verdict)` that normalizes surrounding whitespace and trailing punctuation (`.,;:!?`) and is `None`-safe. `_calculate_score` and both reason generators consume the same predicate, so a verdict can never be scored one way and reasoned about the opposite way.

## Backward compatibility

- Well-formed `yes` / `no` verdicts: identical score and reason behavior.
- `yes.` / `Yes ` now score as aligned *and* appear in `factual_alignments` (previously the reason listed them as contradictions).
- `no.` / `No ` now count as contradictions in both places (previously the score called them aligned).
- Empty verdict list still scores `1`.

## Tests

New `tests/test_metrics/test_hallucination_verdict_normalization.py` (6 cases): the malformed tokens from the issue, score counting, mixed well-formed verdicts, the structural score/reason agreement, and the empty case. All deterministic, no API key required.

```
6 passed
```

Existing `test_hallucination_metric.py` shows no failures (skipped without an API key), and the repo is `black`-clean.