### PR TITLE
fix(metrics): copy pre-configured metric subclasses without crashing

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -130,18 +130,37 @@ def copy_metrics(
         metric_class = type(metric)
         args = vars(metric)
 
+        # Gather every parameter the constructor can accept from the whole MRO,
+        # so configuration a base class ``__init__`` stored on the instance is
+        # replayed onto the copy too.
         superclasses = metric_class.__mro__
-
-        valid_params = []
-
+        valid_params = set()
         for superclass in superclasses:
-            signature = inspect.signature(superclass.__init__)
-            superclass_params = signature.parameters.keys()
-            valid_params.extend(superclass_params)
-        valid_params = set(valid_params)
+            valid_params.update(
+                inspect.signature(superclass.__init__).parameters
+            )
         valid_args = {key: args[key] for key in valid_params if key in args}
 
-        copied_metrics.append(metric_class(**valid_args))
+        target_params = inspect.signature(metric_class.__init__).parameters
+        accepts_var_keyword = any(
+            param.kind == inspect.Parameter.VAR_KEYWORD
+            for param in target_params.values()
+        )
+        # The leaf constructor accepts every collected kwarg (directly or via
+        # ``**kwargs``): replay them unchanged, exactly as before.
+        if accepts_var_keyword or valid_args.keys() <= set(target_params):
+            copied_metrics.append(metric_class(**valid_args))
+            continue
+
+        # A subclass may deliberately narrow its ``__init__`` signature — the
+        # documented way to pre-configure a built-in metric (e.g. a GEval
+        # subclass that hard-codes ``name``/``criteria``). Replaying parent-only
+        # kwargs into that constructor raised a ``TypeError`` that aborted the
+        # whole async ``evaluate()`` run (#3037). Fall back to the params the
+        # leaf constructor accepts; its ``__init__`` re-applies the pre-set
+        # values itself, so no configuration is lost.
+        narrowed_args = {key: args[key] for key in target_params if key in args}
+        copied_metrics.append(metric_class(**narrowed_args))
     return copied_metrics
 
 

--- a/tests/test_core/test_evaluation/test_copy_metrics_subclass_init.py
+++ b/tests/test_core/test_evaluation/test_copy_metrics_subclass_init.py
@@ -1,0 +1,129 @@
+"""copy_metrics must replay configuration onto a fresh metric instance even
+when the metric subclasses a built-in with a narrower ``__init__``.
+
+Regression test for #3037: reconstructing a copy used to collect candidate
+kwargs from every class in the MRO but replay them into the leaf constructor,
+so any subclass that deliberately narrows its ``__init__`` (the documented way
+to pre-configure a built-in metric) crashed with a ``TypeError`` and aborted
+the whole async ``evaluate()`` run before a single metric executed.
+"""
+
+import pytest
+
+from deepeval import evaluate
+from deepeval.evaluate.configs import AsyncConfig, DisplayConfig
+from deepeval.metrics import ExactMatchMetric, ToolPermissionMetric
+from deepeval.metrics.utils import copy_metrics
+from deepeval.test_case import LLMTestCase, ToolCall
+
+
+class NoShellMetric(ToolPermissionMetric):
+    """Reusable policy metric: a team-wide 'never call shell' gate."""
+
+    def __init__(self, threshold: float = 1.0):
+        super().__init__(denied_tools=["shell"], threshold=threshold)
+
+
+class StrictSafeToolsMetric(ToolPermissionMetric):
+    """Two-level narrowing: only read/write allowed, shell denied."""
+
+    def __init__(self, threshold: float = 1.0):
+        super().__init__(
+            allowed_tools=["read", "write"],
+            denied_tools=["shell"],
+            threshold=threshold,
+        )
+
+
+_QUIET_DISPLAY = DisplayConfig(show_indicator=False, print_results=False)
+_QUIET_ASYNC = AsyncConfig(run_async=False)
+
+
+def _case() -> LLMTestCase:
+    return LLMTestCase(
+        input="hi",
+        actual_output="hello",
+        tools_called=[ToolCall(name="search")],
+    )
+
+
+# --- Default behaviour must not regress ----------------------------------
+
+
+def test_copy_plain_metric_preserves_config():
+    metric = ToolPermissionMetric(denied_tools=["shell"], threshold=0.9)
+    copied = copy_metrics([metric])[0]
+
+    assert copied is not metric
+    assert copied.denied_tools == {"shell"}
+    assert copied.threshold == 0.9
+
+
+def test_copy_preserves_flaky_and_flags():
+    metric = ExactMatchMetric(flaky=True, verbose_mode=False)
+    copied = copy_metrics([metric])[0]
+
+    assert copied.flaky is True
+    assert copied.verbose_mode is False
+
+
+def test_copies_are_fresh_instances_that_do_not_leak_score():
+    metric = NoShellMetric()
+    first, second = copy_metrics([metric, metric])
+
+    first.measure(_case(), _show_indicator=False)
+    assert first.score == 1.0
+    assert second.score is None
+
+
+# --- New capability: narrowed subclasses copy without crashing ------------
+
+
+def test_copy_narrowed_subclass_does_not_raise():
+    metric = NoShellMetric(threshold=0.8)
+    copied = copy_metrics([metric])[0]
+
+    assert type(copied) is NoShellMetric
+    assert copied.denied_tools == {"shell"}
+    assert copied.threshold == 0.8
+
+
+def test_copy_narrowed_subclass_keeps_defaults():
+    copied = copy_metrics([NoShellMetric()])[0]
+
+    assert copied.threshold == 1.0
+    assert copied.denied_tools == {"shell"}
+
+
+def test_copy_narrowed_subclass_keeps_non_default_threshold():
+    copied = copy_metrics([NoShellMetric(threshold=0.5)])[0]
+
+    assert copied.threshold == 0.5
+
+
+def test_copy_narrowed_subclass_multiple_config_values():
+    copied = copy_metrics([StrictSafeToolsMetric(threshold=0.6)])[0]
+
+    assert type(copied) is StrictSafeToolsMetric
+    assert copied.allowed_tools == {"read", "write"}
+    assert copied.denied_tools == {"shell"}
+    assert copied.threshold == 0.6
+
+
+def test_evaluate_async_runs_narrowed_subclass_end_to_end():
+    result = evaluate(test_cases=[_case()], metrics=[NoShellMetric()])
+
+    assert len(result.test_results) == 1
+    assert result.test_results[0].metrics_data[0].score == 1.0
+
+
+def test_evaluate_sync_runs_narrowed_subclass_end_to_end():
+    result = evaluate(
+        test_cases=[_case()],
+        metrics=[NoShellMetric()],
+        display_config=_QUIET_DISPLAY,
+        async_config=_QUIET_ASYNC,
+    )
+
+    assert len(result.test_results) == 1
+    assert result.test_results[0].metrics_data[0].score == 1.0


### PR DESCRIPTION
## Summary

Fixes #3037. `copy_metrics` rebuilds a metric per test case by replaying stored
instance attributes through its constructor, but it gathered candidate kwargs
from **every class in the MRO** and applied them to the **leaf** `__init__`.
Subclassing a built-in to pre-configure it (the documented way to share one
`GEval`/`ToolPermissionMetric` configuration across a team) narrows the
constructor signature, so every parent-only kwarg became an unexpected keyword
argument:

```
TypeError: NoShellMetric.__init__() got an unexpected keyword argument 'denied_tools'
```

Because `copy_metrics` runs while scheduling each test case, outside per-metric
error handling, the crash aborted the **entire async `evaluate()` run** before a
single metric executed.

The fix checks the leaf constructor's own signature first:
- kwargs it can accept (directly or via `**kwargs`) are replayed unchanged —
  behaviour for every metric that already worked is identical;
- when the leaf narrows the parent signature, we fall back to the params it
  does accept. Its `__init__` re-applies the pre-configured values itself, so
  no configuration (e.g. `denied_tools=["shell"]`) is lost.

## Backward compatibility

No default behaviour changes: for every metric that copied successfully before,
the exact same kwargs are replayed. Only subclasses that previously crashed now
take the new path.

## Tests

New offline suite `tests/test_core/test_evaluation/test_copy_metrics_subclass_init.py`
(9 cases) split into "default behaviour doesn't regress" and "new capability
works", including an end-to-end `evaluate()` run on both the default async and
sync paths. Verified red on `main` (6 failures, all the reported `TypeError`)
and green with this change. Related suites: `223 passed, 296 skipped (need API
key), 6 xfailed`. `black` clean. No new dependencies.

Closes #3037