### PR TITLE
fix(dag): resolve DAGMetric score deterministically when several verdicts fire

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/dag/runner.py
+++ b/deepeval/metrics/dag/runner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from deepeval.metrics.dag.nodes import (
     BaseNode,
@@ -47,6 +47,11 @@ class _DeepAcyclicGraphRunner:
         self.outputs: Dict[Node, Any] = {}
         self.verdicts: Dict[Node, Any] = {}
         self.depth: Dict[Node, int] = {}
+        # Every fired scoring verdict/child metric contributes a (score, reason)
+        # pair; the final metric score is resolved deterministically at the end
+        # instead of "last write wins" (which depended on node order and on the
+        # sync vs async traversal).
+        self.scores: List[Tuple[float, Optional[str]]] = []
         self._verbose_log = (
             _mt_verbose_log if graph.multiturn else _st_verbose_log
         )
@@ -75,17 +80,35 @@ class _DeepAcyclicGraphRunner:
             self._verbose_log(node, depth, child_metric)
         )
         metric.score = child_metric.score
-        if metric.include_reason:
-            metric.reason = child_metric.reason
+        reason = child_metric.reason if metric.include_reason else None
+        self.scores.append((child_metric.score, reason))
         metric._accrue_cost(child_metric.evaluation_cost)
         metric._accrue_tokens(
             child_metric.input_tokens, child_metric.output_tokens
         )
 
+    def _finalize_score(self, metric: Metric) -> None:
+        """Resolve the final metric score deterministically.
+
+        Every fired scoring verdict/child metric contributes a (score, reason)
+        pair. The score is picked with a conservative ``min`` aggregation so
+        the result no longer depends on node declaration order or on whether
+        the graph ran in sync or async mode. A DAG with a single scoring
+        path is unaffected.
+        """
+        scored = [(s, r) for s, r in self.scores if s is not None]
+        if not scored:
+            return
+        score, reason = min(scored, key=lambda item: item[0])
+        metric.score = score
+        if metric.include_reason and reason is not None:
+            metric.reason = reason
+
     # ------------------------------------------------------------------ sync
     def run(self, metric: Metric, test_case: TestCase) -> None:
         for root in self.graph.root_nodes:
             self._visit(root, metric, test_case, 0)
+        self._finalize_score(metric)
 
     def _visit(
         self, node: Node, metric: Metric, test_case: TestCase, depth: int
@@ -123,8 +146,12 @@ class _DeepAcyclicGraphRunner:
         if child is None:
             metric._verbose_steps.append(self._verbose_log(node, depth))
             metric.score = node.score / 10
-            if metric.include_reason:
-                metric.reason = node._generate_reason(metric=metric)
+            reason = (
+                node._generate_reason(metric=metric)
+                if metric.include_reason
+                else None
+            )
+            self.scores.append((metric.score, reason))
         elif isinstance(child, _NODE):
             self._visit(child, metric, test_case, depth)
         else:
@@ -138,6 +165,7 @@ class _DeepAcyclicGraphRunner:
                 for root in self.graph.root_nodes
             )
         )
+        self._finalize_score(metric)
 
     async def _a_visit(
         self, node: Node, metric: Metric, test_case: TestCase, depth: int
@@ -179,8 +207,12 @@ class _DeepAcyclicGraphRunner:
         if child is None:
             metric._verbose_steps.append(self._verbose_log(node, depth))
             metric.score = node.score / 10
-            if metric.include_reason:
-                metric.reason = await node._a_generate_reason(metric=metric)
+            reason = (
+                await node._a_generate_reason(metric=metric)
+                if metric.include_reason
+                else None
+            )
+            self.scores.append((metric.score, reason))
         elif isinstance(child, _NODE):
             await self._a_visit(child, metric, test_case, depth)
         else:

--- a/tests/test_metrics/test_dag_score_determinism.py
+++ b/tests/test_metrics/test_dag_score_determinism.py
@@ -1,0 +1,160 @@
+"""DAGMetric score determinism when several scoring verdicts fire.
+
+A DAG with more than one reachable scoring verdict used to resolve to
+whichever verdict wrote ``metric.score`` last, so the outcome depended on
+node declaration order and on whether the graph ran in sync or async mode.
+The runner now collects every fired verdict score and resolves the final
+score deterministically with a conservative ``min``, so the result only
+depends on the DAG as written.
+"""
+
+import asyncio
+
+import pytest
+
+from deepeval.metrics import DAGMetric
+from deepeval.metrics.dag import (
+    TaskNode,
+    BinaryJudgementNode,
+    DeepAcyclicGraph,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+
+PARAMS = [SingleTurnParams.ACTUAL_OUTPUT]
+
+
+class AlwaysYes(DeepEvalBaseLLM):
+    """Answers True to every judgement so every scoring verdict is reached.
+
+    ``a_generate`` yields to the event loop so async runs really interleave;
+    otherwise the async parametrization silently executes serially.
+    """
+
+    def load_model(self):
+        return self
+
+    def generate(self, prompt, schema=None, **kwargs):
+        if schema.__name__ == "TaskNodeOutput":
+            return schema(output=["Intro", "Body", "Conclusion"])
+        return schema(verdict=True, reason="fixed")
+
+    async def a_generate(self, prompt, schema=None, **kwargs):
+        await asyncio.sleep(0)
+        return self.generate(prompt, schema=schema, **kwargs)
+
+    def get_model_name(self):
+        return "always-yes"
+
+
+def build_two_scoring_branches(deep_first: bool) -> DeepAcyclicGraph:
+    """Two independent scoring branches, both always reached.
+
+    ``deep`` is two judgements deep and scores 10 (1.0); ``shallow`` is one
+    judgement deep and scores 5 (0.5). ``deep_first`` toggles which one is
+    declared first so tests can prove the result does not depend on it.
+    """
+    extract = TaskNode(
+        instructions="Extract the headings",
+        output_label="Headings",
+        evaluation_params=PARAMS,
+    )
+    deep = BinaryJudgementNode(criteria="All three headings present?")
+    inner = BinaryJudgementNode(criteria="Headings in the right order?")
+    shallow = BinaryJudgementNode(criteria="Summary under 100 words?")
+
+    if deep_first:
+        extract.add_node(deep)
+        extract.add_node(shallow)
+    else:
+        extract.add_node(shallow)
+        extract.add_node(deep)
+
+    deep.add_verdict(True, then=inner)
+    deep.add_verdict(False, score=0)
+    inner.add_verdict(True, score=10)
+    inner.add_verdict(False, score=0)
+    shallow.add_verdict(True, score=5)
+    shallow.add_verdict(False, score=0)
+    return DeepAcyclicGraph(root_nodes=[extract])
+
+
+def build_single_scoring_branch() -> DeepAcyclicGraph:
+    """A DAG with exactly one scoring verdict, for the no-regression case."""
+    extract = TaskNode(
+        instructions="Extract the headings",
+        output_label="Headings",
+        evaluation_params=PARAMS,
+    )
+    shallow = BinaryJudgementNode(criteria="Summary under 100 words?")
+    extract.add_node(shallow)
+    shallow.add_verdict(True, score=10)
+    shallow.add_verdict(False, score=0)
+    return DeepAcyclicGraph(root_nodes=[extract])
+
+
+def measure(
+    dag: DeepAcyclicGraph, async_mode: bool, include_reason: bool = False
+) -> DAGMetric:
+    metric = DAGMetric(
+        name="Score Determinism",
+        dag=dag,
+        model=AlwaysYes(model="always-yes"),
+        include_reason=include_reason,
+        async_mode=async_mode,
+    )
+    metric.measure(
+        LLMTestCase(
+            input="Summarize.",
+            actual_output="Intro\nBody\nConclusion",
+        ),
+        _show_indicator=False,
+    )
+    return metric
+
+
+class TestMultiScoringVerdicts:
+    """Two reachable scoring verdicts resolve deterministically."""
+
+    def test_sync_and_async_agree(self):
+        scores = [
+            measure(build_two_scoring_branches(deep_first), async_mode).score
+            for deep_first in (True, False)
+            for async_mode in (False, True)
+        ]
+        assert len(set(scores)) == 1
+
+    def test_score_is_conservative_min_of_fired_verdicts(self):
+        # deep scores 1.0, shallow scores 0.5; min wins
+        metric = measure(
+            build_two_scoring_branches(deep_first=True), async_mode=False
+        )
+        assert metric.score == 0.5
+
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_declaration_order_irrelevant(self, async_mode):
+        assert (
+            measure(
+                build_two_scoring_branches(deep_first=True), async_mode
+            ).score
+            == measure(
+                build_two_scoring_branches(deep_first=False), async_mode
+            ).score
+        )
+
+    def test_reason_tracks_selected_score(self):
+        metric = measure(
+            build_two_scoring_branches(deep_first=True),
+            async_mode=False,
+            include_reason=True,
+        )
+        assert metric.score == 0.5
+        assert metric.reason == "fixed"
+
+
+class TestSingleScoringVerdict:
+    """A DAG with one scoring verdict is unaffected (no regression)."""
+
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_score_unchanged(self, async_mode):
+        assert measure(build_single_scoring_branch(), async_mode).score == 1.0


### PR DESCRIPTION
Closes #3025

## Problem

When a DAG has more than one scoring verdict that can fire in a single run,
they all write to `metric.score` and whichever writes **last** wins. Which
one writes last depends on:

- the order the nodes were declared in (sync traversal is depth-first, so it
  finishes the first-declared branch last), and
- whether the graph runs in sync or async mode (`asyncio.gather` interleaves
  the branches differently).

So the same DAG with the same judgements can return different scores.

Repro (deterministic fake judge, no API key needed):

```
deep declared first    async=False score=0.5
deep declared first    async=True  score=1.0
shallow declared first async=False score=1.0
shallow declared first async=True  score=1.0
```

The sync-vs-async disagreement is the worst part: a user cannot reason about
it, since the result ends up being whatever verdict finished last.

## Fix

The runner now collects every fired scoring verdict / child-metric
`(score, reason)` pair into `self.scores` while traversing, then resolves the
final score **once** at the end of `run`/`a_run` with a conservative `min`
aggregation. The result therefore only depends on the DAG as written:

- sync and async agree,
- node declaration order is irrelevant,
- a DAG with a single scoring path is unchanged (the `min` of one score is
  that score).

`min` was chosen as the conservative pick for an eval metric (the same option
the issue discussion flags): the most critical failing branch governs.

## Changes

- `deepeval/metrics/dag/runner.py`
  - track `self.scores` for every fired scoring verdict and child metric
  - add `_finalize_score()` (min-aggregation) invoked at the end of both the
    sync and async entry points
- `tests/test_metrics/test_dag_score_determinism.py` (new)
  - multi-scoring-verdict DAG: sync/async agree, declaration order
    irrelevant, score is the conservative min, reason tracks the selected
    score
  - single-scoring-verdict DAG: score unchanged (no regression)

## Test results

```
$ python -m pytest tests/test_metrics/test_dag_score_determinism.py tests/test_metrics/test_dag.py tests/test_metrics/test_conversational_dag.py tests/test_metrics/test_dag_serialization.py -q
126 passed, 6 skipped, 6 xfailed
```

`test_dag_score_determinism.py` fails on `main` (`test_sync_and_async_agree`
reports `{0.5, 1.0}`, `test_declaration_order_irrelevant` reports `0.5` vs
`1.0`) and passes with this change.

```
$ black --check deepeval/metrics/dag/runner.py tests/test_metrics/test_dag_score_determinism.py
All done!
$ ruff check --select E4,E7,E9,F deepeval/metrics/dag/runner.py tests/test_metrics/test_dag_score_determinism.py
All checks passed!
```

## Backward compatibility

No public API changes, no new dependencies, no default-behaviour change for
DAGs with a single scoring path. Existing DAG user code keeps working; only
the previously order/async-dependent multi-scoring case becomes
deterministic.