### PR TITLE
fix(scorer): treat whitespace-only predictions as empty in string scorers

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -106,20 +106,20 @@ class Scorer:
         Returns:
             int: The exact match score.
         """
-        if not prediction:
+        if not prediction or not prediction.strip():
             return 0
         return 1 if prediction.strip() == target.strip() else 0
 
     @classmethod
     def quasi_exact_match_score(cls, target: str, prediction: str) -> int:
-        if not prediction:
+        if not prediction or not prediction.strip():
             return 0
         return 1 if normalize_text(target) == normalize_text(prediction) else 0
 
     @classmethod
     def quasi_contains_score(cls, targets: List[str], prediction: str) -> int:
         normalized_targets = [normalize_text(t) for t in targets]
-        if not prediction:
+        if not prediction or not prediction.strip():
             return 0
         return 1 if normalize_text(prediction) in normalized_targets else 0
 

--- a/tests/test_metrics/test_scorer_answer_scoring_hardening.py
+++ b/tests/test_metrics/test_scorer_answer_scoring_hardening.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for the deterministic string scorers' handling of
+whitespace-only predictions.
+
+All three string scorers previously treated a whitespace-only prediction as
+non-empty, so ``exact_match_score('', '   ')`` returned 1 while
+``exact_match_score('', '')`` returned 0 — the same "no answer" input scored
+differently depending on whether it contained spaces.
+
+These tests are offline: no model, network, dataset download, or API key
+required.
+"""
+
+import pytest
+
+from deepeval.scorer.scorer import Scorer
+
+
+class TestExactMatchScore:
+    def test_default_behaviour_unchanged(self):
+        assert Scorer.exact_match_score("hello", "hello") == 1
+        assert Scorer.exact_match_score("hello", "world") == 0
+        assert Scorer.exact_match_score("hello", "") == 0
+        assert Scorer.exact_match_score("hello", "  hello  ") == 1
+        assert Scorer.exact_match_score("  hello", "hello  ") == 1
+
+    @pytest.mark.parametrize(
+        "target,prediction",
+        [
+            ("", ""),
+            ("", "   "),
+            ("", "\n\t"),
+            ("hello", "   "),
+            ("hello", "\t"),
+        ],
+    )
+    def test_whitespace_only_prediction_is_empty(self, target, prediction):
+        # empty and whitespace-only predictions are treated alike (score 0)
+        assert Scorer.exact_match_score(target, prediction) == 0
+
+
+class TestQuasiExactMatchScore:
+    def test_default_behaviour_unchanged(self):
+        assert (
+            Scorer.quasi_exact_match_score("Hello, World!", "hello world") == 1
+        )
+        assert Scorer.quasi_exact_match_score("hello world", "world") == 0
+        assert Scorer.quasi_exact_match_score("x", "") == 0
+
+    @pytest.mark.parametrize(
+        "target,prediction",
+        [
+            ("", ""),
+            ("", "   "),
+            ("hello", " \t "),
+        ],
+    )
+    def test_whitespace_only_prediction_is_empty(self, target, prediction):
+        assert Scorer.quasi_exact_match_score(target, prediction) == 0
+
+
+class TestQuasiContainsScore:
+    def test_default_behaviour_unchanged(self):
+        assert Scorer.quasi_contains_score(["hello world"], "hello  world") == 1
+        assert Scorer.quasi_contains_score(["a", "b"], "a") == 1
+        assert Scorer.quasi_contains_score(["hello"], "world") == 0
+        assert Scorer.quasi_contains_score(["hello"], "") == 0
+
+    @pytest.mark.parametrize(
+        "targets,prediction",
+        [
+            ([""], ""),
+            ([""], "   "),
+            (["hello"], "   "),
+            (["hello"], "\t"),
+        ],
+    )
+    def test_whitespace_only_prediction_is_empty(self, targets, prediction):
+        assert Scorer.quasi_contains_score(targets, prediction) == 0


### PR DESCRIPTION
## Summary

Engineering hardening for the deterministic (non-LLM) string scorers, closing
the gap described in #3186.

The three string scorers guarded against an empty prediction, but only checked
the literal empty string:

```python
if not prediction:
    return 0
```

A whitespace-only prediction (`"   "`, `"\t"`, `"\n"`) is truthy, so it skipped
the guard and could score 1 against an empty (or, for `quasi_*`,
normalized-empty) target:

```python
Scorer.exact_match_score("", "")     # 0  -- empty prediction -> no answer
Scorer.exact_match_score("", "   ")  # 1  -- whitespace-only -> "correct"
Scorer.quasi_contains_score([""], "   ")  # 1
```

The same "no answer" input therefore scored differently depending on whether it
contained spaces. This change treats whitespace-only predictions the same as
empty ones (score `0`) in `exact_match_score`, `quasi_exact_match_score`, and
`quasi_contains_score`:

```python
if not prediction or not prediction.strip():
    return 0
```

## Backward compatibility

Non-empty predictions are completely unaffected — real answers keep their exact
current scores. The only behaviour that changes is a whitespace-only prediction
now scoring `0` instead of bypassing the empty guard, so no existing benchmark
scores move.

## Tests

New `tests/test_metrics/test_scorer_answer_scoring_hardening.py` (offline, no
new dependencies):

- **Default behaviour unchanged**: exact / quasi-exact / quasi-contains still
  return their current scores for real predictions, including surrounding
  whitespace on non-empty answers.
- **New consistency**: empty and whitespace-only predictions now both score 0
  across all three scorers (parametrized over `"   "`, `"\t"`, `"\n"`).

## Verification

- `pytest tests/test_metrics/test_scorer_answer_scoring_hardening.py` — 15 passed
- `pytest tests/test_metrics tests/test_benchmarks` — 207 passed, 278 skipped
  (API-key-gated LLM tests), 6 xfailed; no regressions
- Red/green: reverting the fix fails 4 of the new tests and leaves the 11
  default-behaviour tests green
- `black --check` clean on both changed files

Closes #3186