### PR TITLE
fix(metrics): reject empty scenario/expected_outcome in conversational param checks

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -310,8 +310,24 @@ def check_conversational_test_case_params(
         raise MissingTestCaseParamsError(error_str)
 
     if (
+        MultiTurnParams.EXPECTED_OUTCOME in test_case_params
+        and test_case.expected_outcome == ""
+    ):
+        error_str = f"'expected_outcome' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
+        metric.error = error_str
+        raise MissingTestCaseParamsError(error_str)
+
+    if (
         MultiTurnParams.SCENARIO in test_case_params
         and test_case.scenario is None
+    ):
+        error_str = f"'scenario' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
+        metric.error = error_str
+        raise MissingTestCaseParamsError(error_str)
+
+    if (
+        MultiTurnParams.SCENARIO in test_case_params
+        and test_case.scenario == ""
     ):
         error_str = f"'scenario' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
         metric.error = error_str

--- a/tests/test_metrics/test_g_eval_utils.py
+++ b/tests/test_metrics/test_g_eval_utils.py
@@ -171,3 +171,45 @@ def test_conversational_geval_requires_tags_when_selected():
             [MultiTurnParams.TAGS],
             DummyConversationalMetric(),
         )
+
+
+def test_conversational_geval_requires_expected_outcome_when_empty():
+    test_case = ConversationalTestCase(
+        turns=[Turn(role="user", content="hello")],
+        expected_outcome="",
+    )
+
+    with pytest.raises(MissingTestCaseParamsError):
+        check_conversational_test_case_params(
+            test_case,
+            [MultiTurnParams.EXPECTED_OUTCOME],
+            DummyConversationalMetric(),
+        )
+
+
+def test_conversational_geval_requires_scenario_when_empty():
+    test_case = ConversationalTestCase(
+        turns=[Turn(role="user", content="hello")],
+        scenario="",
+    )
+
+    with pytest.raises(MissingTestCaseParamsError):
+        check_conversational_test_case_params(
+            test_case,
+            [MultiTurnParams.SCENARIO],
+            DummyConversationalMetric(),
+        )
+
+
+def test_conversational_geval_accepts_non_empty_expected_outcome_and_scenario():
+    test_case = ConversationalTestCase(
+        turns=[Turn(role="user", content="hello")],
+        expected_outcome="the assistant should acknowledge the user",
+        scenario="a user greets the assistant",
+    )
+
+    check_conversational_test_case_params(
+        test_case,
+        [MultiTurnParams.EXPECTED_OUTCOME, MultiTurnParams.SCENARIO],
+        DummyConversationalMetric(),
+    )


### PR DESCRIPTION
Fixes #3192

## Summary

`check_conversational_test_case_params` rejected `None` for `scenario` and `expected_outcome` while its error message promised "cannot be empty", and single-turn validation ([`check_llm_test_case_params`](deepeval/metrics/utils.py)) already rejects empty strings for required params. This made conversational validation accept `""` where single-turn validation would not, so the two code paths disagreed on what "missing/empty param" means.

This PR makes conversational validation symmetric with single-turn validation: when a metric requires `expected_outcome` or `scenario`, an empty string is now rejected just like `None`.

## Changes

- `deepeval/metrics/utils.py`: reject `expected_outcome == ""` and `scenario == ""` when the corresponding `MultiTurnParams` is required by the metric.
- `tests/test_metrics/test_g_eval_utils.py`: added unit tests covering:
  - empty `expected_outcome` raises `MissingTestCaseParamsError` (new behavior)
  - empty `scenario` raises `MissingTestCaseParamsError` (new behavior)
  - non-empty `expected_outcome`/`scenario` pass validation (no regression)

## Test results

```
$ python -m pytest tests/test_metrics/test_g_eval_utils.py -q
10 passed in 0.04s

$ python -m pytest tests/test_core/test_test_case/test_multi_turn/test_conversational_test_case.py -q
34 passed
```

Formatting: `black deepeval/metrics/utils.py tests/test_metrics/test_g_eval_utils.py` — clean.

## Backward compatibility

Default behavior is unchanged: test cases that omit these fields (`None`) were already rejected, and test cases that provide real values still pass. The only behavioral change is that `""` is now treated as empty, matching the existing single-turn semantics and the error message already emitted by this function.