### PR TITLE
fix(benchmarks): compare prediction counts with equality, not identity

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -257,7 +257,7 @@ class BigBenchHard(DeepEvalBaseBenchmark):
             predictions = [str(pred) for pred in predictions]
             used_schema = False
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -233,7 +233,7 @@ class HellaSwag(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/logi_qa/logi_qa.py
+++ b/deepeval/benchmarks/logi_qa/logi_qa.py
@@ -217,7 +217,7 @@ class LogiQA(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -220,7 +220,7 @@ class MathQA(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -238,7 +238,7 @@ class MMLU(DeepEvalBaseBenchmark):
             ]
             predictions = model.batch_generate(prompts)
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/deepeval/benchmarks/truthful_qa/truthful_qa.py
+++ b/deepeval/benchmarks/truthful_qa/truthful_qa.py
@@ -258,7 +258,7 @@ class TruthfulQA(DeepEvalBaseBenchmark):
             predictions = model.batch_generate(prompts)
             predictions = [str(pred) for pred in predictions]
 
-        if len(predictions) is not len(goldens):
+        if len(predictions) != len(goldens):
             raise ValueError(
                 "Custom `batch_generate` method did not return the same number of generations as the number of prompts."
             )

--- a/tests/test_benchmarks/test_benchmark_batch_count_equality.py
+++ b/tests/test_benchmarks/test_benchmark_batch_count_equality.py
@@ -1,0 +1,104 @@
+"""
+Regression tests for #2982: benchmark `batch_predict` compared the number of
+generations against the number of goldens with `is not` (identity) instead of
+`!=` (equality).
+
+CPython only caches small integers (-5..256) as singletons, so two equal but
+separately-computed lengths compare unequal under `is not` once they exceed
+256. Any custom model with a `batch_generate` method evaluated against more
+than 256 goldens therefore hit a false `ValueError` even though the counts
+matched. These tests drive the schema-less fallback path that custom models
+exercise, with > 256 goldens to expose the bug.
+"""
+
+import pytest
+
+from deepeval.dataset import Golden
+from deepeval.scorer.scorer import Scorer
+from deepeval.benchmarks.hellaswag.hellaswag import HellaSwag
+from deepeval.benchmarks.hellaswag.task import HellaSwagTask
+from deepeval.benchmarks.math_qa.math_qa import MathQA
+from deepeval.benchmarks.logi_qa.logi_qa import LogiQA
+from deepeval.benchmarks.mmlu.mmlu import MMLU
+from deepeval.benchmarks.mmlu.task import MMLUTask
+from deepeval.benchmarks.truthful_qa.truthful_qa import TruthfulQA
+from deepeval.benchmarks.truthful_qa.mode import TruthfulQAMode
+from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
+from deepeval.benchmarks.big_bench_hard.task import BigBenchHardTask
+
+# Above CPython's small-int singleton cache so `is not` would always be True
+# for two equal lengths computed independently.
+N_GOLDENS = 300
+
+
+class _SchemaLessBatchModel:
+    """A custom model that only supports schema-less `batch_generate`,
+    simulating the fallback path real custom models take."""
+
+    def batch_generate(self, prompts, schemas=None):
+        if schemas is not None:
+            raise TypeError("schema-less generation not supported")
+        return [f"answer-{i}" for i in range(len(prompts))]
+
+
+def _goldens(n: int):
+    return [
+        Golden(input=f"question {i}", expected_output=f"expected {i}")
+        for i in range(n)
+    ]
+
+
+def _benchmark(klass, **attrs):
+    # Bypass __init__ (which imports the optional HF `datasets` package); the
+    # batch path only needs the attributes set below.
+    bench = klass.__new__(klass)
+    bench.scorer = Scorer()
+    for name, value in attrs.items():
+        setattr(bench, name, value)
+    return bench
+
+
+def test_hellaswag_batch_predict_accepts_over_256_goldens():
+    bench = _benchmark(HellaSwag, shots_dataset=[], n_shots=0)
+    result = bench.batch_predict(
+        _SchemaLessBatchModel(), HellaSwagTask.WAKEBOARDING, _goldens(N_GOLDENS)
+    )
+    assert len(result) == N_GOLDENS
+
+
+def test_math_qa_batch_predict_accepts_over_256_goldens():
+    bench = _benchmark(MathQA, n_shots=0)
+    result = bench.batch_predict(_SchemaLessBatchModel(), _goldens(N_GOLDENS))
+    assert len(result) == N_GOLDENS
+
+
+def test_logi_qa_batch_predict_accepts_over_256_goldens():
+    bench = _benchmark(LogiQA, n_shots=0)
+    result = bench.batch_predict(_SchemaLessBatchModel(), _goldens(N_GOLDENS))
+    assert len(result) == N_GOLDENS
+
+
+def test_mmlu_batch_predict_accepts_over_256_goldens():
+    bench = _benchmark(MMLU, shots_dataset=["dummy"], n_shots=0)
+    result = bench.batch_predict(
+        _SchemaLessBatchModel(), MMLUTask.VIROLOGY, _goldens(N_GOLDENS)
+    )
+    assert len(result) == N_GOLDENS
+
+
+def test_truthful_qa_batch_predict_accepts_over_256_goldens():
+    bench = _benchmark(TruthfulQA)
+    result = bench.batch_predict(
+        _SchemaLessBatchModel(), _goldens(N_GOLDENS), TruthfulQAMode.MC1
+    )
+    assert len(result) == N_GOLDENS
+
+
+def test_big_bench_hard_batch_predict_accepts_over_256_goldens():
+    bench = _benchmark(BigBenchHard, n_shots=0, enable_cot=False)
+    result = bench.batch_predict(
+        _SchemaLessBatchModel(),
+        BigBenchHardTask.HYPERBATON,
+        _goldens(N_GOLDENS),
+    )
+    assert len(result) == N_GOLDENS


### PR DESCRIPTION
Fixes #2982

## Summary

Six benchmarks compared the number of model generations against the number of goldens with `is not` (identity) instead of `!=` (equality):

- hellaswag
- math_qa
- logi_qa
- mmlu
- truthful_qa
- big_bench_hard

CPython only caches small integers (-5..256) as singletons, so `is not` silently passed below that range but always reported a mismatch above it: two equal lengths computed separately are no longer the same object. Any custom model with a `batch_generate` method run against more than 256 goldens got a false `ValueError` even though the count was correct.

## Changes

- `deepeval/benchmarks/{hellaswag,math_qa,logi_qa,mmlu,truthful_qa,big_bench_hard}/*.py`: `len(predictions) is not len(goldens)` → `len(predictions) != len(goldens)`.
- `tests/test_benchmarks/test_benchmark_batch_count_equality.py`: new offline unit tests that drive each benchmark's schema-less fallback path with 300 goldens (above the small-int cache) and assert no false `ValueError` is raised.

## Test results

```
$ python -m pytest tests/test_benchmarks/test_benchmark_batch_count_equality.py tests/test_benchmarks/test_benchmark_answer_scoring.py -q
19 passed in 0.17s
```

Verified red/green: reverting one file to `is not` makes its test fail with the reported `ValueError`.

Formatting: `black` on all changed files — clean.

## Backward compatibility

No behavior change for counts up to 256 (the common case): equal lengths compare equal under both operators there. The change only removes the false `ValueError` for counts above 256.