### PR TITLE
fix: support all documented log_hyperparameters decorator forms

### DIFF
--- a/deepeval/test_run/hyperparameters.py
+++ b/deepeval/test_run/hyperparameters.py
@@ -58,25 +58,53 @@ def process_hyperparameters(
     return processed_hyperparameters
 
 
-def log_hyperparameters(func):
+def log_hyperparameters(func=None, **hyperparameter_kwargs):
+    """Log hyperparameters for the current test run.
+
+    Supports all three documented decorator forms:
+
+    * ``@log_hyperparameters``
+    * ``@log_hyperparameters()``
+    * ``@log_hyperparameters(model="gpt-4", prompt_template="...")``
+
+    The decorated function may return a dict of extra hyperparameters, which
+    are merged with any explicitly passed keyword arguments. The returned
+    wrapper keeps the decorated function callable.
+    """
     test_run = global_test_run_manager.get_test_run()
 
-    def modified_hyperparameters():
-        base_hyperparameters = func()
-        return base_hyperparameters
+    def decorator(decorated_func):
+        base_hyperparameters = decorated_func()
+        if base_hyperparameters is None:
+            base_hyperparameters = {}
+        if not isinstance(base_hyperparameters, dict):
+            raise TypeError("Hyperparameters must be a dictionary or None")
 
-    hyperparameters = process_hyperparameters(modified_hyperparameters())
-    test_run.hyperparameters = hyperparameters
-    global_test_run_manager.save_test_run(TEMP_FILE_PATH)
+        merged_hyperparameters = {
+            **hyperparameter_kwargs,
+            **base_hyperparameters,
+        }
+        hyperparameters = process_hyperparameters(
+            merged_hyperparameters or None
+        )
+        test_run.hyperparameters = hyperparameters
+        global_test_run_manager.save_test_run(TEMP_FILE_PATH)
 
-    # Define the wrapper function that will be the actual decorator
-    def wrapper(*args, **kwargs):
-        # Optional: You can decide if you want to do something else here
-        # every time the decorated function is called
-        return func(*args, **kwargs)
+        # Define the wrapper function that will be the actual decorator
+        def wrapper(*args, **kwargs):
+            # Optional: You can decide if you want to do something else here
+            # every time the decorated function is called
+            return decorated_func(*args, **kwargs)
 
-    # Return the wrapper function to be used as the decorator
-    return wrapper
+        # Return the wrapper function to be used as the decorator
+        return wrapper
+
+    if func is not None:
+        # Bare form: @log_hyperparameters
+        return decorator(func)
+
+    # Called form: @log_hyperparameters() or @log_hyperparameters(**kwargs)
+    return decorator
 
 
 def process_prompts(

--- a/tests/test_core/test_hyperparameters.py
+++ b/tests/test_core/test_hyperparameters.py
@@ -1,0 +1,98 @@
+import pytest
+
+from deepeval.test_run import (
+    global_test_run_manager,
+    log_hyperparameters,
+)
+
+
+@pytest.fixture(autouse=True)
+def fresh_test_run():
+    global_test_run_manager.reset()
+    global_test_run_manager.create_test_run()
+    yield
+    global_test_run_manager.reset()
+
+
+def test_log_hyperparameters_bare_form_sets_hyperparameters():
+    @log_hyperparameters
+    def run():
+        return {"model": "gpt-4", "temperature": 0.7}
+
+    assert run() == {"model": "gpt-4", "temperature": 0.7}
+    assert global_test_run_manager.get_test_run().hyperparameters == {
+        "model": "gpt-4",
+        "temperature": "0.7",
+    }
+
+
+def test_log_hyperparameters_called_form():
+    @log_hyperparameters()
+    def run():
+        return {"max_tokens": 128}
+
+    assert run() == {"max_tokens": 128}
+    assert global_test_run_manager.get_test_run().hyperparameters == {
+        "max_tokens": "128",
+    }
+
+
+def test_log_hyperparameters_with_kwargs_merges_returned_dict():
+    @log_hyperparameters(model="gpt-4")
+    def run():
+        return {"temperature": 0.2}
+
+    assert run() == {"temperature": 0.2}
+    hyperparameters = global_test_run_manager.get_test_run().hyperparameters
+    assert hyperparameters == {"model": "gpt-4", "temperature": "0.2"}
+
+
+def test_log_hyperparameters_returned_dict_takes_precedence():
+    @log_hyperparameters(model="gpt-4")
+    def run():
+        return {"model": "gpt-4o"}
+
+    assert run() == {"model": "gpt-4o"}
+    hyperparameters = global_test_run_manager.get_test_run().hyperparameters
+    assert hyperparameters == {"model": "gpt-4o"}
+
+
+def test_log_hyperparameters_none_return_yields_none_hyperparameters():
+    @log_hyperparameters
+    def run():
+        return None
+
+    assert run() is None
+    assert global_test_run_manager.get_test_run().hyperparameters is None
+
+
+def test_log_hyperparameters_non_dict_return_raises_type_error():
+    with pytest.raises(TypeError, match="Hyperparameters must be a dictionary"):
+
+        @log_hyperparameters
+        def run():
+            return "not a dict"
+
+
+def test_log_hyperparameters_wrapper_preserves_callable_result():
+    @log_hyperparameters(seed=42)
+    def run():
+        return {"temperature": 0.1}
+
+    # The decorated function stays callable and returns its original value.
+    assert run() == {"temperature": 0.1}
+    assert global_test_run_manager.get_test_run().hyperparameters == {
+        "seed": "42",
+        "temperature": "0.1",
+    }
+
+
+def test_log_hyperparameters_skips_none_values():
+    @log_hyperparameters(model=None)
+    def run():
+        return {"temperature": 0.5}
+
+    assert run() == {"temperature": 0.5}
+    assert global_test_run_manager.get_test_run().hyperparameters == {
+        "temperature": "0.5",
+    }


### PR DESCRIPTION
## What does this PR do?

Fixes #3134. The `@deepeval.log_hyperparameters` decorator only accepted the bare form (`@log_hyperparameters`), but the [evaluation prompts docs](https://deepeval.com/docs/evaluation-prompts) use `@log_hyperparameters()` and the [hyperparameters guide](https://deepeval.com/guides/guides-optimizing-hyperparameters) use `@log_hyperparameters(model="gpt-4", prompt_template="...")`. Both of those documented forms raised:

```text
TypeError: log_hyperparameters() missing 1 required positional argument: 'func'
```

This PR reworks the decorator to dispatch on whether the first positional argument is a callable:

- `@log_hyperparameters` — applies the decorator directly (unchanged behavior)
- `@log_hyperparameters()` — returns a nested decorator
- `@log_hyperparameters(model="gpt-4", prompt_template="...")` — merges the keyword args with the dict returned by the decorated function

The decorated function's returned dict and the explicitly-passed keyword arguments are merged (returned values take precedence). A non-dict/`None` return now raises a clear `TypeError` instead of failing deep inside `process_hyperparameters`.

## Testing

- Added `tests/test_core/test_hyperparameters.py` with 8 unit tests covering all three documented decorator forms, kwarg/dict merge precedence, `None` handling, the new `TypeError` for non-dict returns, and that the decorated function stays callable.
- `python -m pytest tests/test_core/test_hyperparameters.py tests/test_core/test_imports.py` → 23 passed.
- `black --check` passes on both modified files.

## Backward compatibility

The bare `@log_hyperparameters` form behaves exactly as before: the decorated function is invoked once at decoration time, its returned dict is logged as hyperparameters, and the wrapper keeps the function callable. No default behavior changes; this only unlocks the two previously-broken documented forms.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How should this be tested?

```python
import deepeval

@deepeval.log_hyperparameters()
def hyperparameters():
    return {"temperature": 1}
```

```python
import deepeval

@deepeval.log_hyperparameters(model="gpt-4", prompt_template="...")
def hyperparameters():
    return {"temperature": 1}
```

Both should now log hyperparameters without raising `TypeError`.