### PR TITLE
fix: don't swallow exceptions in async eval loop cleanup

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/evaluate/execute/loop.py
+++ b/deepeval/evaluate/execute/loop.py
@@ -800,53 +800,57 @@ def a_execute_agentic_test_cases_from_loop(
                     asyncio.gather(*created_tasks, return_exceptions=True)
                 )
             finally:
-
-                # if it is already closed, we are done
-                if loop.is_closed():
-                    return
-
-                try:
-                    current_tasks = set()
-                    # Find tasks that were created during this run but we didn’t track
-                    current_tasks = loop.run_until_complete(_snapshot_tasks())
-                except RuntimeError:
-                    # this might happen if the loop is already closing
-                    pass
-
-                leftovers = [
-                    t
-                    for t in current_tasks
-                    if t not in baseline_tasks
-                    and t not in created_tasks
-                    and not t.done()
-                ]
-
-                if get_settings().DEEPEVAL_DEBUG_ASYNC:
-                    if len(leftovers) > 0:
-                        logger.warning(
-                            "[deepeval] %d stray task(s) not tracked; cancelling...",
-                            len(leftovers),
-                        )
-                    for t in leftovers:
-                        meta = task_meta.get(t, {})
-                        name = t.get_name()
-                        logger.warning("  - STRAY %s meta=%s", name, meta)
-
-                if leftovers:
-                    for t in leftovers:
-                        t.cancel()
-
-                    # Drain strays so they don’t leak into the next iteration
+                # If the loop is already closed, skip the cleanup entirely.
+                # Guard the cleanup body instead of returning from the
+                # finally block, since a `return` here would suppress any
+                # exception that is currently propagating.
+                if not loop.is_closed():
                     try:
-                        loop.run_until_complete(
-                            asyncio.gather(*leftovers, return_exceptions=True)
+                        current_tasks = set()
+                        # Find tasks that were created during this run but we didn’t track
+                        current_tasks = loop.run_until_complete(
+                            _snapshot_tasks()
                         )
                     except RuntimeError:
-                        # If the loop is closing here, just continue
-                        if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                        # this might happen if the loop is already closing
+                        pass
+
+                    leftovers = [
+                        t
+                        for t in current_tasks
+                        if t not in baseline_tasks
+                        and t not in created_tasks
+                        and not t.done()
+                    ]
+
+                    if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                        if len(leftovers) > 0:
                             logger.warning(
-                                "[deepeval] failed to drain stray tasks because loop is closing"
+                                "[deepeval] %d stray task(s) not tracked; cancelling...",
+                                len(leftovers),
                             )
+                        for t in leftovers:
+                            meta = task_meta.get(t, {})
+                            name = t.get_name()
+                            logger.warning("  - STRAY %s meta=%s", name, meta)
+
+                    if leftovers:
+                        for t in leftovers:
+                            t.cancel()
+
+                        # Drain strays so they don’t leak into the next iteration
+                        try:
+                            loop.run_until_complete(
+                                asyncio.gather(
+                                    *leftovers, return_exceptions=True
+                                )
+                            )
+                        except RuntimeError:
+                            # If the loop is closing here, just continue
+                            if get_settings().DEEPEVAL_DEBUG_ASYNC:
+                                logger.warning(
+                                    "[deepeval] failed to drain stray tasks because loop is closing"
+                                )
 
         # Pre-evaluation guard: refuse a run that has no metric source.
         # Lazy check is the only correct option because span-level metrics

--- a/tests/test_core/test_evaluation/test_execute/test_error_boundary.py
+++ b/tests/test_core/test_evaluation/test_execute/test_error_boundary.py
@@ -860,3 +860,62 @@ async def test_trace_errored_skips_trace_metrics(
         getattr(m, "name", "<noname>") for m in record_measure_calls["metrics"]
     }
     assert "tm" not in names_called
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_exception_propagates_when_loop_closed_in_cleanup(monkeypatch):
+    """A RuntimeError raised while the event loop is already closed must
+    propagate out of the iterator instead of being suppressed by a bare
+    `return` inside the cleanup ``finally`` block.
+
+    The never-awaited coroutine warning is expected here: closing the loop
+    makes run_until_complete raise before it can await the created tasks.
+    """
+    # Don't execute real metrics
+    monkeypatch.setattr(
+        _agentic_mod,
+        "measure_metrics_with_indicator",
+        lambda *a, **k: None,
+        raising=True,
+    )
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+
+        goldens = [Golden(input="x")]
+        results = []
+        it = exec_mod.a_execute_agentic_test_cases_from_loop(
+            goldens=goldens,
+            trace_metrics=[_DummyMetric()],
+            test_results=results,
+            loop=loop,
+            display_config=DisplayConfig(show_indicator=False),
+            async_config=AsyncConfig(run_async=True),
+            error_config=ErrorConfig(
+                ignore_errors=True, skip_on_missing_params=True
+            ),
+        )
+        golden = next(it)
+
+        async def sleeper(_):
+            await asyncio.sleep(5)
+
+        task = asyncio.create_task(sleeper(golden.input))
+
+        # Close the loop before the iterator awaits its tasks, so the
+        # run_until_complete call raises RuntimeError while loop.is_closed()
+        # is True. The cleanup finally must not swallow that exception.
+        loop.close()
+
+        with pytest.raises(RuntimeError):
+            try:
+                it.send(task)
+            except StopIteration:
+                pass
+            for _ in it:
+                pass
+    finally:
+        asyncio.set_event_loop(None)
+        if not loop.is_closed():
+            loop.close()


### PR DESCRIPTION
## What does this PR do?

Fixes #2903. The async evaluation loop's cleanup `finally` block in `deepeval/evaluate/execute/loop.py` used a bare `return` when `loop.is_closed()` was `True`:

```python
finally:
    if loop.is_closed():
        return
    ...
```

Python suppresses any exception that is currently propagating whenever execution returns from a `finally` block, so an exception raised while the loop was shutting down (e.g. `RuntimeError: Event loop is closed` from `loop.run_until_complete` on a closed loop) was silently dropped. Python also emits `SyntaxWarning: 'return' in a 'finally' block`.

This PR guards the cleanup body with `if not loop.is_closed():` instead of returning early. The stray-task cleanup is skipped exactly when the loop is already closed, while any in-flight exception now propagates normally.

## Testing

- Added `test_exception_propagates_when_loop_closed_in_cleanup` in `tests/test_core/test_evaluation/test_execute/test_error_boundary.py`. It drives `a_execute_agentic_test_cases_from_loop` with a synthetic event loop, closes the loop before the iterator awaits its tasks, and asserts the resulting `RuntimeError` propagates instead of being suppressed.
- `python -m pytest tests/test_core/test_evaluation/test_execute/ tests/test_core/test_tracing/test_integration/test_dataset_iterator.py` → 23 passed (13 skipped, API-key dependent).
- `black --check` passes on both modified files.

## Backward compatibility

Cleanup behavior is unchanged when the loop is alive: stray tasks are still snapped, logged, cancelled and drained exactly as before. The only difference is that exceptions are no longer swallowed when the loop is already closed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)