### PR TITLE
feat(pattern_match): support literal (non-regex) pattern matching

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/pattern_match/pattern_match.py
+++ b/deepeval/metrics/pattern_match/pattern_match.py
@@ -20,19 +20,30 @@ class PatternMatchMetric(BaseMetric):
         self,
         pattern: str,
         ignore_case: bool = False,
+        regex: bool = True,
         threshold: Optional[float] = 1.0,
         verbose_mode: bool = False,
         flaky: bool = False,
     ):
+        if not isinstance(pattern, str):
+            raise TypeError(
+                f"`pattern` must be a string for the 'Pattern Match' metric, "
+                f"got {type(pattern).__name__}."
+            )
         self.pattern = pattern.strip()
         self.ignore_case = ignore_case
+        self.regex = regex
         self.verbose_mode = verbose_mode
         self.flaky = flaky
         self.threshold = threshold
 
         flags = re.IGNORECASE if ignore_case else 0
+        # In literal mode (`regex=False`) every regex metacharacter is inert,
+        # so `re.escape` turns e.g. "C++" into "C\+\+" and the pattern matches
+        # plain text exactly. `ignore_case` still applies.
+        compiled_pattern = self.pattern if regex else re.escape(self.pattern)
         try:
-            self._compiled_pattern = re.compile(self.pattern, flags)
+            self._compiled_pattern = re.compile(compiled_pattern, flags)
         except re.error as e:
             raise ValueError(f"Invalid regex pattern: {pattern} — {e}")
 
@@ -71,6 +82,7 @@ class PatternMatchMetric(BaseMetric):
                     self,
                     steps=[
                         f"Pattern: {self.pattern}",
+                        f"Mode: {'regex' if self.regex else 'literal (regex disabled)'}",
                         f"Actual: {actual}",
                         f"Score: {self.score:.2f}",
                         f"Reason: {self.reason}",

--- a/tests/test_metrics/test_pattern_match_literal_mode.py
+++ b/tests/test_metrics/test_pattern_match_literal_mode.py
@@ -1,0 +1,132 @@
+"""Unit tests for the `regex` toggle of PatternMatchMetric.
+
+`PatternMatchMetric` is fully deterministic (no LLM / API key required), so
+these tests run offline. They cover both sides of the contract:
+
+* default behavior does not regress — `regex=True` keeps the historical
+  regex semantics exactly;
+* the new capability works — `regex=False` treats the pattern as a literal
+  string, with every regex metacharacter inert.
+"""
+
+import pytest
+
+from deepeval.metrics import PatternMatchMetric
+from deepeval.test_case import LLMTestCase
+
+
+def _test_case(actual_output: str) -> LLMTestCase:
+    return LLMTestCase(
+        input="dummy input",
+        actual_output=actual_output,
+        expected_output=actual_output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default behavior must not regress (regex=True)
+# ---------------------------------------------------------------------------
+
+
+def test_regex_mode_is_the_default():
+    # A dot is a regex wildcard, so "a.b" matches "acb" in default mode.
+    metric = PatternMatchMetric(pattern="a.b")
+    assert metric.measure(_test_case("acb")) == 1.0
+    assert metric.measure(_test_case("aXb")) == 1.0
+    # The middle dot also matches a literal dot, so "a.b" matches too…
+    assert metric.measure(_test_case("a.b")) == 1.0
+    # …but exactly one character is required between "a" and "b".
+    assert metric.measure(_test_case("ab")) == 0.0
+
+
+def test_regex_mode_anchors_fullmatch_by_default():
+    metric = PatternMatchMetric(pattern=r"^Hello")
+    assert metric.measure(_test_case("Hello world")) == 0.0  # fullmatch
+    assert metric.measure(_test_case("Hello")) == 1.0
+
+
+def test_regex_mode_supports_character_classes():
+    metric = PatternMatchMetric(pattern=r"\d{2}-\d{2}")
+    assert metric.measure(_test_case("12-34")) == 1.0
+    assert metric.measure(_test_case("12-3")) == 0.0
+
+
+def test_regex_mode_ignore_case_still_applies():
+    metric = PatternMatchMetric(pattern="hello", ignore_case=True)
+    assert metric.measure(_test_case("HELLO")) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# New capability: literal (regex=False) matching
+# ---------------------------------------------------------------------------
+
+
+def test_literal_mode_matches_metacharacters_verbatim():
+    # In literal mode "C++" is plain text, not "C" followed by two "+" quantifiers.
+    metric = PatternMatchMetric(pattern="C++", regex=False)
+    assert metric.measure(_test_case("C++")) == 1.0
+    assert metric.measure(_test_case("C+")) == 0.0
+    assert metric.measure(_test_case("Cplusplus")) == 0.0
+
+
+def test_literal_mode_dot_is_not_a_wildcard():
+    metric = PatternMatchMetric(pattern="a.b", regex=False)
+    assert metric.measure(_test_case("a.b")) == 1.0
+    assert metric.measure(_test_case("acb")) == 0.0
+    assert metric.measure(_test_case("aXb")) == 0.0
+
+
+def test_literal_mode_dollar_and_parentheses_are_inert():
+    metric = PatternMatchMetric(pattern="price: $5.00 (tax incl.)", regex=False)
+    assert metric.measure(_test_case("price: $5.00 (tax incl.)")) == 1.0
+    assert metric.measure(_test_case("price: 5.00 tax incl")) == 0.0
+
+
+def test_literal_mode_with_ignore_case():
+    metric = PatternMatchMetric(
+        pattern="version 1.2.3", regex=False, ignore_case=True
+    )
+    assert metric.measure(_test_case("VERSION 1.2.3")) == 1.0
+    assert metric.measure(_test_case("version 1.2.4")) == 0.0
+
+
+def test_literal_mode_strips_pattern_like_regex_mode():
+    # Whitespace around the pattern is trimmed in both modes.
+    metric = PatternMatchMetric(pattern="  C++  ", regex=False)
+    assert metric.measure(_test_case("C++")) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_non_string_pattern_raises_type_error():
+    with pytest.raises(
+        TypeError, match="`pattern` must be a string for the 'Pattern Match'"
+    ):
+        PatternMatchMetric(pattern=123)
+
+
+def test_invalid_regex_still_raises_value_error_in_regex_mode():
+    with pytest.raises(ValueError, match="Invalid regex pattern"):
+        PatternMatchMetric(pattern="[unclosed", regex=True)
+
+
+def test_literal_mode_never_raises_invalid_regex():
+    # Even a string that is an invalid regex compiles fine once escaped.
+    metric = PatternMatchMetric(pattern="[unclosed", regex=False)
+    assert metric.measure(_test_case("[unclosed")) == 1.0
+
+
+def test_score_and_success_are_set_in_both_modes():
+    metric = PatternMatchMetric(pattern="ok", regex=False)
+    score = metric.measure(_test_case("ok"))
+    assert score == 1.0
+    assert metric.score == 1.0
+    assert metric.success is True
+    assert metric.reason is not None
+
+    metric2 = PatternMatchMetric(pattern="ok", regex=False)
+    assert metric2.measure(_test_case("not ok")) == 0.0
+    assert metric2.success is False


### PR DESCRIPTION
## What does this PR do?

Fixes #3198. `PatternMatchMetric` always compiles `pattern` as a regular expression, which makes literal matching awkward and surprising:

* Matching a literal string that contains regex metacharacters (`"C++"`, `"price: \.00"`, `"1.2.3"`) requires hand-escaping every character.
* A pattern such as `"a.b"` silently matches `"acb"` — the dot is a wildcard, not a literal character — so a user who thinks they wrote a literal check actually wrote a wildcard.

This PR adds a `regex: bool = True` toggle:

```python
PatternMatchMetric(pattern="C++", regex=False)
PatternMatchMetric(pattern="price: \.00", regex=False, ignore_case=True)
```

When `regex=False`, the pattern is treated as a literal string and matched via `re.escape(pattern)`, so metacharacters are inert while `ignore_case` still applies. When `regex=True` (the default) behavior is unchanged.

It also raises a clear `TypeError` when `pattern` is not a string — previously `PatternMatchMetric(pattern=123)` died with a confusing `AttributeError: 'int' object has no attribute 'strip'`.

## Testing

Added `tests/test_metrics/test_pattern_match_literal_mode.py` (13 offline tests) covering both sides of the contract:

* **No regression** — `regex=True` keeps regex semantics: `"a.b"` still matches `"acb"`, character classes and `ignore_case` still work, invalid regex still raises `ValueError`.
* **New capability** — `regex=False` matches metacharacters verbatim (`"C++"`, `"a.b"`, `"price: \.00 (tax incl.)"`), `.strip()` still trims the pattern, and a string that is an invalid regex compiles fine once escaped.
* `python -m pytest tests/test_metrics/test_pattern_match_literal_mode.py tests/test_metrics/test_pattern_match_metric.py tests/test_core/test_imports.py` → 28 passed, 2 skipped (API-key dependent).
* `black --check` passes on all modified files.

## Backward compatibility

`regex` defaults to `True`, so all existing callers keep the exact historical regex behavior. The `TypeError` only fires for inputs that previously crashed with an `AttributeError`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)