### PR TITLE
fix(metrics): reject non-positive window_size in sliding window helper

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -186,6 +186,10 @@ def convert_turn_to_dict(
 
 
 def get_turns_in_sliding_window(turns: List[Turn], window_size: int):
+    if window_size < 1:
+        raise ValueError(
+            f"`window_size` must be a positive integer, got {window_size}."
+        )
     for i in range(len(turns)):
         yield turns[max(0, i - window_size + 1) : i + 1]
 

--- a/tests/test_core/test_test_case/test_multi_turn/test_utils.py
+++ b/tests/test_core/test_test_case/test_multi_turn/test_utils.py
@@ -1,5 +1,9 @@
 from deepeval.test_case import Turn
-from deepeval.metrics.utils import get_unit_interactions
+from deepeval.metrics.utils import (
+    get_unit_interactions,
+    get_turns_in_sliding_window,
+)
+import pytest
 
 
 def make_turns(seq):
@@ -71,3 +75,53 @@ class TestGetUnitInteractions:
         assert [
             [(t.role, t.content) for t in unit] for unit in result
         ] == expected
+
+
+def roles(result):
+    """Flatten a sliding-window result to (role, content) lists."""
+    return [[(t.role, t.content) for t in window] for window in result]
+
+
+class TestGetTurnsInSlidingWindow:
+    def test_zero_window_size_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            list(get_turns_in_sliding_window(make_turns([("user", "u1")]), 0))
+
+    def test_negative_window_size_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            list(get_turns_in_sliding_window(make_turns([("user", "u1")]), -3))
+
+    def test_window_size_one_yields_single_turn_windows(self):
+        seq = [("user", "u1"), ("assistant", "a1"), ("user", "u2")]
+        expected = [
+            [("user", "u1")],
+            [("assistant", "a1")],
+            [("user", "u2")],
+        ]
+        assert (
+            roles(get_turns_in_sliding_window(make_turns(seq), 1)) == expected
+        )
+
+    def test_window_size_two_slides_forward(self):
+        seq = [("user", "u1"), ("assistant", "a1"), ("user", "u2")]
+        expected = [
+            [("user", "u1")],
+            [("user", "u1"), ("assistant", "a1")],
+            [("assistant", "a1"), ("user", "u2")],
+        ]
+        assert (
+            roles(get_turns_in_sliding_window(make_turns(seq), 2)) == expected
+        )
+
+    def test_window_size_larger_than_turns_returns_full_window(self):
+        seq = [("user", "u1"), ("assistant", "a1")]
+        expected = [
+            [("user", "u1")],
+            [("user", "u1"), ("assistant", "a1")],
+        ]
+        assert (
+            roles(get_turns_in_sliding_window(make_turns(seq), 10)) == expected
+        )
+
+    def test_empty_turns_with_valid_window_size(self):
+        assert list(get_turns_in_sliding_window([], 2)) == []


### PR DESCRIPTION
## Summary

`get_turns_in_sliding_window(turns, window_size)` drives the `turn_*` conversational metrics with a user-configurable `window_size`. When `window_size <= 0`, the slice arithmetic `turns[max(0, i - window_size + 1) : i + 1]` produces an **empty list** for every index, so callers feed empty windows into verdict generation and get empty/meaningless verdicts (or a downstream crash) with no hint that the configured size is invalid.

The helper now raises a clear `ValueError` when `window_size < 1`.

Closes: #3202

## Changes

- `deepeval/metrics/utils.py` — `get_turns_in_sliding_window` validates `window_size >= 1` at the top of the generator.

## Why this design

- **One fix covers all callers**: `TurnRelevancyMetric`, `TurnContextualPrecisionMetric`, `TurnContextualRecallMetric`, `TurnContextualRelevancyMetric`, `TurnFaithfulnessMetric`, `TurnRelevancyMetric` all go through this single helper, so the validation lives at the shared source instead of being duplicated across six `__init__` methods.
- **Fail fast, fail clearly**: a sliding window of size `<= 0` is meaningless by construction; an explicit `ValueError` at the source beats silently emitting degenerate windows that later surface as confusing empty verdicts.
- **Backward compatible**: `window_size >= 1` produces byte-for-byte the same windows as before; only the previously-silent degenerate inputs now error.

## Tests

Added `TestGetTurnsInSlidingWindow` to `tests/test_core/test_test_case/test_multi_turn/test_utils.py` (6 cases):

- **Default behavior (no regression)**: `window_size = 1`, `2`, `> len(turns)`, and empty turns all produce the same windows as before.
- **New capability**: `window_size = 0` and negative values raise `ValueError` with a clear message.

Local results:

```
$ python -m pytest tests/test_core/test_test_case/test_multi_turn/test_utils.py -q
13 passed in 0.56s

$ python -m pytest tests/test_core/test_test_case/test_multi_turn/ -q
89 passed
```

`black --check` passes on all touched files. No new dependencies.