### PR TITLE
fix(ci): format .scripts/release.py to unblock the repo-wide black lint

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {


### PR DESCRIPTION
## Summary

The repo-wide `black --check` lint job (`.github/workflows/black.yml`, pinned to black `25.12.0`) is red on `main` because `.scripts/release.py` has one unformatted spot. Since the lint job checks the whole repository (`src: "."`) and not just the PR diff, **every open PR currently fails `lint (ubuntu-latest)`** even when the PR itself only touches `deepeval/` and `tests/`.

This PR applies the exact black 25.12.0 formatting to `.scripts/release.py` so the shared lint job goes green and the contribution pipeline is unblocked.

## What changed

- `.scripts/release.py`: reflowed the inline comment on the `single_digit` dataclass field to what black 25.12.0 requires. Formatting only — no behavior change to the release script.

## Verification

- `black --check .` now passes across the whole repo (`992 files would be left unchanged`).
- Formatting-only change; the release script logic is untouched.

## Backward compatibility

No API or behavior change. The release script behaves identically; only its source formatting is normalized.

Closes #3204