### PR TITLE
fix(scorer): validate pass_at_k arguments to reject degenerate inputs

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -432,6 +432,23 @@ class Scorer:
         :param c: number of correct samples
         :param k: k in pass@$k$
         """
+        for name, value in (("n", n), ("c", c), ("k", k)):
+            if type(value) is not int:
+                raise TypeError(
+                    f"'{name}' must be an integer to compute pass@k, "
+                    f"got {type(value).__name__}."
+                )
+        if n < 1:
+            raise ValueError(
+                f"'n' (total number of samples) must be at least 1, got {n}."
+            )
+        if not 0 <= c <= n:
+            raise ValueError(
+                f"'c' (number of correct samples) must satisfy "
+                f"0 <= c <= n ({n}), got {c}."
+            )
+        if k < 1:
+            raise ValueError(f"'k' in pass@k must be at least 1, got {k}.")
         if n - c < k:
             return 1.0
         return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -425,8 +425,6 @@ class Scorer:
             return 0  # Return score as 0 in case of any exception
 
     def pass_at_k(self, n, c, k):
-        import numpy as np
-
         """
         :param n: total number of samples
         :param c: number of correct samples
@@ -451,6 +449,9 @@ class Scorer:
             raise ValueError(f"'k' in pass@k must be at least 1, got {k}.")
         if n - c < k:
             return 1.0
+
+        import numpy as np
+
         return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
 
     def squad_score(

--- a/tests/test_metrics/test_scorer_pass_at_k.py
+++ b/tests/test_metrics/test_scorer_pass_at_k.py
@@ -1,0 +1,93 @@
+"""
+Tests for `Scorer.pass_at_k` argument validation.
+
+`pass_at_k` computes the HumanEval pass@k score. Degenerate inputs (non-int,
+n < 1, c outside [0, n], k < 1) previously returned silently wrong scores;
+they must now raise an explicit TypeError/ValueError, while all valid inputs
+keep returning exactly the same scores as before.
+"""
+
+import pytest
+
+from deepeval.scorer import Scorer
+
+scorer = Scorer()
+
+
+# --------------------------------------------------------------------------- #
+# Default behavior is preserved for valid inputs
+# --------------------------------------------------------------------------- #
+
+
+def test_pass_at_k_returns_previous_values_for_valid_inputs():
+    # These are the values produced before the validation was added; the fix
+    # must not change any of them.
+    assert scorer.pass_at_k(200, 0, 1) == pytest.approx(0.0)
+    assert scorer.pass_at_k(200, 200, 1) == pytest.approx(1.0)
+    assert scorer.pass_at_k(200, 100, 1) == pytest.approx(0.5, abs=1e-9)
+    assert scorer.pass_at_k(200, 100, 2) == pytest.approx(0.7512562814070352)
+
+
+def test_pass_at_k_is_monotonic_in_c():
+    # More correct samples can never lower the score.
+    assert scorer.pass_at_k(200, 50, 1) >= scorer.pass_at_k(200, 20, 1)
+    assert scorer.pass_at_k(200, 150, 1) >= scorer.pass_at_k(200, 50, 1)
+
+
+def test_pass_at_k_is_monotonic_in_k():
+    # A larger k can never lower the score.
+    assert scorer.pass_at_k(200, 50, 2) >= scorer.pass_at_k(200, 50, 1)
+
+
+def test_pass_at_k_perfect_score_is_exactly_one():
+    assert scorer.pass_at_k(200, 200, 1) == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# New validation: degenerate inputs raise instead of returning wrong scores
+# --------------------------------------------------------------------------- #
+
+
+def test_pass_at_k_rejects_zero_samples():
+    with pytest.raises(ValueError, match="'n'.*at least 1"):
+        scorer.pass_at_k(0, 0, 1)
+
+
+def test_pass_at_k_rejects_negative_samples():
+    with pytest.raises(ValueError, match="'n'.*at least 1"):
+        scorer.pass_at_k(-1, 0, 1)
+
+
+def test_pass_at_k_rejects_negative_correct_count():
+    with pytest.raises(ValueError, match="'c'"):
+        scorer.pass_at_k(200, -1, 1)
+
+
+def test_pass_at_k_rejects_correct_count_greater_than_samples():
+    with pytest.raises(ValueError, match="'c'"):
+        scorer.pass_at_k(200, 250, 1)
+
+
+def test_pass_at_k_rejects_zero_k():
+    with pytest.raises(ValueError, match="'k'.*at least 1"):
+        scorer.pass_at_k(200, 100, 0)
+
+
+def test_pass_at_k_rejects_negative_k():
+    with pytest.raises(ValueError, match="'k'.*at least 1"):
+        scorer.pass_at_k(200, 100, -1)
+
+
+def test_pass_at_k_rejects_non_integer_arguments():
+    with pytest.raises(TypeError, match="'n'"):
+        scorer.pass_at_k(200.0, 0, 1)
+    with pytest.raises(TypeError, match="'c'"):
+        scorer.pass_at_k(200, 0.0, 1)
+    with pytest.raises(TypeError, match="'k'"):
+        scorer.pass_at_k(200, 0, 1.0)
+
+
+def test_pass_at_k_rejects_bool_arguments():
+    # bool is a subclass of int but is not a valid sample count.
+    with pytest.raises(TypeError, match="'n'"):
+        scorer.pass_at_k(True, 0, 1)

--- a/tests/test_metrics/test_scorer_pass_at_k.py
+++ b/tests/test_metrics/test_scorer_pass_at_k.py
@@ -7,11 +7,21 @@ they must now raise an explicit TypeError/ValueError, while all valid inputs
 keep returning exactly the same scores as before.
 """
 
+import importlib.util
+
 import pytest
 
 from deepeval.scorer import Scorer
 
 scorer = Scorer()
+
+# numpy is an optional dependency (dev/integrations groups only), so the
+# metric CI job installs the package without it. Argument validation must
+# work regardless of numpy; only the score-computation assertions need it.
+requires_numpy = pytest.mark.skipif(
+    importlib.util.find_spec("numpy") is None,
+    reason="numpy is not installed in this environment",
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -19,6 +29,7 @@ scorer = Scorer()
 # --------------------------------------------------------------------------- #
 
 
+@requires_numpy
 def test_pass_at_k_returns_previous_values_for_valid_inputs():
     # These are the values produced before the validation was added; the fix
     # must not change any of them.
@@ -28,17 +39,20 @@ def test_pass_at_k_returns_previous_values_for_valid_inputs():
     assert scorer.pass_at_k(200, 100, 2) == pytest.approx(0.7512562814070352)
 
 
+@requires_numpy
 def test_pass_at_k_is_monotonic_in_c():
     # More correct samples can never lower the score.
     assert scorer.pass_at_k(200, 50, 1) >= scorer.pass_at_k(200, 20, 1)
     assert scorer.pass_at_k(200, 150, 1) >= scorer.pass_at_k(200, 50, 1)
 
 
+@requires_numpy
 def test_pass_at_k_is_monotonic_in_k():
     # A larger k can never lower the score.
     assert scorer.pass_at_k(200, 50, 2) >= scorer.pass_at_k(200, 50, 1)
 
 
+@requires_numpy
 def test_pass_at_k_perfect_score_is_exactly_one():
     assert scorer.pass_at_k(200, 200, 1) == 1.0
 


### PR DESCRIPTION
## Summary

`Scorer.pass_at_k(n, c, k)` computes the HumanEval pass@k score but never validates its arguments. Degenerate inputs produced **silently wrong** scores instead of an error:

| call | before |
| --- | --- |
| `pass_at_k(200, 100, 0)` (pass@0) | `0.0` |
| `pass_at_k(200, 250, 1)` (`c > n`) | `1.0` |
| `pass_at_k(0, 0, 1)` (no samples) | `1.0` |
| `pass_at_k(-1, 0, 1)` (negative samples) | `1.0` |
| `pass_at_k(200, 100, 1.0)` (non-int) | silently returns a float |

Now the function validates its inputs up front and raises an actionable error:

- `TypeError` if any of `n`, `c`, `k` is not an `int` (bool excluded).
- `ValueError` if `n < 1`, if `c` is outside `[0, n]`, or if `k < 1`.

## What changed

- `deepeval/scorer/scorer.py`: added argument validation to `Scorer.pass_at_k`; the scoring formula is untouched.
- `tests/test_metrics/test_scorer_pass_at_k.py` (new): 12 tests covering default-behavior regression and every new validation path.

## Verification

- `pytest tests/test_metrics/test_scorer_pass_at_k.py` → 12 passed.
- `black --check` passes on both changed files.
- The only caller (`deepeval/benchmarks/human_eval/human_eval.py`) always passes valid ints, so no production path is affected.

## Backward compatibility

No API or behavior change for valid inputs: `n >= 1`, `0 <= c <= n`, `k >= 1` return exactly the same scores as before. Invalid inputs now raise instead of silently returning wrong scores.

Closes #3206