### PR TITLE
fix(benchmarks): validate Winogrande n_shots/n_problems with explicit exceptions

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/benchmarks/winogrande/winogrande.py
+++ b/deepeval/benchmarks/winogrande/winogrande.py
@@ -24,8 +24,26 @@ class Winogrande(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "Winogrande only supports n_shots <= 5"
-        assert n_problems <= 1267, "Winogrande only supports n_problems <= 1267"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but `n_problems` must be >= 1: evaluate() divides the
+        # number of correct predictions by it, so 0 would crash with a
+        # ZeroDivisionError.
+        for name, value in (("n_shots", n_shots), ("n_problems", n_problems)):
+            if type(value) is not int:
+                raise TypeError(
+                    f"'{name}' must be an integer, got {type(value).__name__}."
+                )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (Winogrande only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
+        if not 1 <= n_problems <= 1267:
+            raise ValueError(
+                f"'n_problems' must be between 1 and 1267 (Winogrande only "
+                f"supports n_problems <= 1267), got {n_problems}."
+            )
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.n_shots: int = n_shots

--- a/tests/test_benchmarks/test_winogrande_params.py
+++ b/tests/test_benchmarks/test_winogrande_params.py
@@ -1,0 +1,93 @@
+"""Tests for Winogrande benchmark argument validation.
+
+``Winogrande.__init__`` used bare ``assert`` statements to validate ``n_shots``
+and ``n_problems``. ``assert`` is an anti-pattern here: it is stripped when the
+interpreter runs with ``-O``/``-OO``, it raises ``AssertionError`` instead of
+the ``ValueError``/``TypeError`` callers expect, and it only checked upper
+bounds. In particular ``n_problems=0`` passed validation even though it makes
+``evaluate()`` divide by zero.
+
+These tests verify that:
+  * invalid types raise ``TypeError``;
+  * ``n_shots`` outside ``[0, 5]`` (zero-shot is allowed) raises ``ValueError``;
+  * ``n_problems`` outside ``[1, 1267]`` raises ``ValueError``;
+  * the default and previously-valid configurations still construct fine
+    (no regression).
+
+The tests are fully offline: the ``datasets`` package is stubbed out, so no
+dataset download or network access is required.
+"""
+
+import sys
+import types
+
+import pytest
+
+from deepeval.benchmarks.winogrande.winogrande import Winogrande
+
+
+@pytest.fixture
+def fake_datasets(monkeypatch):
+    """Fake the optional ``datasets`` package imported by the base benchmark."""
+    module = types.ModuleType("datasets")
+
+    class Dataset:
+        pass
+
+    module.Dataset = Dataset
+    monkeypatch.setitem(sys.modules, "datasets", module)
+    return module
+
+
+def test_default_construction_succeeds(fake_datasets):
+    bench = Winogrande()
+    assert bench.n_shots == 5
+    assert bench.n_problems == 1267
+
+
+def test_zero_shot_is_allowed(fake_datasets):
+    bench = Winogrande(n_shots=0)
+    assert bench.n_shots == 0
+
+
+def test_valid_non_default_values_construct(fake_datasets):
+    bench = Winogrande(n_shots=3, n_problems=100)
+    assert bench.n_shots == 3
+    assert bench.n_problems == 100
+
+
+def test_n_shots_above_upper_bound_rejected(fake_datasets):
+    with pytest.raises(ValueError, match="n_shots.*5"):
+        Winogrande(n_shots=6)
+
+
+def test_n_shots_negative_rejected(fake_datasets):
+    with pytest.raises(ValueError, match="n_shots"):
+        Winogrande(n_shots=-1)
+
+
+def test_n_shots_non_integer_rejected(fake_datasets):
+    with pytest.raises(TypeError, match="'n_shots'.*integer"):
+        Winogrande(n_shots=2.5)
+
+
+def test_n_problems_above_upper_bound_rejected(fake_datasets):
+    with pytest.raises(ValueError, match="n_problems.*1267"):
+        Winogrande(n_problems=1268)
+
+
+def test_n_problems_negative_rejected(fake_datasets):
+    with pytest.raises(ValueError, match="n_problems"):
+        Winogrande(n_problems=-100)
+
+
+def test_n_problems_zero_rejected(fake_datasets):
+    # Previously accepted (0 <= 1267), but evaluate() divides by n_problems,
+    # so 0 would crash with a ZeroDivisionError.
+    with pytest.raises(ValueError, match="n_problems.*1"):
+        Winogrande(n_problems=0)
+
+
+def test_n_problems_non_integer_rejected(fake_datasets):
+    with pytest.raises(TypeError, match="'n_problems'.*integer"):
+        Winogrande(n_problems="100")


### PR DESCRIPTION
## Summary

Fixes #3212.

`Winogrande.__init__` validated its `n_shots` and `n_problems` arguments with bare `assert` statements:

```python
assert n_shots <= 5, "Winogrande only supports n_shots <= 5"
assert n_problems <= 1267, "Winogrande only supports n_problems <= 1267"
```

This mirrors the pattern we already fixed for HumanEval (#3208/#3209):

1. **`assert` is stripped under `python -O`/`-OO`** — in optimized runs the checks silently disappear.
2. **Only upper bounds were checked** — negative values (`n_shots=-1`, `n_problems=-100`) passed, and `n_problems=0` passed even though it makes `evaluate()` divide by zero (`overall_correct_predictions / overall_total_predictions` → `ZeroDivisionError`).
3. **Wrong exception type** — `AssertionError` instead of `TypeError`/`ValueError`.

## Changes

- Replace the two bare `assert`s with explicit validation:
  - non-integer `n_shots`/`n_problems` → `TypeError`;
  - `n_shots` outside `[0, 5]` → `ValueError` (zero-shot is a legitimate configuration, so `0` stays valid);
  - `n_problems` outside `[1, 1267]` → `ValueError`, which also fixes the `n_problems=0` division-by-zero crash.
- Error messages keep the original "Winogrande only supports n_shots <= 5" / "n_problems <= 1267" guidance.
- Added `tests/test_benchmarks/test_winogrande_params.py` (10 tests): default construction, zero-shot, valid non-default values, and rejection of out-of-range/negative/zero/non-integer inputs.

## Tests & quality

- `pytest tests/test_benchmarks/` → **23 passed** (10 new + 13 existing, no regression).
- `black --check` → clean (black 25.12.0, matching the CI pin).
- The new tests are offline: `datasets` is stubbed out via `monkeypatch`, so no network/model access is required.

## Backward compatibility

Default behaviour is unchanged. Every input that previously constructed a `Winogrande` successfully (valid `n_shots`/`n_problems`, including `n_shots=0`) still does; the only newly-rejected values are degenerate ones that either could never have worked (`n_problems=0`) or were accepted by accident (negatives, non-integers, out-of-range values).
