### PR TITLE
fix(test_case): validate MLLMImage local flag with an explicit ValueError

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -61,7 +61,16 @@ class MLLMImage:
         else:
             is_local = self.is_local_path(self.url)
             if self.local is not None:
-                assert self.local == is_local, "Local path mismatch"
+                # Reject a caller-provided `local` that contradicts the URL
+                # with a clear ValueError instead of a bare assert, which is
+                # stripped under `python -O` and only raises AssertionError.
+                if self.local != is_local:
+                    kind = "local" if is_local else "remote"
+                    raise ValueError(
+                        f"Local path mismatch: '{self.url}' resolves to a "
+                        f"{kind} path, but 'local' was explicitly set to "
+                        f"{self.local}."
+                    )
             else:
                 self.local = is_local
 

--- a/tests/test_core/test_test_case/test_mllm_image_local_validation.py
+++ b/tests/test_core/test_test_case/test_mllm_image_local_validation.py
@@ -1,0 +1,96 @@
+"""Tests for MLLMImage `local`-flag validation.
+
+``MLLMImage.__post_init__`` used a bare ``assert self.local == is_local`` to
+validate a caller-provided ``local`` flag against the URL. ``assert`` is an
+anti-pattern here: it is stripped when the interpreter runs with ``-O``/``-OO``,
+raises ``AssertionError`` instead of ``ValueError``, and its message does not
+explain which value contradicted the URL.
+
+These tests verify that:
+  * a ``local`` flag that contradicts the URL raises a clear ``ValueError``;
+  * matching explicit values and ``local=None`` (auto-detect) still construct
+    fine (no regression);
+  * the mismatch is still rejected under ``python -O`` where bare asserts
+    would have been stripped.
+
+The tests are fully offline and need no network or model access.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from deepeval.test_case import MLLMImage
+
+REMOTE_URL = "https://example.com/image.png"
+
+
+def test_remote_url_with_matching_local_false_ok():
+    img = MLLMImage(url=REMOTE_URL, local=False)
+    assert img.local is False
+
+
+def test_remote_url_with_none_local_auto_detects_remote():
+    img = MLLMImage(url=REMOTE_URL)
+    assert img.local is False
+
+
+def test_remote_url_with_contradictory_local_true_rejected():
+    with pytest.raises(ValueError, match="Local path mismatch.*remote"):
+        MLLMImage(url=REMOTE_URL, local=True)
+
+
+def test_local_file_with_matching_local_true_ok(tmp_path):
+    path = tmp_path / "img.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    img = MLLMImage(url=str(path), local=True)
+    assert img.local is True
+    assert img.dataBase64 is not None
+
+
+def test_local_file_with_none_local_auto_detects_local(tmp_path):
+    path = tmp_path / "img.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    img = MLLMImage(url=str(path))
+    assert img.local is True
+
+
+def test_local_file_with_contradictory_local_false_rejected(tmp_path):
+    path = tmp_path / "img.png"
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    with pytest.raises(ValueError, match="Local path mismatch.*local"):
+        MLLMImage(url=str(path), local=False)
+
+
+def test_base64_path_is_unaffected():
+    # Base64-backed images skip the URL/local logic entirely.
+    img = MLLMImage(dataBase64="aGVsbG8=", mimeType="image/png", local=True)
+    assert img.local is True
+
+
+def test_mismatch_still_rejected_under_python_optimize():
+    """The check must survive `python -O` (bare asserts would be stripped)."""
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    code = (
+        "from deepeval.test_case import MLLMImage\n"
+        "try:\n"
+        "    MLLMImage(url='https://example.com/image.png', local=True)\n"
+        "except ValueError:\n"
+        "    pass\n"
+        "else:\n"
+        "    raise SystemExit('contradictory local flag accepted under -O')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": repo_root},
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Fixes #3214.

`MLLMImage.__post_init__` validated a caller-provided `local` flag against the URL with a bare `assert`:

```python
is_local = self.is_local_path(self.url)
if self.local is not None:
    assert self.local == is_local, "Local path mismatch"
else:
    self.local = is_local
```

This is the same assert anti-pattern already cleaned up elsewhere (#3191, #3208):

1. **Stripped under `python -O`/`-OO`** — in optimized runs a contradictory `local` flag is silently accepted, and the wrong value is used downstream (e.g. `FileNotFoundError` for a mislabelled "local" flag, or remote-URL validation being skipped).
2. **Wrong exception type** — `AssertionError` instead of the `ValueError` callers expect from a public constructor.
3. **Opaque message** — "Local path mismatch" never says which value contradicted the URL.

## Changes

- Replaced the bare `assert` with an explicit `ValueError` that names the URL, how it resolved (`local` vs `remote`), and the caller's `local` value.
- Added `tests/test_core/test_test_case/test_mllm_image_local_validation.py` (8 tests):
  - remote URL with matching `local=False` / `local=None` → constructs;
  - remote URL with contradictory `local=True` → `ValueError`;
  - local file with matching `local=True` / `local=None` → constructs and loads bytes;
  - local file with contradictory `local=False` → `ValueError`;
  - Base64-backed images (which skip the URL logic) are unaffected;
  - a `python -O` subprocess check proving the mismatch is still rejected where a bare `assert` would have been stripped.

## Tests & quality

- `pytest tests/test_core/test_test_case/` → **149 passed, 6 skipped** (skips are pre-existing `mcp`-module skips), no regression.
- `black --check` → clean (black 25.12.0, matching the CI pin).
- Fully offline: no network or model access.

## Backward compatibility

Default behaviour is unchanged. Every valid combination (a matching explicit `local`, or `local=None` for auto-detection) constructs exactly as before; the only newly-affected input is the contradictory-flag case, which previously crashed with `AssertionError` (or was silently accepted under `-O`) and now raises a clear `ValueError`.
