### PR TITLE
fix(scorer): quasi_contains_score mis-scores a bare string target

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -117,7 +117,15 @@ class Scorer:
         return 1 if normalize_text(target) == normalize_text(prediction) else 0
 
     @classmethod
-    def quasi_contains_score(cls, targets: List[str], prediction: str) -> int:
+    def quasi_contains_score(
+        cls, targets: Union[str, List[str]], prediction: str
+    ) -> int:
+        # Accept a single string as `targets` and treat it as a one-element
+        # list. Iterating over a bare string would otherwise split it into
+        # single characters and silently produce nonsense scores (e.g. an exact
+        # match scoring 0).
+        if isinstance(targets, str):
+            targets = [targets]
         normalized_targets = [normalize_text(t) for t in targets]
         if not prediction:
             return 0

--- a/tests/test_metrics/test_scorer_quasi_contains.py
+++ b/tests/test_metrics/test_scorer_quasi_contains.py
@@ -1,0 +1,57 @@
+"""Tests for ``Scorer.quasi_contains_score`` with a bare-string target.
+
+``quasi_contains_score(targets, prediction)`` declared ``targets: List[str]``
+but never validated it. Strings are iterable, so a caller passing a bare string
+(say, the expected answer) silently split it into **single characters**,
+producing nonsense scores — an exact match scored ``0`` while a single-character
+prediction scored ``1``.
+
+These tests verify that:
+  * a bare-string target with an exact (normalized) match scores ``1``;
+  * a bare-string target no longer yields spurious character matches;
+  * list targets keep their previous behaviour (no regression);
+  * an empty prediction still scores ``0``;
+  * normalization (case / extra whitespace) still applies.
+"""
+
+import pytest
+
+from deepeval.scorer.scorer import Scorer
+
+
+def test_bare_string_target_exact_match_scores_one():
+    assert Scorer.quasi_contains_score("cat", "cat") == 1
+
+
+def test_bare_string_target_no_spurious_character_match():
+    # Previously "cat" was split into ["c", "a", "t"], so a single-character
+    # prediction matched spuriously.
+    assert Scorer.quasi_contains_score("cat", "c") == 0
+    assert Scorer.quasi_contains_score("cat", "ca") == 0
+
+
+def test_bare_string_target_normalized_match_scores_one():
+    # normalize_text lower-cases and collapses whitespace.
+    assert Scorer.quasi_contains_score("Cat", "cat") == 1
+    assert Scorer.quasi_contains_score("cat", " cat ") == 1
+
+
+def test_list_target_exact_match_scores_one():
+    assert Scorer.quasi_contains_score(["cat"], "cat") == 1
+
+
+def test_list_target_non_member_scores_zero():
+    assert Scorer.quasi_contains_score(["cat", "dog"], "bird") == 0
+
+
+def test_list_target_picks_a_member():
+    assert Scorer.quasi_contains_score(["cat", "dog"], "dog") == 1
+
+
+def test_empty_prediction_scores_zero():
+    assert Scorer.quasi_contains_score("cat", "") == 0
+    assert Scorer.quasi_contains_score(["cat"], "") == 0
+
+
+def test_empty_targets_scores_zero():
+    assert Scorer.quasi_contains_score([], "cat") == 0


### PR DESCRIPTION
## Summary

`Scorer.quasi_contains_score(targets, prediction)` declared `targets: List[str]` but never validated it. Because strings are iterable, a caller passing a bare string (e.g. a single expected answer) silently split it into **single characters**, producing nonsense scores: an exact match scored `0` while a one-character prediction scored `1`.

## Changes

- Accept `Union[str, List[str]]` for `targets` and normalize a bare string into a one-element list.
- List targets keep their previous behaviour (no regression).

## Tests

New `tests/test_metrics/test_scorer_quasi_contains.py` (8 tests) covering:

- bare-string exact match scores `1`;
- no spurious character matches (`quasi_contains_score("cat", "c") == 0`);
- normalization (case / whitespace) still applies;
- list targets unchanged (no regression);
- empty prediction and empty targets score `0`.

Local results: `pytest` 8 passed (plus 21 existing scorer/benchmark scoring tests still green); `black --check` clean on both changed files.

## Backward compatibility

No default behaviour changes for existing callers: list targets and normalized comparison behave exactly as before. Only the previously-broken bare-string path is fixed.

Closes #3218