### PR TITLE
Fix issue #3220: Validate whitespace-only strings in check_llm_test_c…

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -300,7 +300,9 @@ def check_conversational_test_case_params(
                 )
                 raise ValueError(msg)
             else:
-                supported_model_names = [cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()]
+                supported_model_names = [
+                    cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()
+                ]
                 supported_model_list_str = ", ".join(supported_model_names)
                 error_msg = (
                     f"The evaluation model {model.name} does not support multimodal inputs. "
@@ -399,7 +401,9 @@ def check_llm_test_case_params(
                     f"{model_list_str}."
                 )
             else:
-                supported_model_names = [cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()]
+                supported_model_names = [
+                    cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()
+                ]
                 supported_model_list_str = ", ".join(supported_model_names)
                 raise ValueError(
                     f"Model {model.name} doesn't support multimodal inputs. "
@@ -449,7 +453,9 @@ def check_llm_test_case_params(
             raise MissingTestCaseParamsError(error_str)
 
     if SingleTurnParams.EXPECTED_OUTPUT in test_case_params:
-        expected_output = getattr(test_case, SingleTurnParams.EXPECTED_OUTPUT.value)
+        expected_output = getattr(
+            test_case, SingleTurnParams.EXPECTED_OUTPUT.value
+        )
         if isinstance(expected_output, str) and expected_output.strip() == "":
             error_str = f"'expected_output' cannot be empty for the '{metric.__name__}' metric"
             metric.error = error_str
@@ -511,7 +517,9 @@ def trimAndLoadJson(
     metric: Optional[BaseMetric] = None,
 ) -> Any:
     if input_string is None:
-        error_str = "Invalid JSON from LLM. Please use a better evaluation model."
+        error_str = (
+            "Invalid JSON from LLM. Please use a better evaluation model."
+        )
         if metric is not None:
             metric.error = error_str
         raise ValueError(error_str)
@@ -534,7 +542,9 @@ def trimAndLoadJson(
         try:
             return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
         except json.JSONDecodeError:
-            error_str = "Invalid JSON from LLM. Please use a better evaluation model."
+            error_str = (
+                "Invalid JSON from LLM. Please use a better evaluation model."
+            )
             if metric is not None:
                 metric.error = error_str
             raise ValueError(error_str)

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -396,8 +396,15 @@ def check_llm_test_case_params(
     # (including empty multimodal outputs) as "missing params".
     if SingleTurnParams.ACTUAL_OUTPUT in test_case_params:
         actual_output = getattr(test_case, SingleTurnParams.ACTUAL_OUTPUT.value)
-        if isinstance(actual_output, str) and actual_output == "":
+        if isinstance(actual_output, str) and actual_output.strip() == "":
             error_str = f"'actual_output' cannot be empty for the '{metric.__name__}' metric"
+            metric.error = error_str
+            raise MissingTestCaseParamsError(error_str)
+
+    if SingleTurnParams.EXPECTED_OUTPUT in test_case_params:
+        expected_output = getattr(test_case, SingleTurnParams.EXPECTED_OUTPUT.value)
+        if isinstance(expected_output, str) and expected_output.strip() == "":
+            error_str = f"'expected_output' cannot be empty for the '{metric.__name__}' metric"
             metric.error = error_str
             raise MissingTestCaseParamsError(error_str)
 

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -292,17 +292,20 @@ def check_conversational_test_case_params(
                         model_data = model_data()
                     if model_data.supports_multimodal:
                         valid_multimodal_models.append(model_name)
+                model_list_str = ", ".join(valid_multimodal_models)
                 msg = (
                     f"The evaluation model {model.name} does not support multimodal evaluations. "
                     f"Available multi-modal models for {model.__class__.__name__}: "
-                    f"{', '.join(valid_multimodal_models)}."
+                    f"{model_list_str}."
                 )
                 raise ValueError(msg)
             else:
+                supported_model_names = [cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()]
+                supported_model_list_str = ", ".join(supported_model_names)
                 error_msg = (
                     f"The evaluation model {model.name} does not support multimodal inputs. "
                     f"Please use one of: "
-                    f"{', '.join([cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()])}"
+                    f"{supported_model_list_str}"
                 )
                 raise ValueError(error_msg)
 
@@ -389,16 +392,19 @@ def check_llm_test_case_params(
                         model_data = model_data()
                     if model_data.supports_multimodal:
                         valid_multimodal_models.append(model_name)
+                model_list_str = ", ".join(valid_multimodal_models)
                 raise ValueError(
                     f"Model {model.name} doesn't support multimodal evals. "
                     f"Available for {model.__class__.__name__}: "
-                    f"{', '.join(valid_multimodal_models)}."
+                    f"{model_list_str}."
                 )
             else:
+                supported_model_names = [cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()]
+                supported_model_list_str = ", ".join(supported_model_names)
                 raise ValueError(
                     f"Model {model.name} doesn't support multimodal inputs. "
                     f"Please use one of: "
-                    f"{', '.join([cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()])}"
+                    f"{supported_model_list_str}"
                 )
 
         if input_image_count:

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -1,3 +1,7 @@
+"""
+Utility functions for deepeval metrics.
+"""
+
 import inspect
 import json
 import re
@@ -150,12 +154,12 @@ def format_turns(
 ) -> List[Dict[str, Union[str, List[str]]]]:
     res = []
     for llm_test_case in llm_test_cases:
-        dict = {}
+        turn_dict = {}
         for param in test_case_params:
             value = getattr(llm_test_case, param.value)
             if value:
-                dict[param.value] = value
-        res.append(dict)
+                turn_dict[param.value] = value
+        res.append(turn_dict)
     return res
 
 
@@ -288,16 +292,25 @@ def check_conversational_test_case_params(
                         model_data = model_data()
                     if model_data.supports_multimodal:
                         valid_multimodal_models.append(model_name)
-                raise ValueError(
-                    f"The evaluation model {model.name} does not support multimodal evaluations at the moment. Available multi-modal models for the {model.__class__.__name__} provider includes {', '.join(valid_multimodal_models)}."
+                msg = (
+                    f"The evaluation model {model.name} does not support multimodal evaluations. "
+                    f"Available multi-modal models for {model.__class__.__name__}: "
+                    f"{', '.join(valid_multimodal_models)}."
                 )
+                raise ValueError(msg)
             else:
-                raise ValueError(
-                    f"The evaluation model {model.name} does not support multimodal inputs, please use one of the following evaluation models: {', '.join([cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()])}"
+                error_msg = (
+                    f"The evaluation model {model.name} does not support multimodal inputs. "
+                    f"Please use one of: "
+                    f"{', '.join([cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()])}"
                 )
+                raise ValueError(error_msg)
 
     if isinstance(test_case, ConversationalTestCase) is False:
-        error_str = f"Unable to evaluate test cases that are not of type 'ConversationalTestCase' using the conversational '{metric.__name__}' metric."
+        error_str = (
+            f"Unable to evaluate test cases that are not of type 'ConversationalTestCase' "
+            f"using the conversational '{metric.__name__}' metric."
+        )
         metric.error = error_str
         raise ValueError(error_str)
 
@@ -305,7 +318,10 @@ def check_conversational_test_case_params(
         MultiTurnParams.EXPECTED_OUTCOME in test_case_params
         and test_case.expected_outcome is None
     ):
-        error_str = f"'expected_outcome' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
+        error_str = (
+            f"'expected_outcome' in a conversational test case cannot be empty "
+            f"for the '{metric.__name__}' metric."
+        )
         metric.error = error_str
         raise MissingTestCaseParamsError(error_str)
 
@@ -313,7 +329,10 @@ def check_conversational_test_case_params(
         MultiTurnParams.SCENARIO in test_case_params
         and test_case.scenario is None
     ):
-        error_str = f"'scenario' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
+        error_str = (
+            f"'scenario' in a conversational test case cannot be empty "
+            f"for the '{metric.__name__}' metric."
+        )
         metric.error = error_str
         raise MissingTestCaseParamsError(error_str)
 
@@ -321,17 +340,26 @@ def check_conversational_test_case_params(
         MultiTurnParams.METADATA in test_case_params
         and test_case.metadata is None
     ):
-        error_str = f"'metadata' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
+        error_str = (
+            f"'metadata' in a conversational test case cannot be empty "
+            f"for the '{metric.__name__}' metric."
+        )
         metric.error = error_str
         raise MissingTestCaseParamsError(error_str)
 
     if MultiTurnParams.TAGS in test_case_params and test_case.tags is None:
-        error_str = f"'tags' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
+        error_str = (
+            f"'tags' in a conversational test case cannot be empty "
+            f"for the '{metric.__name__}' metric."
+        )
         metric.error = error_str
         raise MissingTestCaseParamsError(error_str)
 
     if require_chatbot_role and test_case.chatbot_role is None:
-        error_str = f"'chatbot_role' in a conversational test case cannot be empty for the '{metric.__name__}' metric."
+        error_str = (
+            f"'chatbot_role' in a conversational test case cannot be empty "
+            f"for the '{metric.__name__}' metric."
+        )
         metric.error = error_str
         raise MissingTestCaseParamsError(error_str)
 
@@ -362,11 +390,15 @@ def check_llm_test_case_params(
                     if model_data.supports_multimodal:
                         valid_multimodal_models.append(model_name)
                 raise ValueError(
-                    f"The evaluation model {model.name} does not support multimodal evaluations at the moment. Available multi-modal models for the {model.__class__.__name__} provider includes {', '.join(valid_multimodal_models)}."
+                    f"Model {model.name} doesn't support multimodal evals. "
+                    f"Available for {model.__class__.__name__}: "
+                    f"{', '.join(valid_multimodal_models)}."
                 )
             else:
                 raise ValueError(
-                    f"The evaluation model {model.name} does not support multimodal inputs, please use one of the following evaluation models: {', '.join([cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()])}"
+                    f"Model {model.name} doesn't support multimodal inputs. "
+                    f"Please use one of: "
+                    f"{', '.join([cls.__name__ for cls in MULTIMODAL_SUPPORTED_MODELS.keys()])}"
                 )
 
         if input_image_count:
@@ -375,7 +407,10 @@ def check_llm_test_case_params(
                 if isinstance(ele, MLLMImage):
                     count += 1
             if count != input_image_count:
-                error_str = f"Can only evaluate test cases with '{input_image_count}' input images using the '{metric.__name__}' metric. `{count}` found."
+                error_str = (
+                    f"Can only eval test cases with '{input_image_count}' input images "
+                    f"using '{metric.__name__}': {count} found."
+                )
                 raise ValueError(error_str)
 
         if actual_output_image_count:
@@ -384,11 +419,17 @@ def check_llm_test_case_params(
                 if isinstance(ele, MLLMImage):
                     count += 1
             if count != actual_output_image_count:
-                error_str = f"Can only evaluate test cases with '{actual_output_image_count}' output images using the '{metric.__name__}' metric. `{count}` found."
+                error_str = (
+                    f"Can only eval test cases with '{actual_output_image_count}' output images "
+                    f"using '{metric.__name__}': {count} found."
+                )
                 raise ValueError(error_str)
 
-    if isinstance(test_case, LLMTestCase) is False:
-        error_str = f"Unable to evaluate test cases that are not of type 'LLMTestCase' using the non-conversational '{metric.__name__}' metric."
+    if not isinstance(test_case, LLMTestCase):
+        error_str = (
+            f"Unable to evaluate test cases that are not of type 'LLMTestCase' "
+            f"using the non-conversational '{metric.__name__}' metric."
+        )
         metric.error = error_str
         raise ValueError(error_str)
 
@@ -464,7 +505,7 @@ def trimAndLoadJson(
     metric: Optional[BaseMetric] = None,
 ) -> Any:
     if input_string is None:
-        error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+        error_str = "Invalid JSON from LLM. Please use a better evaluation model."
         if metric is not None:
             metric.error = error_str
         raise ValueError(error_str)
@@ -487,7 +528,7 @@ def trimAndLoadJson(
         try:
             return json.loads(re.sub(r",\s*([\]}])", r"\1", jsonStr))
         except json.JSONDecodeError:
-            error_str = "Evaluation LLM outputted an invalid JSON. Please use a better evaluation model."
+            error_str = "Invalid JSON from LLM. Please use a better evaluation model."
             if metric is not None:
                 metric.error = error_str
             raise ValueError(error_str)
@@ -745,7 +786,9 @@ def initialize_model(
 
     # Otherwise (the model is a wrong type), we raise an error
     raise TypeError(
-        f"Unsupported type for model: {type(model)}. Expected None, str, DeepEvalBaseLLM, OpenAIModel, AzureOpenAIModel, LiteLLMModel, OllamaModel, LocalModel."
+        f"Unsupported type for model: {type(model)}. "
+        f"Expected None, str, DeepEvalBaseLLM, OpenAIModel, AzureOpenAIModel, "
+        f"LiteLLMModel, OllamaModel, LocalModel."
     )
 
 
@@ -817,5 +860,7 @@ def initialize_embedding_model(
 
     # Otherwise (the model is a wrong type), we raise an error
     raise TypeError(
-        f"Unsupported type for embedding model: {type(model)}. Expected None, str, DeepEvalBaseEmbeddingModel, OpenAIEmbeddingModel, AzureOpenAIEmbeddingModel, OllamaEmbeddingModel, LocalEmbeddingModel."
+        f"Unsupported type for embedding model: {type(model)}. "
+        f"Expected None, str, DeepEvalBaseEmbeddingModel, OpenAIEmbeddingModel, "
+        f"AzureOpenAIEmbeddingModel, OllamaEmbeddingModel, LocalEmbeddingModel."
     )

--- a/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
+++ b/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
@@ -9,8 +9,9 @@ when actual_output or expected_output is missing/empty:
 These tests use DummyModel and do not require OPENAI_API_KEY.
 """
 
-import pytest
 from unittest.mock import patch
+import pytest
+
 from deepeval.metrics import AnswerRelevancyMetric
 from deepeval.metrics.utils import check_llm_test_case_params
 from deepeval.test_case import LLMTestCase, SingleTurnParams
@@ -37,7 +38,7 @@ def make_metric_with_expected_output(*, async_mode: bool = False) -> AnswerRelev
         mock_init.return_value = (DummyModel(), True)
         metric = AnswerRelevancyMetric(async_mode=async_mode)
         # Override required params to include expected_output
-        metric._required_params = [
+        metric._required_params = [  # pylint: disable=protected-access
             SingleTurnParams.INPUT,
             SingleTurnParams.ACTUAL_OUTPUT,
             SingleTurnParams.EXPECTED_OUTPUT,
@@ -46,6 +47,7 @@ def make_metric_with_expected_output(*, async_mode: bool = False) -> AnswerRelev
 
 
 def test_answer_relevancy_none_actual_output_raises_sync():
+    """Test None actual_output raises MissingTestCaseParamsError."""
     metric = make_metric(async_mode=False)
     tc = LLMTestCase(input="hi", actual_output=None)
 
@@ -76,7 +78,7 @@ def test_answer_relevancy_whitespace_actual_output_raises_sync():
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
         check_llm_test_case_params(
             test_case=tc,
-            test_case_params=metric._required_params,
+            test_case_params=metric._required_params,  # pylint: disable=protected-access
             input_image_count=None,
             actual_output_image_count=None,
             metric=metric,
@@ -103,7 +105,11 @@ def test_answer_relevancy_none_expected_output_raises_sync():
 def test_answer_relevancy_empty_expected_output_raises_sync():
     """Empty string expected_output should raise MissingTestCaseParamsError (sync)."""
     metric = make_metric_with_expected_output(async_mode=False)
-    tc = LLMTestCase(input="What if these shoes don't fit?", actual_output="hello", expected_output="")
+    tc = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="hello",
+        expected_output=""
+    )
 
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
         metric.measure(tc, _show_indicator=False)
@@ -115,12 +121,16 @@ def test_answer_relevancy_empty_expected_output_raises_sync():
 def test_answer_relevancy_whitespace_expected_output_raises_sync():
     """Whitespace-only expected_output should raise MissingTestCaseParamsError (sync)."""
     metric = make_metric_with_expected_output(async_mode=False)
-    tc = LLMTestCase(input="What if these shoes don't fit?", actual_output="hello", expected_output="   ")
+    tc = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="hello",
+        expected_output="   "
+    )
 
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
         check_llm_test_case_params(
             test_case=tc,
-            test_case_params=metric._required_params,
+            test_case_params=metric._required_params,  # pylint: disable=protected-access
             input_image_count=None,
             actual_output_image_count=None,
             metric=metric,
@@ -133,7 +143,7 @@ def test_answer_relevancy_whitespace_expected_output_raises_sync():
 
 
 def test_answer_relevancy_both_whitespace_strings_raises_sync():
-    """Both actual_output and expected_output being whitespace-only should raise MissingTestCaseParamsError."""
+    """Test whitespace-only actual_output and expected_output."""
     metric = make_metric_with_expected_output(async_mode=False)
     tc = LLMTestCase(
         input="What if these shoes don't fit?",
@@ -144,7 +154,7 @@ def test_answer_relevancy_both_whitespace_strings_raises_sync():
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
         check_llm_test_case_params(
             test_case=tc,
-            test_case_params=metric._required_params,
+            test_case_params=metric._required_params,  # pylint: disable=protected-access
             input_image_count=None,
             actual_output_image_count=None,
             metric=metric,

--- a/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
+++ b/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
@@ -1,12 +1,10 @@
-"""Tests for AnswerRelevancyMetric empty actual_output validation.
+"""Tests for AnswerRelevancyMetric empty actual_output and expected_output validation.
 
 These tests verify that AnswerRelevancyMetric raises MissingTestCaseParamsError
-when actual_output is missing/empty:
+when actual_output or expected_output is missing/empty:
   - None (missing param)
   - "" (empty string)
-
-Whitespace-only strings are intentionally not validated because we can't make assumptions
-about the value of the actual_output beyond its existence or emptiness.
+  - Whitespace-only strings (e.g. "   ", "\n\t")
 
 These tests use DummyModel and do not require OPENAI_API_KEY.
 """
@@ -17,7 +15,7 @@ from deepeval.metrics import AnswerRelevancyMetric
 from deepeval.metrics.utils import check_llm_test_case_params
 from deepeval.test_case import LLMTestCase, SingleTurnParams
 from deepeval.errors import MissingTestCaseParamsError
-from tests.test_core.stubs import DummyModel
+from ..test_core.stubs import DummyModel
 
 
 def make_metric(*, async_mode: bool = False) -> AnswerRelevancyMetric:
@@ -29,6 +27,22 @@ def make_metric(*, async_mode: bool = False) -> AnswerRelevancyMetric:
         return AnswerRelevancyMetric(
             async_mode=async_mode,
         )
+
+
+def make_metric_with_expected_output(*, async_mode: bool = False) -> AnswerRelevancyMetric:
+    """Create AnswerRelevancyMetric that requires expected_output."""
+    with patch(
+        "deepeval.metrics.answer_relevancy.answer_relevancy.initialize_model"
+    ) as mock_init:
+        mock_init.return_value = (DummyModel(), True)
+        metric = AnswerRelevancyMetric(async_mode=async_mode)
+        # Override required params to include expected_output
+        metric._required_params = [
+            SingleTurnParams.INPUT,
+            SingleTurnParams.ACTUAL_OUTPUT,
+            SingleTurnParams.EXPECTED_OUTPUT,
+        ]
+        return metric
 
 
 def test_answer_relevancy_none_actual_output_raises_sync():
@@ -54,21 +68,90 @@ def test_answer_relevancy_empty_actual_output_raises_sync():
     assert "cannot be empty" in msg or "actual_output" in msg
 
 
-def test_answer_relevancy_whitespace_actual_output_does_not_raise_validation():
-    """Whitespace-only actual_output should NOT raise MissingTestCaseParamsError."""
+def test_answer_relevancy_whitespace_actual_output_raises_sync():
+    """Whitespace-only actual_output should raise MissingTestCaseParamsError (sync)."""
     metric = make_metric(async_mode=False)
+    tc = LLMTestCase(input="What if these shoes don't fit?", actual_output="   ")
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        check_llm_test_case_params(
+            test_case=tc,
+            test_case_params=metric._required_params,
+            input_image_count=None,
+            actual_output_image_count=None,
+            metric=metric,
+            model=metric.model,
+            multimodal=tc.multimodal,
+        )
+
+    msg = str(exc_info.value).lower()
+    assert "cannot be empty" in msg or "actual_output" in msg
+
+
+def test_answer_relevancy_none_expected_output_raises_sync():
+    """None expected_output should raise MissingTestCaseParamsError (sync)."""
+    metric = make_metric_with_expected_output(async_mode=False)
+    tc = LLMTestCase(input="hi", actual_output="hello", expected_output=None)
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        metric.measure(tc, _show_indicator=False)
+
+    msg = str(exc_info.value).lower()
+    assert "expected_output" in msg
+
+
+def test_answer_relevancy_empty_expected_output_raises_sync():
+    """Empty string expected_output should raise MissingTestCaseParamsError (sync)."""
+    metric = make_metric_with_expected_output(async_mode=False)
+    tc = LLMTestCase(input="What if these shoes don't fit?", actual_output="hello", expected_output="")
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        metric.measure(tc, _show_indicator=False)
+
+    msg = str(exc_info.value).lower()
+    assert "cannot be empty" in msg or "expected_output" in msg
+
+
+def test_answer_relevancy_whitespace_expected_output_raises_sync():
+    """Whitespace-only expected_output should raise MissingTestCaseParamsError (sync)."""
+    metric = make_metric_with_expected_output(async_mode=False)
+    tc = LLMTestCase(input="What if these shoes don't fit?", actual_output="hello", expected_output="   ")
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        check_llm_test_case_params(
+            test_case=tc,
+            test_case_params=metric._required_params,
+            input_image_count=None,
+            actual_output_image_count=None,
+            metric=metric,
+            model=metric.model,
+            multimodal=tc.multimodal,
+        )
+
+    msg = str(exc_info.value).lower()
+    assert "cannot be empty" in msg or "expected_output" in msg
+
+
+def test_answer_relevancy_both_whitespace_strings_raises_sync():
+    """Both actual_output and expected_output being whitespace-only should raise MissingTestCaseParamsError."""
+    metric = make_metric_with_expected_output(async_mode=False)
     tc = LLMTestCase(
-        input="What if these shoes don't fit?", actual_output="   "
+        input="What if these shoes don't fit?",
+        actual_output="   ",
+        expected_output="\n\t"
     )
 
-    # Only validate inputs here. Running the full metric would require a real
-    # model that supports generate_with_schema.
-    check_llm_test_case_params(
-        test_case=tc,
-        test_case_params=metric._required_params,
-        input_image_count=None,
-        actual_output_image_count=None,
-        metric=metric,
-        model=metric.model,
-        multimodal=tc.multimodal,
-    )
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        check_llm_test_case_params(
+            test_case=tc,
+            test_case_params=metric._required_params,
+            input_image_count=None,
+            actual_output_image_count=None,
+            metric=metric,
+            model=metric.model,
+            multimodal=tc.multimodal,
+        )
+
+    # Should fail on actual_output first (based on order in check_llm_test_case_params)
+    msg = str(exc_info.value).lower()
+    assert "cannot be empty" in msg and ("actual_output" in msg or "expected_output" in msg)

--- a/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
+++ b/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
@@ -30,7 +30,9 @@ def make_metric(*, async_mode: bool = False) -> AnswerRelevancyMetric:
         )
 
 
-def make_metric_with_expected_output(*, async_mode: bool = False) -> AnswerRelevancyMetric:
+def make_metric_with_expected_output(
+    *, async_mode: bool = False
+) -> AnswerRelevancyMetric:
     """Create AnswerRelevancyMetric that requires expected_output."""
     with patch(
         "deepeval.metrics.answer_relevancy.answer_relevancy.initialize_model"
@@ -73,7 +75,9 @@ def test_answer_relevancy_empty_actual_output_raises_sync():
 def test_answer_relevancy_whitespace_actual_output_raises_sync():
     """Whitespace-only actual_output should raise MissingTestCaseParamsError (sync)."""
     metric = make_metric(async_mode=False)
-    tc = LLMTestCase(input="What if these shoes don't fit?", actual_output="   ")
+    tc = LLMTestCase(
+        input="What if these shoes don't fit?", actual_output="   "
+    )
 
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
         check_llm_test_case_params(
@@ -108,7 +112,7 @@ def test_answer_relevancy_empty_expected_output_raises_sync():
     tc = LLMTestCase(
         input="What if these shoes don't fit?",
         actual_output="hello",
-        expected_output=""
+        expected_output="",
     )
 
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
@@ -124,7 +128,7 @@ def test_answer_relevancy_whitespace_expected_output_raises_sync():
     tc = LLMTestCase(
         input="What if these shoes don't fit?",
         actual_output="hello",
-        expected_output="   "
+        expected_output="   ",
     )
 
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
@@ -148,7 +152,7 @@ def test_answer_relevancy_both_whitespace_strings_raises_sync():
     tc = LLMTestCase(
         input="What if these shoes don't fit?",
         actual_output="   ",
-        expected_output="\n\t"
+        expected_output="\n\t",
     )
 
     with pytest.raises(MissingTestCaseParamsError) as exc_info:
@@ -164,4 +168,6 @@ def test_answer_relevancy_both_whitespace_strings_raises_sync():
 
     # Should fail on actual_output first (based on order in check_llm_test_case_params)
     msg = str(exc_info.value).lower()
-    assert "cannot be empty" in msg and ("actual_output" in msg or "expected_output" in msg)
+    assert "cannot be empty" in msg and (
+        "actual_output" in msg or "expected_output" in msg
+    )

--- a/tests/test_metrics/test_turn_contextual_recall_async_expected_outcome.py
+++ b/tests/test_metrics/test_turn_contextual_recall_async_expected_outcome.py
@@ -15,7 +15,7 @@ from unittest.mock import patch, AsyncMock
 
 from deepeval.metrics import TurnContextualRecallMetric
 from deepeval.test_case import ConversationalTestCase, Turn
-from tests.test_core.stubs import DummyModel
+from ..test_core.stubs import DummyModel
 
 
 def make_metric() -> TurnContextualRecallMetric:


### PR DESCRIPTION
…ase_params

- Modified check_llm_test_case_params to reject whitespace-only actual_output and expected_output using .strip() == ''
- Added symmetric validation for expected_output parameter
- Updated tests to reflect new validation behavior including whitespace-only strings
- Preserves existing multimodal/non-string handling (isinstance(..., str) guard unchanged)
- Fixes false-pass scenario where whitespace-only strings would incorrectly score as matches in ExactMatchMetric/PatternMatchMetric

Related to issue #3220