### PR TITLE
fix: reject whitespace-only metric params

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -392,14 +392,21 @@ def check_llm_test_case_params(
         metric.error = error_str
         raise ValueError(error_str)
 
-    # Centralized: if a metric requires actual_output, reject empty/whitespace
-    # (including empty multimodal outputs) as "missing params".
-    if SingleTurnParams.ACTUAL_OUTPUT in test_case_params:
-        actual_output = getattr(test_case, SingleTurnParams.ACTUAL_OUTPUT.value)
-        if isinstance(actual_output, str) and actual_output == "":
-            error_str = f"'actual_output' cannot be empty for the '{metric.__name__}' metric"
-            metric.error = error_str
-            raise MissingTestCaseParamsError(error_str)
+    # Centralized: if a metric requires actual or expected output, reject empty
+    # or whitespace-only text as "missing params".
+    for param in (
+        SingleTurnParams.ACTUAL_OUTPUT,
+        SingleTurnParams.EXPECTED_OUTPUT,
+    ):
+        if param in test_case_params:
+            value = getattr(test_case, param.value)
+            if isinstance(value, str) and value.strip() == "":
+                error_str = (
+                    f"'{param.value}' cannot be empty for the "
+                    f"'{metric.__name__}' metric"
+                )
+                metric.error = error_str
+                raise MissingTestCaseParamsError(error_str)
 
     missing_params = []
     for param in test_case_params:

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -402,9 +402,7 @@ class LLMTestCase(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     completion_time: Optional[float] = Field(
         default=None,

--- a/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
+++ b/tests/test_metrics/test_answer_relevancy_metric_empty_output.py
@@ -4,9 +4,7 @@ These tests verify that AnswerRelevancyMetric raises MissingTestCaseParamsError
 when actual_output is missing/empty:
   - None (missing param)
   - "" (empty string)
-
-Whitespace-only strings are intentionally not validated because we can't make assumptions
-about the value of the actual_output beyond its existence or emptiness.
+  - whitespace-only strings
 
 These tests use DummyModel and do not require OPENAI_API_KEY.
 """
@@ -18,6 +16,11 @@ from deepeval.metrics.utils import check_llm_test_case_params
 from deepeval.test_case import LLMTestCase, SingleTurnParams
 from deepeval.errors import MissingTestCaseParamsError
 from tests.test_core.stubs import DummyModel
+
+
+class DummyMetric:
+    __name__ = "DummyMetric"
+    error = None
 
 
 def make_metric(*, async_mode: bool = False) -> AnswerRelevancyMetric:
@@ -54,21 +57,44 @@ def test_answer_relevancy_empty_actual_output_raises_sync():
     assert "cannot be empty" in msg or "actual_output" in msg
 
 
-def test_answer_relevancy_whitespace_actual_output_does_not_raise_validation():
-    """Whitespace-only actual_output should NOT raise MissingTestCaseParamsError."""
+def test_answer_relevancy_whitespace_actual_output_raises_validation():
+    """Whitespace-only actual_output should raise MissingTestCaseParamsError."""
     metric = make_metric(async_mode=False)
     tc = LLMTestCase(
         input="What if these shoes don't fit?", actual_output="   "
     )
 
-    # Only validate inputs here. Running the full metric would require a real
-    # model that supports generate_with_schema.
-    check_llm_test_case_params(
-        test_case=tc,
-        test_case_params=metric._required_params,
-        input_image_count=None,
-        actual_output_image_count=None,
-        metric=metric,
-        model=metric.model,
-        multimodal=tc.multimodal,
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        check_llm_test_case_params(
+            test_case=tc,
+            test_case_params=metric._required_params,
+            input_image_count=None,
+            actual_output_image_count=None,
+            metric=metric,
+            model=metric.model,
+            multimodal=tc.multimodal,
+        )
+
+    assert "actual_output" in str(exc_info.value)
+
+
+def test_expected_output_whitespace_raises_when_required():
+    tc = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="A response",
+        expected_output=" \n\t ",
     )
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        check_llm_test_case_params(
+            test_case=tc,
+            test_case_params=[
+                SingleTurnParams.ACTUAL_OUTPUT,
+                SingleTurnParams.EXPECTED_OUTPUT,
+            ],
+            input_image_count=None,
+            actual_output_image_count=None,
+            metric=DummyMetric(),
+        )
+
+    assert "expected_output" in str(exc_info.value)

--- a/tests/test_metrics/test_deterministic_metric_empty_output.py
+++ b/tests/test_metrics/test_deterministic_metric_empty_output.py
@@ -1,0 +1,46 @@
+import pytest
+
+from deepeval.errors import MissingTestCaseParamsError
+from deepeval.metrics import ExactMatchMetric, PatternMatchMetric
+from deepeval.test_case import LLMTestCase
+
+
+def test_exact_match_rejects_whitespace_actual_output():
+    metric = ExactMatchMetric()
+    test_case = LLMTestCase(
+        input="question",
+        actual_output=" \n\t ",
+        expected_output="expected",
+    )
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        metric.measure(test_case, _show_indicator=False)
+
+    assert "actual_output" in str(exc_info.value)
+
+
+def test_exact_match_rejects_whitespace_expected_output():
+    metric = ExactMatchMetric()
+    test_case = LLMTestCase(
+        input="question",
+        actual_output="actual",
+        expected_output=" \n\t ",
+    )
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        metric.measure(test_case, _show_indicator=False)
+
+    assert "expected_output" in str(exc_info.value)
+
+
+def test_pattern_match_rejects_whitespace_actual_output():
+    metric = PatternMatchMetric(pattern=r"\s*")
+    test_case = LLMTestCase(
+        input="question",
+        actual_output=" \n\t ",
+    )
+
+    with pytest.raises(MissingTestCaseParamsError) as exc_info:
+        metric.measure(test_case, _show_indicator=False)
+
+    assert "actual_output" in str(exc_info.value)


### PR DESCRIPTION
## Why

Whitespace-only required outputs can pass parameter validation and then be stripped by deterministic metrics before scoring. That lets effectively empty `actual_output` or `expected_output` values behave like valid test-case fields.

Fixes #3220.

## What changed

- Treat whitespace-only text `actual_output` and `expected_output` values as empty in shared LLM test-case parameter validation.
- Update the AnswerRelevancy empty-output validation coverage for whitespace-only `actual_output`.
- Add offline regression coverage for ExactMatchMetric and PatternMatchMetric.
- Apply project Black formatting to two files covered by the full-repository lint check.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_metrics\test_deterministic_metric_empty_output.py tests\test_metrics\test_answer_relevancy_metric_empty_output.py tests\test_metrics\test_g_eval_utils.py -q` - 14 passed
- `.\.venv\Scripts\python.exe -m black --check --verbose .scripts\release.py deepeval\test_case\llm_test_case.py deepeval\metrics\utils.py tests\test_metrics\test_answer_relevancy_metric_empty_output.py tests\test_metrics\test_deterministic_metric_empty_output.py`
- `.\.venv\Scripts\python.exe -m py_compile deepeval\metrics\utils.py deepeval\test_case\llm_test_case.py .scripts\release.py tests\test_metrics\test_answer_relevancy_metric_empty_output.py tests\test_metrics\test_deterministic_metric_empty_output.py`
- `git diff --check HEAD~1..HEAD`

## Risk / follow-up

Low risk: this only rejects degenerate whitespace-only strings for required text outputs. Non-string and multimodal outputs are unchanged. The additional formatting changes are Black-only.
