### PR TITLE
fix: validate pass at k arguments

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -1,3 +1,4 @@
+from numbers import Integral
 from typing import Union, List, Optional, Any
 import textwrap
 
@@ -425,16 +426,28 @@ class Scorer:
             return 0  # Return score as 0 in case of any exception
 
     def pass_at_k(self, n, c, k):
-        import numpy as np
+        from math import prod
 
         """
         :param n: total number of samples
         :param c: number of correct samples
         :param k: k in pass@$k$
         """
+        if any(
+            isinstance(value, bool) or not isinstance(value, Integral)
+            for value in (n, c, k)
+        ):
+            raise TypeError("n, c, and k must be integers")
+        if n < 1:
+            raise ValueError("n must be at least 1")
+        if c < 0 or c > n:
+            raise ValueError("c must be between 0 and n")
+        if k < 1:
+            raise ValueError("k must be at least 1")
+
         if n - c < k:
             return 1.0
-        return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
+        return 1.0 - prod(1.0 - k / i for i in range(n - c + 1, n + 1))
 
     def squad_score(
         self,

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -402,9 +402,7 @@ class LLMTestCase(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     completion_time: Optional[float] = Field(
         default=None,

--- a/tests/test_benchmarks/test_scorer_pass_at_k.py
+++ b/tests/test_benchmarks/test_scorer_pass_at_k.py
@@ -1,0 +1,45 @@
+import pytest
+
+from deepeval.scorer.scorer import Scorer
+
+
+@pytest.mark.parametrize(
+    ("n", "c", "k", "expected"),
+    [
+        (200, 0, 1, 0.0),
+        (200, 1, 1, 0.005),
+        (200, 100, 1, 0.5),
+        (200, 100, 200, 1.0),
+    ],
+)
+def test_pass_at_k_valid_inputs_keep_existing_scores(n, c, k, expected):
+    assert Scorer().pass_at_k(n, c, k) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    ("n", "c", "k"),
+    [
+        (0, 0, 1),
+        (-1, 0, 1),
+        (200, -1, 1),
+        (200, 201, 1),
+        (200, 100, 0),
+    ],
+)
+def test_pass_at_k_rejects_out_of_range_inputs(n, c, k):
+    with pytest.raises(ValueError):
+        Scorer().pass_at_k(n, c, k)
+
+
+@pytest.mark.parametrize(
+    ("n", "c", "k"),
+    [
+        (200.0, 100, 1),
+        (200, 100.0, 1),
+        (200, 100, 1.0),
+        (True, 0, 1),
+    ],
+)
+def test_pass_at_k_rejects_non_integer_inputs(n, c, k):
+    with pytest.raises(TypeError):
+        Scorer().pass_at_k(n, c, k)


### PR DESCRIPTION
## Why

`Scorer.pass_at_k(n, c, k)` can currently return plausible scores for invalid inputs, including `k=0`, `c > n`, or `n <= 0`. Those cases make empty or impossible runs look valid instead of surfacing a caller error.

Fixes #3206.

## What changed

- Validate that `n`, `c`, and `k` are integer counts.
- Reject `n < 1`, `c` outside `[0, n]`, and `k < 1` with explicit exceptions.
- Replace the local NumPy product with `math.prod`, keeping valid-score behavior without requiring an extra runtime import.
- Add offline regression tests for valid scores, invalid ranges, and non-integer inputs.
- Apply project Black formatting to two files covered by the full-repository lint check.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_benchmarks\test_scorer_pass_at_k.py -q` - 13 passed
- `.\.venv\Scripts\python.exe -m black --check --verbose .scripts\release.py deepeval\test_case\llm_test_case.py deepeval\scorer\scorer.py tests\test_benchmarks\test_scorer_pass_at_k.py`
- `.\.venv\Scripts\python.exe -m py_compile deepeval\scorer\scorer.py deepeval\test_case\llm_test_case.py .scripts\release.py tests\test_benchmarks\test_scorer_pass_at_k.py`
- `git diff --check`

## Risk / follow-up

Low risk for valid callers: valid integer inputs keep the same pass@k formula. The behavior change is limited to invalid argument combinations that previously returned misleading scores. The additional formatting changes are Black-only.
