### PR TITLE
feat(metrics): add NamedReferenceAttributionMetric (community)

### DIFF
--- a/deepeval/metrics/community/__init__.py
+++ b/deepeval/metrics/community/__init__.py
@@ -1,7 +1,11 @@
 from .citation_faithfulness.citation_faithfulness import (
     CitationFaithfulnessMetric,
 )
+from .named_reference_attribution.named_reference_attribution import (
+    NamedReferenceAttributionMetric,
+)
 
 __all__ = [
     "CitationFaithfulnessMetric",
+    "NamedReferenceAttributionMetric",
 ]

--- a/deepeval/metrics/community/named_reference_attribution/__init__.py
+++ b/deepeval/metrics/community/named_reference_attribution/__init__.py
@@ -1,0 +1,5 @@
+from deepeval.metrics.community.named_reference_attribution.named_reference_attribution import (
+    NamedReferenceAttributionMetric,
+)
+
+__all__ = ["NamedReferenceAttributionMetric"]

--- a/deepeval/metrics/community/named_reference_attribution/named_reference_attribution.py
+++ b/deepeval/metrics/community/named_reference_attribution/named_reference_attribution.py
@@ -1,0 +1,290 @@
+from typing import List, Optional, Union
+import asyncio
+
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from deepeval.metrics import BaseMetric
+from deepeval.utils import get_or_create_event_loop, prettify_list
+from deepeval.metrics.utils import (
+    construct_verbose_logs,
+    check_llm_test_case_params,
+    initialize_model,
+    a_generate_with_schema_and_extract,
+    generate_with_schema_and_extract,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics.indicator import metric_progress_indicator
+from deepeval.metrics.community.named_reference_attribution.template import (
+    NamedReferenceAttributionTemplate,
+)
+from deepeval.metrics.community.named_reference_attribution.schema import (
+    NamedReference,
+    NamedReferences,
+    NamedReferenceVerdict,
+    Verdicts,
+    NamedReferenceAttributionScoreReason,
+)
+
+
+class NamedReferenceAttributionMetric(BaseMetric):
+    """Named structural-reference attribution.
+
+    Checks whether references in `actual_output` to a document's own
+    structural labels (e.g. "Table 3", "Section 4.2", "footnote 4") are
+    attributed to the right label, not just whether the claim is true
+    somewhere in `retrieval_context`.
+
+    This is a sibling to `CitationFaithfulnessMetric`, which checks `[N]`
+    markers numbered by the metric itself. `NamedReferenceAttributionMetric`
+    instead checks a document's own native labels, which a model may cite by
+    name (e.g. "According to Table 3...") without ever emitting a `[N]`
+    marker.
+
+    The score is the fraction of named references whose claim is supported
+    by the content that actually appears under that label in
+    `retrieval_context`.
+    """
+
+    _required_params: List[SingleTurnParams] = [
+        SingleTurnParams.INPUT,
+        SingleTurnParams.ACTUAL_OUTPUT,
+        SingleTurnParams.RETRIEVAL_CONTEXT,
+    ]
+
+    def __init__(
+        self,
+        threshold: Optional[float] = 0.5,
+        model: Optional[Union[str, DeepEvalBaseLLM]] = None,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        strict_mode: bool = False,
+        verbose_mode: bool = False,
+        flaky: bool = False,
+    ):
+        self.threshold = 1 if strict_mode else threshold
+        self.model, self.using_native_model = initialize_model(model)
+        self.evaluation_model = self.model.get_model_name()
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+        self.strict_mode = strict_mode
+        self.verbose_mode = verbose_mode
+        self.flaky = flaky
+
+    def measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            False,
+        )
+
+        self.evaluation_cost = 0 if self.using_native_model else None
+        self.input_tokens = 0 if self.using_native_model else None
+        self.output_tokens = 0 if self.using_native_model else None
+        with metric_progress_indicator(
+            self, _show_indicator=_show_indicator, _in_component=_in_component
+        ):
+            if self.async_mode:
+                loop = get_or_create_event_loop()
+                loop.run_until_complete(
+                    self.a_measure(
+                        test_case,
+                        _show_indicator=False,
+                        _in_component=_in_component,
+                    )
+                )
+            else:
+                self.references = self._extract_references(
+                    test_case.actual_output
+                )
+                self.verdicts = self._generate_verdicts(
+                    test_case.retrieval_context
+                )
+                self.score = self._calculate_score()
+                self.reason = self._generate_reason()
+                self.success = self.is_successful()
+                self.verbose_logs = construct_verbose_logs(
+                    self,
+                    steps=[
+                        f"References:\n{prettify_list(self.references)}",
+                        f"Verdicts:\n{prettify_list(self.verdicts)}",
+                        f"Score: {self.score}\nReason: {self.reason}",
+                    ],
+                )
+
+            return self.score
+
+    async def a_measure(
+        self,
+        test_case: LLMTestCase,
+        _show_indicator: bool = True,
+        _in_component: bool = False,
+    ) -> float:
+        check_llm_test_case_params(
+            test_case,
+            self._required_params,
+            None,
+            None,
+            self,
+            self.model,
+            False,
+        )
+
+        self.evaluation_cost = 0 if self.using_native_model else None
+        self.input_tokens = 0 if self.using_native_model else None
+        self.output_tokens = 0 if self.using_native_model else None
+        with metric_progress_indicator(
+            self,
+            async_mode=True,
+            _show_indicator=_show_indicator,
+            _in_component=_in_component,
+        ):
+            self.references = await self._a_extract_references(
+                test_case.actual_output
+            )
+            self.verdicts = await self._a_generate_verdicts(
+                test_case.retrieval_context
+            )
+            self.score = self._calculate_score()
+            self.reason = await self._a_generate_reason()
+            self.success = self.is_successful()
+            self.verbose_logs = construct_verbose_logs(
+                self,
+                steps=[
+                    f"References:\n{prettify_list(self.references)}",
+                    f"Verdicts:\n{prettify_list(self.verdicts)}",
+                    f"Score: {self.score}\nReason: {self.reason}",
+                ],
+            )
+            return self.score
+
+    def _extract_references(self, actual_output: str) -> List[NamedReference]:
+        prompt = NamedReferenceAttributionTemplate.extract_references(
+            actual_output
+        )
+        return generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=NamedReferences,
+            extract_schema=lambda s: list(s.references),
+            extract_json=lambda data: [
+                NamedReference(**item) for item in data["references"]
+            ],
+        )
+
+    async def _a_extract_references(
+        self, actual_output: str
+    ) -> List[NamedReference]:
+        prompt = NamedReferenceAttributionTemplate.extract_references(
+            actual_output
+        )
+        return await a_generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=NamedReferences,
+            extract_schema=lambda s: list(s.references),
+            extract_json=lambda data: [
+                NamedReference(**item) for item in data["references"]
+            ],
+        )
+
+    def _generate_verdicts(
+        self, retrieval_context: List[str]
+    ) -> List[NamedReferenceVerdict]:
+        if len(self.references) == 0:
+            return []
+
+        prompt = NamedReferenceAttributionTemplate.generate_verdicts(
+            references=self.references, retrieval_context=retrieval_context
+        )
+        return generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=Verdicts,
+            extract_schema=lambda s: list(s.verdicts),
+            extract_json=lambda data: [
+                NamedReferenceVerdict(**item) for item in data["verdicts"]
+            ],
+        )
+
+    async def _a_generate_verdicts(
+        self, retrieval_context: List[str]
+    ) -> List[NamedReferenceVerdict]:
+        if len(self.references) == 0:
+            return []
+
+        prompt = NamedReferenceAttributionTemplate.generate_verdicts(
+            references=self.references, retrieval_context=retrieval_context
+        )
+        return await a_generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=Verdicts,
+            extract_schema=lambda s: list(s.verdicts),
+            extract_json=lambda data: [
+                NamedReferenceVerdict(**item) for item in data["verdicts"]
+            ],
+        )
+
+    def _calculate_score(self) -> float:
+        number_of_verdicts = len(self.verdicts)
+        if number_of_verdicts == 0:
+            return 1
+
+        correct_count = 0
+        for verdict in self.verdicts:
+            if verdict.verdict.strip().lower() == "yes":
+                correct_count += 1
+
+        score = correct_count / number_of_verdicts
+        return 0 if self.strict_mode and score < self.threshold else score
+
+    def _misattributions(self) -> List[str]:
+        return [
+            f'"{verdict.label}": {verdict.reason}'
+            for verdict in self.verdicts
+            if verdict.verdict.strip().lower() != "yes"
+        ]
+
+    def _generate_reason(self) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+
+        prompt = NamedReferenceAttributionTemplate.generate_reason(
+            misattributions=self._misattributions(),
+            score=format(self.score, ".2f"),
+        )
+        return generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=NamedReferenceAttributionScoreReason,
+            extract_schema=lambda s: s.reason,
+            extract_json=lambda data: data["reason"],
+        )
+
+    async def _a_generate_reason(self) -> Optional[str]:
+        if self.include_reason is False:
+            return None
+
+        prompt = NamedReferenceAttributionTemplate.generate_reason(
+            misattributions=self._misattributions(),
+            score=format(self.score, ".2f"),
+        )
+        return await a_generate_with_schema_and_extract(
+            metric=self,
+            prompt=prompt,
+            schema_cls=NamedReferenceAttributionScoreReason,
+            extract_schema=lambda s: s.reason,
+            extract_json=lambda data: data["reason"],
+        )
+
+    @property
+    def __name__(self):
+        return "Named Reference Attribution"

--- a/deepeval/metrics/community/named_reference_attribution/schema.py
+++ b/deepeval/metrics/community/named_reference_attribution/schema.py
@@ -1,0 +1,29 @@
+from typing import List, Optional, Literal
+from pydantic import BaseModel, Field
+
+
+class NamedReference(BaseModel):
+    """A mention in `actual_output` of a document-native structural label
+    (e.g. "Table 3", "Section 4.2", "footnote 4") together with the claim
+    attached to it."""
+
+    label: str
+    claim: str
+
+
+class NamedReferences(BaseModel):
+    references: List[NamedReference]
+
+
+class NamedReferenceVerdict(BaseModel):
+    label: str
+    verdict: Literal["yes", "no", "idk"]
+    reason: Optional[str] = Field(default=None)
+
+
+class Verdicts(BaseModel):
+    verdicts: List[NamedReferenceVerdict]
+
+
+class NamedReferenceAttributionScoreReason(BaseModel):
+    reason: str

--- a/deepeval/metrics/community/named_reference_attribution/template.py
+++ b/deepeval/metrics/community/named_reference_attribution/template.py
@@ -1,0 +1,123 @@
+from typing import List
+
+from deepeval.metrics.community.named_reference_attribution.schema import (
+    NamedReference,
+)
+
+
+class NamedReferenceAttributionTemplate:
+    """Prompts for named-reference attribution.
+
+    Unlike `CitationFaithfulnessMetric` (which checks whether `[N]` citation
+    markers assigned by the metric itself point to a supporting passage), this
+    checks references to a document's *own* structural labels: "Table 3",
+    "Section 4.2", "footnote 4", and similar names that exist in the source
+    document independent of how a RAG pipeline chunked it. It is designed to
+    catch a model citing the right kind of fact under the wrong named label,
+    e.g. answering "Table 3" with a figure that actually appears under
+    "Table 2".
+    """
+
+    @staticmethod
+    def extract_references(actual_output: str) -> str:
+        return f"""You are given a candidate answer. Identify every mention of a named,
+document-native structural element (a table, section, footnote, figure, appendix,
+or clause referred to by its own name or number, e.g. "Table 3", "Section 4.2",
+"footnote 4", "Appendix B") together with the specific claim attached to that
+mention.
+
+Do NOT include generic references that don't name a specific labeled element
+(e.g. "the document says" or "as shown above" do not count).
+
+Return a JSON object with one key, "references", a list of objects each with:
+- "label": the exact structural label mentioned (e.g. "Table 3")
+- "claim": the specific claim attached to that label
+
+If the answer makes no reference to any named structural element, return an
+empty list.
+
+**
+IMPORTANT: Please make sure to only return in JSON format, with the
+"references" key as a list of JSON objects.
+
+Example candidate answer: "According to Table 3, EMEA revenue was $12M, and
+Section 4.2 sets a 30 day notice period."
+Example JSON:
+{{
+    "references": [
+        {{"label": "Table 3", "claim": "EMEA revenue was $12M"}},
+        {{"label": "Section 4.2", "claim": "sets a 30 day notice period"}}
+    ]
+}}
+**
+
+Candidate answer:
+{actual_output}
+
+JSON:
+"""
+
+    @staticmethod
+    def generate_verdicts(
+        references: List[NamedReference], retrieval_context: List[str]
+    ) -> str:
+        joined_context = "\n\n".join(retrieval_context)
+        references_json = "\n".join(
+            f'- label: "{reference.label}", claim: "{reference.claim}"'
+            for reference in references
+        )
+
+        return f"""You are an attribution judge. You are given a source document (as
+retrieved passages, which may preserve the document's own headings, table
+captions, section numbers, or footnote markers) and a list of references, each
+naming a structural label and a claim attributed to it.
+
+For EACH reference, decide whether the content that actually appears under
+that exact label in the source document supports the claim attributed to it.
+
+The 'verdict' key should STRICTLY be either 'yes', 'no', or 'idk':
+- 'yes': the label exists in the source and its content supports the claim.
+- 'no': the label either does not appear in the source, or its content
+  contradicts or does not support the claim (including when the claim is true
+  under a *different* label than the one cited).
+- 'idk': the source does not contain enough information to decide.
+
+Provide a 'reason' ONLY if the verdict is 'no' or 'idk'. If the claim is true
+under a different label than the one cited, name the correct label in the
+reason.
+
+**
+IMPORTANT: Please make sure to only return in JSON format, with the
+'verdicts' key as a list of JSON objects, each with 'label', 'verdict', and
+optionally 'reason'.
+**
+
+Source document:
+{joined_context}
+
+References:
+{references_json}
+
+JSON:
+"""
+
+    @staticmethod
+    def generate_reason(misattributions: List[str], score: str) -> str:
+        return f"""Below is a list of named-reference misattributions found in a
+candidate answer, and the overall attribution score. Summarize, in one or two
+sentences, why the answer received this score. If the list is empty, state
+that every named reference was correctly attributed.
+
+Score:
+{score}
+
+Misattributions:
+{misattributions}
+
+**
+IMPORTANT: Please make sure to only return in JSON format, with the 'reason'
+key providing the reason.
+**
+
+JSON:
+"""

--- a/docs/content/docs/(community)/meta.json
+++ b/docs/content/docs/(community)/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "community-metrics-overview",
     "metrics-citation-faithfulness",
+    "metrics-named-reference-attribution",
     "metrics-agent-loop-detection",
     "metrics-tool-permission"
   ]

--- a/docs/content/docs/(community)/metrics-named-reference-attribution.mdx
+++ b/docs/content/docs/(community)/metrics-named-reference-attribution.mdx
@@ -1,0 +1,82 @@
+---
+id: metrics-named-reference-attribution
+title: Named Reference Attribution
+sidebar_label: Named Reference Attribution
+languages: [python]
+---
+
+<MetricTagsDisplayer community={true} singleTurn={true} rag={true} referenceless={true} />
+
+The named reference attribution metric uses LLM-as-a-judge to check whether references in your RAG pipeline's `actual_output` to a document's own structural labels — "Table 3", "Section 4.2", "footnote 4", and similar names that exist in the source document itself — are attributed to the right label. `deepeval`'s named reference attribution metric is a self-explaining LLM-Eval, meaning it outputs a reason for its metric score.
+
+:::info
+The `NamedReferenceAttributionMetric` is a **community metric**, contributed and maintained by the `deepeval` community. Community metrics are not exported from `deepeval.metrics` — import them explicitly from `deepeval.metrics.community` instead.
+:::
+
+:::note
+This is a sibling to [`CitationFaithfulnessMetric`](/docs/metrics-citation-faithfulness), not a replacement. `CitationFaithfulnessMetric` checks `[N]` citation markers that the metric itself assigns to `retrieval_context` passages. `NamedReferenceAttributionMetric` instead checks a document's own native labels, which a model may cite by name (e.g. "According to Table 3...") without ever emitting a `[N]` marker. It's also stricter than [`FaithfulnessMetric`](/docs/metrics-faithfulness): faithfulness asks whether a claim is supported by the retrieval context _somewhere_, while named reference attribution additionally checks that the content under the exact label cited supports the claim — catching a model that states a true fact but attributes it to the wrong table, section, or footnote.
+:::
+
+## Required Arguments
+
+To use the `NamedReferenceAttributionMetric`, you'll have to provide the following arguments when creating an [`LLMTestCase`](/docs/evaluation-test-cases#llm-test-case):
+
+- `input`
+- `actual_output`
+- `retrieval_context`
+
+For this metric to be useful, `retrieval_context` passages should preserve the document's own structural labels in their text (e.g. a passage starting with "Table 3:" or "Section 4.2:"), since the judge looks up a cited label directly in the retrieved content.
+
+## Usage
+
+The `NamedReferenceAttributionMetric()` can be used for [end-to-end](/docs/evaluation-end-to-end-llm-evals) evaluation of text-based test cases:
+
+```python
+from deepeval import evaluate
+from deepeval.test_case import LLMTestCase
+from deepeval.metrics.community import NamedReferenceAttributionMetric
+
+# Replace this with the actual output from your LLM application.
+# The revenue figure is attributed to Table 3, but it actually appears
+# under Table 2.
+actual_output = "According to Table 3, EMEA revenue was $12M."
+
+# Replace this with the actual retrieved context from your RAG pipeline
+retrieval_context = [
+    "Table 2: Revenue by region, 2025. EMEA revenue was $12M.",
+    "Table 3: Revenue by region, 2026. EMEA revenue was $15M.",
+]
+
+metric = NamedReferenceAttributionMetric()
+test_case = LLMTestCase(
+    input="What does Table 3 say about EMEA revenue?",
+    actual_output=actual_output,
+    retrieval_context=retrieval_context,
+)
+
+# To run metric as a standalone
+# metric.measure(test_case)
+# print(metric.score, metric.reason)
+
+evaluate(test_cases=[test_case], metrics=[metric])
+```
+
+In the example above, `FaithfulnessMetric` would pass the answer, because $12M is a true figure found somewhere in the retrieval context. `NamedReferenceAttributionMetric` fails it, because the content under "Table 3" is actually $15M — the $12M figure belongs to "Table 2".
+
+There are seven optional parameters when creating a `NamedReferenceAttributionMetric`:
+
+- [Optional] `threshold`: a float representing the minimum passing score. Can also be set to `None` to run the metric in [score-only mode](/docs/metrics-introduction#metric-thresholds). Defaulted to `0.5`.
+- [Optional] `model`: a string specifying which of OpenAI's GPT models to use, OR [any custom LLM model](/docs/metrics-introduction#using-a-custom-llm) of type `DeepEvalBaseLLM`. Defaulted to <DefaultLLMModel />.
+- [Optional] `include_reason`: a boolean which when set to `True`, will include a reason for its evaluation score. Defaulted to `True`.
+- [Optional] `strict_mode`: a boolean which when set to `True`, enforces a binary metric score: `0` for perfection, `1` otherwise. It also overrides the current threshold and sets it to `1`. Defaulted to `False`.
+- [Optional] `async_mode`: a boolean which when set to `True`, enables [concurrent execution within the `measure()` method](/docs/metrics-introduction#measuring-metrics-in-async). Defaulted to `True`.
+- [Optional] `verbose_mode`: a boolean which when set to `True`, prints the intermediate steps used to calculate said metric to the console. Defaulted to `False`.
+- [Optional] `flaky`: a boolean which when set to `True`, [marks the metric as flaky](/docs/metrics-introduction#flaky-metrics). Defaulted to `False`.
+
+## How Is It Calculated?
+
+The `NamedReferenceAttributionMetric` score is calculated according to the following equation:
+
+<Equation formula="\text{Named Reference Attribution} = \frac{\text{Number of Correctly Attributed References}}{\text{Total Number of Named References}}" />
+
+An LLM judge first extracts every reference in `actual_output` to a named structural label (e.g. "Table 3", "Section 4.2", "footnote 4") along with the claim attached to it. For each reference, a second judgment call checks whether the content that actually appears under that exact label in `retrieval_context` supports the claim. If `actual_output` makes no named references, the score defaults to `1`.

--- a/tests/test_metrics/test_named_reference_attribution_metric.py
+++ b/tests/test_metrics/test_named_reference_attribution_metric.py
@@ -1,0 +1,188 @@
+"""Tests for NamedReferenceAttributionMetric.
+
+These tests use a fake DeepEvalBaseLLM judge so they run without any API key.
+They prove the metric catches a claim attributed to the wrong document-native
+label (e.g. "Table 3" when the fact actually appears under "Table 2"), which
+FaithfulnessMetric would pass because the fact is true somewhere in context,
+and CitationFaithfulnessMetric would not even parse (it only understands `[N]`
+markers, not named labels).
+"""
+
+from deepeval.metrics.community import NamedReferenceAttributionMetric
+from deepeval.metrics.community.named_reference_attribution.schema import (
+    NamedReference,
+    NamedReferences,
+    NamedReferenceVerdict,
+    Verdicts,
+    NamedReferenceAttributionScoreReason,
+)
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import LLMTestCase
+
+
+class FakeJudge(DeepEvalBaseLLM):
+    """Returns preset responses from a queue, one per call, keyed by schema."""
+
+    def __init__(self, responses):
+        # responses: list of objects to return, in call order
+        self._responses = list(responses)
+        self.prompts = []
+        super().__init__(model="fake-judge")
+
+    def load_model(self, *args, **kwargs):
+        return None
+
+    def generate(self, prompt, *args, schema=None, **kwargs):
+        self.prompts.append(prompt)
+        return self._responses.pop(0)
+
+    async def a_generate(self, prompt, *args, schema=None, **kwargs):
+        self.prompts.append(prompt)
+        return self._responses.pop(0)
+
+    def get_model_name(self, *args, **kwargs):
+        return "fake-judge"
+
+
+QUERY = "What does Table 3 say about EMEA revenue, and what does Section 4.2 say about notice?"
+RETRIEVAL_CONTEXT = [
+    "Table 2: Revenue by region, 2025. EMEA revenue was $12M.",
+    "Table 3: Revenue by region, 2026. EMEA revenue was $15M.",
+    "Section 4.2: Either party may terminate with 30 days written notice.",
+]
+
+
+def test_fails_wrong_table_attribution():
+    judge = FakeJudge(
+        [
+            NamedReferences(
+                references=[
+                    NamedReference(
+                        label="Table 3", claim="EMEA revenue was $12M"
+                    )
+                ]
+            ),
+            Verdicts(
+                verdicts=[
+                    NamedReferenceVerdict(
+                        label="Table 3",
+                        verdict="no",
+                        reason="Table 3 states EMEA revenue was $15M; $12M appears under Table 2.",
+                    )
+                ]
+            ),
+            NamedReferenceAttributionScoreReason(
+                reason="The EMEA revenue figure is attributed to Table 3 but actually appears under Table 2."
+            ),
+        ]
+    )
+    metric = NamedReferenceAttributionMetric(model=judge, async_mode=False)
+    test_case = LLMTestCase(
+        input=QUERY,
+        actual_output="According to Table 3, EMEA revenue was $12M.",
+        retrieval_context=RETRIEVAL_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 0.0
+    assert metric.is_successful() is False
+    assert metric.reason is not None
+
+
+def test_passes_correct_attribution():
+    judge = FakeJudge(
+        [
+            NamedReferences(
+                references=[
+                    NamedReference(
+                        label="Table 3", claim="EMEA revenue was $15M"
+                    ),
+                    NamedReference(
+                        label="Section 4.2",
+                        claim="30 day notice period",
+                    ),
+                ]
+            ),
+            Verdicts(
+                verdicts=[
+                    NamedReferenceVerdict(label="Table 3", verdict="yes"),
+                    NamedReferenceVerdict(label="Section 4.2", verdict="yes"),
+                ]
+            ),
+            NamedReferenceAttributionScoreReason(
+                reason="Every named reference matches its labeled content."
+            ),
+        ]
+    )
+    metric = NamedReferenceAttributionMetric(model=judge, async_mode=False)
+    test_case = LLMTestCase(
+        input=QUERY,
+        actual_output=(
+            "According to Table 3, EMEA revenue was $15M, and per Section "
+            "4.2, notice is 30 days."
+        ),
+        retrieval_context=RETRIEVAL_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+
+
+def test_no_named_references_scores_one():
+    judge = FakeJudge(
+        [
+            NamedReferences(references=[]),
+            NamedReferenceAttributionScoreReason(
+                reason="The answer made no named structural references."
+            ),
+        ]
+    )
+    metric = NamedReferenceAttributionMetric(model=judge, async_mode=False)
+    test_case = LLMTestCase(
+        input=QUERY,
+        actual_output="EMEA revenue grew year over year.",
+        retrieval_context=RETRIEVAL_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 1.0
+    assert metric.is_successful() is True
+
+
+def test_async_measure_matches_sync():
+    judge = FakeJudge(
+        [
+            NamedReferences(
+                references=[
+                    NamedReference(
+                        label="Table 3", claim="EMEA revenue was $12M"
+                    )
+                ]
+            ),
+            Verdicts(
+                verdicts=[
+                    NamedReferenceVerdict(
+                        label="Table 3",
+                        verdict="no",
+                        reason="$12M appears under Table 2, not Table 3.",
+                    )
+                ]
+            ),
+            NamedReferenceAttributionScoreReason(reason="Misattributed."),
+        ]
+    )
+    metric = NamedReferenceAttributionMetric(model=judge, async_mode=True)
+    test_case = LLMTestCase(
+        input=QUERY,
+        actual_output="According to Table 3, EMEA revenue was $12M.",
+        retrieval_context=RETRIEVAL_CONTEXT,
+    )
+
+    metric.measure(test_case)
+
+    assert metric.score == 0.0
+    assert metric.is_successful() is False


### PR DESCRIPTION
Closes #3230

## Summary

Adds `NamedReferenceAttributionMetric`, a community metric that checks whether references in `actual_output` to a document's own structural labels (e.g. "Table 3", "Section 4.2", "footnote 4") are attributed to the right label — not just whether the claim is true somewhere in `retrieval_context`.

This is a sibling to `CitationFaithfulnessMetric`, not a replacement:

- `CitationFaithfulnessMetric` checks `[N]` citation markers that the metric itself numbers over `retrieval_context` at eval time.
- `NamedReferenceAttributionMetric` checks a document's own native labels, which a model may cite by name (e.g. "According to Table 3...") without ever emitting a `[N]` marker.
- `FaithfulnessMetric` asks whether a claim is true *somewhere* in context; this metric additionally checks that the content under the *exact label cited* supports the claim, catching a model that states a true fact but attributes it to the wrong table/section/footnote.

## Implementation

Follows the same structure as `CitationFaithfulnessMetric` (`metrics/community/named_reference_attribution/` with the metric class, `schema.py`, `template.py`), and the same extract → verdict → score → reason pattern used by `FaithfulnessMetric`:

1. Extract named structural references from `actual_output` (label + attached claim).
2. For each reference, an LLM judge checks whether the content under that exact label in `retrieval_context` supports the claim.
3. Score = fraction of references correctly attributed (defaults to `1.0` if the answer makes no named references).
4. Generates a reason summarizing any misattributions.

Exported from `deepeval.metrics.community`, per `CONTRIBUTING.md`'s community-metric convention (not exported from `deepeval.metrics` directly).

## Testing

Added `tests/test_metrics/test_named_reference_attribution_metric.py` with a fake judge (no API key needed), covering:
- a claim correctly cited but under the wrong table (fails, score `0.0`)
- correct attribution across two references (passes, score `1.0`)
- no named references in the output (vacuous pass, score `1.0`)
- async `a_measure` matches sync `measure`

All new and existing tests pass locally; `black` formatting applied.

## Docs

Added `docs/content/docs/(community)/metrics-named-reference-attribution.mdx`, registered in the community `meta.json`, explicitly cross-referencing `CitationFaithfulnessMetric` and `FaithfulnessMetric` so the distinction between the three is documented rather than implied.