### PR TITLE
chore: format three files with the pinned Black, unblocking lint CI

### DIFF
--- a/.scripts/release.py
+++ b/.scripts/release.py
@@ -77,7 +77,9 @@ class Target:
     json_key: str  # key in sdk-versions.json
     publish_commands: List[str]  # printed at the end, never run
     paths: List[str]  # what shipping this SDK covers, for "did it change?"
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
 
 
 TARGETS: Dict[str, Target] = {

--- a/deepeval/dataset/golden.py
+++ b/deepeval/dataset/golden.py
@@ -202,9 +202,7 @@ class Golden(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     source_file: Optional[str] = Field(
         default=None, serialization_alias="sourceFile"

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -402,9 +402,7 @@ class LLMTestCase(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     completion_time: Optional[float] = Field(
         default=None,


### PR DESCRIPTION
`lint (ubuntu-latest)` is currently failing on **`main`**, not only on pull requests.

The workflow (`.github/workflows/black.yml`) runs:

```yaml
- uses: psf/black@stable
  with:
    options: "--check --verbose"
    src: "."
    version: "25.12.0"
```

Three files in the tree aren't formatted the way that pinned version formats them:

```
deepeval/dataset/golden.py
deepeval/test_case/llm_test_case.py
.scripts/release.py
```

Because Black checks the **whole tree** (`src: "."`) rather than the PR diff, every open PR inherits this failure no matter what it touches. The red X on a contributor's PR currently says nothing about that PR — which makes the signal useless for triage, and is discouraging for first-time contributors who assume they broke something.

Running the pinned Black on those three files clears it:

```console
$ black --check .
All done! ✨ 🍰 ✨
998 files would be left unchanged.
```

## The changes are whitespace only

Two call sites collapse onto one line now that they fit within the configured width:

```diff
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
```

and one annotated dataclass field gains the parentheses Black uses when a trailing comment would push the line over:

```diff
-    single_digit: bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    single_digit: (
+        bool  # cap x.y.z at 9 and carry left, rather than plain semver
+    )
```

I verified this is formatting-only rather than asserting it — the parsed AST of each file is identical before and after:

```
IDENTICAL AST  deepeval/dataset/golden.py
IDENTICAL AST  deepeval/test_case/llm_test_case.py
IDENTICAL AST  .scripts/release.py
```

No behaviour change, no public API change, and nothing else is touched — so this can land independently of any pending work.

Note `main` also currently has other red checks (`test`, `langchain`, `llama-index`, `openai-agents`, `pydantic-ai`). This PR only addresses `lint`; I haven't looked into the others, and I'm happy to if that would help.
