### PR TITLE
fix(dataset): keep token usage fields when save_as rebuilds goldens

### DIFF
--- a/deepeval/dataset/dataset.py
+++ b/deepeval/dataset/dataset.py
@@ -1296,6 +1296,9 @@ class EvaluationDataset:
                     source_file=golden.source_file,
                     tools_called=golden.tools_called,
                     expected_tools=golden.expected_tools,
+                    token_cost=golden.token_cost,
+                    input_token_count=golden.input_token_count,
+                    output_token_count=golden.output_token_count,
                     additional_metadata=golden.additional_metadata,
                     custom_column_key_values=golden.custom_column_key_values,
                 )

--- a/tests/test_core/test_datasets/test_dataset.py
+++ b/tests/test_core/test_datasets/test_dataset.py
@@ -274,6 +274,33 @@ class TestSaveAndLoad:
                     "owner": "platform"
                 }, fmt
 
+    def test_save_as_round_trips_token_usage_fields(self):
+        """save_as rebuilds each golden field by field, so a field the loaders
+        read but that rebuild omits is written back as null."""
+        golden = Golden(
+            input="q",
+            actual_output="a",
+            token_cost=0.0123,
+            input_token_count=42,
+            output_token_count=7,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for fmt, loader in (
+                ("json", "add_goldens_from_json_file"),
+                ("csv", "add_goldens_from_csv_file"),
+                ("jsonl", "add_goldens_from_jsonl_file"),
+            ):
+                path = EvaluationDataset([golden]).save_as(
+                    fmt, directory=tmpdir, file_name=f"token_usage_{fmt}"
+                )
+                reloaded = EvaluationDataset()
+                getattr(reloaded, loader)(path)
+                loaded = reloaded.goldens[0]
+                assert loaded.token_cost == 0.0123, fmt
+                assert loaded.input_token_count == 42, fmt
+                assert loaded.output_token_count == 7, fmt
+
     def test_save_as_round_trips_retrieval_context_data(self):
         """save_as serializes a RetrievedContextData (a type-allowed member of
         Golden.retrieval_context that used to crash the save) as a namespaced,


### PR DESCRIPTION
`save_as` rebuilds each golden field by field before serializing, and `token_cost` / `input_token_count` / `output_token_count` are missing from that rebuild — so all three writers read them off a fresh `Golden` that never received them and write `null` back.

## Changes

- `save_as` now passes the three token usage fields through when it rebuilds a single-turn golden (`deepeval/dataset/dataset.py`).
- Added a round-trip regression test covering json, csv and jsonl (`tests/test_core/test_datasets/test_dataset.py`).

The loaders and all three writers already handle these fields, and both `convert_test_cases_to_goldens` and `convert_goldens_to_test_cases` carry them, so the gap is confined to the in-place rebuild. The asymmetry is visible inside a single save: with `include_test_cases=True`, a golden derived from a test case keeps its token usage while a golden held by the dataset loses it.

## Reproduction

```python
from deepeval.dataset import EvaluationDataset, Golden

golden = Golden(input="q", actual_output="a",
                token_cost=0.0123, input_token_count=42, output_token_count=7)
path = EvaluationDataset([golden]).save_as("json", directory=".", file_name="rt")
# before: "token_cost": null, "input_token_count": null, "output_token_count": null
# after:  "token_cost": 0.0123, "input_token_count": 42, "output_token_count": 7
```

Verified on all three formats (json `[None, None, None]`, csv `['', '', '']`, jsonl `[None, None, None]` before the change).

## Checks

- `pytest tests/test_core/test_datasets/` — 38 passed
- `black --check` clean on both touched files
- The new test fails on `main` (`assert None == 0.0123`) and passes with the change

One open question: `add_test_cases_from_csv_file` and `add_test_cases_from_json_file` do not read the token usage columns that `save_as` writes, so the test-case load path still drops them. Happy to follow up if wiring those two up is wanted — I left it out here since it looked like a deliberate scope choice rather than an oversight.
