### PR TITLE
fix(ragas): record NaN scores as unmeasured, not as a failing score

### DIFF
--- a/deepeval/metrics/ragas.py
+++ b/deepeval/metrics/ragas.py
@@ -1,5 +1,6 @@
 """An implementation of the Ragas metric"""
 
+import math
 from typing import Optional, Union, List
 
 
@@ -35,6 +36,34 @@ def format_ragas_metric_name(name: str):
 #############################################################
 
 
+def _record_ragas_score(
+    metric: BaseMetric, ragas_metric_name: str, score: Optional[float]
+) -> Optional[float]:
+    """Store a ragas score, treating NaN as "not measured" rather than a failure.
+
+    ragas returns NaN when it has nothing to score: no statements extracted from
+    the answer, an unparseable judge response, an empty verdict list. Any
+    comparison against the threshold is then False, so a test case that was
+    never measured is reported as one that failed. A NaN also survives the
+    `score is not None` guard the console report aggregates behind, so one
+    unmeasured metric turns the mean score for the whole run into NaN.
+
+    `BaseMetric.is_successful` already routes a metric with an `error` set, and
+    a score of None is excluded from the aggregate rather than poisoning it.
+    """
+    if score is None or math.isnan(score):
+        metric.error = (
+            f"ragas could not compute {ragas_metric_name} for this test case, "
+            "so it has no score."
+        )
+        metric.score = None
+    else:
+        metric.score = score
+    # Re-derives metric.success from the score and error just set.
+    metric.is_successful()
+    return metric.score
+
+
 class RAGASContextualPrecisionMetric(BaseMetric):
     """This metric checks the contextual precision using Ragas"""
 
@@ -51,7 +80,7 @@ class RAGASContextualPrecisionMetric(BaseMetric):
         if isinstance(model, str):
             self.evaluation_model = model
 
-    def measure(self, test_case: LLMTestCase):
+    def measure(self, test_case: LLMTestCase) -> Optional[float]:
         try:
             import_ragas()
             from ragas import evaluate
@@ -93,13 +122,13 @@ class RAGASContextualPrecisionMetric(BaseMetric):
 
         # Ragas only does dataset-level comparisons
         context_precision_score = scores["context_precision"][0]
-        self.success = context_precision_score >= self.threshold
-        self.score = context_precision_score
-        return self.score
+        return _record_ragas_score(
+            self, "context_precision", context_precision_score
+        )
 
     async def a_measure(
         self, test_case: LLMTestCase, _show_indicator: bool = False
-    ):
+    ) -> Optional[float]:
         return self.measure(test_case)
 
     @property
@@ -129,10 +158,10 @@ class RAGASContextualRecallMetric(BaseMetric):
 
     async def a_measure(
         self, test_case: LLMTestCase, _show_indicator: bool = False
-    ):
+    ) -> Optional[float]:
         return self.measure(test_case)
 
-    def measure(self, test_case: LLMTestCase):
+    def measure(self, test_case: LLMTestCase) -> Optional[float]:
         # sends to server
         try:
             from ragas import evaluate
@@ -169,9 +198,7 @@ class RAGASContextualRecallMetric(BaseMetric):
         )
         scores = evaluate(dataset, [context_recall], llm=chat_model)
         context_recall_score = scores["context_recall"][0]
-        self.success = context_recall_score >= self.threshold
-        self.score = context_recall_score
-        return self.score
+        return _record_ragas_score(self, "context_recall", context_recall_score)
 
     @property
     def __name__(self):
@@ -200,10 +227,10 @@ class RAGASContextualEntitiesRecall(BaseMetric):
 
     async def a_measure(
         self, test_case: LLMTestCase, _show_indicator: bool = False
-    ):
+    ) -> Optional[float]:
         return self.measure(test_case)
 
-    def measure(self, test_case: LLMTestCase):
+    def measure(self, test_case: LLMTestCase) -> Optional[float]:
         # sends to server
         try:
             import_ragas()
@@ -245,9 +272,9 @@ class RAGASContextualEntitiesRecall(BaseMetric):
             llm=chat_model,
         )
         contextual_entity_score = scores["context_entity_recall"][0]
-        self.success = contextual_entity_score >= self.threshold
-        self.score = contextual_entity_score
-        return self.score
+        return _record_ragas_score(
+            self, "context_entity_recall", contextual_entity_score
+        )
 
     @property
     def __name__(self):
@@ -350,10 +377,10 @@ class RAGASAnswerRelevancyMetric(BaseMetric):
 
     async def a_measure(
         self, test_case: LLMTestCase, _show_indicator: bool = False
-    ):
+    ) -> Optional[float]:
         return self.measure(test_case)
 
-    def measure(self, test_case: LLMTestCase):
+    def measure(self, test_case: LLMTestCase) -> Optional[float]:
         # sends to server
         try:
             import_ragas()
@@ -397,9 +424,9 @@ class RAGASAnswerRelevancyMetric(BaseMetric):
             embeddings=self.embeddings,
         )
         answer_relevancy_score = scores["answer_relevancy"][0]
-        self.success = answer_relevancy_score >= self.threshold
-        self.score = answer_relevancy_score
-        return self.score
+        return _record_ragas_score(
+            self, "answer_relevancy", answer_relevancy_score
+        )
 
     @property
     def __name__(self):
@@ -426,10 +453,10 @@ class RAGASFaithfulnessMetric(BaseMetric):
 
     async def a_measure(
         self, test_case: LLMTestCase, _show_indicator: bool = False
-    ):
+    ) -> Optional[float]:
         return self.measure(test_case)
 
-    def measure(self, test_case: LLMTestCase):
+    def measure(self, test_case: LLMTestCase) -> Optional[float]:
         # sends to server
         try:
             import_ragas()
@@ -467,9 +494,7 @@ class RAGASFaithfulnessMetric(BaseMetric):
         )
         scores = evaluate(dataset, metrics=[faithfulness], llm=chat_model)
         faithfulness_score = scores["faithfulness"][0]
-        self.success = faithfulness_score >= self.threshold
-        self.score = faithfulness_score
-        return self.score
+        return _record_ragas_score(self, "faithfulness", faithfulness_score)
 
     @property
     def __name__(self):
@@ -498,10 +523,10 @@ class RagasMetric(BaseMetric):
 
     async def a_measure(
         self, test_case: LLMTestCase, _show_indicator: bool = False
-    ):
+    ) -> Optional[float]:
         return self.measure(test_case)
 
-    def measure(self, test_case: LLMTestCase):
+    def measure(self, test_case: LLMTestCase) -> Optional[float]:
         # sends to server
         try:
             from ragas import evaluate  # noqa: F401
@@ -539,11 +564,24 @@ class RagasMetric(BaseMetric):
             score = metric.measure(test_case)
             score_breakdown[metric.__name__] = score
 
-        ragas_score = sum(score_breakdown.values()) / len(score_breakdown)
-
-        self.success = ragas_score >= self.threshold
-        self.score = ragas_score
         self.score_breakdown = score_breakdown
+        # A sub-metric that could not be measured has no score to average in.
+        # Averaging over only the ones that did compute would report a plausible
+        # composite for a test case that was measured in part.
+        unmeasured = [
+            name for name, score in score_breakdown.items() if score is None
+        ]
+        if unmeasured:
+            self.error = (
+                "ragas could not compute "
+                + ", ".join(unmeasured)
+                + " for this test case, so there is no composite score."
+            )
+            self.score = None
+        else:
+            self.score = sum(score_breakdown.values()) / len(score_breakdown)
+        # Re-derives self.success from the score and error just set.
+        self.is_successful()
         return self.score
 
     @property

--- a/tests/test_metrics/test_ragas_metric.py
+++ b/tests/test_metrics/test_ragas_metric.py
@@ -51,6 +51,12 @@ def ragas_scores(monkeypatch):
     monkeypatch.setitem(sys.modules, "ragas", ragas)
     monkeypatch.setitem(sys.modules, "ragas.metrics", ragas_metrics)
     monkeypatch.setitem(sys.modules, "datasets", datasets)
+    # The constructors gate on langchain_core being importable, which is an
+    # optional dependency. The tests never reach langchain, so satisfy the gate
+    # rather than requiring the package to be installed.
+    monkeypatch.setattr(
+        "deepeval.metrics.ragas.langchain_available", True, raising=False
+    )
     return scores
 
 

--- a/tests/test_metrics/test_ragas_metric.py
+++ b/tests/test_metrics/test_ragas_metric.py
@@ -1,0 +1,153 @@
+"""Tests for the ragas metric wrappers.
+
+ragas reports NaN when it has nothing to score, so these cover what the
+wrappers do with that. No API key is needed: ragas itself is stubbed, since
+what is under test is deepeval's handling of the score it hands back.
+"""
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+from deepeval.test_case import LLMTestCase
+
+RAGAS_METRIC_NAMES = (
+    "context_precision",
+    "context_recall",
+    "context_entity_recall",
+    "answer_relevancy",
+    "faithfulness",
+)
+
+SUB_METRICS = (
+    "RAGASContextualPrecisionMetric",
+    "RAGASContextualRecallMetric",
+    "RAGASContextualEntitiesRecall",
+    "RAGASAnswerRelevancyMetric",
+    "RAGASFaithfulnessMetric",
+)
+
+
+@pytest.fixture
+def ragas_scores(monkeypatch):
+    """Stub `ragas.evaluate` and yield the dict its result is read from."""
+    scores = {}
+
+    ragas = types.ModuleType("ragas")
+    ragas.__version__ = "0.2.1"
+    ragas.evaluate = lambda *args, **kwargs: scores
+    ragas_metrics = types.ModuleType("ragas.metrics")
+    for name in RAGAS_METRIC_NAMES:
+        setattr(ragas_metrics, name, object())
+    ragas.metrics = ragas_metrics
+
+    datasets = types.ModuleType("datasets")
+    datasets.Dataset = type(
+        "Dataset", (), {"from_dict": staticmethod(lambda data: data)}
+    )
+
+    monkeypatch.setitem(sys.modules, "ragas", ragas)
+    monkeypatch.setitem(sys.modules, "ragas.metrics", ragas_metrics)
+    monkeypatch.setitem(sys.modules, "datasets", datasets)
+    return scores
+
+
+@pytest.fixture
+def test_case():
+    return LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        expected_output="We offer a 30-day full refund at no extra cost.",
+        retrieval_context=["All customers get a 30 day full refund."],
+    )
+
+
+# A non-string model skips the OpenAI client construction, which would
+# otherwise need an API key.
+MODEL = object()
+
+
+class TestRagasSubMetrics:
+    """Each wrapper reads one score straight out of the ragas result."""
+
+    def test_a_score_is_recorded_as_measured(self, ragas_scores, test_case):
+        from deepeval.metrics.ragas import RAGASFaithfulnessMetric
+
+        ragas_scores["faithfulness"] = [0.8]
+        metric = RAGASFaithfulnessMetric(threshold=0.5, model=MODEL)
+
+        assert metric.measure(test_case) == 0.8
+        assert metric.success is True
+        assert metric.error is None
+
+    def test_nan_is_not_reported_as_a_failing_score(
+        self, ragas_scores, test_case
+    ):
+        from deepeval.metrics.ragas import RAGASFaithfulnessMetric
+
+        # ragas returns NaN when no statements could be extracted from the
+        # answer. Comparing that to the threshold is False, which would report
+        # a test case that was never measured as one that failed.
+        ragas_scores["faithfulness"] = [float("nan")]
+        metric = RAGASFaithfulnessMetric(threshold=0.5, model=MODEL)
+
+        assert metric.measure(test_case) is None
+        assert metric.score is None
+        assert metric.error is not None
+        assert "faithfulness" in metric.error
+
+    def test_a_missing_score_is_not_reported_as_a_failing_score(
+        self, ragas_scores, test_case
+    ):
+        # Defensive: ragas is a third-party dependency and the version floor is
+        # a lower bound, so the shape of its result is not guaranteed.
+        from deepeval.metrics.ragas import RAGASFaithfulnessMetric
+
+        ragas_scores["faithfulness"] = [None]
+        metric = RAGASFaithfulnessMetric(threshold=0.5, model=MODEL)
+
+        assert metric.measure(test_case) is None
+        assert metric.error is not None
+
+
+class TestRagasCompositeMetric:
+    """The composite averages the five sub-metric scores."""
+
+    @staticmethod
+    def _run(test_case, sub_scores):
+        from deepeval.metrics.ragas import RagasMetric
+
+        patches = [
+            patch(f"deepeval.metrics.ragas.{name}.measure", return_value=score)
+            for name, score in zip(SUB_METRICS, sub_scores)
+        ]
+        for p in patches:
+            p.start()
+        try:
+            metric = RagasMetric(threshold=0.5, model=MODEL)
+            return metric, metric.measure(test_case)
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_averages_when_every_sub_metric_was_measured(
+        self, ragas_scores, test_case
+    ):
+        metric, score = self._run(test_case, [0.9, 0.8, 0.7, 0.9, 0.6])
+
+        assert score == pytest.approx(0.78)
+        assert metric.success is True
+        assert metric.error is None
+
+    def test_no_composite_when_a_sub_metric_was_not_measured(
+        self, ragas_scores, test_case
+    ):
+        # Averaging the four that did compute would report a plausible score
+        # for a test case that was only measured in part.
+        metric, score = self._run(test_case, [0.9, 0.8, 0.7, 0.9, None])
+
+        assert score is None
+        assert metric.error is not None
+        assert metric.score_breakdown["Faithfulness (ragas)"] is None


### PR DESCRIPTION
## The problem

The ragas wrappers take the score straight out of ragas and compare it to the threshold:

```python
faithfulness_score = scores["faithfulness"][0]
self.success = faithfulness_score >= self.threshold
self.score = faithfulness_score
```

ragas returns `np.nan` when it has nothing to score, and it's explicit about it: no statements extracted from the answer, an unparseable judge response, an empty verdict list. `nan >= threshold` is `False`, so a test case that was never measured is reported as one that failed.

The docs for this metric already say this is common:

> You'll often meet `NaN` scores in `ragas` because of invalid JSONs generated

Running ragas 0.2.1's own code, no LLM needed:

```
No statements were generated from the answer.          <- ragas' warning
Faithfulness._compute_score(no statements) -> nan
deepeval: self.success = score >= 0.5  ->  False
```

The part that bothered me more is the aggregate. `console_report.py` sums with `if m.score is not None`, and `nan is not None` is `True`, so a NaN goes into `score_sum` and the mean score for the entire run comes out NaN:

```
today : run mean over 5 metrics = nan
fixed : run mean over 4 metrics = 0.8375
```

One metric that couldn't be computed takes the reported average for every other metric in the run with it.

## The change

NaN is recorded as "not measured" rather than as a score: `error` is set, `score` stays `None`, and `is_successful()` derives success from those. That's the path the framework already has. `MetricData.score` and `error` are both `Optional`, the console report already guards `m.score is not None` everywhere it formats or aggregates, and a metric with `error` set renders as ERRORED rather than FAILED, which is the distinction that was missing.

The composite `RagasMetric` no longer averages when a sub-metric has no score. Averaging the four that did compute would report a plausible composite for a test case that was only measured in part.

Six copy-pasted call sites now go through one helper. Tests stub ragas, so they need no API key.

I checked whether this belongs in `BaseMetric.is_successful` instead, as a single guard covering everything. It doesn't: no other metric in the library produces NaN, so it would only ever fire for ragas, and the useful half of the message ("ragas could not compute `faithfulness`") needs the ragas metric name that only the wrapper has.

## Three things I'd rather you decide

**`measure()` now returns `Optional[float]`.** `BaseMetric.measure` is declared `-> float` and these overrides had no annotation at all, so I've added `-> Optional[float]` to make the divergence visible rather than silent. Anyone calling `metric.measure(tc)` directly and comparing the result gets a `TypeError` where they used to get `False`. That's a real break for direct callers and it's the strongest reason to want a different shape here. I couldn't find one: any float returned in this case is a score, which is the thing we're trying not to invent.

**I'm writing to `error` outside an exception handler**, which is new for this codebase — elsewhere it's only set from `except` blocks. `_is_metric_successful` says "if the metric recorded an error, treat as failure", and that is what's happening, but if you'd rather have a separate field for "unmeasured" I'm happy to do that instead.

**Unmeasured still counts as a failure.** `_is_metric_successful` makes that your documented policy so I've followed it, but `success = None` is available and is arguably the honest answer for a metric with no verdict. Changing it affects every metric, so I've left it alone.

Smaller: `score_breakdown` values on the composite can now be `None`.
