### PR TITLE
fix(mmlu): use per-task few-shot examples

### DIFF
--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -32,7 +32,7 @@ class MMLU(DeepEvalBaseBenchmark):
         self.tasks: List[MMLUTask] = list(MMLUTask) if tasks is None else tasks
         self.n_problems_per_task: Optional[int] = n_problems_per_task
         self.scorer = Scorer()
-        self.shots_dataset: List[Dict] = None
+        self.shots_by_task: Dict[MMLUTask, List[Dict]] = {}
         self.n_shots: int = n_shots
         self.predictions: Optional[pd.DataFrame] = None
         self.task_scores: Optional[pd.DataFrame] = None
@@ -168,10 +168,10 @@ class MMLU(DeepEvalBaseBenchmark):
     ) -> Dict:
         # Define prompt template
         assert (
-            self.shots_dataset
+            task in self.shots_by_task
         ), "Example dataset is empty. Call load_benchmark."
         prompt = MMLUTemplate.generate_output(
-            train_set=self.shots_dataset,
+            train_set=self.shots_by_task[task],
             input=golden.input,
             task=task,
             n_shots=self.n_shots,
@@ -206,13 +206,13 @@ class MMLU(DeepEvalBaseBenchmark):
     ) -> List[Dict]:
         # Define prompt template
         assert (
-            self.shots_dataset
+            task in self.shots_by_task
         ), "Example dataset is empty. Call load_benchmark."
 
         prompts = []
         for golden in goldens:
             prompt = MMLUTemplate.generate_output(
-                train_set=self.shots_dataset,
+                train_set=self.shots_by_task[task],
                 input=golden.input,
                 task=task,
                 n_shots=self.n_shots,
@@ -264,14 +264,16 @@ class MMLU(DeepEvalBaseBenchmark):
         )
         self.dataset = dataset
 
-        # If dataset has not been previously loaded, construct
-        # dataset of examples and save as instance var (to save time)
-        if not self.shots_dataset:
+        # If shots for this task have not been previously loaded,
+        # construct dataset of examples from the task's dev split and
+        # save as instance var, keyed by task (each MMLU subject has its
+        # own dev split, so shots must not be shared across tasks)
+        if task not in self.shots_by_task:
             train_set = dataset["dev"]
             shots_set = []
             for data in train_set:
                 shots_set.append(data)
-            self.shots_dataset = shots_set
+            self.shots_by_task[task] = shots_set
 
         # Construct test set
         goldens: List[Golden] = []

--- a/tests/test_benchmarks/test_mmlu_per_task_shots.py
+++ b/tests/test_benchmarks/test_mmlu_per_task_shots.py
@@ -1,0 +1,99 @@
+"""
+Regression tests for MMLU few-shot leakage across tasks.
+
+MMLU.load_benchmark_dataset used to build its few-shot example set only once,
+from the FIRST loaded task's dev split. Every subsequent task was then
+prompted with few-shot examples from the first task's subject (e.g. running
+all 57 tasks prompted 56 subjects with the first task's dev examples instead
+of their own). These tests are offline: datasets.load_dataset is mocked.
+"""
+
+from unittest import mock
+
+import datasets
+
+from deepeval.benchmarks.mmlu.mmlu import MMLU
+from deepeval.benchmarks.mmlu.task import MMLUTask
+from deepeval.benchmarks.schema import MultipleChoiceSchema
+
+
+def _make_dataset(subject: str):
+    dev = [
+        {
+            "question": f"[{subject}] dev question {i}",
+            "choices": ["w", "x", "y", "z"],
+            "answer": i % 4,
+        }
+        for i in range(5)
+    ]
+    test = [
+        {
+            "question": f"[{subject}] test question 0",
+            "choices": ["w", "x", "y", "z"],
+            "answer": 1,
+        }
+    ]
+    return {"dev": dev, "test": test}
+
+
+def _fake_load_dataset(name, config):
+    assert name == "cais/mmlu"
+    return _make_dataset(config)
+
+
+class _CapturingModel:
+    """Fake model that records the prompts it was given and answers "A"."""
+
+    def __init__(self):
+        self.prompts = []
+
+    def get_model_name(self):
+        return "fake"
+
+    def generate(self, prompt, schema=None):
+        self.prompts.append(prompt)
+        return MultipleChoiceSchema(answer="A")
+
+    def batch_generate(self, prompts, schemas=None):
+        self.prompts.extend(prompts)
+        return [schema(answer="A") for schema in schemas]
+
+
+def _load_two_task_benchmark():
+    t1, t2 = MMLUTask.ABSTRACT_ALGEBRA, MMLUTask.ANATOMY
+    bench = MMLU(tasks=[t1, t2], n_shots=2)
+    bench.load_benchmark_dataset(t1)
+    goldens_t2 = bench.load_benchmark_dataset(t2)
+    return bench, t2, goldens_t2
+
+
+def _assert_prompt_uses_task_shots(prompt):
+    # The anatomy prompt must contain anatomy's dev examples...
+    assert "[anatomy] dev question 0" in prompt
+    assert "[anatomy] dev question 1" in prompt
+    # ...and not abstract_algebra's (the first task loaded).
+    assert "[abstract_algebra]" not in prompt
+
+
+def test_mmlu_predict_uses_each_tasks_own_few_shot_examples():
+    with mock.patch.object(
+        datasets, "load_dataset", side_effect=_fake_load_dataset
+    ):
+        bench, t2, goldens_t2 = _load_two_task_benchmark()
+        model = _CapturingModel()
+        bench.predict(model, t2, goldens_t2[0])
+
+    _assert_prompt_uses_task_shots(model.prompts[0])
+
+
+def test_mmlu_batch_predict_uses_each_tasks_own_few_shot_examples():
+    with mock.patch.object(
+        datasets, "load_dataset", side_effect=_fake_load_dataset
+    ):
+        bench, t2, goldens_t2 = _load_two_task_benchmark()
+        model = _CapturingModel()
+        bench.batch_predict(model, t2, goldens_t2)
+
+    assert len(model.prompts) == len(goldens_t2)
+    for prompt in model.prompts:
+        _assert_prompt_uses_task_shots(prompt)


### PR DESCRIPTION
Fixes #3235

## What

MMLU cached the first loaded task's dev split and reused those few-shot examples for every later task. This change caches shots by task and makes both `predict` and `batch_predict` use the current task's examples.

## Tests

- Added offline regression coverage for both prediction paths.
- `pytest tests/test_benchmarks/` — 15 passed.
- `black --check` passes for the changed files.