### PR TITLE
fix: reject non-positive conversational window sizes

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -187,6 +187,9 @@ def convert_turn_to_dict(
 
 
 def get_turns_in_sliding_window(turns: List[Turn], window_size: int):
+    if window_size < 1:
+        raise ValueError("window_size must be at least 1")
+
     for i in range(len(turns)):
         yield turns[max(0, i - window_size + 1) : i + 1]
 

--- a/tests/test_core/test_test_case/test_multi_turn/test_utils.py
+++ b/tests/test_core/test_test_case/test_multi_turn/test_utils.py
@@ -1,5 +1,10 @@
+import pytest
+
+from deepeval.metrics.utils import (
+    get_turns_in_sliding_window,
+    get_unit_interactions,
+)
 from deepeval.test_case import Turn
-from deepeval.metrics.utils import get_unit_interactions
 
 
 def make_turns(seq):
@@ -71,3 +76,23 @@ class TestGetUnitInteractions:
         assert [
             [(t.role, t.content) for t in unit] for unit in result
         ] == expected
+
+
+class TestGetTurnsInSlidingWindow:
+    def test_preserves_valid_windows(self):
+        turns = make_turns(
+            [("user", "u1"), ("assistant", "a1"), ("user", "u2")]
+        )
+
+        assert list(get_turns_in_sliding_window(turns, 2)) == [
+            [turns[0]],
+            [turns[0], turns[1]],
+            [turns[1], turns[2]],
+        ]
+
+    @pytest.mark.parametrize("window_size", [0, -1])
+    def test_rejects_non_positive_window_size(self, window_size):
+        turns = make_turns([("user", "u1")])
+
+        with pytest.raises(ValueError, match="window_size must be at least 1"):
+            list(get_turns_in_sliding_window(turns, window_size))


### PR DESCRIPTION
Closes #3202.

## Summary

- reject zero and negative conversational window sizes with a clear `ValueError`
- preserve the existing sliding-window behavior for valid sizes
- add direct coverage for invalid sizes and a size-two window sequence

## Verification

- both invalid-size regressions failed on current `main` before the guard
- focused helper tests: 10 passed
- broader offline multi-turn and deterministic relevancy tests: 101 passed
- Black check passed
- Ruff check passed for the changed test module
- `git diff --check` passed
