### PR TITLE
fix: deduplicate TruthfulQA answer indices

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -383,42 +383,36 @@ class Scorer:
         Metrics that calculates the number of correct true answers identified in the prediction.
 
         This method assumes both target and prediction are strings representing lists of integers,
-        formatted like '1,2,3'. It converts these strings to lists of integers, counts how many items
-        in the prediction list are also in the target list, and returns this count as the score.
+        formatted like '1,2,3'. It converts these strings to sets of integers, counts the unique
+        matching indices, and returns their percentage of the unique target indices.
 
         Args:
             target (str): The target string representing the list of correct answers.
             prediction (str): The predicted string from the LLM, representing the guessed answers.
 
         Returns:
-            int: The number of correct answers identified.
+            int: The percentage of unique correct answers identified.
         """
         try:
             if not prediction or not target:
                 return 0  # Return score as 0 if prediction or target is empty
 
-            # Convert strings to sorted lists of integers
-            target_list = sorted(
-                [int(item) for item in target.strip("[]").split(",") if item]
-            )
-            prediction_list = sorted(
-                [
-                    int(item)
-                    for item in prediction.strip("[]").split(",")
-                    if item
-                ]
-            )
+            # Convert strings to sets so repeated indices count only once.
+            target_set = {
+                int(item) for item in target.strip("[]").split(",") if item
+            }
+            prediction_set = {
+                int(item) for item in prediction.strip("[]").split(",") if item
+            }
 
-            if not target_list:
-                return 0  # Return 0 if target list is empty to avoid division by zero
+            if not target_set:
+                return 0  # Return 0 if target set is empty to avoid division by zero
 
             # Count the number of correct matches
-            correct_matches = sum(
-                1 for item in prediction_list if item in target_list
-            )
+            correct_matches = len(prediction_set.intersection(target_set))
 
             # Calculate percentage
-            score_percentage = (correct_matches / len(target_list)) * 100
+            score_percentage = (correct_matches / len(target_set)) * 100
 
             return round(score_percentage)  # Return rounded percentage
         except Exception as e:

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -8,13 +8,13 @@ download, or API key required.
 
 import pytest
 
-from deepeval.scorer.scorer import Scorer
-from deepeval.benchmarks.schema import MultipleChoiceSchemaLower
-from deepeval.benchmarks.drop.template import DROPTemplate
-from deepeval.benchmarks.drop.drop import DELIMITER
 from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
+from deepeval.benchmarks.drop.drop import DELIMITER
+from deepeval.benchmarks.drop.template import DROPTemplate
+from deepeval.benchmarks.schema import MultipleChoiceSchemaLower
 from deepeval.benchmarks.tasks import BigBenchHardTask
 from deepeval.dataset import Golden
+from deepeval.scorer.scorer import Scorer
 
 # --------------------------------------------------------------------------- #
 # MathQA: the answer schema must be able to represent option "e"
@@ -101,3 +101,24 @@ def test_bbh_batch_predict_scores_schema_answer_correctly(enable_cot):
     # schema answer, turning "(A)" into "(A)" -> "(A" and scoring it 0.
     assert result[0]["prediction"] == "(A)"
     assert result[0]["score"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# TruthfulQA: repeated answer indices must not inflate percentage scores
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("target", "prediction", "expected"),
+    [
+        pytest.param("1,2", "1,1,1,2", 100, id="duplicate-predictions"),
+        pytest.param("1,3,4", "[1, 1, 3, 4]", 100, id="bracketed-duplicates"),
+        pytest.param("1,1,2", "1,2", 100, id="duplicate-targets"),
+        pytest.param("1,2", "3,3,3", 0, id="repeated-wrong-answer"),
+        pytest.param("1,2,3", "1,3", 67, id="unique-inputs-unchanged"),
+    ],
+)
+def test_truth_identification_counts_each_index_once(
+    target, prediction, expected
+):
+    assert Scorer.truth_identification_score(target, prediction) == expected


### PR DESCRIPTION
Closes #3210.

## Summary

- parse target and predicted TruthfulQA indices as sets
- count each answer index once in both the numerator and denominator
- preserve existing scores for unique inputs while keeping every result between 0 and 100

## Verification

- three duplicate-index regressions failed on current `main` before the fix
- focused duplicate and unique cases: 5 passed
- complete benchmark answer-scoring module: 18 passed
- Black 25.12.0 check passed for both changed files
- Ruff check passed for the changed test module
- `git diff --check` passed
