### PR TITLE
fix: normalize bare quasi contains targets

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -117,7 +117,10 @@ class Scorer:
         return 1 if normalize_text(target) == normalize_text(prediction) else 0
 
     @classmethod
-    def quasi_contains_score(cls, targets: List[str], prediction: str) -> int:
+    def quasi_contains_score(
+        cls, targets: Union[str, List[str]], prediction: str
+    ) -> int:
+        targets = [targets] if isinstance(targets, str) else targets
         normalized_targets = [normalize_text(t) for t in targets]
         if not prediction:
             return 0

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -60,6 +60,20 @@ def test_drop_delimiter_is_not_a_character_that_occurs_in_answers():
 
 
 # --------------------------------------------------------------------------- #
+# Scorer: a bare target string is one answer, not an iterable of characters
+# --------------------------------------------------------------------------- #
+
+
+def test_quasi_contains_treats_bare_string_target_as_one_answer():
+    assert Scorer.quasi_contains_score("cat", "cat") == 1
+    assert Scorer.quasi_contains_score("cat", "c") == 0
+
+
+def test_quasi_contains_list_targets_keep_existing_behavior():
+    assert Scorer.quasi_contains_score(["cat", "dog"], "dog") == 1
+
+
+# --------------------------------------------------------------------------- #
 # BigBenchHard: the batch path must not corrupt schema-constrained answers
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Closes #3218.

## Summary

- accept either one target string or a list of target strings in `quasi_contains_score`
- normalize a bare string as one answer instead of iterating over its characters
- preserve existing list-target behavior

## Verification

- on current `main`, `"cat"` against `"cat"` scored 0 and `"cat"` against `"c"` scored 1
- complete benchmark answer-scoring module: 15 passed
- broader offline scorer report-contract module: 2 passed
- direct normalization matrix passed, including empty predictions
- Black 25.12.0 check passed for both changed files
- `git diff --check` passed
