### PR TITLE
fix(benchmarks): import pandas at module level in ifeval

### DIFF
--- a/deepeval/benchmarks/ifeval/ifeval.py
+++ b/deepeval/benchmarks/ifeval/ifeval.py
@@ -8,6 +8,8 @@ from tqdm import tqdm
 import re
 import json
 
+import pandas as pd
+
 from deepeval.dataset import Golden
 from deepeval.benchmarks.base_benchmark import (
     DeepEvalBaseBenchmark,


### PR DESCRIPTION
## Summary

`IFEvalResult` annotates `predictions: "pd.DataFrame"` (line 24), but `pandas` was only imported locally inside two methods — never at module scope. Pydantic therefore can't resolve the forward reference: instantiating the model raises

```
PydanticUserError: 'IFEvalResult' is not fully defined; you should define 'pd', then call IFEvalResult.model_rebuild()
```

…even with pandas installed, which crashes `IFEval.evaluate()` (`results.append(IFEvalResult(...))`). This adds the module-level `import pandas as pd`.

## Reproduction

```python
from deepeval.benchmarks.ifeval import IFEvalResult   # class body references pd
# any construction of IFEvalResult(...) -> PydanticUserError (pydantic 2.x)
```

Reproduced standalone against pydantic 2.x with a minimal replica of the model before fixing; no existing test constructs `IFEvalResult` (which is why CI never caught it).

## Test plan

- [x] Verified `predictions` is the only pandas-typed field and the import matches usage in `generate_scoring`
- [ ] Full suite not run locally (heavy benchmark deps); CI covers it
