### PR TITLE
fix(integrations): correct mangled aggregation_method error and stale docstring

### DIFF
--- a/deepeval/integrations/hugging_face/callback.py
+++ b/deepeval/integrations/hugging_face/callback.py
@@ -89,7 +89,6 @@ try:
             Aggregate metric scores using the specified method.
 
             Args:
-                aggregation_method (str): Method for aggregating scores.
                 scores (Dict[str, List[float]]): Metric scores for each test case.
 
             Returns:
@@ -102,7 +101,7 @@ try:
             }
             if self.aggregation_method not in aggregation_functions:
                 raise ValueError(
-                    "Incorrect 'aggregation_method', only accepts ['avg', 'min, 'max']"
+                    "Incorrect 'aggregation_method', only accepts ['avg', 'min', 'max']"
                 )
             return {
                 key: aggregation_functions[self.aggregation_method](value)


### PR DESCRIPTION
## Summary

Two small fixes in `deepeval/integrations/hugging_face/callback.py`:

1. The `ValueError` for an invalid aggregation method quoted the accepted values as `['avg', 'min, 'max']` — a misplaced quote inside the string literal, so the rendered message listed a mangled `'min,` entry and dropped `'max'`. Now renders `['avg', 'min', 'max']`.
2. `_aggregate_scores(self, scores)` documented an `aggregation_method` parameter it does not take (the method reads `self.aggregation_method`); removed the stale Args entry.

## Test plan

- [x] Message/docstring-only change; no behavior change beyond correct error text
- [ ] CI suite
