### PR TITLE
docs: fix dead anchors and typos in README, TS test-run doc, simulator prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
     <p>
         <a href="https://deepeval.com/docs/getting-started?utm_source=GitHub">Documentation</a> |
         <a href="#-metrics-and-features">Metrics and Features</a> |
-        <a href="#-quickstart">Getting Started</a> |
+        <a href="#-vibe-coder-quickstart">Getting Started</a> |
         <a href="#-integrations">Integrations</a> |
         <a href="https://www.confident-ai.com?utm_source=deepeval&utm_medium=github&utm_content=header_nav&ref_page=github/readme">Confident AI</a>
     <p>

--- a/deepeval/simulator/controller/template.py
+++ b/deepeval/simulator/controller/template.py
@@ -18,7 +18,7 @@ class SimulatorControllerTemplate:
             IMPORTANT: The output must be formatted as a JSON object with two keys:
             `is_complete` (a boolean) and `reason` (a string).
 
-            Example Expected Outcome: "The user has succesfully reset their password."
+            Example Expected Outcome: "The user has successfully reset their password."
             Example Conversation History:
             [
                 {{"role": "user", "content": "I forgot my password and need to reset it."}},
@@ -27,7 +27,7 @@ class SimulatorControllerTemplate:
             Example JSON Output:
             {{
                 "is_complete": false,
-                "reason": "The assistant explained how to forget password but ahas not confirmed that the user successfully set a new password."
+                "reason": "The assistant explained how to forget password but has not confirmed that the user successfully set a new password."
             }}
 
             Expected Outcome: "{expected_outcome}"

--- a/typescript/src/evaluate/test-run/README.md
+++ b/typescript/src/evaluate/test-run/README.md
@@ -174,7 +174,7 @@ adoption at all.
 `evalsIterator` and Mastra's `DeepEvalExporter` write to. Whichever runs last
 wins, and the per-test `endTraceCapture()` clears it outright. Calling
 `evalsIterator` inside a test file therefore misbehaves. This is
-[gap 6 in the integrations README](../../integrations/README.md#6-evalsiterator-and-mastra-fight-over-one-capture-sink),
+[gap 6 in the integrations README](../../integrations/README.md#6-evalsiterator-mastra-and-the-test-runner-fight-over-one-capture-sink),
 now with a third consumer — it needs a subscriber list rather than one slot.
 
 ### 11. `chatbotRole` is dropped from conversational uploads


### PR DESCRIPTION
## Summary

Three small doc/text fixes:

1. `README.md` nav: the "Getting Started" link pointed at `#-quickstart`, which matches no heading (the actual sections are "🤖 Vibe-Coder QuickStart" and "🚀 Human QuickStart"; sibling nav anchors like `#-metrics-and-features` work). Now points at `#-vibe-coder-quickstart`.
2. `typescript/src/evaluate/test-run/README.md`: the gap-6 cross-link's anchor had drifted from the actual heading slug in `../integrations/README.md` (`### 6. evalsIterator, Mastra and the test runner fight over one capture sink`).
3. `deepeval/simulator/controller/template.py`: `succesfully` → `successfully` and the stray `ahas` → `has` in the simulator's example prompt text (shown to the simulator LLM).

## Test plan

- [x] Text/docs-only change; both new anchor targets verified against actual headings
- [ ] CI suite
