### PR TITLE
fix: validate MLLMImage local flag explicitly

### DIFF
--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -61,7 +61,8 @@ class MLLMImage:
         else:
             is_local = self.is_local_path(self.url)
             if self.local is not None:
-                assert self.local == is_local, "Local path mismatch"
+                if self.local != is_local:
+                    raise ValueError("Local path mismatch")
             else:
                 self.local = is_local
 

--- a/tests/test_core/test_test_case/test_mllm_image.py
+++ b/tests/test_core/test_test_case/test_mllm_image.py
@@ -30,6 +30,7 @@ def test_accepts_remote_url_marked_as_remote():
 
     assert image.local is False
 
+
 def test_auto_detects_remote_url():
     image = MLLMImage(
         url="https://example.com/image.jpg",

--- a/tests/test_core/test_test_case/test_mllm_image.py
+++ b/tests/test_core/test_test_case/test_mllm_image.py
@@ -1,0 +1,38 @@
+import pytest
+
+from deepeval.test_case import MLLMImage
+
+
+def test_rejects_remote_url_marked_as_local():
+    with pytest.raises(ValueError):
+        MLLMImage(
+            url="https://example.com/image.jpg",
+            local=True,
+        )
+
+
+def test_rejects_local_path_marked_as_remote(tmp_path):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"fake image")
+
+    with pytest.raises(ValueError):
+        MLLMImage(
+            url=str(image_path),
+            local=False,
+        )
+
+
+def test_accepts_remote_url_marked_as_remote():
+    image = MLLMImage(
+        url="https://example.com/image.jpg",
+        local=False,
+    )
+
+    assert image.local is False
+
+def test_auto_detects_remote_url():
+    image = MLLMImage(
+        url="https://example.com/image.jpg",
+    )
+
+    assert image.local is False


### PR DESCRIPTION
## Summary

Fixes #3214.

`MLLMImage.__post_init__` used a bare `assert` to validate whether an explicitly provided `local` flag matched the URL/path classification.

Bare assertions are removed when Python runs with `-O`/`-OO`, so contradictory values could bypass validation entirely.

## Changes

- replace the bare `assert` with an explicit `ValueError`
- preserve existing behavior when `local=None` or when the explicit value matches detection
- add regression tests for local/remote mismatches and valid inputs

## Verification

- focused MLLMImage tests: 4 passed
- validation still raises under `python -O`
- `git diff --check` passes