### PR TITLE
fix(tool_correctness): align exact-match type diagnostics with call positions

### DIFF
--- a/deepeval/metrics/tool_correctness/tool_correctness.py
+++ b/deepeval/metrics/tool_correctness/tool_correctness.py
@@ -336,8 +336,13 @@ class ToolCorrectnessMetric(BaseMetric):
 
     def _get_type_mismatches(self) -> List[str]:
         mismatches = []
-        for expected_tool in self.expected_tools:
-            for called_tool in self.tools_called:
+        for index, expected_tool in enumerate(self.expected_tools):
+            called_tools = (
+                self.tools_called[index : index + 1]
+                if self.should_exact_match
+                else self.tools_called
+            )
+            for called_tool in called_tools:
                 if (
                     expected_tool.name == called_tool.name
                     and expected_tool.type != called_tool.type

--- a/tests/test_metrics/test_tool_correctness_exact_type_reason.py
+++ b/tests/test_metrics/test_tool_correctness_exact_type_reason.py
@@ -1,0 +1,46 @@
+import pytest
+
+from deepeval.metrics import ToolCorrectnessMetric
+from deepeval.test_case import ToolCall
+
+
+@pytest.mark.parametrize(
+    "called_types, expected_score, expected_mismatches",
+    [
+        (["FUNCTION", "MCP"], 1.0, []),
+        (
+            ["MCP", "FUNCTION"],
+            0.0,
+            [
+                "search (expected FUNCTION, called MCP)",
+                "search (expected MCP, called FUNCTION)",
+            ],
+        ),
+        (
+            ["FUNCTION", "FUNCTION"],
+            0.0,
+            ["search (expected MCP, called FUNCTION)"],
+        ),
+        (["FUNCTION"], 0.0, []),
+        (["FUNCTION", "MCP", "FUNCTION"], 0.0, []),
+    ],
+)
+def test_exact_match_type_reason_uses_corresponding_calls(
+    called_types, expected_score, expected_mismatches
+):
+    # Exercise deterministic helpers without initializing an LLM provider.
+    metric = ToolCorrectnessMetric.__new__(ToolCorrectnessMetric)
+    metric.should_exact_match = True
+    metric.evaluation_params = []
+    metric.expected_tools = [
+        ToolCall(name="search", type=tool_type)
+        for tool_type in ["FUNCTION", "MCP"]
+    ]
+    metric.tools_called = [
+        ToolCall(name="search", type=tool_type) for tool_type in called_types
+    ]
+
+    assert metric._calculate_exact_match_score() == expected_score
+    assert metric._get_type_mismatches() == expected_mismatches
+    reason = metric._generate_reason()
+    assert ("Tool type mismatches" in reason) == bool(expected_mismatches)


### PR DESCRIPTION
Fixes #3245

In exact-match mode, identical sequences containing same-name FUNCTION and MCP calls score 1.0 but report false type mismatches. Compare type diagnostics only at corresponding call positions so the reason agrees with the exact-match scoring logic.

The production change is limited to `_get_type_mismatches()` (7 lines added, 2 removed). Scoring and other matching modes are unchanged.

**Validation**

- Added five offline regression cases: identical mixed types, swapped types, a genuine mismatch, and missing/extra calls. Before the fix: 3 failed, 2 passed. After: 5 passed.
- Separately ran 12 local public-entry-point checks across `measure()` and `a_measure()`: all passed after the fix, with zero LLM calls. These local reproduction scripts are not included in the PR.
- `python -m black --check deepeval/metrics/tool_correctness/tool_correctness.py tests/test_metrics/test_tool_correctness_exact_type_reason.py` with Black 25.12.0: passed.
- `git diff --check`: passed.

Run the included regression tests with:

```bash
DEEPEVAL_TELEMETRY_OPT_OUT=YES DEEPEVAL_DISABLE_DOTENV=1 python -m pytest -q tests/test_metrics/test_tool_correctness_exact_type_reason.py
```
