### PR TITLE
fix(benchmarks): validate n_shots/n_problems with explicit exceptions (#3216)

### DIFF
--- a/deepeval/benchmarks/arc/arc.py
+++ b/deepeval/benchmarks/arc/arc.py
@@ -26,21 +26,44 @@ class ARC(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "ARC only supports n_shots <= 5"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot). `n_problems` must be >= 1: evaluate() divides the
+        # number of correct predictions by it, so 0 would crash with a
+        # ZeroDivisionError.
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (ARC only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.mode: ARCMode = mode
         self.scorer = Scorer()
         self.n_shots: int = n_shots
         if mode == ARCMode.EASY:
-            self.n_problems: int = 2376 if n_problems is None else n_problems
-            assert (
-                self.n_problems <= 2376
-            ), "ARC-Easy only supports n_problems <= 2376"
+            max_problems = 2376
+            mode_label = "ARC-Easy"
         else:
-            self.n_problems: int = 1172 if n_problems is None else n_problems
-            assert (
-                self.n_problems <= 1172
-            ), "ARC-Challenge only supports n_problems <= 1172"
+            max_problems = 1172
+            mode_label = "ARC-Challenge"
+        self.n_problems: int = (
+            max_problems if n_problems is None else n_problems
+        )
+        if type(self.n_problems) is not int:
+            raise TypeError(
+                f"'n_problems' must be an integer, got "
+                f"{type(self.n_problems).__name__}."
+            )
+        if not 1 <= self.n_problems <= max_problems:
+            raise ValueError(
+                f"'n_problems' must be between 1 and {max_problems} "
+                f"({mode_label} only supports n_problems <= {max_problems}), "
+                f"got {self.n_problems}."
+            )
         self.predictions: Optional[pd.DataFrame] = None
         self.overall_score: Optional[float] = None
         self.verbose_mode = verbose_mode

--- a/deepeval/benchmarks/bbq/bbq.py
+++ b/deepeval/benchmarks/bbq/bbq.py
@@ -26,7 +26,18 @@ class BBQ(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "BBQ only supports n_shots <= 5"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 5].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (BBQ only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[BBQTask] = list(BBQTask) if tasks is None else tasks
         self.n_problems_per_task: Optional[int] = n_problems_per_task

--- a/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
+++ b/deepeval/benchmarks/big_bench_hard/big_bench_hard.py
@@ -60,7 +60,18 @@ class BigBenchHard(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 3, "BBH only supports n_shots <= 3"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 3].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 3:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 3 (BBH only supports "
+                f"n_shots <= 3), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[BigBenchHardTask] = (
             list(BigBenchHardTask) if tasks is None else tasks

--- a/deepeval/benchmarks/bool_q/bool_q.py
+++ b/deepeval/benchmarks/bool_q/bool_q.py
@@ -24,8 +24,26 @@ class BoolQ(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "BoolQ only supports n_shots <= 5"
-        assert n_problems <= 3270, "BoolQ only supports n_problems <= 3270"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but `n_problems` must be >= 1: evaluate() divides the
+        # number of correct predictions by it, so 0 would crash with a
+        # ZeroDivisionError.
+        for name, value in (("n_shots", n_shots), ("n_problems", n_problems)):
+            if type(value) is not int:
+                raise TypeError(
+                    f"'{name}' must be an integer, got {type(value).__name__}."
+                )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (BoolQ only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
+        if not 1 <= n_problems <= 3270:
+            raise ValueError(
+                f"'n_problems' must be between 1 and 3270 (BoolQ only supports "
+                f"n_problems <= 3270), got {n_problems}."
+            )
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.n_shots: int = n_shots

--- a/deepeval/benchmarks/drop/drop.py
+++ b/deepeval/benchmarks/drop/drop.py
@@ -42,7 +42,18 @@ class DROP(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "DROP only supports n_shots <= 5"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 5].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (DROP only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[DROPTask] = list(DROPTask) if tasks is None else tasks
         self.n_problems_per_task: Optional[int] = n_problems_per_task

--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -25,7 +25,26 @@ class GSM8K(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 15, "GSM8K only supports n_shots <= 15"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but `n_problems` must be >= 1: evaluate() divides the
+        # number of correct predictions by it, so 0 would crash with a
+        # ZeroDivisionError.
+        for name, value in (("n_shots", n_shots), ("n_problems", n_problems)):
+            if type(value) is not int:
+                raise TypeError(
+                    f"'{name}' must be an integer, got {type(value).__name__}."
+                )
+        if not 0 <= n_shots <= 15:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 15 (GSM8K only supports "
+                f"n_shots <= 15), got {n_shots}."
+            )
+        if not 1 <= n_problems <= 1319:
+            raise ValueError(
+                f"'n_problems' must be between 1 and 1319 (GSM8K only supports "
+                f"n_problems <= 1319), got {n_problems}."
+            )
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.shots_dataset: List[Dict] = None

--- a/deepeval/benchmarks/hellaswag/hellaswag.py
+++ b/deepeval/benchmarks/hellaswag/hellaswag.py
@@ -27,7 +27,18 @@ class HellaSwag(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 15, "HellaSwag only supports n_shots <= 15."
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 15].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 15:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 15 (HellaSwag only supports "
+                f"n_shots <= 15), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[HellaSwagTask] = (
             list(HellaSwagTask) if tasks is None else tasks

--- a/deepeval/benchmarks/lambada/lambada.py
+++ b/deepeval/benchmarks/lambada/lambada.py
@@ -24,8 +24,26 @@ class LAMBADA(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "LAMBADA only supports n_shots <= 5"
-        assert n_problems <= 5153, "LAMBADA only supports n_problems <= 5153"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but `n_problems` must be >= 1: evaluate() divides the
+        # number of correct predictions by it, so 0 would crash with a
+        # ZeroDivisionError.
+        for name, value in (("n_shots", n_shots), ("n_problems", n_problems)):
+            if type(value) is not int:
+                raise TypeError(
+                    f"'{name}' must be an integer, got {type(value).__name__}."
+                )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (LAMBADA only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
+        if not 1 <= n_problems <= 5153:
+            raise ValueError(
+                f"'n_problems' must be between 1 and 5153 (LAMBADA only "
+                f"supports n_problems <= 5153), got {n_problems}."
+            )
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.n_shots: int = n_shots

--- a/deepeval/benchmarks/logi_qa/logi_qa.py
+++ b/deepeval/benchmarks/logi_qa/logi_qa.py
@@ -29,7 +29,18 @@ class LogiQA(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "LogiQA only supports n_shots <= 5"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 5].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (LogiQA only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[LogiQATask] = (
             list(LogiQATask) if tasks is None else tasks

--- a/deepeval/benchmarks/math_qa/math_qa.py
+++ b/deepeval/benchmarks/math_qa/math_qa.py
@@ -27,7 +27,18 @@ class MathQA(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "MathQA only supports n_shots <= 5"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 5].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (MathQA only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[MathQATask] = (
             list(MathQATask) if tasks is None else tasks

--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -27,7 +27,18 @@ class MMLU(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "MMLU only supports n_shots <= 5"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 5].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (MMLU only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[MMLUTask] = list(MMLUTask) if tasks is None else tasks
         self.n_problems_per_task: Optional[int] = n_problems_per_task

--- a/deepeval/benchmarks/squad/squad.py
+++ b/deepeval/benchmarks/squad/squad.py
@@ -29,7 +29,18 @@ class SQuAD(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "SQuAD only supports n_shots <= 5"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but it must be an integer within [0, 5].
+        if type(n_shots) is not int:
+            raise TypeError(
+                f"'n_shots' must be an integer, got {type(n_shots).__name__}."
+            )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (SQuAD only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
         super().__init__(**kwargs)
         self.tasks: List[SQuADTask] = (
             list(SQuADTask) if tasks is None else tasks

--- a/tests/test_benchmarks/test_benchmark_param_validation.py
+++ b/tests/test_benchmarks/test_benchmark_param_validation.py
@@ -1,0 +1,277 @@
+"""Tests for benchmark constructor argument validation.
+
+The following benchmarks validated ``n_shots`` (and sometimes ``n_problems``)
+with bare ``assert`` statements: HellaSwag, GSM8K, BoolQ, ARC, BBQ, MathQA,
+MMLU, LogiQA, LAMBADA, DROP, SQuAD and BigBenchHard. ``assert`` is an
+anti-pattern here: it is stripped when the interpreter runs with
+``-O``/``-OO``, it raises ``AssertionError`` instead of the
+``ValueError``/``TypeError`` callers expect, and it only checked upper bounds.
+In particular ``n_problems=0`` passed validation even though ``evaluate()``
+divides the number of correct predictions by it.
+
+These tests verify that, for every affected benchmark:
+  * the default and previously-valid configurations still construct (no
+    regression);
+  * invalid types raise ``TypeError``;
+  * ``n_shots`` outside ``[0, max_shots]`` (zero-shot is allowed) raises
+    ``ValueError``;
+  * ``n_problems`` outside ``[1, max_problems]`` raises ``ValueError``;
+  * the checks still fire under ``python -O`` (where asserts vanish).
+
+The tests are fully offline: the ``datasets`` package is stubbed out, so no
+dataset download or network access is required.
+"""
+
+import os
+import subprocess
+import sys
+import types
+
+import pytest
+
+from deepeval.benchmarks.arc.arc import ARC
+from deepeval.benchmarks.arc.mode import ARCMode
+from deepeval.benchmarks.bbq.bbq import BBQ
+from deepeval.benchmarks.big_bench_hard.big_bench_hard import BigBenchHard
+from deepeval.benchmarks.bool_q.bool_q import BoolQ
+from deepeval.benchmarks.drop.drop import DROP
+from deepeval.benchmarks.gsm8k.gsm8k import GSM8K
+from deepeval.benchmarks.hellaswag.hellaswag import HellaSwag
+from deepeval.benchmarks.lambada.lambada import LAMBADA
+from deepeval.benchmarks.logi_qa.logi_qa import LogiQA
+from deepeval.benchmarks.math_qa.math_qa import MathQA
+from deepeval.benchmarks.mmlu.mmlu import MMLU
+from deepeval.benchmarks.squad.squad import SQuAD
+
+
+@pytest.fixture
+def fake_datasets(monkeypatch):
+    """Fake the optional ``datasets`` package imported by the base benchmark."""
+    module = types.ModuleType("datasets")
+
+    class Dataset:
+        pass
+
+    module.Dataset = Dataset
+    monkeypatch.setitem(sys.modules, "datasets", module)
+    # ``SQuAD.__init__`` normalizes its evaluation model through
+    # ``initialize_model``, which constructs an ``OpenAIModel`` unless a key is
+    # configured. A dummy key lets the constructor run without any network I/O.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# Benchmarks that validate ``n_shots`` only
+# --------------------------------------------------------------------------- #
+
+N_SHOTS_ONLY = [
+    (HellaSwag, 10, 15),
+    (BBQ, 5, 5),
+    (MathQA, 5, 5),
+    (MMLU, 5, 5),
+    (LogiQA, 5, 5),
+    (SQuAD, 5, 5),
+    (DROP, 5, 5),
+    (BigBenchHard, 3, 3),
+]
+
+# Benchmarks that also validate ``n_problems`` (used as a divisor in
+# ``evaluate()``, so 0 must be rejected).
+N_SHOTS_AND_PROBLEMS = [
+    (GSM8K, 3, 15, 1319),
+    (BoolQ, 5, 5, 3270),
+    (LAMBADA, 5, 5, 5153),
+]
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots", N_SHOTS_ONLY
+)
+def test_default_construction_succeeds(
+    fake_datasets, benchmark_cls, default_shots, max_shots
+):
+    bench = benchmark_cls()
+    assert bench.n_shots == default_shots
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots", N_SHOTS_ONLY
+)
+def test_zero_shot_is_allowed(
+    fake_datasets, benchmark_cls, default_shots, max_shots
+):
+    bench = benchmark_cls(n_shots=0)
+    assert bench.n_shots == 0
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots", N_SHOTS_ONLY
+)
+def test_n_shots_above_upper_bound_rejected(
+    fake_datasets, benchmark_cls, default_shots, max_shots
+):
+    with pytest.raises(ValueError, match="n_shots"):
+        benchmark_cls(n_shots=max_shots + 1)
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots", N_SHOTS_ONLY
+)
+def test_n_shots_negative_rejected(
+    fake_datasets, benchmark_cls, default_shots, max_shots
+):
+    with pytest.raises(ValueError, match="n_shots"):
+        benchmark_cls(n_shots=-1)
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots", N_SHOTS_ONLY
+)
+def test_n_shots_non_integer_rejected(
+    fake_datasets, benchmark_cls, default_shots, max_shots
+):
+    with pytest.raises(TypeError, match="'n_shots'.*integer"):
+        benchmark_cls(n_shots=2.5)
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots, max_problems",
+    N_SHOTS_AND_PROBLEMS,
+)
+def test_problem_benchmarks_default_construction_succeeds(
+    fake_datasets, benchmark_cls, default_shots, max_shots, max_problems
+):
+    bench = benchmark_cls()
+    assert bench.n_shots == default_shots
+    assert bench.n_problems == max_problems
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots, max_problems",
+    N_SHOTS_AND_PROBLEMS,
+)
+def test_problem_benchmarks_n_shots_rejected(
+    fake_datasets, benchmark_cls, default_shots, max_shots, max_problems
+):
+    with pytest.raises(ValueError, match="n_shots"):
+        benchmark_cls(n_shots=max_shots + 1)
+    with pytest.raises(ValueError, match="n_shots"):
+        benchmark_cls(n_shots=-1)
+    with pytest.raises(TypeError, match="'n_shots'.*integer"):
+        benchmark_cls(n_shots="5")
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots, max_problems",
+    N_SHOTS_AND_PROBLEMS,
+)
+def test_problem_benchmarks_n_problems_above_upper_bound_rejected(
+    fake_datasets, benchmark_cls, default_shots, max_shots, max_problems
+):
+    with pytest.raises(ValueError, match="n_problems"):
+        benchmark_cls(n_problems=max_problems + 1)
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots, max_problems",
+    N_SHOTS_AND_PROBLEMS,
+)
+def test_problem_benchmarks_n_problems_zero_rejected(
+    fake_datasets, benchmark_cls, default_shots, max_shots, max_problems
+):
+    # Previously accepted (0 <= max), but evaluate() divides by n_problems,
+    # so 0 would crash with a ZeroDivisionError.
+    with pytest.raises(ValueError, match="n_problems"):
+        benchmark_cls(n_problems=0)
+
+
+@pytest.mark.parametrize(
+    "benchmark_cls, default_shots, max_shots, max_problems",
+    N_SHOTS_AND_PROBLEMS,
+)
+def test_problem_benchmarks_n_problems_non_integer_rejected(
+    fake_datasets, benchmark_cls, default_shots, max_shots, max_problems
+):
+    with pytest.raises(TypeError, match="'n_problems'.*integer"):
+        benchmark_cls(n_problems="100")
+
+
+# --------------------------------------------------------------------------- #
+# ARC has a mode-dependent n_problems bound
+# --------------------------------------------------------------------------- #
+
+
+def test_arc_easy_defaults(fake_datasets):
+    bench = ARC()
+    assert bench.n_shots == 5
+    assert bench.n_problems == 2376
+
+
+def test_arc_challenge_defaults(fake_datasets):
+    bench = ARC(mode=ARCMode.CHALLENGE)
+    assert bench.n_problems == 1172
+
+
+def test_arc_easy_rejects_problems_above_bound(fake_datasets):
+    with pytest.raises(ValueError, match="n_problems.*2376"):
+        ARC(mode=ARCMode.EASY, n_problems=2377)
+
+
+def test_arc_challenge_rejects_problems_above_bound(fake_datasets):
+    with pytest.raises(ValueError, match="n_problems.*1172"):
+        ARC(mode=ARCMode.CHALLENGE, n_problems=1173)
+
+
+def test_arc_easy_rejects_zero_problems(fake_datasets):
+    with pytest.raises(ValueError, match="n_problems"):
+        ARC(mode=ARCMode.EASY, n_problems=0)
+
+
+def test_arc_rejects_non_integer_problems(fake_datasets):
+    with pytest.raises(TypeError, match="'n_problems'.*integer"):
+        ARC(mode=ARCMode.EASY, n_problems="10")
+
+
+# --------------------------------------------------------------------------- #
+# The checks must survive `python -O` (bare asserts would be stripped)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # n_shots above the HellaSwag bound
+        (
+            "from deepeval.benchmarks.hellaswag.hellaswag import HellaSwag\n"
+            "try:\n"
+            "    HellaSwag(n_shots=16)\n"
+            "except ValueError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise SystemExit('out-of-range n_shots accepted under -O')\n"
+        ),
+        # n_problems == 0 for GSM8K (a bare assert would never reject it)
+        (
+            "from deepeval.benchmarks.gsm8k.gsm8k import GSM8K\n"
+            "try:\n"
+            "    GSM8K(n_problems=0)\n"
+            "except ValueError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise SystemExit('n_problems=0 accepted under -O')\n"
+        ),
+    ],
+)
+def test_mismatch_still_rejected_under_python_optimize(code):
+    """The checks must survive `python -O` (bare asserts would be stripped)."""
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": repo_root},
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
### Summary
Replaces bare `assert` statements validating `n_shots` and `n_problems` in benchmark constructors with explicit `TypeError` and `ValueError` checks.

Bare `assert` statements in public API constructors are an anti-pattern:
1. They are stripped under `python -O`/`-OO`, causing validation to vanish in optimized runtimes.
2. They raise `AssertionError` instead of standard `TypeError` / `ValueError`.
3. They only check upper bounds, allowing `n_problems=0` to proceed into `evaluate()` where division by `n_problems` crashes with `ZeroDivisionError`.

### Proposed Changes
- Replaced bare `assert` checks across 12 benchmarks:
  - `n_shots` only: `HellaSwag` (15), `BBQ` (5), `MathQA` (5), `MMLU` (5), `LogiQA` (5), `SQuAD` (5), `DROP` (5), `BigBenchHard` (3).
  - `n_shots` + `n_problems`: `GSM8K` (15, 1319), `BoolQ` (5, 3270), `LAMBADA` (5, 5153).
  - `ARC`: mode-dependent `n_problems` bound (2376 easy / 1172 challenge).
- Non-integer inputs raise `TypeError`.
- Out-of-bounds `n_shots` (`< 0` or `> max`) raise `ValueError` (zero-shot remains supported).
- Non-positive or out-of-bounds `n_problems` (`< 1` or `> max`) raise `ValueError`.
- Preserved full backward compatibility for all valid configurations.

### Verification
- Added `tests/test_benchmarks/test_benchmark_param_validation.py` with 63 comprehensive unit test cases covering:
  - Valid and default configurations construct cleanly without regressions.
  - Zero-shot (`n_shots=0`) constructs successfully.
  - Upper-bound and lower-bound violations raise `ValueError`.
  - Non-integer arguments raise `TypeError`.
  - Division-by-zero prevention (`n_problems=0`).
  - Mode-dependent bounds for ARC (Easy vs. Challenge).
  - Subprocess tests under `python -O` confirming validation survives bytecode optimization.
- Test suite: **63/63 passed** cleanly in 26.98s.
- Formatted and verified with `black`.

Closes #3216.
