### PR TITLE
fix(agent_loop_detection): canonicalize tool-call arg signature for order-insensitive repetition

### DIFF
--- a/deepeval/dataset/golden.py
+++ b/deepeval/dataset/golden.py
@@ -202,9 +202,7 @@ class Golden(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     source_file: Optional[str] = Field(
         default=None, serialization_alias="sourceFile"

--- a/deepeval/metrics/agent_loop_detection/agent_loop_detection.py
+++ b/deepeval/metrics/agent_loop_detection/agent_loop_detection.py
@@ -291,6 +291,26 @@ class AgentLoopDetectionMetric(BaseMetric):
         traverse(trace_dict)
         return spans
 
+    @staticmethod
+    def _args_signature(input_val) -> str:
+        """Return a canonical, order-insensitive serialization of tool arguments.
+
+        Serializes dicts and lists using json.dumps(sort_keys=True) so that nested
+        dict key order is normalized while list ordering is preserved.
+        """
+        if isinstance(input_val, str):
+            try:
+                input_val = json.loads(input_val)
+            except Exception:
+                pass
+
+        if isinstance(input_val, (dict, list)):
+            try:
+                return json.dumps(input_val, sort_keys=True, default=str)
+            except Exception:
+                return str(input_val)
+        return str(input_val)
+
     def _score_tool_repetition(self, tool_spans: list) -> Tuple[float, str]:
         if not tool_spans:
             return 1.0, "No tool spans found."
@@ -298,22 +318,8 @@ class AgentLoopDetectionMetric(BaseMetric):
         tool_counts = {}
         for span in tool_spans:
             name = span.get("name", "")
-
             input_val = span.get("input", {})
-            if isinstance(input_val, str):
-                try:
-                    input_val = json.loads(input_val)
-                except Exception:
-                    pass
-
-            if isinstance(input_val, dict):
-                args_tuple = tuple(
-                    sorted((str(k), str(v)) for k, v in input_val.items())
-                )
-            else:
-                args_tuple = (str(input_val),)
-
-            call_hash = (name, args_tuple)
+            call_hash = (name, self._args_signature(input_val))
             tool_counts[call_hash] = tool_counts.get(call_hash, 0) + 1
 
         max_reps = max(tool_counts.values()) if tool_counts else 0

--- a/deepeval/test_case/llm_test_case.py
+++ b/deepeval/test_case/llm_test_case.py
@@ -402,9 +402,7 @@ class LLMTestCase(BaseModel):
     output_token_count: Optional[int] = Field(
         default=None,
         serialization_alias="outputTokenCount",
-        validation_alias=AliasChoices(
-            "outputTokenCount", "output_token_count"
-        ),
+        validation_alias=AliasChoices("outputTokenCount", "output_token_count"),
     )
     completion_time: Optional[float] = Field(
         default=None,

--- a/tests/test_agent_loop_detection.py
+++ b/tests/test_agent_loop_detection.py
@@ -370,3 +370,139 @@ def test_reordered_stagnation_detected():
 
     # SequenceMatcher should push the similarity above 0.75
     assert metric.score_breakdown["reasoning_stagnation"] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Reordered dict keys in tool arguments are detected as repetition
+# ---------------------------------------------------------------------------
+
+
+def test_reordered_dict_keys_detected_as_repetition():
+    """Tool calls with identical key-value pairs in different insertion orders
+    should produce the same signature and trigger repetition detection."""
+    trace = _make_agent_span(
+        "looping_agent",
+        [
+            _make_tool_span(
+                "get_weather", {"city": "Paris", "unit": "celsius"}
+            ),
+            _make_tool_span(
+                "get_weather", {"unit": "celsius", "city": "Paris"}
+            ),
+            _make_tool_span(
+                "get_weather", {"city": "Paris", "unit": "celsius"}
+            ),
+            _make_tool_span(
+                "get_weather", {"unit": "celsius", "city": "Paris"}
+            ),
+        ],
+    )
+    metric = AgentLoopDetectionMetric(
+        threshold=0.7,
+        repetition_threshold=3,
+        check_reasoning_stagnation=False,
+        check_call_graph_cycles=False,
+    )
+    tc = _make_test_case(trace)
+    metric._calculate_metric(tc)
+
+    assert metric.score_breakdown["tool_repetition"] <= 0.5
+    assert metric.success is False
+    assert "Tool 'get_weather' called 4 times" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Nested reordered dict keys in tool arguments are detected
+# ---------------------------------------------------------------------------
+
+
+def test_nested_reordered_dict_keys_detected_as_repetition():
+    """Tool calls with nested dict arguments whose sub-keys are reordered
+    should canonicalize to the same signature."""
+    trace = _make_agent_span(
+        "looping_agent",
+        [
+            _make_tool_span(
+                "search", {"query": "Paris", "meta": {"page": 1, "limit": 10}}
+            ),
+            _make_tool_span(
+                "search", {"meta": {"limit": 10, "page": 1}, "query": "Paris"}
+            ),
+            _make_tool_span(
+                "search", {"query": "Paris", "meta": {"page": 1, "limit": 10}}
+            ),
+            _make_tool_span(
+                "search", {"meta": {"limit": 10, "page": 1}, "query": "Paris"}
+            ),
+        ],
+    )
+    metric = AgentLoopDetectionMetric(
+        threshold=0.7,
+        repetition_threshold=3,
+        check_reasoning_stagnation=False,
+        check_call_graph_cycles=False,
+    )
+    tc = _make_test_case(trace)
+    metric._calculate_metric(tc)
+
+    assert metric.score_breakdown["tool_repetition"] <= 0.5
+    assert metric.success is False
+    assert "Tool 'search' called 4 times" in metric.reason
+
+
+# ---------------------------------------------------------------------------
+# Test 13: Stringified JSON blobs with reordered keys are detected
+# ---------------------------------------------------------------------------
+
+
+def test_stringified_json_reordered_keys_detected_as_repetition():
+    """Stringified JSON input with reordered keys should be parsed and canonicalized."""
+    trace = _make_agent_span(
+        "looping_agent",
+        [
+            _make_tool_span(
+                "execute", '{"action": "click", "target": "button"}'
+            ),
+            _make_tool_span(
+                "execute", '{"target": "button", "action": "click"}'
+            ),
+            _make_tool_span(
+                "execute", '{"action": "click", "target": "button"}'
+            ),
+            _make_tool_span(
+                "execute", '{"target": "button", "action": "click"}'
+            ),
+        ],
+    )
+    metric = AgentLoopDetectionMetric(
+        threshold=0.7,
+        repetition_threshold=3,
+        check_reasoning_stagnation=False,
+        check_call_graph_cycles=False,
+    )
+    tc = _make_test_case(trace)
+    metric._calculate_metric(tc)
+
+    assert metric.score_breakdown["tool_repetition"] <= 0.5
+    assert metric.success is False
+
+
+# ---------------------------------------------------------------------------
+# Test 14: List arguments preserve semantic element order
+# ---------------------------------------------------------------------------
+
+
+def test_args_signature_preserves_list_ordering():
+    """List ordering is semantically significant and must not be collapsed."""
+    sig1 = AgentLoopDetectionMetric._args_signature({"items": [1, 2]})
+    sig2 = AgentLoopDetectionMetric._args_signature({"items": [2, 1]})
+    assert sig1 != sig2
+
+    # But nested dicts inside lists SHOULD have their keys sorted
+    sig3 = AgentLoopDetectionMetric._args_signature(
+        [{"a": 1, "b": 2}, {"x": 10, "y": 20}]
+    )
+    sig4 = AgentLoopDetectionMetric._args_signature(
+        [{"b": 2, "a": 1}, {"y": 20, "x": 10}]
+    )
+    assert sig3 == sig4


### PR DESCRIPTION
## Description
Resolves #3175

In `AgentLoopDetectionMetric`, tool-call repetition counts identical `(name, args)` invocations. Previously, dictionary arguments were encoded via `sorted((str(k), str(v)) for k, v in input.items())`, but `str(v)` for nested dicts retained arbitrary Python dict key insertion order.

As a result, semantically identical tool calls with reordered keys (or nested dict arguments) produced different hashes and were split into separate groups, allowing infinite loops to slip through undetected.

## Changes
- Added static method `_args_signature(input_val) -> str` to `AgentLoopDetectionMetric` that canonicalizes dict/list arguments using `json.dumps(..., sort_keys=True, default=str)`. This normalizes dictionary key ordering across all nesting levels while preserving semantic list ordering.
- Updated `_score_tool_repetition()` to use `(name, self._args_signature(input_val))` for repetition grouping.
- Added comprehensive unit tests in `tests/test_agent_loop_detection.py` covering:
  - Tool calls with reordered top-level keys.
  - Tool calls with reordered nested dictionary keys.
  - Stringified JSON inputs with reordered keys.
  - Verification that list element ordering remains preserved.

## Verification
- Ran `pytest tests/test_agent_loop_detection.py` (14/14 passed).
- Ran `black --check .` (clean).