### PR TITLE
fix: forward trust_remote_code to hallucination CrossEncoder

### DIFF
--- a/deepeval/models/hallucination_model.py
+++ b/deepeval/models/hallucination_model.py
@@ -3,9 +3,27 @@ from typing import Optional
 from deepeval.singleton import Singleton
 from deepeval.progress_context import progress_context
 
+DEFAULT_HALLUCINATION_MODEL = "vectara/hallucination_evaluation_model"
+
 
 class HallucinationModel(metaclass=Singleton):
-    def __init__(self, model_name: Optional[str] = None):
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        trust_remote_code: Optional[bool] = None,
+        **kwargs,
+    ):
+        """Load a CrossEncoder used for hallucination scoring.
+
+        Args:
+            model_name: Hugging Face CrossEncoder id. Defaults to
+                ``vectara/hallucination_evaluation_model``.
+            trust_remote_code: Forwarded to ``CrossEncoder``. Defaults to True
+                for the default Vectara model (which requires custom code) and
+                False for any other model unless the caller passes True.
+            **kwargs: Additional arguments forwarded to
+                ``sentence_transformers.CrossEncoder``.
+        """
         try:
             from sentence_transformers import CrossEncoder
         except ImportError:
@@ -14,14 +32,16 @@ class HallucinationModel(metaclass=Singleton):
             )
         # We use a smple cross encoder model
         model_name = (
-            "vectara/hallucination_evaluation_model"
-            if model_name is None
-            else model_name
+            DEFAULT_HALLUCINATION_MODEL if model_name is None else model_name
         )
+        if trust_remote_code is None:
+            trust_remote_code = model_name == DEFAULT_HALLUCINATION_MODEL
         os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
         # TODO: add this progress context in the correct place
         with progress_context(
             "Downloading HallucinationEvaluationModel (may take up to 2 minutes if running for the first time)..."
         ):
-            self.model = CrossEncoder(model_name)
+            self.model = CrossEncoder(
+                model_name, trust_remote_code=trust_remote_code, **kwargs
+            )

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -457,7 +457,8 @@ class Scorer:
         evaluation_model: DeepEvalBaseLLM,
         using_native_evaluation_model: bool,
     ):
-        prompt = textwrap.dedent(f"""
+        prompt = textwrap.dedent(
+            f"""
             Given the question and context, evaluate if the prediction is correct based on the expected output.
             Ensure to account for cases where the prediction and expected output might differ in form, such as '2' versus 'two'.
 
@@ -471,7 +472,8 @@ class Scorer:
             {{
                 "answer": <number>
             }}
-        """)
+        """
+        )
 
         # Generate the score using the model
         if using_native_evaluation_model:

--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -238,7 +238,12 @@ class Scorer:
 
     @classmethod
     def hallucination_score(
-        cls, source: str, prediction: str, model: Optional[str] = None
+        cls,
+        source: str,
+        prediction: str,
+        model: Optional[str] = None,
+        trust_remote_code: Optional[bool] = None,
+        **kwargs,
     ) -> float:
         """Calculate the hallucination score of a prediction compared to a source text.
 
@@ -248,6 +253,10 @@ class Scorer:
         Args:
             source (str): The source document where the information is summarized from.
             prediction (str): The generated summary that is validated against the source summary.
+            model (Optional[str], optional): Hugging Face CrossEncoder model name.
+            trust_remote_code (Optional[bool], optional): Forwarded to CrossEncoder.
+                Defaults to True for the default Vectara model and False otherwise.
+            **kwargs: Additional arguments forwarded to sentence_transformers.CrossEncoder.
 
         Returns:
             float: The computed hallucination score. Lower values indicate greater hallucination.
@@ -260,7 +269,11 @@ class Scorer:
             print(
                 f"Vectera Hallucination detection model can not be loaded.\n{e}"
             )
-        scorer = HallucinationModel(model_name=model)
+        scorer = HallucinationModel(
+            model_name=model,
+            trust_remote_code=trust_remote_code,
+            **kwargs,
+        )
         return scorer.model.predict([source, prediction])
 
     @classmethod
@@ -444,8 +457,7 @@ class Scorer:
         evaluation_model: DeepEvalBaseLLM,
         using_native_evaluation_model: bool,
     ):
-        prompt = textwrap.dedent(
-            f"""
+        prompt = textwrap.dedent(f"""
             Given the question and context, evaluate if the prediction is correct based on the expected output.
             Ensure to account for cases where the prediction and expected output might differ in form, such as '2' versus 'two'.
 
@@ -459,8 +471,7 @@ class Scorer:
             {{
                 "answer": <number>
             }}
-        """
-        )
+        """)
 
         # Generate the score using the model
         if using_native_evaluation_model:

--- a/tests/test_core/test_hallucination_model.py
+++ b/tests/test_core/test_hallucination_model.py
@@ -1,0 +1,123 @@
+"""Offline tests for HallucinationModel / Scorer.hallucination_score kwargs.
+
+CrossEncoder is mocked so these tests never download Hugging Face models.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepeval.models.hallucination_model import (
+    DEFAULT_HALLUCINATION_MODEL,
+    HallucinationModel,
+)
+from deepeval.scorer.scorer import Scorer
+from deepeval.singleton import Singleton
+
+
+@pytest.fixture(autouse=True)
+def _clear_singleton_cache():
+    Singleton._instances.clear()
+    yield
+    Singleton._instances.clear()
+
+
+@pytest.fixture
+def mock_cross_encoder():
+    mock_cls = MagicMock(name="CrossEncoder")
+    mock_instance = MagicMock()
+    mock_instance.predict.return_value = 0.42
+    mock_cls.return_value = mock_instance
+
+    mock_module = MagicMock()
+    mock_module.CrossEncoder = mock_cls
+    with patch.dict(sys.modules, {"sentence_transformers": mock_module}):
+        yield mock_cls
+
+
+def test_default_model_trusts_remote_code(mock_cross_encoder):
+    HallucinationModel()
+    mock_cross_encoder.assert_called_once_with(
+        DEFAULT_HALLUCINATION_MODEL, trust_remote_code=True
+    )
+
+
+def test_explicit_vectara_model_trusts_remote_code(mock_cross_encoder):
+    HallucinationModel(model_name=DEFAULT_HALLUCINATION_MODEL)
+    mock_cross_encoder.assert_called_once_with(
+        DEFAULT_HALLUCINATION_MODEL, trust_remote_code=True
+    )
+
+
+def test_custom_model_does_not_trust_remote_code_by_default(mock_cross_encoder):
+    HallucinationModel(model_name="custom/hallucination-model")
+    mock_cross_encoder.assert_called_once_with(
+        "custom/hallucination-model", trust_remote_code=False
+    )
+
+
+def test_explicit_trust_remote_code_false_on_default_model(mock_cross_encoder):
+    HallucinationModel(trust_remote_code=False)
+    mock_cross_encoder.assert_called_once_with(
+        DEFAULT_HALLUCINATION_MODEL, trust_remote_code=False
+    )
+
+
+def test_explicit_trust_remote_code_true_on_custom_model(mock_cross_encoder):
+    HallucinationModel(
+        model_name="custom/hallucination-model", trust_remote_code=True
+    )
+    mock_cross_encoder.assert_called_once_with(
+        "custom/hallucination-model", trust_remote_code=True
+    )
+
+
+def test_extra_cross_encoder_kwargs_are_forwarded(mock_cross_encoder):
+    HallucinationModel(device="cpu", max_length=256)
+    mock_cross_encoder.assert_called_once_with(
+        DEFAULT_HALLUCINATION_MODEL,
+        trust_remote_code=True,
+        device="cpu",
+        max_length=256,
+    )
+
+
+def test_scorer_forwards_trust_remote_code_and_kwargs():
+    mock_instance = MagicMock()
+    mock_instance.model.predict.return_value = 0.5
+
+    with patch(
+        "deepeval.models.hallucination_model.HallucinationModel",
+        return_value=mock_instance,
+    ) as mock_hm:
+        score = Scorer.hallucination_score(
+            "source text",
+            "prediction text",
+            model="custom/hallucination-model",
+            trust_remote_code=True,
+            device="cpu",
+        )
+
+    mock_hm.assert_called_once_with(
+        model_name="custom/hallucination-model",
+        trust_remote_code=True,
+        device="cpu",
+    )
+    mock_instance.model.predict.assert_called_once_with(
+        ["source text", "prediction text"]
+    )
+    assert score == 0.5
+
+
+def test_scorer_default_model_omits_explicit_flag():
+    mock_instance = MagicMock()
+    mock_instance.model.predict.return_value = 0.1
+
+    with patch(
+        "deepeval.models.hallucination_model.HallucinationModel",
+        return_value=mock_instance,
+    ) as mock_hm:
+        Scorer.hallucination_score("source", "prediction")
+
+    mock_hm.assert_called_once_with(model_name=None, trust_remote_code=None)


### PR DESCRIPTION
Allow callers to pass trust_remote_code and other CrossEncoder kwargs through HallucinationModel and Scorer.hallucination_score. Default the flag to True for the Vectara model so non-interactive loads succeed.

Fixes #1220