### PR TITLE
fix(dag): a GEval or ConversationalGEval leaf silently loses its rubric and strict_mode

### DIFF
--- a/deepeval/metrics/conversational_dag/nodes.py
+++ b/deepeval/metrics/conversational_dag/nodes.py
@@ -14,6 +14,7 @@ from deepeval.metrics.conversational_g_eval.conversational_g_eval import (
 from deepeval.metrics.g_eval.utils import CONVERSATIONAL_G_EVAL_PARAMS
 from deepeval.metrics.utils import (
     copy_metrics,
+    initialize_model,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
 )
@@ -126,21 +127,22 @@ class ConversationalVerdictNode(ConversationalBaseNode):
         )
 
     def _build_child_metric(self, metric: BaseConversationalMetric):
-        if isinstance(self.child, ConversationalGEval):
-            args = {
-                "name": self.child.name,
-                "model": metric.model,
-                "verbose_mode": False,
-            }
-            if self.child.criteria:
-                args["criteria"] = self.child.criteria
-            else:
-                args["evaluation_steps"] = self.child.evaluation_steps
-            if self.child.evaluation_params:
-                args["evaluation_params"] = self.child.evaluation_params
-            return ConversationalGEval(**args)
         copied = copy_metrics([self.child])[0]
         copied.verbose_mode = False
+        if isinstance(copied, ConversationalGEval):
+            # A ConversationalGEval leaf usually carries no 'model' of its
+            # own, so the DAG's judge drives it. Override the judge on the
+            # copy instead of rebuilding the metric from a subset of its
+            # arguments, which dropped 'rubric', 'strict_mode',
+            # 'top_logprobs', 'evaluation_template', 'async_mode', 'flaky'
+            # and '_include_g_eval_suffix'.
+            # TODO: a leaf that was given an explicit 'model' still has it
+            # overridden here. Only a leaf without one should fall back to
+            # the DAG's judge.
+            copied.model, copied.using_native_model = initialize_model(
+                metric.model
+            )
+            copied.evaluation_model = copied.model.get_model_name()
         return copied
 
     def _run_child_metric(

--- a/deepeval/metrics/dag/nodes.py
+++ b/deepeval/metrics/dag/nodes.py
@@ -14,6 +14,7 @@ from deepeval.metrics.g_eval.g_eval import GEval
 from deepeval.metrics.g_eval.utils import G_EVAL_PARAMS
 from deepeval.metrics.utils import (
     copy_metrics,
+    initialize_model,
     a_generate_with_schema_and_extract,
     generate_with_schema_and_extract,
 )
@@ -100,20 +101,22 @@ class VerdictNode(BaseNode):
         )
 
     def _build_child_metric(self, metric: BaseMetric):
-        if isinstance(self.child, GEval):
-            args = {
-                "name": self.child.name,
-                "evaluation_params": self.child.evaluation_params,
-                "model": metric.model,
-                "verbose_mode": False,
-            }
-            if self.child.criteria:
-                args["criteria"] = self.child.criteria
-            else:
-                args["evaluation_steps"] = self.child.evaluation_steps
-            return GEval(**args)
         copied = copy_metrics([self.child])[0]
         copied.verbose_mode = False
+        if isinstance(copied, GEval):
+            # A GEval leaf usually carries no 'model' of its own, so the
+            # DAG's judge drives it. Override the judge on the copy instead
+            # of rebuilding the metric from a subset of its arguments, which
+            # dropped 'rubric', 'strict_mode', 'top_logprobs',
+            # 'evaluation_template', 'async_mode', 'flaky' and
+            # '_include_g_eval_suffix'.
+            # TODO: a leaf that was given an explicit 'model' still has it
+            # overridden here. Only a leaf without one should fall back to
+            # the DAG's judge.
+            copied.model, copied.using_native_model = initialize_model(
+                metric.model
+            )
+            copied.evaluation_model = copied.model.get_model_name()
         return copied
 
     def _run_child_metric(self, metric: BaseMetric, test_case: LLMTestCase):

--- a/tests/test_metrics/test_conversational_dag.py
+++ b/tests/test_metrics/test_conversational_dag.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 from deepeval import evaluate
-from deepeval.metrics import ConversationalDAGMetric
+from deepeval.metrics import ConversationalDAGMetric, ConversationalGEval
 from deepeval.metrics.dag import (
     DeepAcyclicGraph,
 )
@@ -14,7 +14,11 @@ from deepeval.metrics.conversational_dag import (
     ConversationalNonBinaryJudgementNode,
     ConversationalVerdictNode,
 )
-from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics.conversational_g_eval.conversational_g_eval import (
+    ConversationalGEvalTemplate,
+)
+from deepeval.metrics.g_eval.utils import Rubric
+from deepeval.models import DeepEvalBaseLLM, OllamaModel
 from deepeval.test_case import ConversationalTestCase, MultiTurnParams, Turn
 from deepeval.metrics.dag.utils import (
     is_valid_dag_from_roots,
@@ -620,3 +624,178 @@ class TestConversationalExclusiveVerdictSharedNode:
         metric.measure(self._conversation(), _show_indicator=False)
         assert metric.score == 1.0
         assert model.schema_calls.count("NonBinaryJudgementVerdict") == 1
+
+
+CONVERSATIONAL_LEAF_RUBRIC = [
+    Rubric(score_range=(1, 1), expected_outcome="Rude."),
+    Rubric(score_range=(5, 5), expected_outcome="Excellent."),
+]
+
+
+class ConversationalGEvalLeafTemplate(ConversationalGEvalTemplate):
+    """Marker template, only here to be recognised on the copied leaf."""
+
+
+class ConversationalGEvalLeafModel(DeepEvalBaseLLM):
+    """Deterministic judge that scores on the rubric it was shown.
+
+    ``ConversationalGEval`` has no ``score_range``, always divides by 10,
+    and asks for a 0-to-10 score whether or not there is a rubric. The
+    rubric only adds or removes the Rubric block in the prompt, so it can
+    move the score only by moving the judge: this one answers 5 when it is
+    shown the 1-to-5 rubric and 10 when it is not.
+    """
+
+    def __init__(self, name: str = "conversational-geval-leaf-model"):
+        self.schema_calls = []
+        super().__init__(model=name)
+
+    def load_model(self):
+        return self
+
+    def generate(self, prompt, schema=None, **kwargs):
+        assert schema is not None
+        self.schema_calls.append(schema.__name__)
+
+        if schema.__name__ == "BinaryJudgementVerdict":
+            return schema(verdict=True, reason="mocked")
+        if schema.__name__ == "ReasonScore":
+            saw_rubric = "Excellent." in prompt
+            return schema(score=5 if saw_rubric else 10, reason="mocked")
+
+        raise AssertionError(f"Unexpected schema: {schema.__name__}")
+
+    async def a_generate(self, prompt, schema=None, **kwargs):
+        await asyncio.sleep(0)
+        return self.generate(prompt, schema=schema, **kwargs)
+
+    def get_model_name(self):
+        return self.name
+
+
+def build_conversational_geval_leaf(
+    model: DeepEvalBaseLLM, **kwargs
+) -> ConversationalGEval:
+    return ConversationalGEval(
+        name="Tone",
+        evaluation_params=[MultiTurnParams.CONTENT],
+        evaluation_steps=["Score the tone against the rubric."],
+        rubric=CONVERSATIONAL_LEAF_RUBRIC,
+        model=model,
+        **kwargs,
+    )
+
+
+class TestConversationalGEvalLeaf:
+    """A ConversationalGEval leaf must keep its own configuration."""
+
+    @staticmethod
+    def _conversation() -> ConversationalTestCase:
+        return ConversationalTestCase(
+            turns=[
+                Turn(role="user", content="Can you help me?"),
+                Turn(role="assistant", content="Of course, happy to help."),
+            ],
+        )
+
+    @staticmethod
+    def _build_metric(
+        leaf: ConversationalGEval, model, async_mode: bool
+    ) -> ConversationalDAGMetric:
+        judge = ConversationalBinaryJudgementNode(
+            criteria="Did the assistant reply at all?",
+            evaluation_params=[MultiTurnParams.CONTENT],
+        )
+        judge.add_verdict(True, then=leaf)
+        judge.add_verdict(False, score=0)
+        return ConversationalDAGMetric(
+            name="Tone",
+            dag=DeepAcyclicGraph(root_nodes=[judge]),
+            model=model,
+            include_reason=False,
+            async_mode=async_mode,
+        )
+
+    @classmethod
+    def _copy_leaf(
+        cls, leaf: ConversationalGEval, dag_model
+    ) -> ConversationalGEval:
+        metric = cls._build_metric(leaf, dag_model, async_mode=False)
+        verdict_node = next(
+            child
+            for child in metric.dag.root_nodes[0].children
+            if child.verdict is True
+        )
+        return verdict_node._build_child_metric(metric)
+
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_rubric_scores_the_same_inside_the_dag(self, async_mode):
+        """The rubric reaches the judge standalone, so it must in the DAG."""
+        standalone = build_conversational_geval_leaf(
+            ConversationalGEvalLeafModel(), async_mode=async_mode
+        )
+        standalone_score = standalone.measure(
+            self._conversation(), _show_indicator=False
+        )
+        assert standalone_score == 0.5
+
+        model = ConversationalGEvalLeafModel()
+        metric = self._build_metric(
+            build_conversational_geval_leaf(model, async_mode=async_mode),
+            model,
+            async_mode=async_mode,
+        )
+        dag_score = metric.measure(self._conversation(), _show_indicator=False)
+
+        assert dag_score == standalone_score
+
+    def test_child_metric_keeps_its_own_settings_and_the_dag_judge(self):
+        """Only the judge is the DAG's; the rest belongs to the leaf."""
+        dag_model = ConversationalGEvalLeafModel("dag-judge")
+        # OllamaModel is a native model this repo builds without an API
+        # key, which is what makes 'using_native_model' differ between the
+        # leaf and the DAG's judge.
+        leaf = build_conversational_geval_leaf(
+            OllamaModel(model="llama3"),
+            strict_mode=True,
+            top_logprobs=5,
+            async_mode=False,
+            flaky=True,
+            verbose_mode=True,
+            _include_g_eval_suffix=False,
+            evaluation_template=ConversationalGEvalLeafTemplate,
+        )
+        assert leaf.using_native_model is True
+
+        copied = self._copy_leaf(leaf, dag_model)
+
+        assert copied.rubric == CONVERSATIONAL_LEAF_RUBRIC
+        assert copied.strict_mode is True
+        assert copied.top_logprobs == 5
+        assert copied.async_mode is False
+        assert copied.flaky is True
+        assert copied._include_g_eval_suffix is False
+        assert copied.evaluation_template is ConversationalGEvalLeafTemplate
+        # The leaf asked to be verbose; the DAG silences it on purpose.
+        assert copied.verbose_mode is False
+        # The DAG's judge replaces the leaf's own model and 'using_native_model'
+        # is re-derived from it. Overriding an *explicit* model is a known
+        # defect that this fix deliberately leaves alone, not behaviour worth
+        # wanting; the assertions stay because they are the only thing pinning
+        # the injection a leaf without a model of its own depends on.
+        assert copied.model is dag_model
+        assert copied.evaluation_model == "dag-judge"
+        assert copied.using_native_model is False
+
+    def test_child_metric_keeps_a_threshold_strict_mode_did_not_set(self):
+        """'threshold' has to survive the copy on its own, not via strict_mode."""
+        leaf = build_conversational_geval_leaf(
+            ConversationalGEvalLeafModel("leaf-judge"), threshold=0.9
+        )
+
+        copied = self._copy_leaf(
+            leaf, ConversationalGEvalLeafModel("dag-judge")
+        )
+
+        assert copied.strict_mode is False
+        assert copied.threshold == 0.9

--- a/tests/test_metrics/test_conversational_dag.py
+++ b/tests/test_metrics/test_conversational_dag.py
@@ -18,7 +18,7 @@ from deepeval.metrics.conversational_g_eval.conversational_g_eval import (
     ConversationalGEvalTemplate,
 )
 from deepeval.metrics.g_eval.utils import Rubric
-from deepeval.models import DeepEvalBaseLLM, OllamaModel
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import ConversationalTestCase, MultiTurnParams, Turn
 from deepeval.metrics.dag.utils import (
     is_valid_dag_from_roots,
@@ -368,7 +368,6 @@ class TestConversationalDeepAcyclicGraph:
 
 
 class TestConversationalTopDownBuilder:
-
     def test_top_down_build_emits_no_deprecation_warning(self):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -487,7 +486,6 @@ class TestConversationalTopDownBuilder:
 
 @requires_openai
 class TestConversationalDAGMetric:
-
     @staticmethod
     def _build_dag() -> DeepAcyclicGraph:
         summary = ConversationalTaskNode(
@@ -752,11 +750,8 @@ class TestConversationalGEvalLeaf:
     def test_child_metric_keeps_its_own_settings_and_the_dag_judge(self):
         """Only the judge is the DAG's; the rest belongs to the leaf."""
         dag_model = ConversationalGEvalLeafModel("dag-judge")
-        # OllamaModel is a native model this repo builds without an API
-        # key, which is what makes 'using_native_model' differ between the
-        # leaf and the DAG's judge.
         leaf = build_conversational_geval_leaf(
-            OllamaModel(model="llama3"),
+            ConversationalGEvalLeafModel("leaf-judge"),
             strict_mode=True,
             top_logprobs=5,
             async_mode=False,
@@ -765,7 +760,10 @@ class TestConversationalGEvalLeaf:
             _include_g_eval_suffix=False,
             evaluation_template=ConversationalGEvalLeafTemplate,
         )
-        assert leaf.using_native_model is True
+        # A custom judge is never native, so flip the flag by hand to stand in for
+        # a leaf that carries a native one. Building a real native model here would
+        # drag in an optional provider package that CI does not install.
+        leaf.using_native_model = True
 
         copied = self._copy_leaf(leaf, dag_model)
 

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -4,7 +4,7 @@ import warnings
 
 import pytest
 from deepeval import evaluate
-from deepeval.metrics import DAGMetric
+from deepeval.metrics import DAGMetric, GEval
 from deepeval.metrics.dag import (
     TaskNode,
     BinaryJudgementNode,
@@ -12,7 +12,9 @@ from deepeval.metrics.dag import (
     VerdictNode,
     DeepAcyclicGraph,
 )
-from deepeval.models import DeepEvalBaseLLM
+from deepeval.metrics.g_eval.g_eval import GEvalTemplate
+from deepeval.metrics.g_eval.utils import Rubric
+from deepeval.models import DeepEvalBaseLLM, OllamaModel
 from deepeval.test_case import LLMTestCase, SingleTurnParams
 from deepeval.metrics.dag.utils import (
     is_valid_dag_from_roots,
@@ -1099,6 +1101,168 @@ class TestCrossJudgementSharedNode:
             build_direct_and_tasknode_shared_dag(), model, async_mode=False
         )
         assert model.schema_calls.count("NonBinaryJudgementVerdict") == 0
+
+
+GEVAL_LEAF_RUBRIC = [
+    Rubric(score_range=(1, 1), expected_outcome="Unusable."),
+    Rubric(score_range=(5, 5), expected_outcome="Excellent."),
+]
+
+
+class GEvalLeafTemplate(GEvalTemplate):
+    """Marker template, only here to be recognised on the copied leaf."""
+
+
+class GEvalLeafModel(DeepEvalBaseLLM):
+    """Deterministic judge: top verdict, and a raw score of 5 either way.
+
+    ``score_range`` is both the range the prompt asks for and the divisor
+    ``GEval`` applies afterwards, so a judge that tracked the requested
+    range would cancel the two effects out. This one answers 5 whatever
+    range it is asked for, which is what makes a dropped rubric visible
+    as a score.
+    """
+
+    def __init__(self, name: str = "geval-leaf-model"):
+        self.schema_calls = []
+        super().__init__(model=name)
+
+    def load_model(self):
+        return self
+
+    def generate(self, prompt, schema=None, **kwargs):
+        assert schema is not None
+        self.schema_calls.append(schema.__name__)
+
+        if schema.__name__ == "BinaryJudgementVerdict":
+            return schema(verdict=True, reason="mocked")
+        if schema.__name__ == "ReasonScore":
+            return schema(score=5, reason="mocked")
+
+        raise AssertionError(f"Unexpected schema: {schema.__name__}")
+
+    async def a_generate(self, prompt, schema=None, **kwargs):
+        await asyncio.sleep(0)
+        return self.generate(prompt, schema=schema, **kwargs)
+
+    def get_model_name(self):
+        return self.name
+
+
+def build_geval_leaf(model: DeepEvalBaseLLM, **kwargs) -> GEval:
+    return GEval(
+        name="Writing Quality",
+        evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        evaluation_steps=["Score the writing against the rubric."],
+        rubric=GEVAL_LEAF_RUBRIC,
+        model=model,
+        **kwargs,
+    )
+
+
+class TestGEvalLeaf:
+    """A GEval leaf must keep the configuration it was built with."""
+
+    @staticmethod
+    def _test_case() -> LLMTestCase:
+        return LLMTestCase(
+            input="Write a paragraph.",
+            actual_output="A well written paragraph.",
+        )
+
+    @staticmethod
+    def _build_metric(leaf: GEval, model, async_mode: bool) -> DAGMetric:
+        judge = BinaryJudgementNode(
+            criteria="Is the output non-empty?",
+            evaluation_params=[SingleTurnParams.ACTUAL_OUTPUT],
+        )
+        judge.add_verdict(True, then=leaf)
+        judge.add_verdict(False, score=0)
+        return DAGMetric(
+            name="Writing Quality",
+            dag=DeepAcyclicGraph(root_nodes=[judge]),
+            model=model,
+            include_reason=False,
+            async_mode=async_mode,
+        )
+
+    @classmethod
+    def _copy_leaf(cls, leaf: GEval, dag_model) -> GEval:
+        metric = cls._build_metric(leaf, dag_model, async_mode=False)
+        verdict_node = next(
+            child
+            for child in metric.dag.root_nodes[0].children
+            if child.verdict is True
+        )
+        return verdict_node._build_child_metric(metric)
+
+    @pytest.mark.parametrize("async_mode", [False, True])
+    def test_rubric_scores_the_same_inside_the_dag(self, async_mode):
+        """A rubric that moves the standalone score must move the DAG's."""
+        standalone = build_geval_leaf(GEvalLeafModel(), async_mode=async_mode)
+        standalone_score = standalone.measure(
+            self._test_case(), _show_indicator=False
+        )
+        assert standalone.score_range == (1, 5)
+        assert standalone_score == 1.0
+
+        model = GEvalLeafModel()
+        metric = self._build_metric(
+            build_geval_leaf(model, async_mode=async_mode),
+            model,
+            async_mode=async_mode,
+        )
+        dag_score = metric.measure(self._test_case(), _show_indicator=False)
+
+        assert dag_score == standalone_score
+
+    def test_child_metric_keeps_its_own_settings_and_the_dag_judge(self):
+        """Only the judge is the DAG's; the rest belongs to the leaf."""
+        dag_model = GEvalLeafModel("dag-judge")
+        # OllamaModel is a native model this repo builds without an API
+        # key, which is what makes 'using_native_model' differ between the
+        # leaf and the DAG's judge.
+        leaf = build_geval_leaf(
+            OllamaModel(model="llama3"),
+            strict_mode=True,
+            top_logprobs=5,
+            async_mode=False,
+            flaky=True,
+            verbose_mode=True,
+            _include_g_eval_suffix=False,
+            evaluation_template=GEvalLeafTemplate,
+        )
+        assert leaf.using_native_model is True
+
+        copied = self._copy_leaf(leaf, dag_model)
+
+        assert copied.rubric == GEVAL_LEAF_RUBRIC
+        assert copied.score_range == (1, 5)
+        assert copied.strict_mode is True
+        assert copied.top_logprobs == 5
+        assert copied.async_mode is False
+        assert copied.flaky is True
+        assert copied._include_g_eval_suffix is False
+        assert copied.evaluation_template is GEvalLeafTemplate
+        # The leaf asked to be verbose; the DAG silences it on purpose.
+        assert copied.verbose_mode is False
+        # The DAG's judge replaces the leaf's own model and 'using_native_model'
+        # is re-derived from it. Overriding an *explicit* model is a known
+        # defect that this fix deliberately leaves alone, not behaviour worth
+        # wanting; the assertions stay because they are the only thing pinning
+        # the injection a leaf without a model of its own depends on.
+        assert copied.model is dag_model
+        assert copied.evaluation_model == "dag-judge"
+        assert copied.using_native_model is False
+
+    def test_child_metric_keeps_a_threshold_strict_mode_did_not_set(self):
+        """'threshold' has to survive the copy on its own, not via strict_mode."""
+        leaf = build_geval_leaf(GEvalLeafModel("leaf-judge"), threshold=0.9)
+
+        copied = self._copy_leaf(leaf, GEvalLeafModel("dag-judge"))
+
+        assert copied.strict_mode is False
+        assert copied.threshold == 0.9
 
 
 @requires_openai

--- a/tests/test_metrics/test_dag.py
+++ b/tests/test_metrics/test_dag.py
@@ -14,7 +14,7 @@ from deepeval.metrics.dag import (
 )
 from deepeval.metrics.g_eval.g_eval import GEvalTemplate
 from deepeval.metrics.g_eval.utils import Rubric
-from deepeval.models import DeepEvalBaseLLM, OllamaModel
+from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import LLMTestCase, SingleTurnParams
 from deepeval.metrics.dag.utils import (
     is_valid_dag_from_roots,
@@ -486,7 +486,6 @@ class TestDeepAcyclicGraph:
 
 
 class TestTopDownBuilder:
-
     def test_top_down_build_emits_no_deprecation_warning(self):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -1219,11 +1218,8 @@ class TestGEvalLeaf:
     def test_child_metric_keeps_its_own_settings_and_the_dag_judge(self):
         """Only the judge is the DAG's; the rest belongs to the leaf."""
         dag_model = GEvalLeafModel("dag-judge")
-        # OllamaModel is a native model this repo builds without an API
-        # key, which is what makes 'using_native_model' differ between the
-        # leaf and the DAG's judge.
         leaf = build_geval_leaf(
-            OllamaModel(model="llama3"),
+            GEvalLeafModel("leaf-judge"),
             strict_mode=True,
             top_logprobs=5,
             async_mode=False,
@@ -1232,7 +1228,10 @@ class TestGEvalLeaf:
             _include_g_eval_suffix=False,
             evaluation_template=GEvalLeafTemplate,
         )
-        assert leaf.using_native_model is True
+        # A custom judge is never native, so flip the flag by hand to stand in for
+        # a leaf that carries a native one. Building a real native model here would
+        # drag in an optional provider package that CI does not install.
+        leaf.using_native_model = True
 
         copied = self._copy_leaf(leaf, dag_model)
 
@@ -1267,7 +1266,6 @@ class TestGEvalLeaf:
 
 @requires_openai
 class TestDAGMetric:
-
     @staticmethod
     def _build_dag() -> DeepAcyclicGraph:
         extract = TaskNode(


### PR DESCRIPTION
`VerdictNode._build_child_metric` and `ConversationalVerdictNode._build_child_metric` special-cased a
`GEval` child and rebuilt it from a hand-picked argument dict instead of copying it:

```python
def _build_child_metric(self, metric: BaseMetric):
    if isinstance(self.child, GEval):
        args = {
            "name": self.child.name,
            "evaluation_params": self.child.evaluation_params,
            "model": metric.model,
            "verbose_mode": False,
        }
        ...
        return GEval(**args)
    copied = copy_metrics([self.child])[0]      # the correct path, already on the next line
```

Seven constructor arguments never reached the metric that ran: `rubric`, `strict_mode`, `top_logprobs`,
`evaluation_template`, `async_mode`, `flaky` and `_include_g_eval_suffix`. Silently, with no warning.

Two other places in this package already copy a `GEval` child by enumerating every `__init__` parameter
(`dag/utils.py:copy_graph` and `dag/serialization/serialization.py:_serialize_geval`), so the hand-picked
list was the only one left.

### Why it matters downstream

`rubric` is not cosmetic. `GEval.__init__` derives `score_range` from it, and `score_range` is used twice:
interpolated into the prompt as the range to answer in (`g_eval.py:297`, `:369`, and the template at
`generate_evaluation_results.txt:3`), and then as the divisor (`g_eval.py:154-155`).

**The score effect is conditional on the judge, not guaranteed.** A judge that honours the requested range
cancels the two uses out. A judge that does not diverges by the ratio of `(raw-lo)/(hi-lo)` to `raw/10`,
which on a 1-to-5 rubric is 1.25x at raw 2, 1.67x at raw 3, and exactly 2x only at raw 5. On the multi-turn
path there is no `score_range` at all: `ConversationalGEval` always divides by 10 and always asks for 0 to
10, so the rubric moves the score only by moving the judge.

`strict_mode=True` on a leaf was ignored entirely, which is the plainer loss.

`threshold` is an eighth argument the old dict dropped, and the fix restores it, but it belongs in the
copy-fidelity column rather than this one. A leaf's own threshold never reaches the DAG outcome: the runner
propagates the leaf through `child_metric.score` (`runner.py:76`), never `is_successful()`, and the only
`is_successful()` calls in the package are the DAG metric's own (`dag.py:94`, `:132`) against the DAG's
threshold. So restoring it changes what a copied leaf reports about itself, not the number the DAG returns.
Naming it because its absence from the list above otherwise reads as an oversight rather than a decision.

### Behaviour changes

1. Restoring `strict_mode` changes scores. Single-turn now takes the strict prompt; multi-turn collapses to
   0 unless the judge answers 10, because `conversational_g_eval.py:140-144` zeroes any score under a
   threshold that `strict_mode` pins to 1.
2. A `GEval` subclass leaf is now preserved. The old code hard-coded `GEval(**args)` and downgraded it.
3. A leaf whose `evaluation_steps` is already populated, however it got there, no longer regenerates steps
   per run. One fewer model call.

### Known defect deliberately not fixed

A leaf given an explicit `model` still has it overridden by the DAG's judge. That cannot be fixed here:
`GEval.__init__` collapses "the user gave me a model" and "I defaulted" into the same attribute, so telling
them apart needs GEval to record provenance. `TODO` added in both modules, and the test that pins the
override says inline that it documents a defect rather than intent.

### Tests

Eight added across the two test files. `grep -c rubric` was 0 in both before this. They use the keyless
`DeepEvalBaseLLM` judges the files already establish, cover sync and async, and reach the node through
`metric.dag.root_nodes[0].children` so the rubric is proven to survive `copy_graph` too.

The DAG suites go 98 to 106 passed (6 skipped, 6 xfailed unchanged). `tests/test_metrics/` 179 to 187.
`tests/test_core/` unchanged at 1566 passed, 35 skipped. `black --check` clean on all four touched files.

Both previously-vacuous assertions were re-pinned and then mutation-tested: deleting `copied.verbose_mode =
False` now fails the assertion (it passed before, because the leaf was already `False`), and removing
`threshold` from the copy's parameters now fails too (the old `== 1` was entailed by `strict_mode is True`).

**The red `black` check is pre-existing on `main`**, on `deepeval/dataset/golden.py` and
`deepeval/test_case/llm_test_case.py`. Neither is in this diff, and four open pull requests exist only to
fix them.

### Overlap with in-flight work

#2675, #2446 and #2240 all touch `dag/nodes.py` and all predate the commit that created
`_build_child_metric`, so they need a rebase independently of this. Measured with `git apply --check`, only
#2446 gains anything from this change: one extra line in an import block that already conflicts. #2675 is
complementary rather than competing, since `evaluation_template` is one of the arguments the special case
dropped, so after this a leaf's template actually reaches the metric. Happy to rebase around whichever of
these you want to land first.