### PR TITLE
fix: count each answer once in truth_identification_score

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -412,13 +412,12 @@ class Scorer:
             if not target_list:
                 return 0  # Return 0 if target list is empty to avoid division by zero
 
-            # Count the number of correct matches
-            correct_matches = sum(
-                1 for item in prediction_list if item in target_list
-            )
+            # Count each answer once, so a repeated index cannot score above 100
+            target_answers = set(target_list)
+            correct_matches = len(target_answers & set(prediction_list))
 
             # Calculate percentage
-            score_percentage = (correct_matches / len(target_list)) * 100
+            score_percentage = (correct_matches / len(target_answers)) * 100
 
             return round(score_percentage)  # Return rounded percentage
         except Exception as e:

--- a/tests/test_benchmarks/test_benchmark_answer_scoring.py
+++ b/tests/test_benchmarks/test_benchmark_answer_scoring.py
@@ -101,3 +101,22 @@ def test_bbh_batch_predict_scores_schema_answer_correctly(enable_cot):
     # schema answer, turning "(A)" into "(A)" -> "(A" and scoring it 0.
     assert result[0]["prediction"] == "(A)"
     assert result[0]["score"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# TruthfulQA MC2: a repeated index must not push the score above 100
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "target,prediction,expected",
+    [
+        ("1,2", "1,1,1,2", 100),
+        ("1,3,4", "[1, 1, 3, 4]", 100),
+        ("1,1,2", "1,2", 100),
+        ("1,2", "1", 50),
+        ("1,2", "3", 0),
+    ],
+)
+def test_truth_identification_score_counts_each_answer_once(
+    target, prediction, expected
+):
+    assert Scorer.truth_identification_score(target, prediction) == expected


### PR DESCRIPTION
Fixes #3210. `truth_identification_score` counts each answer once, so repeated indices no longer score above 100.
