### PR TITLE
fix(benchmarks): validate the lower bound of n_problems and n_shots

### DIFF
--- a/deepeval/benchmarks/arc/arc.py
+++ b/deepeval/benchmarks/arc/arc.py
@@ -10,6 +10,7 @@ from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.arc.mode import ARCMode
 from deepeval.benchmarks.arc.template import ARCTemplate
 from deepeval.benchmarks.schema import MultipleChoiceSchema
+from deepeval.benchmarks.utils import validate_n_problems, validate_n_shots
 from deepeval.telemetry import capture_benchmark_run
 
 
@@ -26,21 +27,21 @@ class ARC(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "ARC only supports n_shots <= 5"
+        n_shots = validate_n_shots(n_shots, 5, "ARC")
         super().__init__(**kwargs)
         self.mode: ARCMode = mode
         self.scorer = Scorer()
         self.n_shots: int = n_shots
         if mode == ARCMode.EASY:
-            self.n_problems: int = 2376 if n_problems is None else n_problems
-            assert (
-                self.n_problems <= 2376
-            ), "ARC-Easy only supports n_problems <= 2376"
+            self.n_problems: int = validate_n_problems(
+                2376 if n_problems is None else n_problems, 2376, "ARC-Easy"
+            )
         else:
-            self.n_problems: int = 1172 if n_problems is None else n_problems
-            assert (
-                self.n_problems <= 1172
-            ), "ARC-Challenge only supports n_problems <= 1172"
+            self.n_problems: int = validate_n_problems(
+                1172 if n_problems is None else n_problems,
+                1172,
+                "ARC-Challenge",
+            )
         self.predictions: Optional[pd.DataFrame] = None
         self.overall_score: Optional[float] = None
         self.verbose_mode = verbose_mode

--- a/deepeval/benchmarks/bool_q/bool_q.py
+++ b/deepeval/benchmarks/bool_q/bool_q.py
@@ -9,6 +9,7 @@ from deepeval.benchmarks.base_benchmark import (
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.bool_q.template import BoolQTemplate
 from deepeval.benchmarks.schema import AffirmationSchema
+from deepeval.benchmarks.utils import validate_n_problems, validate_n_shots
 from deepeval.telemetry import capture_benchmark_run
 
 
@@ -24,8 +25,8 @@ class BoolQ(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "BoolQ only supports n_shots <= 5"
-        assert n_problems <= 3270, "BoolQ only supports n_problems <= 3270"
+        n_shots = validate_n_shots(n_shots, 5, "BoolQ")
+        n_problems = validate_n_problems(n_problems, 3270, "BoolQ")
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.n_shots: int = n_shots

--- a/deepeval/benchmarks/gsm8k/gsm8k.py
+++ b/deepeval/benchmarks/gsm8k/gsm8k.py
@@ -9,6 +9,7 @@ from deepeval.benchmarks.base_benchmark import (
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.gsm8k.template import GSM8KTemplate
 from deepeval.benchmarks.schema import NumberSchema
+from deepeval.benchmarks.utils import validate_n_problems, validate_n_shots
 from deepeval.telemetry import capture_benchmark_run
 
 
@@ -25,7 +26,8 @@ class GSM8K(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 15, "GSM8K only supports n_shots <= 15"
+        n_shots = validate_n_shots(n_shots, 15, "GSM8K")
+        n_problems = validate_n_problems(n_problems, 1319, "GSM8K")
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.shots_dataset: List[Dict] = None

--- a/deepeval/benchmarks/lambada/lambada.py
+++ b/deepeval/benchmarks/lambada/lambada.py
@@ -9,6 +9,7 @@ from deepeval.benchmarks.base_benchmark import (
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.benchmarks.lambada.template import LAMBADATemplate
 from deepeval.benchmarks.schema import StringSchema
+from deepeval.benchmarks.utils import validate_n_problems, validate_n_shots
 from deepeval.telemetry import capture_benchmark_run
 
 
@@ -24,8 +25,8 @@ class LAMBADA(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "LAMBADA only supports n_shots <= 5"
-        assert n_problems <= 5153, "LAMBADA only supports n_problems <= 5153"
+        n_shots = validate_n_shots(n_shots, 5, "LAMBADA")
+        n_problems = validate_n_problems(n_problems, 5153, "LAMBADA")
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.n_shots: int = n_shots

--- a/deepeval/benchmarks/utils.py
+++ b/deepeval/benchmarks/utils.py
@@ -3,6 +3,59 @@ from typing import Optional
 from deepeval.models import DeepEvalBaseLLM
 
 
+def validate_n_problems(n_problems: int, maximum: int, benchmark: str) -> int:
+    """Validate a benchmark's ``n_problems`` against its full lower/upper range.
+
+    ``n_problems`` reaches the evaluation loop twice: it slices the goldens
+    (``goldens[: n_problems]``) and it is the denominator of the reported
+    accuracy. A non-positive value is accepted by an upper-bound-only check but
+    corrupts both, so reject it here rather than let it through:
+
+    - ``0`` slices to an empty list and makes the accuracy a ZeroDivisionError.
+    - a negative value slices *from the end* -- ``n_problems=-5`` runs all but
+      the last 5 problems, so nearly the whole benchmark -- and then divides by
+      the negative value, reporting a negative accuracy.
+    """
+    if not isinstance(n_problems, int) or isinstance(n_problems, bool):
+        raise TypeError(
+            f"{benchmark} n_problems must be an int, got "
+            f"{type(n_problems).__name__}."
+        )
+    if n_problems < 1:
+        raise ValueError(
+            f"{benchmark} n_problems must be >= 1, got {n_problems}."
+        )
+    if n_problems > maximum:
+        raise ValueError(
+            f"{benchmark} only supports n_problems <= {maximum}, got "
+            f"{n_problems}."
+        )
+    return n_problems
+
+
+def validate_n_shots(n_shots: int, maximum: int, benchmark: str) -> int:
+    """Validate a benchmark's ``n_shots`` against its full lower/upper range.
+
+    ``n_shots`` selects how many few-shot examples are prepended to each
+    prompt. A negative value is accepted by an upper-bound-only check and then
+    silently slices the example pool from the end, so the prompt is built from
+    a different number of examples than requested and the run is not the
+    n-shot configuration it is reported as.
+    """
+    if not isinstance(n_shots, int) or isinstance(n_shots, bool):
+        raise TypeError(
+            f"{benchmark} n_shots must be an int, got "
+            f"{type(n_shots).__name__}."
+        )
+    if n_shots < 0:
+        raise ValueError(f"{benchmark} n_shots must be >= 0, got {n_shots}.")
+    if n_shots > maximum:
+        raise ValueError(
+            f"{benchmark} only supports n_shots <= {maximum}, got {n_shots}."
+        )
+    return n_shots
+
+
 def should_use_batch(model: DeepEvalBaseLLM, batch_size: Optional[int] = None):
     if batch_size is None:
         return False

--- a/tests/test_benchmarks/test_benchmark_param_validation.py
+++ b/tests/test_benchmarks/test_benchmark_param_validation.py
@@ -1,0 +1,134 @@
+"""
+Regression tests for benchmark ``n_problems`` / ``n_shots`` validation.
+
+The bounds checks on these two parameters used to be upper-bound only, so a
+non-positive value was accepted silently and then corrupted the run rather than
+failing. They are offline: no model, network, dataset download, or API key
+required.
+"""
+
+import pytest
+
+from deepeval.benchmarks.arc.arc import ARC
+from deepeval.benchmarks.arc.mode import ARCMode
+from deepeval.benchmarks.bool_q.bool_q import BoolQ
+from deepeval.benchmarks.gsm8k.gsm8k import GSM8K
+from deepeval.benchmarks.lambada.lambada import LAMBADA
+
+# (class, kwargs building a valid instance, full-size n_problems)
+BENCHMARKS = [
+    (BoolQ, {}, 3270),
+    (LAMBADA, {}, 5153),
+    (GSM8K, {}, 1319),
+    (ARC, {"mode": ARCMode.EASY}, 2376),
+]
+
+IDS = [b[0].__name__ for b in BENCHMARKS]
+
+
+# --------------------------------------------------------------------------- #
+# Why a non-positive n_problems is not merely an odd argument
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("n_problems", [0, -1, -5])
+def test_non_positive_n_problems_would_corrupt_scoring(n_problems):
+    # evaluate() does `goldens[: self.n_problems]` and then divides by
+    # `self.n_problems`. This pins down what those two lines do for a value an
+    # upper-bound-only check lets through, and is the reason the guard rejects
+    # it instead of passing it on.
+    goldens = list(range(3270))
+    selected = goldens[:n_problems]
+
+    if n_problems == 0:
+        assert selected == []
+        with pytest.raises(ZeroDivisionError):
+            _ = 3 / n_problems
+    else:
+        # Negative slices from the end: nearly the whole benchmark still runs,
+        # burning the API budget the small n_problems was meant to cap...
+        assert len(selected) == 3270 + n_problems
+        assert len(selected) > 3000
+        # ...and the reported accuracy comes out negative.
+        assert 3 / n_problems < 0
+
+
+# --------------------------------------------------------------------------- #
+# n_problems
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("benchmark,kwargs,full_size", BENCHMARKS, ids=IDS)
+@pytest.mark.parametrize("n_problems", [0, -1, -5])
+def test_non_positive_n_problems_is_rejected(
+    benchmark, kwargs, full_size, n_problems
+):
+    with pytest.raises(ValueError, match="n_problems must be >= 1"):
+        benchmark(n_problems=n_problems, **kwargs)
+
+
+@pytest.mark.parametrize("benchmark,kwargs,full_size", BENCHMARKS, ids=IDS)
+def test_n_problems_above_maximum_is_rejected(benchmark, kwargs, full_size):
+    with pytest.raises(ValueError, match="n_problems"):
+        benchmark(n_problems=full_size + 1, **kwargs)
+
+
+@pytest.mark.parametrize("benchmark,kwargs,full_size", BENCHMARKS, ids=IDS)
+def test_n_problems_boundaries_are_accepted(benchmark, kwargs, full_size):
+    # 1 and the full size are both legitimate; the guard must not narrow the
+    # range that already worked.
+    assert benchmark(n_problems=1, **kwargs).n_problems == 1
+    assert benchmark(n_problems=full_size, **kwargs).n_problems == full_size
+
+
+@pytest.mark.parametrize("benchmark,kwargs,full_size", BENCHMARKS, ids=IDS)
+def test_non_int_n_problems_is_rejected(benchmark, kwargs, full_size):
+    # A float silently produces `TypeError: slice indices must be integers`
+    # much later, inside evaluate(); bool is an int subclass and n_problems=True
+    # would mean "1 problem", which is never what the caller meant.
+    with pytest.raises(TypeError, match="n_problems must be an int"):
+        benchmark(n_problems=2.5, **kwargs)
+    with pytest.raises(TypeError, match="n_problems must be an int"):
+        benchmark(n_problems=True, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# n_shots
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("benchmark,kwargs,full_size", BENCHMARKS, ids=IDS)
+@pytest.mark.parametrize("n_shots", [-1, -3])
+def test_negative_n_shots_is_rejected(benchmark, kwargs, full_size, n_shots):
+    with pytest.raises(ValueError, match="n_shots must be >= 0"):
+        benchmark(n_shots=n_shots, **kwargs)
+
+
+@pytest.mark.parametrize("benchmark,kwargs,full_size", BENCHMARKS, ids=IDS)
+def test_zero_n_shots_is_accepted(benchmark, kwargs, full_size):
+    # 0 is a real configuration -- zero-shot -- and must stay allowed.
+    assert benchmark(n_shots=0, **kwargs).n_shots == 0
+
+
+@pytest.mark.parametrize("benchmark,kwargs,full_size", BENCHMARKS, ids=IDS)
+def test_n_shots_above_maximum_is_rejected(benchmark, kwargs, full_size):
+    with pytest.raises(ValueError, match="n_shots"):
+        benchmark(n_shots=99, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# ARC picks its n_problems ceiling from the mode
+# --------------------------------------------------------------------------- #
+
+
+def test_arc_challenge_uses_its_own_smaller_maximum():
+    # ARC-Challenge has 1172 problems, fewer than ARC-Easy's 2376, and the
+    # error message should name the mode that was actually validated.
+    assert ARC(mode=ARCMode.CHALLENGE, n_problems=1172).n_problems == 1172
+    with pytest.raises(ValueError, match="ARC-Challenge"):
+        ARC(mode=ARCMode.CHALLENGE, n_problems=1173)
+
+
+def test_arc_default_n_problems_matches_mode():
+    assert ARC(mode=ARCMode.EASY).n_problems == 2376
+    assert ARC(mode=ARCMode.CHALLENGE).n_problems == 1172


### PR DESCRIPTION
## Problem

The bounds checks on `n_problems` and `n_shots` are upper-bound only, so a
non-positive value passes straight through:

```python
BoolQ(n_problems=0)   # accepted
BoolQ(n_problems=-5)  # accepted
BoolQ(n_shots=-1)     # accepted
GSM8K(n_problems=-5)  # accepted (GSM8K has no n_problems check at all)
```

Verified on `main` — all twelve combinations across ARC / BoolQ / GSM8K / LAMBADA
were accepted, e.g. `BoolQ(n_problems=-5).n_problems == -5`.

Neither value is guarded downstream. `n_problems` both slices the goldens *and*
is the denominator of the reported accuracy (`bool_q.py`):

```python
goldens = self.load_benchmark_dataset()[: self.n_problems]
overall_total_predictions = self.n_problems
...
overall_accuracy = overall_correct_predictions / overall_total_predictions
```

So, reproducing that arithmetic exactly:

| `n_problems` | problems actually run | denominator | reported accuracy |
|---|---|---|---|
| `0` | 0 | 0 | **ZeroDivisionError** |
| `-1` | 3269 | -1 | **-3.0** |
| `-5` | 3265 | -5 | **-0.6** |

A negative value slices from the *end*, so `n_problems=-5` runs 3265 of BoolQ's
3270 problems — practically the whole benchmark, spending the API budget the
small `n_problems` was meant to cap — and then reports a **negative accuracy**.
Neither failure says anything about the argument that caused it.

`n_shots` has the same shape: a negative value silently slices the few-shot
example pool from the end, so the prompt is built from a different number of
examples than the run is reported as using.

## Fix

Adds `validate_n_problems()` and `validate_n_shots()` to `benchmarks/utils.py` —
beside the existing shared `should_use_batch()` helper — and routes ARC, BoolQ,
GSM8K and LAMBADA through them:

```
BoolQ(n_problems=0)   -> ValueError: BoolQ n_problems must be >= 1, got 0.
BoolQ(n_problems=-5)  -> ValueError: BoolQ n_problems must be >= 1, got -5.
BoolQ(n_shots=-1)     -> ValueError: BoolQ n_shots must be >= 0, got -1.
BoolQ(n_shots=0)      -> OK (zero-shot)
BoolQ(n_problems=1)   -> OK
BoolQ(n_problems=3270)-> OK
```

Deliberately preserved:

- **`n_shots=0` stays valid.** Zero-shot is a real configuration, so the floor
  for `n_shots` is 0 while the floor for `n_problems` is 1. A single shared
  "must be positive" helper would have broken it.
- **Existing upper bounds and their per-benchmark limits are unchanged.** ARC
  still takes its ceiling from the mode (2376 Easy / 1172 Challenge) and the
  message names the mode that was actually validated.
- **GSM8K gains the 1319 ceiling** the other benchmarks already had; it
  previously had no `n_problems` check.

Non-int values are also rejected, since they otherwise surface much later as
`slice indices must be integers` from inside `evaluate()`. `bool` is excluded
explicitly because it is an `int` subclass and `n_problems=True` would silently
mean "1 problem".

## Verification

```
$ pytest tests/test_benchmarks/test_benchmark_param_validation.py -q
45 passed

$ pytest tests/test_benchmarks/ -q          # incl. the 13 pre-existing tests
58 passed
```

The new file follows the existing `test_benchmark_answer_scoring.py` — offline,
no model, network, dataset download or API key. One test pins the *downstream
arithmetic* rather than just the raised error, so the reason the guard exists
stays visible if someone revisits the bounds later.

**Rollback proof.** Neutralising only the two new lower-bound branches
(`if n_problems < 1:` / `if n_shots < 0:` → `if False:`) fails exactly the 20
lower-bound tests while the other 25 — upper bounds, boundary values, type
checks, ARC mode ceilings — still pass. So the tests are pinned to this
behaviour and are not over-constrained.

`black --check` clean on all six touched files (repo is `line-length = 80`).

## Notes

- Nine other benchmarks share this pattern (`bbq`, `big_bench_hard`, `drop`,
  `hellaswag`, `logi_qa`, `math_qa`, `mmlu`, `squad`, `winogrande`). I kept this
  PR to the four I verified end to end rather than doing a blind sweep — happy to
  extend it in the same shape if the approach looks right to you.
- `ValueError`/`TypeError` rather than `assert`, so the checks survive `python -O`
  and name the offending value.
