### PR TITLE
fix(agentcore): mirror Strands tool-span GenAI hardening

### DIFF
--- a/deepeval/integrations/agentcore/instrumentator.py
+++ b/deepeval/integrations/agentcore/instrumentator.py
@@ -384,9 +384,11 @@ def _extract_tool_call_from_tool_span(span) -> Optional[ToolCall]:
     try:
         input_params = (
             json.loads(args_raw) if isinstance(args_raw, str) else args_raw
-        )
+        ) or {}
     except Exception:
         input_params = {}
+    if not isinstance(input_params, dict):
+        input_params = {"input": input_params}
 
     return ToolCall(name=tool_name, input_parameters=input_params)
 
@@ -890,13 +892,19 @@ class AgentCoreSpanInterceptor(SpanProcessor):
                         serialize_to_json(tc.input_parameters),
                     )
 
-            if ConfidentAttr.SPAN_OUTPUT not in attrs:
-                raw_output = _get_attr(
-                    span, "traceloop.entity.output", "gen_ai.tool.output"
-                )
-                if raw_output:
+            # Extract tool outputs from genai conventions (best effort)
+            tool_output = output_text or _get_attr(
+                span,
+                "traceloop.entity.output",
+                "gen_ai.tool.output",
+                "gen_ai.tool.call.result",
+            )
+            if tool_output:
+                if tc and tc.output is None:
+                    tc.output = tool_output
+                if ConfidentAttr.SPAN_OUTPUT not in attrs:
                     self._set_attr_post_end(
-                        span, ConfidentAttr.SPAN_OUTPUT, raw_output
+                        span, ConfidentAttr.SPAN_OUTPUT, tool_output
                     )
 
         if tools_called and ConfidentAttr.SPAN_TOOLS_CALLED not in attrs:

--- a/tests/test_integrations/test_agentcore/test_span_interceptor.py
+++ b/tests/test_integrations/test_agentcore/test_span_interceptor.py
@@ -789,7 +789,9 @@ class TestToolSpanGenAiParity:
 
         interceptor._serialize_framework_attrs(span)
 
-        assert span.attributes.get(ConfidentAttr.SPAN_OUTPUT) == '{"status": "ok"}'
+        assert (
+            span.attributes.get(ConfidentAttr.SPAN_OUTPUT) == '{"status": "ok"}'
+        )
         raw = span.attributes.get(ConfidentAttr.SPAN_TOOLS_CALLED)
         assert raw
         first = json.loads(raw[0])

--- a/tests/test_integrations/test_agentcore/test_span_interceptor.py
+++ b/tests/test_integrations/test_agentcore/test_span_interceptor.py
@@ -36,7 +36,9 @@ import pytest
 from deepeval.integrations.agentcore.instrumentator import (
     AgentCoreInstrumentationSettings,
     AgentCoreSpanInterceptor,
+    _extract_tool_call_from_tool_span,
 )
+from deepeval.tracing.otel.attributes import ConfidentAttr
 from deepeval.tracing.context import (
     current_span_context,
     current_trace_context,
@@ -745,3 +747,50 @@ def test_settings_no_api_key_does_not_raise(monkeypatch):
     instance = AgentCoreInstrumentationSettings()
     assert instance is not None
     assert instance.api_key is None
+
+
+# ---------------------------------------------------------------------------
+# Tool-span hardening parity with Strands (symmetric fix for #3103).
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpanGenAiParity:
+    @pytest.mark.parametrize(
+        ("args_raw", "expected"),
+        [
+            ("[1, 2, 3]", {"input": [1, 2, 3]}),
+            ('"just a string"', {"input": "just a string"}),
+            ("null", {}),
+        ],
+    )
+    def test_extract_wraps_non_dict_args(self, args_raw, expected):
+        """Non-dict tool args must not raise; mirrors Strands hardening."""
+
+        class _Span:
+            attributes = {
+                "gen_ai.tool.name": "lookup",
+                "gen_ai.tool.call.arguments": args_raw,
+            }
+
+        tc = _extract_tool_call_from_tool_span(_Span())
+        assert tc is not None
+        assert tc.input_parameters == expected
+
+    def test_tool_span_genai_result_key_sets_output(self):
+        """`gen_ai.tool.call.result` must land on SPAN_OUTPUT + tc.output."""
+        interceptor = AgentCoreSpanInterceptor(_make_settings())
+        span = _make_mock_span(
+            operation_name="execute_tool",
+            tool_name="lookup",
+            span_name="execute_tool lookup",
+        )
+        span.attributes["gen_ai.tool.call.arguments"] = '{"q": 1}'
+        span.attributes["gen_ai.tool.call.result"] = '{"status": "ok"}'
+
+        interceptor._serialize_framework_attrs(span)
+
+        assert span.attributes.get(ConfidentAttr.SPAN_OUTPUT) == '{"status": "ok"}'
+        raw = span.attributes.get(ConfidentAttr.SPAN_TOOLS_CALLED)
+        assert raw
+        first = json.loads(raw[0])
+        assert first["output"] == '{"status": "ok"}'


### PR DESCRIPTION
Fixes #3261

## Root Cause
#3103 hardened only the Strands TOOL path: non-dict `gen_ai.tool.call.arguments` are wrapped to `{"input": ...}` (with `or {}` for null) and TOOL output also checks `gen_ai.tool.call.result` (+ `output_text`) with a `tc.output` write-back. The near-identical sister code in `agentcore/instrumentator.py` (same GenAI conventions, header claims parity) was left behind: list/str args raise `ValidationError` (swallowed by `on_end`, dropping the span's framework attrs), `null` yields `input_parameters=None`, and a TOOL span carrying only `gen_ai.tool.call.result` records neither `SPAN_OUTPUT` nor `tc.output`.

## Fix
Mirror the two Strands hunks into `deepeval/integrations/agentcore/instrumentator.py`:
- `_extract_tool_call_from_tool_span`: `or {}` + non-dict wrap (exact copy of Strands).
- TOOL branch of `_serialize_framework_attrs`: `output_text or _get_attr(..., "traceloop.entity.output", "gen_ai.tool.output", "gen_ai.tool.call.result")` with `tc.output` write-back (exact copy of Strands).
Related open PRs touching the same file (#3039 token counts, #3115 error string, #2690 op names) are disjoint hunks; no overlap with this change.

## Test
- [x] Regression test `tests/test_integrations/test_agentcore/test_span_interceptor.py::TestToolSpanGenAiParity` (4 cases: list/str/null args + result-key output)
- [x] pre-fix FAIL实证 (stashed fix, same interpreter):
  - `'[1, 2, 3]'` -> ValidationError: input_parameters should be a valid dictionary (list); `'"hi"'` -> same (str); `'null'` -> input_parameters=None
  - TOOL span with only `gen_ai.tool.call.result`: SPAN_OUTPUT=None, tools_called[0].output=None
- [x] post-fix PASS: 4 passed; full file 40 passed + 2 pre-existing failures requiring OPENAI_API_KEY (identical 2 fail on unmodified Strands suite, unrelated)
- [x] Strands suite unchanged behavior (40 passed + same 2 pre-existing failures)

## Diff scope
2 files, +57/-7 (core 1 file, +15/-7; test 1 file, +42/-0)