### PR TITLE
feat(pattern_match): add regex=False for literal pattern matching

### DIFF
--- a/deepeval/metrics/pattern_match/pattern_match.py
+++ b/deepeval/metrics/pattern_match/pattern_match.py
@@ -19,20 +19,28 @@ class PatternMatchMetric(BaseMetric):
     def __init__(
         self,
         pattern: str,
+        regex: bool = True,
         ignore_case: bool = False,
         threshold: Optional[float] = 1.0,
         verbose_mode: bool = False,
         flaky: bool = False,
     ):
+        if not isinstance(pattern, str):
+            raise TypeError(
+                f"pattern must be a string, got {type(pattern).__name__}"
+            )
+
         self.pattern = pattern.strip()
+        self.regex = regex
         self.ignore_case = ignore_case
         self.verbose_mode = verbose_mode
         self.flaky = flaky
         self.threshold = threshold
 
         flags = re.IGNORECASE if ignore_case else 0
+        compiled_pattern = self.pattern if regex else re.escape(self.pattern)
         try:
-            self._compiled_pattern = re.compile(self.pattern, flags)
+            self._compiled_pattern = re.compile(compiled_pattern, flags)
         except re.error as e:
             raise ValueError(f"Invalid regex pattern: {pattern} — {e}")
 

--- a/tests/test_metrics/test_pattern_match_regex_option.py
+++ b/tests/test_metrics/test_pattern_match_regex_option.py
@@ -1,0 +1,42 @@
+import pytest
+from deepeval.metrics import PatternMatchMetric
+from deepeval.test_case import LLMTestCase
+
+
+def _test_case(actual_output: str) -> LLMTestCase:
+    return LLMTestCase(input="input", actual_output=actual_output)
+
+
+class TestPatternMatchRegexOption:
+    def test_regex_true_is_default_and_preserves_wildcard_behavior(self):
+        metric = PatternMatchMetric(pattern="a.b")
+        metric.measure(_test_case("acb"))
+        assert metric.score == 1.0
+
+    def test_regex_false_treats_metacharacters_as_literal(self):
+        metric = PatternMatchMetric(pattern="a.b", regex=False)
+        metric.measure(_test_case("acb"))
+        assert metric.score == 0.0
+
+        metric.measure(_test_case("a.b"))
+        assert metric.score == 1.0
+
+    def test_regex_false_matches_literal_strings_with_metacharacters(self):
+        metric = PatternMatchMetric(pattern="C++", regex=False)
+        metric.measure(_test_case("C++"))
+        assert metric.score == 1.0
+
+    def test_non_string_pattern_raises_type_error(self):
+        with pytest.raises(TypeError):
+            PatternMatchMetric(pattern=123)
+
+    def test_regex_false_still_respects_ignore_case(self):
+        metric = PatternMatchMetric(
+            pattern="A.B", regex=False, ignore_case=True
+        )
+        metric.measure(_test_case("a.b"))
+        assert metric.score == 1.0
+
+    def test_regex_true_still_raises_on_invalid_pattern(self):
+        with pytest.raises(ValueError):
+            PatternMatchMetric(pattern="[", regex=True)


### PR DESCRIPTION
Motivation:
PatternMatchMetric always compiled `pattern` as a regular expression.
A user who wants to match a literal string containing regex
metacharacters (e.g. "C++", "1.2.3", "price: $5.00") had to
hand-escape every metacharacter, and an unescaped pattern like "a.b"
would silently match "acb" — a footgun for a metric meant to be a
deterministic, exact check.

Approach:
Add a `regex: bool = True` constructor parameter. When `regex=False`,
the pattern is compiled via `re.escape(pattern)` so metacharacters are
matched literally; `ignore_case` still applies. `regex=True` (the
default) reproduces the exact prior behavior for existing callers —
this is purely additive. Also added a `TypeError` when `pattern` is
not a string.

Validation:
Added tests/test_metrics/test_pattern_match_regex_option.py with 6
offline cases: default regex=True preserves wildcard behavior,
regex=False treats metacharacters literally, regex=False matches
literal strings with metacharacters, non-string pattern raises
TypeError, regex=False + ignore_case still works together, and
regex=True + an invalid pattern still raises ValueError.

Report: https://github.com/confident-ai/deepeval/issues/3198
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)