### PR TITLE
chore: format three TypeScript files to unblock the Ts Lint workflow

### DIFF
--- a/typescript/src/dataset/utils.ts
+++ b/typescript/src/dataset/utils.ts
@@ -520,9 +520,7 @@ export function goldenFromRecord(
       keys.tokenCost ? pickKey(record, keys.tokenCost) : undefined,
     ),
     inputTokenCount: parseOptionalNumber(
-      keys.inputTokenCount
-        ? pickKey(record, keys.inputTokenCount)
-        : undefined,
+      keys.inputTokenCount ? pickKey(record, keys.inputTokenCount) : undefined,
       true,
     ),
     outputTokenCount: parseOptionalNumber(

--- a/typescript/src/evaluate/evaluate.ts
+++ b/typescript/src/evaluate/evaluate.ts
@@ -39,11 +39,7 @@ import {
   type Hyperparameters,
 } from "@/evaluate/hyperparameters";
 import { mapWithConcurrency, shouldUseCache } from "@/env-flags";
-import {
-  Entrypoint,
-  captureEvaluationRun,
-  recordTestCase,
-} from "@/telemetry";
+import { Entrypoint, captureEvaluationRun, recordTestCase } from "@/telemetry";
 import {
   cacheMetricData,
   ensureCacheFlushedOnExit,

--- a/typescript/test/test-integrations/test-openinference/openinference-local-evals.test.ts
+++ b/typescript/test/test-integrations/test-openinference/openinference-local-evals.test.ts
@@ -129,9 +129,7 @@ describe("OpenInference local component evals", () => {
 
     // Bare caller → OTLP, so the attrs are the only carrier.
     expect(span.attributes[ROUTE_TO_REST_ATTRIBUTE]).toBeUndefined();
-    expect(span.attributes["confident.span.prompt_alias"]).toBe(
-      "Test prompt",
-    );
+    expect(span.attributes["confident.span.prompt_alias"]).toBe("Test prompt");
     expect(span.attributes["confident.span.prompt_commit_hash"]).toBe("abc123");
     expect(span.attributes["confident.span.prompt_version"]).toBe("00.00.01");
     expect(span.attributes["confident.span.prompt_label"]).toBe("production");


### PR DESCRIPTION
## What

`Ts Lint Lint Lint` is currently failing on `main`. Its second step —

```
npx prettier --check "src/**/*.ts" "test/**/*.ts"
```

— reports three files:

```
[warn] src/dataset/utils.ts
[warn] src/evaluate/evaluate.ts
[warn] test/test-integrations/test-openinference/openinference-local-evals.test.ts
[warn] Code style issues found in 3 files. Run Prettier with --write to fix.
```

Because the workflow also runs on `pull_request` for `typescript/**`, every PR that
touches the TypeScript package inherits a red check it did not cause.

This runs the repo's own pinned Prettier over exactly those three files.

## Why it's safe

Prettier is pinned **exact** (`"prettier": "3.6.2"` in `devDependencies`, and 3.6.2 in
`package-lock.json`), so this is deterministic rather than dependent on whatever
version a contributor happens to have. I used that same version.

All three hunks are the same edit: a multi-line expression collapsed onto one line
because it fits the print width. Nothing else changes.

```diff
-import {
-  Entrypoint,
-  captureEvaluationRun,
-  recordTestCase,
-} from "@/telemetry";
+import { Entrypoint, captureEvaluationRun, recordTestCase } from "@/telemetry";
```

+3 −11, no behaviour change.

## Verification

Both steps of the lint job, run locally in `typescript/` after `npm ci`:

```
$ npm run lint -- .          # eslint .
(exit 0, no output)

$ npx prettier --check "src/**/*.ts" "test/**/*.ts"
Checking formatting...
All matched files use Prettier code style!
```

Scoped to the three files the check names — no repo-wide reformat.