### PR TITLE
fix: unwrap (result, cost) tuple in sync generate_with_schema_and_extract

### DIFF
--- a/deepeval/metrics/utils.py
+++ b/deepeval/metrics/utils.py
@@ -555,6 +555,15 @@ def generate_with_schema_and_extract(
         accrue_token_usage(metric, cost)
     else:
         result = metric.model.generate_with_schema(prompt, schema=schema_cls)
+
+    # Handle models that return (result, cost) tuple even when not native
+    if isinstance(result, tuple) and len(result) == 2:
+        actual_result, cost = result
+        if hasattr(metric, "_accrue_cost"):
+            metric._accrue_cost(cost)
+            accrue_token_usage(metric, cost)
+        result = actual_result
+
     if isinstance(result, schema_cls):
         return extract_schema(result)
     data = trimAndLoadJson(result, metric)

--- a/tests/test_core/test_generate_with_schema_and_extract_parity.py
+++ b/tests/test_core/test_generate_with_schema_and_extract_parity.py
@@ -1,0 +1,91 @@
+"""Regression test: sync/async parity in ``*_generate_with_schema_and_extract``.
+
+``a_generate_with_schema_and_extract`` unwraps a ``(text, cost)`` tuple returned
+by a non-native (custom) model before handing the payload to ``trimAndLoadJson``
+(added in e0684df2, "AttributeError: 'tuple' object has no attribute 'find'").
+The synchronous ``generate_with_schema_and_extract`` never got the same
+treatment, so a custom ``DeepEvalBaseLLM`` whose ``generate`` returns
+``(text, cost)`` works under ``a_measure`` but blows up under ``measure`` with an
+opaque ``AttributeError`` raised from inside ``trimAndLoadJson``.
+
+The cost returned in the tuple (``0.25`` below) is deliberately non-zero so the
+``_accrue_cost`` assertion can only pass if the tuple was actually unwrapped and
+accounted for -- it cannot be satisfied by the default ``0`` accumulator.
+"""
+
+import asyncio
+
+import pytest
+
+from pydantic import BaseModel
+
+from deepeval.metrics.utils import (
+    a_generate_with_schema_and_extract,
+    generate_with_schema_and_extract,
+)
+
+
+class _Verdict(BaseModel):
+    reason: str
+
+
+class _TupleReturningModel:
+    """A non-native custom model that returns ``(text, cost)`` -- the shape the
+    async helper already tolerates."""
+
+    def generate_with_schema(self, prompt, schema=None):
+        return '{"reason": "grounded"}', 0.25
+
+    async def a_generate_with_schema(self, prompt, schema=None):
+        return '{"reason": "grounded"}', 0.25
+
+
+class _Metric:
+    using_native_model = False
+
+    def __init__(self):
+        self.model = _TupleReturningModel()
+        self.accrued_cost = 0.0
+        self.error = None
+
+    def _accrue_cost(self, cost):
+        self.accrued_cost += cost or 0.0
+
+    def _accrue_tokens(self, input_tokens, output_tokens):
+        pass
+
+
+_KWARGS = dict(
+    prompt="irrelevant",
+    schema_cls=_Verdict,
+    extract_schema=lambda r: r.reason,
+    extract_json=lambda data: data["reason"],
+)
+
+
+def test_sync_helper_unwraps_cost_tuple_like_async():
+    metric = _Metric()
+    result = generate_with_schema_and_extract(metric=metric, **_KWARGS)
+    assert result == "grounded"
+    assert metric.accrued_cost == pytest.approx(0.25)
+
+
+def test_async_helper_unwraps_cost_tuple():
+    metric = _Metric()
+    result = asyncio.run(
+        a_generate_with_schema_and_extract(metric=metric, **_KWARGS)
+    )
+    assert result == "grounded"
+    assert metric.accrued_cost == pytest.approx(0.25)
+
+
+def test_sync_and_async_agree():
+    sync_metric, async_metric = _Metric(), _Metric()
+    sync_result = generate_with_schema_and_extract(
+        metric=sync_metric, **_KWARGS
+    )
+    async_result = asyncio.run(
+        a_generate_with_schema_and_extract(metric=async_metric, **_KWARGS)
+    )
+    assert sync_result == async_result
+    assert sync_metric.accrued_cost == async_metric.accrued_cost


### PR DESCRIPTION
### Summary

`a_generate_with_schema_and_extract` unwraps a `(text, cost)` tuple returned by a **non-native** (custom) model before handing the payload to `trimAndLoadJson` — this was added in e0684df2 (*"AttributeError: 'tuple' object has no attribute 'find'"*). The synchronous `generate_with_schema_and_extract` never got the same treatment.

So a custom `DeepEvalBaseLLM` whose `generate()` returns `(text, cost)` (a common pattern for wrappers that also want to report spend):

- works under `a_measure()` / `async_mode=True`
- raises `AttributeError: 'tuple' object has no attribute 'find'` from inside `trimAndLoadJson` under `measure()`

This hits the sync scoring path of `ContextualRelevancyMetric`, `FaithfulnessMetric` (reason step), `ConversationCompletenessMetric`, and the prompt optimizer (`COPRO`, `MIPROv2`, `SIMBA`, rewriter), all of which call the sync helper.

### Change

Mirror the async helper's unwrap block into the sync one, including the `_accrue_cost` / `accrue_token_usage` accrual, so `measure()` and `a_measure()` behave identically for tuple-returning custom models.

```python
# Handle models that return (result, cost) tuple even when not native
if isinstance(result, tuple) and len(result) == 2:
    actual_result, cost = result
    if hasattr(metric, "_accrue_cost"):
        metric._accrue_cost(cost)
        accrue_token_usage(metric, cost)
    result = actual_result
```

### Tests

`tests/test_core/test_generate_with_schema_and_extract_parity.py` — 3 tests covering both helpers and their agreement. The non-zero cost (`0.25`) in the fixture makes the accrual assertion non-vacuous. The two sync cases fail without this change with the exact `AttributeError` above; the async case already passes.

```
$ python -m pytest tests/test_core/test_generate_with_schema_and_extract_parity.py -q
3 passed

# with deepeval/metrics/utils.py reverted:
2 failed, 1 passed   # both sync cases -> AttributeError: 'tuple' object has no attribute 'find'
```

`tests/test_metrics` and `tests/test_core/test_optimization` stay green (257 passed locally, the rest skipped for missing `OPENAI_API_KEY`).

This PR was generated with an AI assistant; I have reviewed the change and run the tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUQxa2vJuTi3o67JHxKG1e