### PR TITLE
fix: cap Scorer.truth_identification_score at 100

### DIFF
--- a/deepeval/scorer/scorer.py
+++ b/deepeval/scorer/scorer.py
@@ -412,9 +412,13 @@ class Scorer:
             if not target_list:
                 return 0  # Return 0 if target list is empty to avoid division by zero
 
-            # Count the number of correct matches
+            # Count the number of correct matches, once per distinct
+            # predicted item. ListOfNumbersSchema (the structured output
+            # TruthfulQA MC2 uses to produce `prediction`) has no uniqueness
+            # constraint, so a repeated correct index would otherwise be
+            # counted once per repeat and push the percentage above 100.
             correct_matches = sum(
-                1 for item in prediction_list if item in target_list
+                1 for item in set(prediction_list) if item in target_list
             )
 
             # Calculate percentage

--- a/tests/test_core/test_scorer_truth_identification.py
+++ b/tests/test_core/test_scorer_truth_identification.py
@@ -1,0 +1,38 @@
+"""Regression test: ``Scorer.truth_identification_score`` could return more
+than 100.
+
+The score is a percentage of ``target_list`` identified correctly, so it must
+never exceed 100. Before this fix, ``correct_matches`` counted every
+occurrence of a correct value in ``prediction_list`` rather than each
+distinct value once, so a prediction that repeated a correct index inflated
+the count past ``len(target_list)``.
+
+This is reachable from ``TruthfulQABenchmark`` in MC2 mode: the model's
+answer comes from ``ListOfNumbersSchema`` (a plain ``List[int]`` with no
+uniqueness constraint), stringified and fed straight into this scorer, so a
+model repeating an index in its structured output reaches this path
+unfiltered.
+"""
+
+from deepeval.scorer import Scorer
+
+scorer = Scorer()
+
+
+def test_repeated_correct_index_does_not_exceed_100():
+    # Two correct answers (1, 2); the model names index 1 three times and
+    # never names 2. Only one distinct correct answer was identified.
+    score = scorer.truth_identification_score(target="1,2", prediction="1,1,1")
+    assert score <= 100
+    assert score == 50
+
+
+def test_all_correct_with_a_repeat_is_capped_at_100():
+    # Both correct answers named, one of them twice.
+    score = scorer.truth_identification_score(target="1,2", prediction="1,1,2")
+    assert score == 100
+
+
+def test_no_repeats_is_unaffected():
+    score = scorer.truth_identification_score(target="1,2,3", prediction="1,2")
+    assert score == round(2 / 3 * 100)


### PR DESCRIPTION
### Summary

`Scorer.truth_identification_score` is documented as a percentage of `target_list` identified correctly, but `correct_matches` counted every occurrence of a correct value in `prediction_list` rather than each distinct value once:

```python
correct_matches = sum(1 for item in prediction_list if item in target_list)
```

So a prediction that repeats a correct index inflates the score past 100:

```python
>>> Scorer().truth_identification_score(target="1,2", prediction="1,1,1")
150
```

### Where this is reachable

`TruthfulQABenchmark` in MC2 mode gets the model's answer from `ListOfNumbersSchema` (a plain `List[int]`, no uniqueness constraint), stringifies it, and passes it straight into this scorer — see `deepeval/benchmarks/truthful_qa/truthful_qa.py`. A model that repeats an index in its structured output (not an unusual failure mode for smaller/local eval models) reaches this path unfiltered, silently inflating the reported MC2 score past 100%.

### Change

Count each predicted value once via `set(prediction_list)`, so a repeat can't add extra credit. No-repeat inputs are unaffected.

### Tests

`tests/test_core/test_scorer_truth_identification.py` — 3 cases. The two that involve a repeated correct index fail without this change (`150` instead of the asserted `<= 100` / `100`); the no-repeat case was already correct and stays green either way.

```
$ python -m pytest tests/test_core/test_scorer_truth_identification.py -q
3 passed

# with the fix reverted:
2 failed  # 150 == 100 -> AssertionError, and score > 100
```

`tests/test_benchmarks/test_benchmark_answer_scoring.py` (the closest existing coverage) stays green.

This PR was generated with an AI assistant; I have reviewed the change and run the tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUQxa2vJuTi3o67JHxKG1e