### PR TITLE
fix: HumanEval overall accuracy should average pass@k, not binarize it

### DIFF
--- a/deepeval/benchmarks/human_eval/human_eval.py
+++ b/deepeval/benchmarks/human_eval/human_eval.py
@@ -122,16 +122,19 @@ class HumanEval(DeepEvalBaseBenchmark):
 
             for task in self.tasks:
                 golden: Golden = self.load_benchmark_dataset(task)
-                task_correct = 0
                 overall_total_predictions += 1
 
-                # Calculate task accuracy
+                # Calculate task accuracy. `score` is the pass@k estimate for
+                # this task (a float in [0, 1], not a pass/fail flag), so it
+                # is accumulated directly rather than truthiness-tested --
+                # otherwise any score above 0 would count as a full pass and
+                # "Overall HumanEval Accuracy" would stop being the mean
+                # pass@k the benchmark is named for.
                 prediction, score = self.predict(
                     model, task, golden, k
                 ).values()
-                if score:
-                    task_correct = 1
-                    overall_correct_predictions += 1
+                task_correct = score
+                overall_correct_predictions += score
                 predictions_row.append(
                     (
                         task.value,

--- a/tests/test_benchmarks/test_human_eval_overall_accuracy.py
+++ b/tests/test_benchmarks/test_human_eval_overall_accuracy.py
@@ -1,0 +1,74 @@
+"""Regression test: HumanEval's "Overall Accuracy" must be the mean pass@k
+over tasks, not the fraction of tasks with pass@k > 0.
+
+`predict()` returns `score` as the pass@k estimate for a task -- a float in
+[0, 1], not a pass/fail flag. `evaluate()` previously did `if score:
+task_correct = 1`, so any task with even one correct sample among n
+generations (score > 0) counted as a full pass. Two fractional scores that
+are individually below 0.5 (0.3 and 0.4) are used below so a binarized
+"count each other 1" bug and the real mean (0.35) are unambiguously
+different numbers -- this can't pass by coincidence.
+
+The benchmark's own dataset loading and code-sample generation are bypassed
+(`__new__` + monkeypatching `predict`/`load_benchmark_dataset`, the same
+pattern `test_bbh_batch_predict_scores_schema_answer_correctly` uses for
+BigBenchHard) so this stays a fast, offline unit test.
+"""
+
+import contextlib
+
+import pytest
+
+import deepeval.benchmarks.human_eval.human_eval as human_eval_module
+from deepeval.benchmarks.human_eval.human_eval import HumanEval
+from deepeval.benchmarks.human_eval.task import HumanEvalTask
+from deepeval.dataset import Golden
+from deepeval.scorer import Scorer
+
+
+def _human_eval(tasks):
+    bench = HumanEval.__new__(HumanEval)
+    bench.tasks = tasks
+    bench.n = 10
+    bench.temperature = 0.0
+    bench.verbose_mode = False
+    bench.scorer = Scorer()
+    bench.c = {}
+    bench.functions = {}
+    return bench
+
+
+def test_overall_accuracy_is_the_mean_pass_at_k(monkeypatch):
+    tasks = [
+        HumanEvalTask.HAS_CLOSE_ELEMENTS,
+        HumanEvalTask.SEPARATE_PAREN_GROUPS,
+    ]
+    per_task_score = {
+        HumanEvalTask.HAS_CLOSE_ELEMENTS: 0.3,
+        HumanEvalTask.SEPARATE_PAREN_GROUPS: 0.4,
+    }
+    bench = _human_eval(tasks)
+
+    monkeypatch.setattr(
+        human_eval_module,
+        "capture_benchmark_run",
+        lambda *a, **k: contextlib.nullcontext(),
+    )
+    monkeypatch.setattr(
+        bench,
+        "load_benchmark_dataset",
+        lambda task: Golden(input="x", expected_output="y"),
+    )
+    monkeypatch.setattr(
+        bench,
+        "predict",
+        lambda model, task, golden, k: {
+            "prediction": "def f(): ...",
+            "score": per_task_score[task],
+        },
+    )
+
+    bench.evaluate(model=object(), k=1)
+
+    assert bench.overall_score == pytest.approx(0.35)
+    assert bench.task_scores["Score"].tolist() == pytest.approx([0.3, 0.4])


### PR DESCRIPTION
### Summary

`HumanEval.predict()` correctly returns `score = self.scorer.pass_at_k(self.n, c, k)` — a float in `[0, 1]`, the unbiased pass@k estimator from the Codex paper (Chen et al. 2021), not a pass/fail flag. `evaluate()` then does:

```python
if score:
    task_correct = 1
    overall_correct_predictions += 1
```

Python truthiness means any `score > 0` — i.e. *any* correct sample among the `n` generations for that task — counts as a full pass. So "Overall HumanEval Accuracy" (`overall_correct_predictions / overall_total_predictions`) is not the mean pass@k the benchmark is named for; it's inflated toward 1.0 whenever a task has at least one correct sample among `n`, regardless of how many.

Concretely, two tasks scoring `0.3` and `0.4` pass@1 currently print:

```
HumanEval Task Accuracy (task=has_close_elements): 1
HumanEval Task Accuracy (task=separate_paren_groups): 1
Overall HumanEval Accuracy: 1.0
```

### Change

Accumulate the score itself instead of testing its truthiness:

```python
task_correct = score
overall_correct_predictions += score
```

The same two tasks now report the mean, `0.35` — matching the standard definition (`np.mean` of per-problem pass@k in OpenAI's own `human-eval` reference script).

### Tests

`tests/test_benchmarks/test_human_eval_overall_accuracy.py` bypasses dataset loading and code execution — `HumanEval.__new__` plus monkeypatching `predict`/`load_benchmark_dataset`, the same pattern `test_bbh_batch_predict_scores_schema_answer_correctly` already uses for `BigBenchHard` — so it stays a fast, offline unit test. `0.3`/`0.4` are chosen so the old (binarized) and new (mean) results can't coincide.

```
$ python -m pytest tests/test_benchmarks/test_human_eval_overall_accuracy.py -q
1 passed

# with human_eval.py reverted:
1 failed  # asserted 0.35, got 1.0
```

`tests/test_benchmarks/` (14 tests) stays green.

This PR was generated with an AI assistant; I have reviewed the change and run the tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUQxa2vJuTi3o67JHxKG1e