### PR TITLE
fix: IFEval case constraints shouldn't fail responses with no letters

### DIFF
--- a/deepeval/benchmarks/ifeval/ifeval.py
+++ b/deepeval/benchmarks/ifeval/ifeval.py
@@ -168,10 +168,17 @@ class IFEvalInstructionVerifier:
     ) -> bool:
         """Verify case-related constraints."""
         if instruction_id == "change_case:english_lowercase":
-            return response.lower() == response and response.islower()
+            # `response.lower() == response` already means "no uppercase
+            # letter is present" -- exactly what "No capital letters are
+            # allowed" requires. The extra `and response.islower()` doesn't
+            # narrow that; it adds an unrelated requirement that at least one
+            # *lowercase* letter be present, so a response with no cased
+            # characters at all (e.g. "42", or an empty string) fails a
+            # constraint it never violated.
+            return response.lower() == response
 
         elif instruction_id == "change_case:english_uppercase":
-            return response.upper() == response and response.isupper()
+            return response.upper() == response
 
         elif instruction_id == "change_case:english_titlecase":
             return response.istitle()

--- a/tests/test_benchmarks/test_ifeval_case_constraints.py
+++ b/tests/test_benchmarks/test_ifeval_case_constraints.py
@@ -1,0 +1,61 @@
+"""Regression test: IFEval's `change_case:english_lowercase` /
+`english_uppercase` checkers rejected responses with no cased characters at
+all, even though such responses trivially satisfy "no capital letters are
+allowed" (there are no letters to be capital).
+
+`response.lower() == response` already means "response has no uppercase
+letter" -- exactly what the lowercase instruction requires. The extra `and
+response.islower()` added an unrelated requirement (at least one *lowercase*
+letter present), since Python's `str.islower()`/`str.isupper()` return False
+when there is no cased character at all. A response like "42" (a valid
+answer to a prompt combined with a lowercase-formatting instruction) or an
+empty response therefore failed a constraint it never violated.
+"""
+
+import pytest
+
+from deepeval.benchmarks.ifeval.ifeval import IFEvalInstructionVerifier
+
+
+@pytest.mark.parametrize(
+    "response",
+    ["42", "", "   ", "3.14", "#1"],
+)
+def test_lowercase_constraint_passes_when_there_are_no_letters(response):
+    assert IFEvalInstructionVerifier.verify_case_constraints(
+        response, "change_case:english_lowercase", {}
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    ["42", "", "   ", "3.14", "#1"],
+)
+def test_uppercase_constraint_passes_when_there_are_no_letters(response):
+    assert IFEvalInstructionVerifier.verify_case_constraints(
+        response, "change_case:english_uppercase", {}
+    )
+
+
+def test_lowercase_constraint_still_rejects_a_capital_letter():
+    assert not IFEvalInstructionVerifier.verify_case_constraints(
+        "Hello world", "change_case:english_lowercase", {}
+    )
+
+
+def test_lowercase_constraint_still_accepts_all_lowercase_text():
+    assert IFEvalInstructionVerifier.verify_case_constraints(
+        "hello world", "change_case:english_lowercase", {}
+    )
+
+
+def test_uppercase_constraint_still_rejects_a_lowercase_letter():
+    assert not IFEvalInstructionVerifier.verify_case_constraints(
+        "HELLo", "change_case:english_uppercase", {}
+    )
+
+
+def test_uppercase_constraint_still_accepts_all_uppercase_text():
+    assert IFEvalInstructionVerifier.verify_case_constraints(
+        "HELLO WORLD", "change_case:english_uppercase", {}
+    )


### PR DESCRIPTION
### Summary

`IFEvalInstructionVerifier.verify_case_constraints` checks the `change_case:english_lowercase` instruction with:

```python
return response.lower() == response and response.islower()
```

(and the mirror image for `english_uppercase` with `.upper()`/`.isupper()`).

`response.lower() == response` already means exactly "this response has no uppercase letter" — which is the whole instruction ("Your entire response should be in English, and in all lowercase letters. No capital letters are allowed."). `str.islower()` is a different, additional check: it returns `False` whenever the string has no cased character at all, regardless of case. So a response with no letters — `"42"`, `""`, `"3.14"`, `"#1"` — fails a lowercase (and uppercase) constraint it never actually violated:

```python
>>> "42".lower() == "42" and "42".islower()
False   # should be True: "42" has no capital letters
```

This is reachable whenever a prompt combines the case instruction with something whose answer can legitimately contain no letters (a number, a symbol, or a model that returns nothing).

### Change

Drop the `islower()`/`isupper()` clause; the equality check alone is the correct and complete condition.

### Tests

`tests/test_benchmarks/test_ifeval_case_constraints.py`:
- 10 parametrized cases (5 no-letter responses × lowercase/uppercase) fail without this change and pass with it.
- 4 cases confirm existing behavior is untouched: a real case violation still fails, a real all-lowercase/all-uppercase response still passes, for both directions.

```
$ python -m pytest tests/test_benchmarks/test_ifeval_case_constraints.py -q
14 passed

# with the fix reverted:
10 failed, 4 passed
```

This PR was generated with an AI assistant; I have reviewed the change and run the tests locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUQxa2vJuTi3o67JHxKG1e