### PR TITLE
fix(benchmarks): validate Winogrande n_shots and n_problems with explicit exceptions (#3212)

### DIFF
--- a/deepeval/benchmarks/winogrande/winogrande.py
+++ b/deepeval/benchmarks/winogrande/winogrande.py
@@ -24,8 +24,26 @@ class Winogrande(DeepEvalBaseBenchmark):
         from deepeval.scorer import Scorer
         import pandas as pd
 
-        assert n_shots <= 5, "Winogrande only supports n_shots <= 5"
-        assert n_problems <= 1267, "Winogrande only supports n_problems <= 1267"
+        # Validate arguments explicitly instead of with bare `assert` (which is
+        # stripped under `python -O` and raises AssertionError). `n_shots` may be
+        # 0 (zero-shot), but `n_problems` must be >= 1: evaluate() divides the
+        # number of correct predictions by it, so 0 would crash with a
+        # ZeroDivisionError.
+        for name, value in (("n_shots", n_shots), ("n_problems", n_problems)):
+            if type(value) is not int:
+                raise TypeError(
+                    f"'{name}' must be an integer, got {type(value).__name__}."
+                )
+        if not 0 <= n_shots <= 5:
+            raise ValueError(
+                f"'n_shots' must be between 0 and 5 (Winogrande only supports "
+                f"n_shots <= 5), got {n_shots}."
+            )
+        if not 1 <= n_problems <= 1267:
+            raise ValueError(
+                f"'n_problems' must be between 1 and 1267 (Winogrande only supports "
+                f"n_problems <= 1267), got {n_problems}."
+            )
         super().__init__(**kwargs)
         self.scorer = Scorer()
         self.n_shots: int = n_shots

--- a/tests/test_benchmarks/test_winogrande_validation.py
+++ b/tests/test_benchmarks/test_winogrande_validation.py
@@ -1,0 +1,104 @@
+import os
+import subprocess
+import sys
+import types
+import pytest
+
+from deepeval.benchmarks.winogrande.winogrande import Winogrande
+
+
+@pytest.fixture(autouse=True)
+def fake_datasets(monkeypatch):
+    """Fake the optional ``datasets`` package imported by the base benchmark."""
+    module = types.ModuleType("datasets")
+
+    class Dataset:
+        pass
+
+    module.Dataset = Dataset
+    monkeypatch.setitem(sys.modules, "datasets", module)
+    return module
+
+
+def test_winogrande_default_construction():
+    bench = Winogrande()
+    assert bench.n_shots == 5
+    assert bench.n_problems == 1267
+
+
+def test_winogrande_zero_shot_is_allowed():
+    bench = Winogrande(n_shots=0)
+    assert bench.n_shots == 0
+
+
+def test_winogrande_boundaries_allowed():
+    bench = Winogrande(n_shots=0, n_problems=1)
+    assert bench.n_shots == 0
+    assert bench.n_problems == 1
+
+    bench_max = Winogrande(n_shots=5, n_problems=1267)
+    assert bench_max.n_shots == 5
+    assert bench_max.n_problems == 1267
+
+
+@pytest.mark.parametrize("n_shots", [-1, -10, 6, 100])
+def test_winogrande_n_shots_out_of_bounds_rejected(n_shots):
+    with pytest.raises(ValueError, match="'n_shots' must be between 0 and 5"):
+        Winogrande(n_shots=n_shots)
+
+
+@pytest.mark.parametrize("n_shots", ["5", 2.5, None, [1]])
+def test_winogrande_n_shots_non_integer_rejected(n_shots):
+    with pytest.raises(TypeError, match="'n_shots' must be an integer"):
+        Winogrande(n_shots=n_shots)
+
+
+@pytest.mark.parametrize("n_problems", [0, -1, -50, 1268, 5000])
+def test_winogrande_n_problems_out_of_bounds_rejected(n_problems):
+    with pytest.raises(
+        ValueError, match="'n_problems' must be between 1 and 1267"
+    ):
+        Winogrande(n_problems=n_problems)
+
+
+@pytest.mark.parametrize("n_problems", ["100", 50.5, None, (1,)])
+def test_winogrande_n_problems_non_integer_rejected(n_problems):
+    with pytest.raises(TypeError, match="'n_problems' must be an integer"):
+        Winogrande(n_problems=n_problems)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        (
+            "from deepeval.benchmarks.winogrande.winogrande import Winogrande\n"
+            "try:\n"
+            "    Winogrande(n_shots=6)\n"
+            "except ValueError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise SystemExit('out-of-range n_shots accepted under -O')\n"
+        ),
+        (
+            "from deepeval.benchmarks.winogrande.winogrande import Winogrande\n"
+            "try:\n"
+            "    Winogrande(n_problems=0)\n"
+            "except ValueError:\n"
+            "    pass\n"
+            "else:\n"
+            "    raise SystemExit('n_problems=0 accepted under -O')\n"
+        ),
+    ],
+)
+def test_winogrande_validation_survives_python_optimize(code):
+    """The checks must survive python -O (bare asserts would be stripped)."""
+    repo_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": repo_root},
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
### Summary
Replaces bare `assert` statements validating `n_shots` and `n_problems` in `Winogrande.__init__` with explicit `TypeError` and `ValueError` checks, following the validation pattern established across other benchmarks.

Bare `assert` statements in public constructor APIs have several drawbacks:
1. They are stripped under `python -O`/`-OO`, causing validation to silently disappear in optimized execution.
2. They raise `AssertionError` instead of standard `TypeError` / `ValueError`.
3. They only check upper bounds, allowing non-positive integers (`n_problems=0`, negative values) to proceed into `evaluate()`, where `overall_correct_predictions / overall_total_predictions` triggers a `ZeroDivisionError`.

### Proposed Changes
- Validate `n_shots` and `n_problems` in `Winogrande.__init__`:
  - Enforce integer types, raising `TypeError` on non-integers.
  - Require `0 <= n_shots <= 5`, raising `ValueError` on out-of-bounds values while preserving valid zero-shot execution.
  - Require `1 <= n_problems <= 1267`, raising `ValueError` on values `< 1` or `> 1267` to prevent `ZeroDivisionError`.
- Added unit test suite in `tests/test_benchmarks/test_winogrande_validation.py` covering:
  - Default and zero-shot construction.
  - Upper and lower boundary construction.
  - Out-of-bounds rejection (`ValueError`).
  - Non-integer argument rejection (`TypeError`).
  - Optimization mode verification under `python -O`.

### Verification
- Ran `pytest tests/test_benchmarks/test_winogrande_validation.py`: 22/22 passed.
- Formatted and verified with `black`.

Closes #3212.
